### PR TITLE
feat: implement TODO file and GitHub Projects v2 tracker backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,10 +54,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -107,6 +129,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +174,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,10 +211,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "ensemble-core"
@@ -163,6 +243,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "liquid",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -171,6 +252,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]
@@ -186,7 +268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -202,10 +284,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -219,6 +419,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -228,6 +439,25 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -250,6 +480,137 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -276,10 +637,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -291,6 +754,22 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -314,6 +793,8 @@ version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -407,6 +888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,7 +937,24 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -453,7 +963,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -472,10 +982,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -556,6 +1120,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +1219,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +1282,40 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -659,10 +1331,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -711,6 +1415,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -763,6 +1479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,14 +1497,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -796,16 +1530,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -869,6 +1644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,7 +1667,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -895,6 +1680,84 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -971,6 +1834,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,16 +1876,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1053,6 +1961,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1122,6 +2040,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +2091,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,11 +2121,107 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1275,6 +2310,95 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 async-trait = "0.1"
+reqwest = { version = "0.12", features = ["json"] }
+wiremock = "0.6"

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -16,7 +16,9 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
 async-trait = { workspace = true }
+reqwest = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+wiremock = { workspace = true }

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -718,10 +718,25 @@ impl GithubTracker {
             });
 
         let state = project_state.unwrap_or_else(|| {
-            node.get("state")
+            let raw_state = node
+                .get("state")
                 .and_then(|v| v.as_str())
                 .unwrap_or("open")
-                .to_lowercase()
+                .to_lowercase();
+
+            // In repo-mode, derive state from labels (matching active/terminal states)
+            // to stay consistent with normalize_repo_issue.
+            labels
+                .iter()
+                .find(|l| {
+                    self.active_states.iter().any(|s| s.eq_ignore_ascii_case(l))
+                        || self
+                            .terminal_states
+                            .iter()
+                            .any(|s| s.eq_ignore_ascii_case(l))
+                })
+                .cloned()
+                .unwrap_or(raw_state)
         });
 
         let url = node
@@ -1324,6 +1339,43 @@ mod tests {
         assert_eq!(issues[1].id, "I_node3");
         assert_eq!(issues[1].state, "closed");
         assert_eq!(issues[1].identifier, "my-repo#99");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_states_by_ids_derives_state_from_labels() {
+        // Regression: repo-mode reconciliation must re-derive state from labels,
+        // not just fall back to raw open/closed.
+        let server = MockServer::start().await;
+
+        let response = graphql_response(json!({
+            "nodes": [
+                {
+                    "id": "I_label_issue",
+                    "number": 55,
+                    "title": "Label-derived state",
+                    "state": "OPEN",
+                    "url": "https://github.com/acme/my-repo/issues/55",
+                    "labels": { "nodes": [{ "name": "todo" }] },
+                    "projectItems": { "nodes": [] }
+                }
+            ]
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), None);
+        let issues = tracker
+            .fetch_issue_states_by_ids(&["I_label_issue".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(issues.len(), 1);
+        // Should derive "todo" from labels, not fall back to "open"
+        assert_eq!(issues[0].state, "todo");
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -1,0 +1,1583 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
+use tracing::{debug, info, warn};
+
+use super::model::Issue;
+use super::{IssueTracker, TrackerError};
+
+// --- GraphQL query constants ---
+
+/// Discovery query: resolve Project v2 node ID and Status field ID.
+const PROJECT_DISCOVERY_QUERY: &str = r#"
+query($owner: String!, $repo: String!, $projectNumber: Int!) {
+  repository(owner: $owner, name: $repo) {
+    projectV2(number: $projectNumber) {
+      id
+      fields(first: 20) {
+        nodes {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+/// Fetch project items with pagination.
+const PROJECT_ITEMS_QUERY: &str = r#"
+query($projectId: ID!, $cursor: String) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 50, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field {
+                  ... on ProjectV2SingleSelectField {
+                    name
+                  }
+                }
+              }
+            }
+          }
+          content {
+            ... on Issue {
+              id
+              number
+              title
+              body
+              createdAt
+              updatedAt
+              url
+              labels(first: 20) {
+                nodes {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+/// Fetch repository issues (no project board).
+const REPO_ISSUES_QUERY: &str = r#"
+query($owner: String!, $repo: String!, $cursor: String, $labels: [String!]) {
+  repository(owner: $owner, name: $repo) {
+    issues(first: 50, after: $cursor, states: [OPEN], labels: $labels, orderBy: {field: CREATED_AT, direction: ASC}) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        number
+        title
+        body
+        createdAt
+        updatedAt
+        url
+        state
+        labels(first: 20) {
+          nodes {
+            name
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+/// Batch query for issue states by node IDs.
+const ISSUE_STATES_QUERY: &str = r#"
+query($ids: [ID!]!) {
+  nodes(ids: $ids) {
+    ... on Issue {
+      id
+      number
+      title
+      state
+      url
+      labels(first: 20) {
+        nodes {
+          name
+        }
+      }
+      projectItems(first: 10) {
+        nodes {
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field {
+                  ... on ProjectV2SingleSelectField {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+/// GitHub Projects v2 issue tracker using GraphQL.
+pub struct GithubTracker {
+    endpoint: String,
+    token: String,
+    owner: String,
+    repo: String,
+    project_number: Option<i64>,
+    active_states: Vec<String>,
+    terminal_states: Vec<String>,
+    labels_filter: Vec<String>,
+    client: reqwest::Client,
+    /// Cached project node ID (resolved at first use when project_number is set).
+    project_node_id: tokio::sync::RwLock<Option<String>>,
+    /// Cached Status field ID.
+    status_field_id: tokio::sync::RwLock<Option<String>>,
+}
+
+impl GithubTracker {
+    /// Create a new GithubTracker.
+    ///
+    /// Parses `owner/repo` from the repository string.
+    /// The reqwest client is created with a 30-second timeout.
+    pub fn new(
+        endpoint: String,
+        token: String,
+        repository: String,
+        project_number: Option<i64>,
+        active_states: Vec<String>,
+        terminal_states: Vec<String>,
+        labels_filter: Vec<String>,
+    ) -> Result<Self, TrackerError> {
+        let (owner, repo) = parse_owner_repo(&repository)?;
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| TrackerError::ApiRequestFailed {
+                reason: format!("failed to build HTTP client: {e}"),
+            })?;
+
+        Ok(Self {
+            endpoint,
+            token,
+            owner,
+            repo,
+            project_number,
+            active_states,
+            terminal_states,
+            labels_filter,
+            client,
+            project_node_id: tokio::sync::RwLock::new(None),
+            status_field_id: tokio::sync::RwLock::new(None),
+        })
+    }
+
+    /// Execute a GraphQL query against the configured endpoint.
+    async fn graphql(&self, query: &str, variables: Value) -> Result<Value, TrackerError> {
+        let body = json!({
+            "query": query,
+            "variables": variables,
+        });
+
+        debug!(endpoint = %self.endpoint, "sending GraphQL request");
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .header("Authorization", format!("bearer {}", self.token))
+            .header("User-Agent", "ensemble-core")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| TrackerError::ApiRequestFailed {
+                reason: e.to_string(),
+            })?;
+
+        // Track rate limit
+        if let Some(remaining) = response
+            .headers()
+            .get("x-ratelimit-remaining")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u32>().ok())
+        {
+            if remaining < 500 {
+                warn!(remaining, "GitHub API rate limit running low");
+            } else {
+                debug!(remaining, "GitHub API rate limit remaining");
+            }
+        }
+
+        let status = response.status();
+        if !status.is_success() {
+            let body_text = response.text().await.unwrap_or_default();
+            return Err(TrackerError::ApiStatus {
+                status: status.as_u16(),
+                body: body_text,
+            });
+        }
+
+        let json_body: Value =
+            response
+                .json()
+                .await
+                .map_err(|e| TrackerError::UnexpectedPayload {
+                    reason: format!("failed to parse response JSON: {e}"),
+                })?;
+
+        // Check for GraphQL errors
+        if let Some(errors) = json_body.get("errors") {
+            if let Some(arr) = errors.as_array() {
+                if !arr.is_empty() {
+                    let messages: Vec<String> = arr
+                        .iter()
+                        .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                        .map(|s| s.to_string())
+                        .collect();
+                    return Err(TrackerError::GraphqlErrors {
+                        errors: messages.join("; "),
+                    });
+                }
+            }
+        }
+
+        json_body
+            .get("data")
+            .cloned()
+            .ok_or_else(|| TrackerError::UnexpectedPayload {
+                reason: "response missing 'data' field".to_string(),
+            })
+    }
+
+    /// Discover the project node ID and status field ID via GraphQL.
+    /// Caches results for subsequent calls.
+    async fn ensure_project_metadata(&self) -> Result<(String, String), TrackerError> {
+        // Check cache first
+        {
+            let node_id = self.project_node_id.read().await;
+            let field_id = self.status_field_id.read().await;
+            if let (Some(nid), Some(fid)) = (node_id.as_ref(), field_id.as_ref()) {
+                return Ok((nid.clone(), fid.clone()));
+            }
+        }
+
+        let project_number =
+            self.project_number
+                .ok_or_else(|| TrackerError::UnexpectedPayload {
+                    reason: "project_number is required for project board mode".to_string(),
+                })?;
+
+        info!(
+            owner = %self.owner,
+            repo = %self.repo,
+            project_number,
+            "discovering project metadata"
+        );
+
+        let variables = json!({
+            "owner": self.owner,
+            "repo": self.repo,
+            "projectNumber": project_number,
+        });
+
+        let data = self.graphql(PROJECT_DISCOVERY_QUERY, variables).await?;
+
+        let project = data.pointer("/repository/projectV2").ok_or_else(|| {
+            TrackerError::UnexpectedPayload {
+                reason: "project not found in discovery response".to_string(),
+            }
+        })?;
+
+        let project_id = project
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| TrackerError::UnexpectedPayload {
+                reason: "project ID not found".to_string(),
+            })?
+            .to_string();
+
+        // Find the Status field
+        let fields = project
+            .pointer("/fields/nodes")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| TrackerError::UnexpectedPayload {
+                reason: "project fields not found".to_string(),
+            })?;
+
+        let status_field_id = fields
+            .iter()
+            .find(|f| f.get("name").and_then(|n| n.as_str()) == Some("Status"))
+            .and_then(|f| f.get("id"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| TrackerError::UnexpectedPayload {
+                reason: "Status field not found in project".to_string(),
+            })?
+            .to_string();
+
+        info!(
+            project_id = %project_id,
+            status_field_id = %status_field_id,
+            "project metadata discovered"
+        );
+
+        // Cache results
+        {
+            let mut node_id_lock = self.project_node_id.write().await;
+            *node_id_lock = Some(project_id.clone());
+        }
+        {
+            let mut field_id_lock = self.status_field_id.write().await;
+            *field_id_lock = Some(status_field_id.clone());
+        }
+
+        Ok((project_id, status_field_id))
+    }
+
+    /// Fetch all project items with pagination, filtering by active states.
+    async fn fetch_project_items(
+        &self,
+        filter_states: &[String],
+    ) -> Result<Vec<Issue>, TrackerError> {
+        let (project_id, _status_field_id) = self.ensure_project_metadata().await?;
+
+        let mut all_issues = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let variables = json!({
+                "projectId": project_id,
+                "cursor": cursor,
+            });
+
+            let data = self.graphql(PROJECT_ITEMS_QUERY, variables).await?;
+
+            let items_data =
+                data.pointer("/node/items")
+                    .ok_or_else(|| TrackerError::UnexpectedPayload {
+                        reason: "items not found in project response".to_string(),
+                    })?;
+
+            let page_info =
+                items_data
+                    .get("pageInfo")
+                    .ok_or_else(|| TrackerError::UnexpectedPayload {
+                        reason: "pageInfo not found".to_string(),
+                    })?;
+
+            let has_next = page_info
+                .get("hasNextPage")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let nodes = items_data
+                .pointer("/nodes")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| TrackerError::UnexpectedPayload {
+                    reason: "items nodes not found".to_string(),
+                })?;
+
+            for node in nodes {
+                if let Some(issue) = self.normalize_project_item(node, filter_states) {
+                    all_issues.push(issue);
+                }
+            }
+
+            if has_next {
+                cursor = page_info
+                    .get("endCursor")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                if cursor.is_none() {
+                    return Err(TrackerError::MissingEndCursor);
+                }
+            } else {
+                break;
+            }
+        }
+
+        Ok(all_issues)
+    }
+
+    /// Normalize a single ProjectV2 item node into an Issue.
+    /// Returns None if the item's status doesn't match the filter states
+    /// or if the content is not an Issue.
+    fn normalize_project_item(&self, node: &Value, filter_states: &[String]) -> Option<Issue> {
+        let content = node.get("content")?;
+
+        // Must be an Issue (not Draft or PR)
+        let id = content.get("id")?.as_str()?;
+        let number = content.get("number")?.as_u64()?;
+        let title = content.get("title")?.as_str()?;
+
+        // Extract status from field values
+        let status = self.extract_status_from_field_values(node);
+
+        // Filter by status if filter_states is provided
+        if !filter_states.is_empty() {
+            let status_ref = status.as_deref().unwrap_or("");
+            if !filter_states
+                .iter()
+                .any(|s| s.eq_ignore_ascii_case(status_ref))
+            {
+                return None;
+            }
+        }
+
+        let body = content
+            .get("body")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty());
+
+        let url = content
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let labels = extract_labels(content);
+        let priority = extract_priority_from_field_values(node);
+
+        let created_at = content
+            .get("createdAt")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<DateTime<Utc>>().ok());
+
+        let updated_at = content
+            .get("updatedAt")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<DateTime<Utc>>().ok());
+
+        let identifier = format!("{}#{}", self.repo, number);
+
+        Some(Issue {
+            id: id.to_string(),
+            identifier,
+            title: title.to_string(),
+            description: body,
+            priority,
+            state: status.unwrap_or_else(|| "unknown".to_string()),
+            branch_name: None,
+            url,
+            labels,
+            blocked_by: vec![],
+            created_at,
+            updated_at,
+        })
+    }
+
+    /// Extract the Status field value from a project item's fieldValues.
+    fn extract_status_from_field_values(&self, node: &Value) -> Option<String> {
+        let field_values = node
+            .pointer("/fieldValues/nodes")
+            .and_then(|v| v.as_array())?;
+
+        for fv in field_values {
+            let field_name = fv.pointer("/field/name").and_then(|v| v.as_str());
+            if field_name == Some("Status") {
+                return fv
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+            }
+        }
+        None
+    }
+
+    /// Fetch repository issues without a project board.
+    async fn fetch_repo_issues(
+        &self,
+        filter_states: &[String],
+    ) -> Result<Vec<Issue>, TrackerError> {
+        let mut all_issues = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        let labels_param: Option<Vec<String>> = if !self.labels_filter.is_empty() {
+            Some(self.labels_filter.clone())
+        } else {
+            None
+        };
+
+        loop {
+            let variables = json!({
+                "owner": self.owner,
+                "repo": self.repo,
+                "cursor": cursor,
+                "labels": labels_param,
+            });
+
+            let data = self.graphql(REPO_ISSUES_QUERY, variables).await?;
+
+            let issues_data = data.pointer("/repository/issues").ok_or_else(|| {
+                TrackerError::UnexpectedPayload {
+                    reason: "issues not found in repo response".to_string(),
+                }
+            })?;
+
+            let page_info =
+                issues_data
+                    .get("pageInfo")
+                    .ok_or_else(|| TrackerError::UnexpectedPayload {
+                        reason: "pageInfo not found".to_string(),
+                    })?;
+
+            let has_next = page_info
+                .get("hasNextPage")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let nodes = issues_data
+                .get("nodes")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| TrackerError::UnexpectedPayload {
+                    reason: "issue nodes not found".to_string(),
+                })?;
+
+            for node in nodes {
+                if let Some(issue) = self.normalize_repo_issue(node, filter_states) {
+                    all_issues.push(issue);
+                }
+            }
+
+            if has_next {
+                cursor = page_info
+                    .get("endCursor")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                if cursor.is_none() {
+                    return Err(TrackerError::MissingEndCursor);
+                }
+            } else {
+                break;
+            }
+        }
+
+        Ok(all_issues)
+    }
+
+    /// Normalize a single repository issue node into an Issue.
+    fn normalize_repo_issue(&self, node: &Value, filter_states: &[String]) -> Option<Issue> {
+        let id = node.get("id")?.as_str()?;
+        let number = node.get("number")?.as_u64()?;
+        let title = node.get("title")?.as_str()?;
+
+        let labels = extract_labels(node);
+
+        // Determine state from labels or open/closed
+        let raw_state = node
+            .get("state")
+            .and_then(|v| v.as_str())
+            .unwrap_or("open")
+            .to_lowercase();
+
+        // Map GitHub state to tracker state:
+        // If labels contain any active_states value, use that.
+        // Otherwise use open/closed.
+        let state = labels
+            .iter()
+            .find(|l| {
+                self.active_states.iter().any(|s| s.eq_ignore_ascii_case(l))
+                    || self
+                        .terminal_states
+                        .iter()
+                        .any(|s| s.eq_ignore_ascii_case(l))
+            })
+            .cloned()
+            .unwrap_or(raw_state);
+
+        // Filter by state
+        if !filter_states.is_empty()
+            && !filter_states.iter().any(|s| s.eq_ignore_ascii_case(&state))
+        {
+            return None;
+        }
+
+        let body = node
+            .get("body")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty());
+
+        let url = node
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let created_at = node
+            .get("createdAt")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<DateTime<Utc>>().ok());
+
+        let updated_at = node
+            .get("updatedAt")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<DateTime<Utc>>().ok());
+
+        let identifier = format!("{}#{}", self.repo, number);
+
+        Some(Issue {
+            id: id.to_string(),
+            identifier,
+            title: title.to_string(),
+            description: body,
+            priority: None,
+            state,
+            branch_name: None,
+            url,
+            labels,
+            blocked_by: vec![],
+            created_at,
+            updated_at,
+        })
+    }
+
+    /// Batch fetch issue states by node IDs.
+    async fn fetch_states_by_node_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let variables = json!({
+            "ids": ids,
+        });
+
+        let data = self.graphql(ISSUE_STATES_QUERY, variables).await?;
+
+        let nodes = data
+            .get("nodes")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| TrackerError::UnexpectedPayload {
+                reason: "nodes not found in state refresh response".to_string(),
+            })?;
+
+        let mut issues = Vec::new();
+        for node in nodes {
+            if node.is_null() {
+                continue;
+            }
+            if let Some(issue) = self.normalize_state_node(node) {
+                issues.push(issue);
+            }
+        }
+
+        Ok(issues)
+    }
+
+    /// Normalize a node from the state refresh query.
+    fn normalize_state_node(&self, node: &Value) -> Option<Issue> {
+        let id = node.get("id")?.as_str()?;
+        let number = node.get("number")?.as_u64()?;
+        let title = node.get("title")?.as_str().unwrap_or("").to_string();
+
+        let labels = extract_labels(node);
+
+        // Try to get state from project items first
+        let project_state = node
+            .pointer("/projectItems/nodes")
+            .and_then(|v| v.as_array())
+            .and_then(|items| {
+                for item in items {
+                    let field_values = item
+                        .pointer("/fieldValues/nodes")
+                        .and_then(|v| v.as_array());
+                    if let Some(fvs) = field_values {
+                        for fv in fvs {
+                            let field_name = fv.pointer("/field/name").and_then(|v| v.as_str());
+                            if field_name == Some("Status") {
+                                return fv
+                                    .get("name")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string());
+                            }
+                        }
+                    }
+                }
+                None
+            });
+
+        let state = project_state.unwrap_or_else(|| {
+            node.get("state")
+                .and_then(|v| v.as_str())
+                .unwrap_or("open")
+                .to_lowercase()
+        });
+
+        let url = node
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let identifier = format!("{}#{}", self.repo, number);
+
+        Some(Issue {
+            id: id.to_string(),
+            identifier,
+            title,
+            description: None,
+            priority: None,
+            state,
+            branch_name: None,
+            url,
+            labels,
+            blocked_by: vec![],
+            created_at: None,
+            updated_at: None,
+        })
+    }
+}
+
+/// Parse "owner/repo" into (owner, repo).
+fn parse_owner_repo(repository: &str) -> Result<(String, String), TrackerError> {
+    let parts: Vec<&str> = repository.splitn(2, '/').collect();
+    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+        return Err(TrackerError::UnexpectedPayload {
+            reason: format!(
+                "invalid repository format '{}', expected 'owner/repo'",
+                repository
+            ),
+        });
+    }
+    Ok((parts[0].to_string(), parts[1].to_string()))
+}
+
+/// Extract lowercased labels from a GitHub issue node.
+fn extract_labels(node: &Value) -> Vec<String> {
+    node.pointer("/labels/nodes")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|l| l.get("name").and_then(|n| n.as_str()))
+                .map(|s| s.to_lowercase())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Extract priority from project item field values.
+///
+/// Looks for a "Priority" single-select field and maps known values:
+/// Urgent=1, High=2, Medium=3, Low=4.
+fn extract_priority_from_field_values(node: &Value) -> Option<i32> {
+    let field_values = node
+        .pointer("/fieldValues/nodes")
+        .and_then(|v| v.as_array())?;
+
+    for fv in field_values {
+        let field_name = fv.pointer("/field/name").and_then(|v| v.as_str());
+        if field_name == Some("Priority") {
+            if let Some(value) = fv.get("name").and_then(|v| v.as_str()) {
+                return match value.to_lowercase().as_str() {
+                    "urgent" => Some(1),
+                    "high" => Some(2),
+                    "medium" => Some(3),
+                    "low" => Some(4),
+                    _ => None,
+                };
+            }
+        }
+    }
+    None
+}
+
+#[async_trait]
+impl IssueTracker for GithubTracker {
+    /// Fetch candidate issues in active states for dispatch.
+    ///
+    /// When project_number is set: queries project board items.
+    /// When not set: queries repository issues.
+    async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+        if self.project_number.is_some() {
+            self.fetch_project_items(&self.active_states).await
+        } else {
+            self.fetch_repo_issues(&self.active_states).await
+        }
+    }
+
+    /// Fetch issues in the given states (used for startup terminal cleanup).
+    async fn fetch_issues_by_states(&self, states: &[String]) -> Result<Vec<Issue>, TrackerError> {
+        if self.project_number.is_some() {
+            self.fetch_project_items(states).await
+        } else {
+            self.fetch_repo_issues(states).await
+        }
+    }
+
+    /// Fetch current states for specific issue IDs (used for reconciliation).
+    async fn fetch_issue_states_by_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError> {
+        self.fetch_states_by_node_ids(ids).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Helper to create a GithubTracker pointed at a wiremock server.
+    fn create_test_tracker(server_url: &str, project_number: Option<i64>) -> GithubTracker {
+        GithubTracker::new(
+            format!("{}/graphql", server_url),
+            "ghp_test_token".to_string(),
+            "acme/my-repo".to_string(),
+            project_number,
+            vec!["Todo".to_string(), "In Progress".to_string()],
+            vec!["Done".to_string(), "Closed".to_string()],
+            vec![],
+        )
+        .unwrap()
+    }
+
+    /// Build a GraphQL response body wrapping the given data.
+    fn graphql_response(data: Value) -> Value {
+        json!({ "data": data })
+    }
+
+    // --- parse_owner_repo tests ---
+
+    #[test]
+    fn test_parse_owner_repo_valid() {
+        let (owner, repo) = parse_owner_repo("acme/my-repo").unwrap();
+        assert_eq!(owner, "acme");
+        assert_eq!(repo, "my-repo");
+    }
+
+    #[test]
+    fn test_parse_owner_repo_with_org_slash() {
+        let (owner, repo) = parse_owner_repo("my-org/my-repo").unwrap();
+        assert_eq!(owner, "my-org");
+        assert_eq!(repo, "my-repo");
+    }
+
+    #[test]
+    fn test_parse_owner_repo_no_slash() {
+        let result = parse_owner_repo("justarepo");
+        assert!(matches!(
+            result,
+            Err(TrackerError::UnexpectedPayload { .. })
+        ));
+    }
+
+    #[test]
+    fn test_parse_owner_repo_empty_parts() {
+        assert!(parse_owner_repo("/repo").is_err());
+        assert!(parse_owner_repo("owner/").is_err());
+        assert!(parse_owner_repo("/").is_err());
+    }
+
+    // --- extract_labels tests ---
+
+    #[test]
+    fn test_extract_labels_lowercased() {
+        let node = json!({
+            "labels": {
+                "nodes": [
+                    { "name": "Bug" },
+                    { "name": "ENHANCEMENT" },
+                    { "name": "p1" }
+                ]
+            }
+        });
+        let labels = extract_labels(&node);
+        assert_eq!(labels, vec!["bug", "enhancement", "p1"]);
+    }
+
+    #[test]
+    fn test_extract_labels_empty() {
+        let node = json!({});
+        let labels = extract_labels(&node);
+        assert!(labels.is_empty());
+    }
+
+    // --- extract_priority tests ---
+
+    #[test]
+    fn test_extract_priority_urgent() {
+        let node = json!({
+            "fieldValues": {
+                "nodes": [
+                    {
+                        "name": "Urgent",
+                        "field": { "name": "Priority" }
+                    }
+                ]
+            }
+        });
+        assert_eq!(extract_priority_from_field_values(&node), Some(1));
+    }
+
+    #[test]
+    fn test_extract_priority_high() {
+        let node = json!({
+            "fieldValues": {
+                "nodes": [
+                    {
+                        "name": "High",
+                        "field": { "name": "Priority" }
+                    }
+                ]
+            }
+        });
+        assert_eq!(extract_priority_from_field_values(&node), Some(2));
+    }
+
+    #[test]
+    fn test_extract_priority_medium() {
+        let node = json!({
+            "fieldValues": {
+                "nodes": [
+                    {
+                        "name": "Medium",
+                        "field": { "name": "Priority" }
+                    }
+                ]
+            }
+        });
+        assert_eq!(extract_priority_from_field_values(&node), Some(3));
+    }
+
+    #[test]
+    fn test_extract_priority_low() {
+        let node = json!({
+            "fieldValues": {
+                "nodes": [
+                    {
+                        "name": "Low",
+                        "field": { "name": "Priority" }
+                    }
+                ]
+            }
+        });
+        assert_eq!(extract_priority_from_field_values(&node), Some(4));
+    }
+
+    #[test]
+    fn test_extract_priority_none() {
+        let node = json!({
+            "fieldValues": {
+                "nodes": []
+            }
+        });
+        assert_eq!(extract_priority_from_field_values(&node), None);
+    }
+
+    #[test]
+    fn test_extract_priority_skips_non_priority_fields() {
+        let node = json!({
+            "fieldValues": {
+                "nodes": [
+                    {
+                        "name": "Todo",
+                        "field": { "name": "Status" }
+                    }
+                ]
+            }
+        });
+        assert_eq!(extract_priority_from_field_values(&node), None);
+    }
+
+    // --- wiremock integration tests ---
+
+    #[tokio::test]
+    async fn test_fetch_candidates_with_project_board() {
+        let server = MockServer::start().await;
+
+        // Mock discovery query
+        let discovery_response = graphql_response(json!({
+            "repository": {
+                "projectV2": {
+                    "id": "PVT_test123",
+                    "fields": {
+                        "nodes": [
+                            {
+                                "id": "FIELD_status_1",
+                                "name": "Status",
+                                "options": [
+                                    { "id": "OPT_1", "name": "Todo" },
+                                    { "id": "OPT_2", "name": "In Progress" },
+                                    { "id": "OPT_3", "name": "Done" }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }));
+
+        // Mock items query
+        let items_response = graphql_response(json!({
+            "node": {
+                "items": {
+                    "pageInfo": {
+                        "hasNextPage": false,
+                        "endCursor": null
+                    },
+                    "nodes": [
+                        {
+                            "fieldValues": {
+                                "nodes": [
+                                    {
+                                        "name": "Todo",
+                                        "field": { "name": "Status" }
+                                    }
+                                ]
+                            },
+                            "content": {
+                                "id": "I_issue1",
+                                "number": 1,
+                                "title": "First issue",
+                                "body": "Issue body",
+                                "createdAt": "2025-01-01T00:00:00Z",
+                                "updatedAt": "2025-01-02T00:00:00Z",
+                                "url": "https://github.com/acme/my-repo/issues/1",
+                                "labels": {
+                                    "nodes": [
+                                        { "name": "Bug" }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "fieldValues": {
+                                "nodes": [
+                                    {
+                                        "name": "Done",
+                                        "field": { "name": "Status" }
+                                    }
+                                ]
+                            },
+                            "content": {
+                                "id": "I_issue2",
+                                "number": 2,
+                                "title": "Done issue",
+                                "body": "",
+                                "createdAt": "2025-01-01T00:00:00Z",
+                                "updatedAt": "2025-01-02T00:00:00Z",
+                                "url": "https://github.com/acme/my-repo/issues/2",
+                                "labels": { "nodes": [] }
+                            }
+                        }
+                    ]
+                }
+            }
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("projectNumber"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&discovery_response))
+            .named("discovery")
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("projectId"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&items_response))
+            .named("items")
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), Some(1));
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+
+        // Only the Todo issue should be returned (Done is filtered out)
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].id, "I_issue1");
+        assert_eq!(issues[0].identifier, "my-repo#1");
+        assert_eq!(issues[0].title, "First issue");
+        assert_eq!(issues[0].description.as_deref(), Some("Issue body"));
+        assert_eq!(issues[0].state, "Todo");
+        assert_eq!(issues[0].labels, vec!["bug"]);
+        assert!(issues[0].url.is_some());
+        assert!(issues[0].created_at.is_some());
+        assert!(issues[0].updated_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_candidates_without_project_board() {
+        let server = MockServer::start().await;
+
+        let response = graphql_response(json!({
+            "repository": {
+                "issues": {
+                    "pageInfo": {
+                        "hasNextPage": false,
+                        "endCursor": null
+                    },
+                    "nodes": [
+                        {
+                            "id": "I_node1",
+                            "number": 10,
+                            "title": "Open issue",
+                            "body": "Some body",
+                            "createdAt": "2025-03-01T12:00:00Z",
+                            "updatedAt": "2025-03-02T12:00:00Z",
+                            "url": "https://github.com/acme/my-repo/issues/10",
+                            "state": "OPEN",
+                            "labels": {
+                                "nodes": [
+                                    { "name": "todo" }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "I_node2",
+                            "number": 11,
+                            "title": "Another issue",
+                            "body": "",
+                            "createdAt": "2025-03-01T13:00:00Z",
+                            "updatedAt": "2025-03-02T13:00:00Z",
+                            "url": "https://github.com/acme/my-repo/issues/11",
+                            "state": "OPEN",
+                            "labels": {
+                                "nodes": [
+                                    { "name": "done" }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), None);
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+
+        // "todo" label matches active state "Todo" (case-insensitive), so it passes.
+        // "done" label matches terminal state "Done", so it does NOT match active states.
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].identifier, "my-repo#10");
+        assert_eq!(issues[0].labels, vec!["todo"]);
+    }
+
+    #[tokio::test]
+    async fn test_pagination_two_pages() {
+        let server = MockServer::start().await;
+
+        let page1_response = graphql_response(json!({
+            "repository": {
+                "issues": {
+                    "pageInfo": {
+                        "hasNextPage": true,
+                        "endCursor": "cursor_page2"
+                    },
+                    "nodes": [
+                        {
+                            "id": "I_p1",
+                            "number": 1,
+                            "title": "Page 1 issue",
+                            "body": "",
+                            "createdAt": "2025-01-01T00:00:00Z",
+                            "updatedAt": "2025-01-01T00:00:00Z",
+                            "url": "https://github.com/acme/my-repo/issues/1",
+                            "state": "OPEN",
+                            "labels": { "nodes": [{ "name": "todo" }] }
+                        }
+                    ]
+                }
+            }
+        }));
+
+        let page2_response = graphql_response(json!({
+            "repository": {
+                "issues": {
+                    "pageInfo": {
+                        "hasNextPage": false,
+                        "endCursor": null
+                    },
+                    "nodes": [
+                        {
+                            "id": "I_p2",
+                            "number": 2,
+                            "title": "Page 2 issue",
+                            "body": "",
+                            "createdAt": "2025-01-02T00:00:00Z",
+                            "updatedAt": "2025-01-02T00:00:00Z",
+                            "url": "https://github.com/acme/my-repo/issues/2",
+                            "state": "OPEN",
+                            "labels": { "nodes": [{ "name": "in progress" }] }
+                        }
+                    ]
+                }
+            }
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("\"cursor\":null"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&page1_response))
+            .named("page1")
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("cursor_page2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&page2_response))
+            .named("page2")
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), None);
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].identifier, "my-repo#1");
+        assert_eq!(issues[1].identifier, "my-repo#2");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_states_by_ids() {
+        let server = MockServer::start().await;
+
+        let response = graphql_response(json!({
+            "nodes": [
+                {
+                    "id": "I_node1",
+                    "number": 42,
+                    "title": "Issue 42",
+                    "state": "OPEN",
+                    "url": "https://github.com/acme/my-repo/issues/42",
+                    "labels": { "nodes": [{ "name": "bug" }] },
+                    "projectItems": {
+                        "nodes": [
+                            {
+                                "fieldValues": {
+                                    "nodes": [
+                                        {
+                                            "name": "In Progress",
+                                            "field": { "name": "Status" }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                null,
+                {
+                    "id": "I_node3",
+                    "number": 99,
+                    "title": "Issue 99",
+                    "state": "CLOSED",
+                    "url": "https://github.com/acme/my-repo/issues/99",
+                    "labels": { "nodes": [] },
+                    "projectItems": { "nodes": [] }
+                }
+            ]
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), Some(1));
+        let issues = tracker
+            .fetch_issue_states_by_ids(&[
+                "I_node1".to_string(),
+                "I_node_missing".to_string(),
+                "I_node3".to_string(),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(issues.len(), 2);
+
+        // First issue has project Status = "In Progress"
+        assert_eq!(issues[0].id, "I_node1");
+        assert_eq!(issues[0].state, "In Progress");
+        assert_eq!(issues[0].identifier, "my-repo#42");
+        assert_eq!(issues[0].labels, vec!["bug"]);
+
+        // Third issue has no project status, falls back to GitHub state
+        assert_eq!(issues[1].id, "I_node3");
+        assert_eq!(issues[1].state, "closed");
+        assert_eq!(issues[1].identifier, "my-repo#99");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_states_empty_ids() {
+        let tracker = GithubTracker::new(
+            "https://api.github.com/graphql".to_string(),
+            "token".to_string(),
+            "acme/repo".to_string(),
+            None,
+            vec![],
+            vec![],
+            vec![],
+        )
+        .unwrap();
+
+        // Empty IDs should return empty without making a request
+        let issues = tracker.fetch_issue_states_by_ids(&[]).await.unwrap();
+        assert!(issues.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_error_non_200_status() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), None);
+        let result = tracker.fetch_candidate_issues().await;
+
+        match result {
+            Err(TrackerError::ApiStatus { status, body }) => {
+                assert_eq!(status, 401);
+                assert!(body.contains("Unauthorized"));
+            }
+            other => panic!("expected ApiStatus error, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_error_graphql_errors() {
+        let server = MockServer::start().await;
+
+        let response = json!({
+            "data": null,
+            "errors": [
+                { "message": "Field 'repository' not found" },
+                { "message": "Another error" }
+            ]
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), None);
+        let result = tracker.fetch_candidate_issues().await;
+
+        match result {
+            Err(TrackerError::GraphqlErrors { errors }) => {
+                assert!(errors.contains("Field 'repository' not found"));
+                assert!(errors.contains("Another error"));
+            }
+            other => panic!("expected GraphqlErrors, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_error_malformed_payload() {
+        let server = MockServer::start().await;
+
+        // Valid JSON but no "data" field
+        let response = json!({ "something": "else" });
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), None);
+        let result = tracker.fetch_candidate_issues().await;
+
+        assert!(matches!(
+            result,
+            Err(TrackerError::UnexpectedPayload { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_normalization_labels_lowercased() {
+        let server = MockServer::start().await;
+
+        let response = graphql_response(json!({
+            "repository": {
+                "issues": {
+                    "pageInfo": { "hasNextPage": false, "endCursor": null },
+                    "nodes": [
+                        {
+                            "id": "I_1",
+                            "number": 1,
+                            "title": "Test",
+                            "body": "",
+                            "createdAt": "2025-01-01T00:00:00Z",
+                            "updatedAt": "2025-01-01T00:00:00Z",
+                            "url": "https://github.com/acme/my-repo/issues/1",
+                            "state": "OPEN",
+                            "labels": {
+                                "nodes": [
+                                    { "name": "BUG" },
+                                    { "name": "TODO" },
+                                    { "name": "P1" }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), None);
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].labels, vec!["bug", "todo", "p1"]);
+    }
+
+    #[tokio::test]
+    async fn test_normalization_identifier_format() {
+        let server = MockServer::start().await;
+
+        let response = graphql_response(json!({
+            "repository": {
+                "issues": {
+                    "pageInfo": { "hasNextPage": false, "endCursor": null },
+                    "nodes": [
+                        {
+                            "id": "I_abc",
+                            "number": 42,
+                            "title": "Test",
+                            "body": "",
+                            "createdAt": "2025-01-01T00:00:00Z",
+                            "updatedAt": "2025-01-01T00:00:00Z",
+                            "url": "https://github.com/acme/my-repo/issues/42",
+                            "state": "OPEN",
+                            "labels": { "nodes": [{ "name": "todo" }] }
+                        }
+                    ]
+                }
+            }
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), None);
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+
+        assert_eq!(issues.len(), 1);
+        // Identifier uses repo name (not owner/repo)
+        assert_eq!(issues[0].identifier, "my-repo#42");
+    }
+
+    #[tokio::test]
+    async fn test_normalization_priority_mapping_from_project() {
+        let server = MockServer::start().await;
+
+        // Discovery
+        let discovery = graphql_response(json!({
+            "repository": {
+                "projectV2": {
+                    "id": "PVT_1",
+                    "fields": {
+                        "nodes": [
+                            {
+                                "id": "F_status",
+                                "name": "Status",
+                                "options": []
+                            }
+                        ]
+                    }
+                }
+            }
+        }));
+
+        // Items with priority field
+        let items = graphql_response(json!({
+            "node": {
+                "items": {
+                    "pageInfo": { "hasNextPage": false, "endCursor": null },
+                    "nodes": [
+                        {
+                            "fieldValues": {
+                                "nodes": [
+                                    {
+                                        "name": "Todo",
+                                        "field": { "name": "Status" }
+                                    },
+                                    {
+                                        "name": "High",
+                                        "field": { "name": "Priority" }
+                                    }
+                                ]
+                            },
+                            "content": {
+                                "id": "I_1",
+                                "number": 1,
+                                "title": "High priority",
+                                "body": "",
+                                "createdAt": "2025-01-01T00:00:00Z",
+                                "updatedAt": "2025-01-01T00:00:00Z",
+                                "url": "https://github.com/acme/my-repo/issues/1",
+                                "labels": { "nodes": [] }
+                            }
+                        }
+                    ]
+                }
+            }
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("projectNumber"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&discovery))
+            .named("discovery")
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("projectId"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&items))
+            .named("items")
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), Some(1));
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].priority, Some(2)); // High = 2
+    }
+}

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -81,7 +81,7 @@ query($projectId: ID!, $cursor: String) {
 const REPO_ISSUES_QUERY: &str = r#"
 query($owner: String!, $repo: String!, $cursor: String, $labels: [String!]) {
   repository(owner: $owner, name: $repo) {
-    issues(first: 50, after: $cursor, states: [OPEN], labels: $labels, orderBy: {field: CREATED_AT, direction: ASC}) {
+    issues(first: 50, after: $cursor, states: [OPEN, CLOSED], labels: $labels, orderBy: {field: CREATED_AT, direction: ASC}) {
       pageInfo {
         hasNextPage
         endCursor
@@ -458,6 +458,17 @@ impl GithubTracker {
             .map(|s| s.to_string());
 
         let labels = extract_labels(content);
+
+        // Client-side label filtering for project-board mode (repo-mode uses
+        // the GraphQL `labels` argument, but project-board queries don't support it).
+        if !self.labels_filter.is_empty()
+            && !labels
+                .iter()
+                .any(|l| self.labels_filter.iter().any(|f| f.eq_ignore_ascii_case(l)))
+        {
+            return None;
+        }
+
         let priority = extract_priority_from_field_values(node);
 
         let created_at = content
@@ -486,6 +497,31 @@ impl GithubTracker {
             created_at,
             updated_at,
         })
+    }
+
+    /// Map a set of lowercased labels to the canonical configured state name.
+    ///
+    /// Finds the first label that case-insensitively matches an active or terminal
+    /// state, then returns the *configured* name (preserving casing) instead of
+    /// the lowercased label value.  Falls back to `fallback` if no label matches.
+    fn canonical_state_from_labels(&self, labels: &[String], fallback: String) -> String {
+        for label in labels {
+            if let Some(s) = self
+                .active_states
+                .iter()
+                .find(|s| s.eq_ignore_ascii_case(label))
+            {
+                return s.clone();
+            }
+            if let Some(s) = self
+                .terminal_states
+                .iter()
+                .find(|s| s.eq_ignore_ascii_case(label))
+            {
+                return s.clone();
+            }
+        }
+        fallback
     }
 
     /// Extract the Status field value from a project item's fieldValues.
@@ -585,27 +621,15 @@ impl GithubTracker {
 
         let labels = extract_labels(node);
 
-        // Determine state from labels or open/closed
+        // Determine state: match labels to canonical configured names,
+        // falling back to raw GitHub open/closed.
         let raw_state = node
             .get("state")
             .and_then(|v| v.as_str())
             .unwrap_or("open")
             .to_lowercase();
 
-        // Map GitHub state to tracker state:
-        // If labels contain any active_states value, use that.
-        // Otherwise use open/closed.
-        let state = labels
-            .iter()
-            .find(|l| {
-                self.active_states.iter().any(|s| s.eq_ignore_ascii_case(l))
-                    || self
-                        .terminal_states
-                        .iter()
-                        .any(|s| s.eq_ignore_ascii_case(l))
-            })
-            .cloned()
-            .unwrap_or(raw_state);
+        let state = self.canonical_state_from_labels(&labels, raw_state);
 
         // Filter by state
         if !filter_states.is_empty()
@@ -724,19 +748,9 @@ impl GithubTracker {
                 .unwrap_or("open")
                 .to_lowercase();
 
-            // In repo-mode, derive state from labels (matching active/terminal states)
-            // to stay consistent with normalize_repo_issue.
-            labels
-                .iter()
-                .find(|l| {
-                    self.active_states.iter().any(|s| s.eq_ignore_ascii_case(l))
-                        || self
-                            .terminal_states
-                            .iter()
-                            .any(|s| s.eq_ignore_ascii_case(l))
-                })
-                .cloned()
-                .unwrap_or(raw_state)
+            // In repo-mode, derive canonical state from labels to stay consistent
+            // with normalize_repo_issue.
+            self.canonical_state_from_labels(&labels, raw_state)
         });
 
         let url = node
@@ -1374,8 +1388,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(issues.len(), 1);
-        // Should derive "todo" from labels, not fall back to "open"
-        assert_eq!(issues[0].state, "todo");
+        // Should derive canonical "Todo" from labels, not fall back to "open"
+        assert_eq!(issues[0].state, "Todo");
     }
 
     #[tokio::test]
@@ -1631,5 +1645,118 @@ mod tests {
 
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].priority, Some(2)); // High = 2
+    }
+
+    #[tokio::test]
+    async fn test_project_board_label_filtering() {
+        let server = MockServer::start().await;
+
+        let discovery = graphql_response(json!({
+            "repository": {
+                "projectV2": {
+                    "id": "PVT_1",
+                    "fields": {
+                        "nodes": [{
+                            "id": "F_status",
+                            "name": "Status",
+                            "options": []
+                        }]
+                    }
+                }
+            }
+        }));
+
+        let items = graphql_response(json!({
+            "node": {
+                "items": {
+                    "pageInfo": { "hasNextPage": false, "endCursor": null },
+                    "nodes": [
+                        {
+                            "fieldValues": { "nodes": [{ "name": "Todo", "field": { "name": "Status" } }] },
+                            "content": {
+                                "id": "I_match", "number": 1, "title": "Has matching label",
+                                "body": "", "createdAt": "2025-01-01T00:00:00Z", "updatedAt": "2025-01-01T00:00:00Z",
+                                "url": "https://github.com/acme/my-repo/issues/1",
+                                "labels": { "nodes": [{ "name": "Bug" }] }
+                            }
+                        },
+                        {
+                            "fieldValues": { "nodes": [{ "name": "Todo", "field": { "name": "Status" } }] },
+                            "content": {
+                                "id": "I_no_match", "number": 2, "title": "No matching label",
+                                "body": "", "createdAt": "2025-01-01T00:00:00Z", "updatedAt": "2025-01-01T00:00:00Z",
+                                "url": "https://github.com/acme/my-repo/issues/2",
+                                "labels": { "nodes": [{ "name": "Feature" }] }
+                            }
+                        }
+                    ]
+                }
+            }
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("projectNumber"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&discovery))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("projectId"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&items))
+            .mount(&server)
+            .await;
+
+        // Tracker with labels_filter = ["bug"]
+        let tracker = GithubTracker::new(
+            format!("{}/graphql", server.uri()),
+            "ghp_test_token".to_string(),
+            "acme/my-repo".to_string(),
+            Some(1),
+            vec!["Todo".to_string()],
+            vec!["Done".to_string()],
+            vec!["bug".to_string()],
+        )
+        .unwrap();
+
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+
+        // Only the issue with "Bug" label should pass the filter
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].id, "I_match");
+    }
+
+    #[tokio::test]
+    async fn test_repo_mode_canonical_state_casing() {
+        let server = MockServer::start().await;
+
+        let response = graphql_response(json!({
+            "repository": {
+                "issues": {
+                    "pageInfo": { "hasNextPage": false, "endCursor": null },
+                    "nodes": [{
+                        "id": "I_1", "number": 1, "title": "Test",
+                        "body": "", "createdAt": "2025-01-01T00:00:00Z", "updatedAt": "2025-01-01T00:00:00Z",
+                        "url": "https://github.com/acme/my-repo/issues/1",
+                        "state": "OPEN",
+                        "labels": { "nodes": [{ "name": "TODO" }] }
+                    }]
+                }
+            }
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), None);
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+
+        assert_eq!(issues.len(), 1);
+        // Label "TODO" (lowercased to "todo") should map to canonical "Todo"
+        assert_eq!(issues[0].state, "Todo");
     }
 }

--- a/crates/ensemble-core/src/tracker/mod.rs
+++ b/crates/ensemble-core/src/tracker/mod.rs
@@ -15,6 +15,8 @@ pub enum TrackerError {
     MissingApiKey,
     #[error("missing tracker repository")]
     MissingRepository,
+    #[error("I/O error: {reason}")]
+    IoError { reason: String },
     #[error("GitHub API request failed: {reason}")]
     ApiRequestFailed { reason: String },
     #[error("GitHub API returned status {status}: {body}")]

--- a/crates/ensemble-core/src/tracker/mod.rs
+++ b/crates/ensemble-core/src/tracker/mod.rs
@@ -1,5 +1,8 @@
+pub mod github;
 pub mod model;
+pub mod todo_file;
 
+use crate::config::typed::ServiceConfig;
 use async_trait::async_trait;
 use model::Issue;
 
@@ -36,4 +39,123 @@ pub trait IssueTracker: Send + Sync {
 
     /// Fetch current states for specific issue IDs (used for reconciliation).
     async fn fetch_issue_states_by_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError>;
+}
+
+/// Create an `IssueTracker` implementation based on the service config.
+///
+/// Matches on `tracker_kind` to return the right backend:
+/// - `"todo_file"` -> `TodoFileTracker`
+/// - `"github"` -> `GithubTracker`
+///
+/// Returns an error if the tracker kind is missing or unsupported, or
+/// if required configuration is absent (e.g., missing API key for GitHub).
+pub fn create_tracker(config: &ServiceConfig) -> Result<Box<dyn IssueTracker>, TrackerError> {
+    let kind = config
+        .tracker_kind
+        .as_deref()
+        .ok_or_else(|| TrackerError::UnsupportedKind {
+            kind: "<none>".to_string(),
+        })?;
+
+    match kind {
+        "todo_file" => {
+            let tracker = todo_file::TodoFileTracker::new(
+                config.tracker_path.clone(),
+                config.tracker_active_states.clone(),
+            );
+            Ok(Box::new(tracker))
+        }
+        "github" => {
+            let token = config
+                .tracker_api_key
+                .as_ref()
+                .ok_or(TrackerError::MissingApiKey)?;
+            let repository = config
+                .tracker_repository
+                .as_ref()
+                .ok_or(TrackerError::MissingRepository)?;
+
+            let tracker = github::GithubTracker::new(
+                config.tracker_endpoint.clone(),
+                token.clone(),
+                repository.clone(),
+                config.tracker_project_number,
+                config.tracker_active_states.clone(),
+                config.tracker_terminal_states.clone(),
+                config.tracker_labels_filter.clone(),
+            )?;
+            Ok(Box::new(tracker))
+        }
+        other => Err(TrackerError::UnsupportedKind {
+            kind: other.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::typed::ServiceConfig;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_create_todo_file_tracker() {
+        let dir = TempDir::new().unwrap();
+        let mut config = ServiceConfig::default();
+        config.tracker_kind = Some("todo_file".to_string());
+        config.tracker_path = dir.path().join("TODO.md");
+
+        let tracker = create_tracker(&config);
+        assert!(tracker.is_ok());
+    }
+
+    #[test]
+    fn test_create_github_tracker() {
+        let mut config = ServiceConfig::default();
+        config.tracker_kind = Some("github".to_string());
+        config.tracker_api_key = Some("ghp_test_token".to_string());
+        config.tracker_repository = Some("acme/repo".to_string());
+
+        let tracker = create_tracker(&config);
+        assert!(tracker.is_ok());
+    }
+
+    #[test]
+    fn test_create_github_tracker_missing_api_key() {
+        let mut config = ServiceConfig::default();
+        config.tracker_kind = Some("github".to_string());
+        config.tracker_api_key = None;
+        config.tracker_repository = Some("acme/repo".to_string());
+
+        let result = create_tracker(&config);
+        assert!(matches!(result, Err(TrackerError::MissingApiKey)));
+    }
+
+    #[test]
+    fn test_create_github_tracker_missing_repository() {
+        let mut config = ServiceConfig::default();
+        config.tracker_kind = Some("github".to_string());
+        config.tracker_api_key = Some("ghp_test_token".to_string());
+        config.tracker_repository = None;
+
+        let result = create_tracker(&config);
+        assert!(matches!(result, Err(TrackerError::MissingRepository)));
+    }
+
+    #[test]
+    fn test_create_unsupported_kind() {
+        let mut config = ServiceConfig::default();
+        config.tracker_kind = Some("linear".to_string());
+
+        let result = create_tracker(&config);
+        assert!(matches!(result, Err(TrackerError::UnsupportedKind { .. })));
+    }
+
+    #[test]
+    fn test_create_no_kind() {
+        let config = ServiceConfig::default();
+        // tracker_kind is None by default
+        let result = create_tracker(&config);
+        assert!(matches!(result, Err(TrackerError::UnsupportedKind { .. })));
+    }
 }

--- a/crates/ensemble-core/src/tracker/todo_file.rs
+++ b/crates/ensemble-core/src/tracker/todo_file.rs
@@ -38,15 +38,15 @@ impl TodoFileTracker {
     }
 
     /// Read and parse the TODO file, returning all issues across all state sections.
-    fn parse_file(&self) -> Result<Vec<ParsedIssue>, TrackerError> {
-        let content = match std::fs::read_to_string(&self.path) {
+    async fn parse_file(&self) -> Result<Vec<ParsedIssue>, TrackerError> {
+        let content = match tokio::fs::read_to_string(&self.path).await {
             Ok(c) => c,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 warn!(path = %self.path.display(), "TODO file not found, returning empty list");
                 return Ok(vec![]);
             }
             Err(e) => {
-                return Err(TrackerError::ApiRequestFailed {
+                return Err(TrackerError::IoError {
                     reason: format!("failed to read {}: {}", self.path.display(), e),
                 });
             }
@@ -242,7 +242,7 @@ impl IssueTracker for TodoFileTracker {
     ///
     /// Reads the file, parses all issues, returns those in active states.
     async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
-        let parsed = self.parse_file()?;
+        let parsed = self.parse_file().await?;
         let issues = parsed
             .iter()
             .filter(|p| state_matches(&p.state, &self.active_states))
@@ -255,7 +255,7 @@ impl IssueTracker for TodoFileTracker {
     ///
     /// Reads the file, returns issues whose state matches any in the provided list.
     async fn fetch_issues_by_states(&self, states: &[String]) -> Result<Vec<Issue>, TrackerError> {
-        let parsed = self.parse_file()?;
+        let parsed = self.parse_file().await?;
         let issues = parsed
             .iter()
             .filter(|p| state_matches(&p.state, states))
@@ -268,7 +268,7 @@ impl IssueTracker for TodoFileTracker {
     ///
     /// Reads the file, returns issues whose identifier matches any in the provided list.
     async fn fetch_issue_states_by_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError> {
-        let parsed = self.parse_file()?;
+        let parsed = self.parse_file().await?;
         let issues = parsed
             .iter()
             .filter(|p| ids.iter().any(|id| id == &p.identifier))

--- a/crates/ensemble-core/src/tracker/todo_file.rs
+++ b/crates/ensemble-core/src/tracker/todo_file.rs
@@ -115,7 +115,8 @@ fn parse_todo_content(content: &str) -> Vec<ParsedIssue> {
 
             if let Some(state) = &current_state {
                 let rest = rest.trim();
-                let (identifier, title) = extract_identifier_and_title(rest);
+                let (identifier, title) =
+                    extract_identifier_and_title(rest, state, position_in_state);
 
                 current_issue = Some(ParsedIssue {
                     identifier,
@@ -157,8 +158,9 @@ fn parse_todo_content(content: &str) -> Vec<ParsedIssue> {
 /// Extract identifier and title from a list item.
 ///
 /// If the line starts with `[IDENTIFIER]`, extracts the identifier and remaining title.
-/// Otherwise generates a stable slug from the title.
-fn extract_identifier_and_title(line: &str) -> (String, String) {
+/// Otherwise generates a stable slug from the title, incorporating the state and
+/// position to ensure uniqueness and handle non-alphanumeric-only titles.
+fn extract_identifier_and_title(line: &str, state: &str, position: i32) -> (String, String) {
     if line.starts_with('[') {
         if let Some(end) = line.find(']') {
             let identifier = line[1..end].to_string();
@@ -168,9 +170,17 @@ fn extract_identifier_and_title(line: &str) -> (String, String) {
             }
         }
     }
-    // No bracketed identifier — generate a stable slug
+    // No bracketed identifier — generate a stable slug with position for uniqueness.
+    // The position suffix ensures duplicate titles produce distinct identifiers,
+    // and provides a fallback when the title contains no ASCII alphanumeric chars.
     let slug = generate_slug(line);
-    (slug, line.to_string())
+    let state_slug = generate_slug(state);
+    let identifier = if slug.is_empty() {
+        format!("{}-{}", state_slug, position)
+    } else {
+        format!("{}-{}-{}", state_slug, position, slug)
+    };
+    (identifier, line.to_string())
 }
 
 /// Generate a stable slug identifier from a title string.
@@ -331,10 +341,10 @@ mod tests {
         let issues = parse_todo_content(content);
         assert_eq!(issues.len(), 2);
 
-        assert_eq!(issues[0].identifier, "add-login-page");
+        assert_eq!(issues[0].identifier, "todo-0-add-login-page");
         assert_eq!(issues[0].title, "Add login page");
 
-        assert_eq!(issues[1].identifier, "fix-the-checkout-bug");
+        assert_eq!(issues[1].identifier, "todo-1-fix-the-checkout-bug");
         assert_eq!(issues[1].title, "Fix the checkout bug!");
     }
 
@@ -398,8 +408,8 @@ mod tests {
         let content = "## Todo\n- [] Some title\n";
         let issues = parse_todo_content(content);
         assert_eq!(issues.len(), 1);
-        // Empty brackets -> fallback to slug
-        assert_eq!(issues[0].identifier, "some-title");
+        // Empty brackets -> fallback to slug with state-position prefix
+        assert_eq!(issues[0].identifier, "todo-0-some-title");
         assert_eq!(issues[0].title, "[] Some title");
     }
 
@@ -407,23 +417,40 @@ mod tests {
 
     #[test]
     fn test_extract_with_identifier() {
-        let (id, title) = extract_identifier_and_title("[PROJ-1] Add login page");
+        let (id, title) = extract_identifier_and_title("[PROJ-1] Add login page", "Todo", 0);
         assert_eq!(id, "PROJ-1");
         assert_eq!(title, "Add login page");
     }
 
     #[test]
     fn test_extract_without_identifier() {
-        let (id, title) = extract_identifier_and_title("Add login page");
-        assert_eq!(id, "add-login-page");
+        let (id, title) = extract_identifier_and_title("Add login page", "Todo", 0);
+        assert_eq!(id, "todo-0-add-login-page");
         assert_eq!(title, "Add login page");
     }
 
     #[test]
     fn test_extract_identifier_with_hash() {
-        let (id, title) = extract_identifier_and_title("[my-repo#42] Fix bug");
+        let (id, title) = extract_identifier_and_title("[my-repo#42] Fix bug", "Todo", 0);
         assert_eq!(id, "my-repo#42");
         assert_eq!(title, "Fix bug");
+    }
+
+    #[test]
+    fn test_extract_non_alphanumeric_title_uses_fallback() {
+        let (id, title) = extract_identifier_and_title("!!!", "Todo", 2);
+        // Slug of "!!!" is empty, so falls back to state-position only
+        assert_eq!(id, "todo-2");
+        assert_eq!(title, "!!!");
+    }
+
+    #[test]
+    fn test_extract_duplicate_titles_get_unique_ids() {
+        let (id1, _) = extract_identifier_and_title("Fix bug", "Todo", 0);
+        let (id2, _) = extract_identifier_and_title("Fix bug", "Todo", 1);
+        assert_ne!(id1, id2);
+        assert_eq!(id1, "todo-0-fix-bug");
+        assert_eq!(id2, "todo-1-fix-bug");
     }
 
     // --- generate_slug tests ---

--- a/crates/ensemble-core/src/tracker/todo_file.rs
+++ b/crates/ensemble-core/src/tracker/todo_file.rs
@@ -1,0 +1,621 @@
+use async_trait::async_trait;
+use std::path::PathBuf;
+use tracing::warn;
+
+use super::model::Issue;
+use super::{IssueTracker, TrackerError};
+
+/// Issue tracker backed by a local Markdown file.
+///
+/// File format:
+/// ```markdown
+/// ## Todo
+/// - [PROJ-1] Add login page
+///   Description here.
+/// - [PROJ-2] Fix checkout bug
+///
+/// ## In Progress
+/// - [PROJ-3] Refactor auth
+///
+/// ## Done
+/// - [PROJ-4] Set up CI
+/// ```
+pub struct TodoFileTracker {
+    path: PathBuf,
+    active_states: Vec<String>,
+}
+
+impl TodoFileTracker {
+    /// Create a new TodoFileTracker.
+    ///
+    /// * `path` — path to the TODO.md file
+    /// * `active_states` — state headings that are considered active for dispatch
+    pub fn new(path: PathBuf, active_states: Vec<String>) -> Self {
+        Self {
+            path,
+            active_states,
+        }
+    }
+
+    /// Read and parse the TODO file, returning all issues across all state sections.
+    fn parse_file(&self) -> Result<Vec<ParsedIssue>, TrackerError> {
+        let content = match std::fs::read_to_string(&self.path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                warn!(path = %self.path.display(), "TODO file not found, returning empty list");
+                return Ok(vec![]);
+            }
+            Err(e) => {
+                return Err(TrackerError::ApiRequestFailed {
+                    reason: format!("failed to read {}: {}", self.path.display(), e),
+                });
+            }
+        };
+        Ok(parse_todo_content(&content))
+    }
+}
+
+/// An issue parsed from the TODO file, before normalization to the Issue model.
+#[derive(Debug, Clone)]
+struct ParsedIssue {
+    identifier: String,
+    title: String,
+    description: Option<String>,
+    state: String,
+    priority: i32,
+}
+
+/// Parse the content of a TODO.md file into a list of ParsedIssues.
+///
+/// Parsing rules:
+/// - Level-2 headings (`## <State>`) define state sections.
+/// - Lines starting with `- ` under a heading are issues.
+/// - `[IDENTIFIER]` at start of title extracts the identifier.
+/// - Indented continuation lines after the title form the description.
+/// - Priority = position within the state section (0 = highest).
+fn parse_todo_content(content: &str) -> Vec<ParsedIssue> {
+    let mut issues = Vec::new();
+    let mut current_state: Option<String> = None;
+    let mut position_in_state: i32 = 0;
+
+    // Track current issue being built (for multi-line descriptions)
+    let mut current_issue: Option<ParsedIssue> = None;
+    let mut current_desc_lines: Vec<String> = Vec::new();
+
+    for line in content.lines() {
+        // Check for heading
+        if let Some(heading) = line.strip_prefix("## ") {
+            // Flush current issue if any
+            if let Some(mut issue) = current_issue.take() {
+                if !current_desc_lines.is_empty() {
+                    issue.description = Some(current_desc_lines.join("\n").trim().to_string());
+                    current_desc_lines.clear();
+                }
+                issues.push(issue);
+            }
+
+            let heading = heading.trim();
+            if !heading.is_empty() {
+                current_state = Some(heading.to_string());
+                position_in_state = 0;
+            }
+            continue;
+        }
+
+        // Check for list item
+        if let Some(rest) = line.strip_prefix("- ") {
+            // Flush current issue if any
+            if let Some(mut issue) = current_issue.take() {
+                if !current_desc_lines.is_empty() {
+                    issue.description = Some(current_desc_lines.join("\n").trim().to_string());
+                    current_desc_lines.clear();
+                }
+                issues.push(issue);
+            }
+
+            if let Some(state) = &current_state {
+                let rest = rest.trim();
+                let (identifier, title) = extract_identifier_and_title(rest);
+
+                current_issue = Some(ParsedIssue {
+                    identifier,
+                    title,
+                    description: None,
+                    state: state.clone(),
+                    priority: position_in_state,
+                });
+                position_in_state += 1;
+            }
+            continue;
+        }
+
+        // Check for description continuation (indented line under current issue)
+        if current_issue.is_some() {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() && (line.starts_with("  ") || line.starts_with('\t')) {
+                current_desc_lines.push(trimmed.to_string());
+            } else if trimmed.is_empty() {
+                // Blank line within description — preserve it if we already have desc lines
+                if !current_desc_lines.is_empty() {
+                    current_desc_lines.push(String::new());
+                }
+            }
+        }
+    }
+
+    // Flush final issue
+    if let Some(mut issue) = current_issue.take() {
+        if !current_desc_lines.is_empty() {
+            issue.description = Some(current_desc_lines.join("\n").trim().to_string());
+        }
+        issues.push(issue);
+    }
+
+    issues
+}
+
+/// Extract identifier and title from a list item.
+///
+/// If the line starts with `[IDENTIFIER]`, extracts the identifier and remaining title.
+/// Otherwise generates a stable slug from the title.
+fn extract_identifier_and_title(line: &str) -> (String, String) {
+    if line.starts_with('[') {
+        if let Some(end) = line.find(']') {
+            let identifier = line[1..end].to_string();
+            let title = line[end + 1..].trim().to_string();
+            if !identifier.is_empty() {
+                return (identifier, title);
+            }
+        }
+    }
+    // No bracketed identifier — generate a stable slug
+    let slug = generate_slug(line);
+    (slug, line.to_string())
+}
+
+/// Generate a stable slug identifier from a title string.
+///
+/// Lowercases, replaces non-alphanumeric chars with hyphens, collapses
+/// consecutive hyphens, and trims leading/trailing hyphens.
+fn generate_slug(title: &str) -> String {
+    let slug: String = title
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+
+    // Collapse consecutive hyphens
+    let mut result = String::new();
+    let mut prev_hyphen = false;
+    for c in slug.chars() {
+        if c == '-' {
+            if !prev_hyphen {
+                result.push(c);
+            }
+            prev_hyphen = true;
+        } else {
+            result.push(c);
+            prev_hyphen = false;
+        }
+    }
+
+    // Trim leading/trailing hyphens
+    result.trim_matches('-').to_string()
+}
+
+/// Convert a ParsedIssue into the normalized Issue model.
+fn to_issue(parsed: &ParsedIssue) -> Issue {
+    Issue {
+        id: parsed.identifier.clone(),
+        identifier: parsed.identifier.clone(),
+        title: parsed.title.clone(),
+        description: parsed.description.clone(),
+        priority: Some(parsed.priority),
+        state: parsed.state.clone(),
+        branch_name: None,
+        url: None,
+        labels: vec![],
+        blocked_by: vec![],
+        created_at: None,
+        updated_at: None,
+    }
+}
+
+/// Check if a state matches any in a list (case-insensitive).
+fn state_matches(state: &str, states: &[String]) -> bool {
+    states.iter().any(|s| s.eq_ignore_ascii_case(state))
+}
+
+#[async_trait]
+impl IssueTracker for TodoFileTracker {
+    /// Fetch candidate issues in active states for dispatch.
+    ///
+    /// Reads the file, parses all issues, returns those in active states.
+    async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+        let parsed = self.parse_file()?;
+        let issues = parsed
+            .iter()
+            .filter(|p| state_matches(&p.state, &self.active_states))
+            .map(to_issue)
+            .collect();
+        Ok(issues)
+    }
+
+    /// Fetch issues in the given states.
+    ///
+    /// Reads the file, returns issues whose state matches any in the provided list.
+    async fn fetch_issues_by_states(&self, states: &[String]) -> Result<Vec<Issue>, TrackerError> {
+        let parsed = self.parse_file()?;
+        let issues = parsed
+            .iter()
+            .filter(|p| state_matches(&p.state, states))
+            .map(to_issue)
+            .collect();
+        Ok(issues)
+    }
+
+    /// Fetch current states for specific issue IDs.
+    ///
+    /// Reads the file, returns issues whose identifier matches any in the provided list.
+    async fn fetch_issue_states_by_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError> {
+        let parsed = self.parse_file()?;
+        let issues = parsed
+            .iter()
+            .filter(|p| ids.iter().any(|id| id == &p.identifier))
+            .map(to_issue)
+            .collect();
+        Ok(issues)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn write_todo(dir: &Path, content: &str) -> PathBuf {
+        let path = dir.join("TODO.md");
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    fn active_states() -> Vec<String> {
+        vec!["Todo".to_string(), "In Progress".to_string()]
+    }
+
+    // --- parse_todo_content tests ---
+
+    #[test]
+    fn test_parse_basic_file() {
+        let content = r#"## Todo
+- [PROJ-1] Add login page
+  Description here.
+- [PROJ-2] Fix checkout bug
+
+## In Progress
+- [PROJ-3] Refactor auth
+
+## Done
+- [PROJ-4] Set up CI
+"#;
+        let issues = parse_todo_content(content);
+        assert_eq!(issues.len(), 4);
+
+        assert_eq!(issues[0].identifier, "PROJ-1");
+        assert_eq!(issues[0].title, "Add login page");
+        assert_eq!(issues[0].description.as_deref(), Some("Description here."));
+        assert_eq!(issues[0].state, "Todo");
+        assert_eq!(issues[0].priority, 0);
+
+        assert_eq!(issues[1].identifier, "PROJ-2");
+        assert_eq!(issues[1].title, "Fix checkout bug");
+        assert_eq!(issues[1].description, None);
+        assert_eq!(issues[1].state, "Todo");
+        assert_eq!(issues[1].priority, 1);
+
+        assert_eq!(issues[2].identifier, "PROJ-3");
+        assert_eq!(issues[2].title, "Refactor auth");
+        assert_eq!(issues[2].state, "In Progress");
+        assert_eq!(issues[2].priority, 0);
+
+        assert_eq!(issues[3].identifier, "PROJ-4");
+        assert_eq!(issues[3].title, "Set up CI");
+        assert_eq!(issues[3].state, "Done");
+        assert_eq!(issues[3].priority, 0);
+    }
+
+    #[test]
+    fn test_parse_no_identifier_generates_slug() {
+        let content = "## Todo\n- Add login page\n- Fix the checkout bug!\n";
+        let issues = parse_todo_content(content);
+        assert_eq!(issues.len(), 2);
+
+        assert_eq!(issues[0].identifier, "add-login-page");
+        assert_eq!(issues[0].title, "Add login page");
+
+        assert_eq!(issues[1].identifier, "fix-the-checkout-bug");
+        assert_eq!(issues[1].title, "Fix the checkout bug!");
+    }
+
+    #[test]
+    fn test_parse_multiline_description() {
+        let content = r#"## Todo
+- [PROJ-1] Add login page
+  First line of description.
+  Second line of description.
+"#;
+        let issues = parse_todo_content(content);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(
+            issues[0].description.as_deref(),
+            Some("First line of description.\nSecond line of description.")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_file() {
+        let issues = parse_todo_content("");
+        assert_eq!(issues.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_no_headings() {
+        let content = "- [PROJ-1] Orphan item\n";
+        let issues = parse_todo_content(content);
+        // Items without a heading section are ignored
+        assert_eq!(issues.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_empty_heading_ignored() {
+        let content = "## \n- [PROJ-1] Item under empty heading\n";
+        let issues = parse_todo_content(content);
+        assert_eq!(issues.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_priority_is_position_within_state() {
+        let content = r#"## Todo
+- [A] First
+- [B] Second
+- [C] Third
+
+## In Progress
+- [D] First in progress
+- [E] Second in progress
+"#;
+        let issues = parse_todo_content(content);
+        assert_eq!(issues[0].priority, 0); // A
+        assert_eq!(issues[1].priority, 1); // B
+        assert_eq!(issues[2].priority, 2); // C
+        assert_eq!(issues[3].priority, 0); // D — resets for new state
+        assert_eq!(issues[4].priority, 1); // E
+    }
+
+    #[test]
+    fn test_parse_empty_bracket_generates_slug() {
+        let content = "## Todo\n- [] Some title\n";
+        let issues = parse_todo_content(content);
+        assert_eq!(issues.len(), 1);
+        // Empty brackets -> fallback to slug
+        assert_eq!(issues[0].identifier, "some-title");
+        assert_eq!(issues[0].title, "[] Some title");
+    }
+
+    // --- extract_identifier_and_title tests ---
+
+    #[test]
+    fn test_extract_with_identifier() {
+        let (id, title) = extract_identifier_and_title("[PROJ-1] Add login page");
+        assert_eq!(id, "PROJ-1");
+        assert_eq!(title, "Add login page");
+    }
+
+    #[test]
+    fn test_extract_without_identifier() {
+        let (id, title) = extract_identifier_and_title("Add login page");
+        assert_eq!(id, "add-login-page");
+        assert_eq!(title, "Add login page");
+    }
+
+    #[test]
+    fn test_extract_identifier_with_hash() {
+        let (id, title) = extract_identifier_and_title("[my-repo#42] Fix bug");
+        assert_eq!(id, "my-repo#42");
+        assert_eq!(title, "Fix bug");
+    }
+
+    // --- generate_slug tests ---
+
+    #[test]
+    fn test_slug_basic() {
+        assert_eq!(generate_slug("Add login page"), "add-login-page");
+    }
+
+    #[test]
+    fn test_slug_special_chars() {
+        assert_eq!(generate_slug("Fix the bug! (urgent)"), "fix-the-bug-urgent");
+    }
+
+    #[test]
+    fn test_slug_consecutive_special() {
+        assert_eq!(generate_slug("a---b___c"), "a-b-c");
+    }
+
+    #[test]
+    fn test_slug_leading_trailing() {
+        assert_eq!(generate_slug("--hello--"), "hello");
+    }
+
+    // --- state_matches tests ---
+
+    #[test]
+    fn test_state_matches_case_insensitive() {
+        let states = vec!["Todo".to_string(), "In Progress".to_string()];
+        assert!(state_matches("todo", &states));
+        assert!(state_matches("TODO", &states));
+        assert!(state_matches("Todo", &states));
+        assert!(state_matches("in progress", &states));
+        assert!(state_matches("In Progress", &states));
+        assert!(!state_matches("Done", &states));
+    }
+
+    // --- IssueTracker impl tests (async) ---
+
+    #[tokio::test]
+    async fn test_fetch_candidates_returns_active_states_only() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"## Todo
+- [PROJ-1] First task
+- [PROJ-2] Second task
+
+## In Progress
+- [PROJ-3] Active task
+
+## Done
+- [PROJ-4] Finished task
+"#;
+        let path = write_todo(dir.path(), content);
+        let tracker = TodoFileTracker::new(path, active_states());
+
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+        assert_eq!(issues.len(), 3);
+        assert_eq!(issues[0].identifier, "PROJ-1");
+        assert_eq!(issues[1].identifier, "PROJ-2");
+        assert_eq!(issues[2].identifier, "PROJ-3");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_candidates_empty_file() {
+        let dir = TempDir::new().unwrap();
+        let path = write_todo(dir.path(), "");
+        let tracker = TodoFileTracker::new(path, active_states());
+
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+        assert_eq!(issues.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_candidates_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("NONEXISTENT.md");
+        let tracker = TodoFileTracker::new(path, active_states());
+
+        // Missing file returns empty list, not an error
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+        assert_eq!(issues.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_by_states() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"## Todo
+- [PROJ-1] Task one
+
+## In Progress
+- [PROJ-2] Task two
+
+## Done
+- [PROJ-3] Task three
+
+## Blocked
+- [PROJ-4] Task four
+"#;
+        let path = write_todo(dir.path(), content);
+        let tracker = TodoFileTracker::new(path, active_states());
+
+        let done_issues = tracker
+            .fetch_issues_by_states(&["Done".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(done_issues.len(), 1);
+        assert_eq!(done_issues[0].identifier, "PROJ-3");
+
+        let multiple = tracker
+            .fetch_issues_by_states(&["Todo".to_string(), "Blocked".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(multiple.len(), 2);
+        assert_eq!(multiple[0].identifier, "PROJ-1");
+        assert_eq!(multiple[1].identifier, "PROJ-4");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_by_states_case_insensitive() {
+        let dir = TempDir::new().unwrap();
+        let content = "## Todo\n- [A] Task\n";
+        let path = write_todo(dir.path(), content);
+        let tracker = TodoFileTracker::new(path, active_states());
+
+        let issues = tracker
+            .fetch_issues_by_states(&["todo".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].identifier, "A");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_states_by_ids() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"## Todo
+- [PROJ-1] First
+- [PROJ-2] Second
+
+## Done
+- [PROJ-3] Third
+"#;
+        let path = write_todo(dir.path(), content);
+        let tracker = TodoFileTracker::new(path, active_states());
+
+        let issues = tracker
+            .fetch_issue_states_by_ids(&["PROJ-1".to_string(), "PROJ-3".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].identifier, "PROJ-1");
+        assert_eq!(issues[0].state, "Todo");
+        assert_eq!(issues[1].identifier, "PROJ-3");
+        assert_eq!(issues[1].state, "Done");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_states_by_ids_not_found() {
+        let dir = TempDir::new().unwrap();
+        let content = "## Todo\n- [PROJ-1] First\n";
+        let path = write_todo(dir.path(), content);
+        let tracker = TodoFileTracker::new(path, active_states());
+
+        let issues = tracker
+            .fetch_issue_states_by_ids(&["NONEXISTENT".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(issues.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_issue_normalization() {
+        let dir = TempDir::new().unwrap();
+        let content = "## Todo\n- [PROJ-1] Add login\n  A description.\n";
+        let path = write_todo(dir.path(), content);
+        let tracker = TodoFileTracker::new(path, active_states());
+
+        let issues = tracker.fetch_candidate_issues().await.unwrap();
+        assert_eq!(issues.len(), 1);
+
+        let issue = &issues[0];
+        assert_eq!(issue.id, "PROJ-1");
+        assert_eq!(issue.identifier, "PROJ-1");
+        assert_eq!(issue.title, "Add login");
+        assert_eq!(issue.description.as_deref(), Some("A description."));
+        assert_eq!(issue.priority, Some(0));
+        assert_eq!(issue.state, "Todo");
+        assert!(issue.branch_name.is_none());
+        assert!(issue.url.is_none());
+        assert!(issue.labels.is_empty());
+        assert!(issue.blocked_by.is_empty());
+        assert!(issue.created_at.is_none());
+        assert!(issue.updated_at.is_none());
+    }
+}

--- a/crates/ensemble-core/tests/tracker_integration.rs
+++ b/crates/ensemble-core/tests/tracker_integration.rs
@@ -1,0 +1,184 @@
+//! Integration test: create a todo_file tracker from config, write a TODO.md, fetch candidates.
+
+use ensemble_core::config::typed::ServiceConfig;
+use ensemble_core::config::workflow::parse_workflow;
+use ensemble_core::tracker::create_tracker;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn test_todo_file_tracker_via_factory() {
+    let dir = TempDir::new().unwrap();
+    let todo_path = dir.path().join("TODO.md");
+
+    // Write a TODO.md
+    std::fs::write(
+        &todo_path,
+        r#"## Todo
+- [PROJ-1] Add login page
+  The login page needs a form.
+- [PROJ-2] Fix checkout bug
+
+## In Progress
+- [PROJ-3] Refactor auth module
+  Breaking out the auth logic.
+
+## Done
+- [PROJ-4] Set up CI pipeline
+"#,
+    )
+    .unwrap();
+
+    // Build config from a WORKFLOW.md-like string
+    let workflow_content = format!(
+        r#"---
+tracker:
+  kind: todo_file
+  path: {}
+---
+Do the work on {{{{ issue.identifier }}}}.
+"#,
+        todo_path.display()
+    );
+
+    let workflow = parse_workflow(&workflow_content).unwrap();
+    let config = ServiceConfig::from_workflow(&workflow).unwrap();
+
+    // Create tracker via factory
+    let tracker = create_tracker(&config).unwrap();
+
+    // Fetch candidates (active states: Todo, In Progress)
+    let candidates = tracker.fetch_candidate_issues().await.unwrap();
+    assert_eq!(candidates.len(), 3);
+
+    // Verify ordering: document order
+    assert_eq!(candidates[0].identifier, "PROJ-1");
+    assert_eq!(candidates[0].title, "Add login page");
+    assert_eq!(
+        candidates[0].description.as_deref(),
+        Some("The login page needs a form.")
+    );
+    assert_eq!(candidates[0].state, "Todo");
+    assert_eq!(candidates[0].priority, Some(0));
+
+    assert_eq!(candidates[1].identifier, "PROJ-2");
+    assert_eq!(candidates[1].title, "Fix checkout bug");
+    assert_eq!(candidates[1].description, None);
+    assert_eq!(candidates[1].state, "Todo");
+    assert_eq!(candidates[1].priority, Some(1));
+
+    assert_eq!(candidates[2].identifier, "PROJ-3");
+    assert_eq!(candidates[2].title, "Refactor auth module");
+    assert_eq!(
+        candidates[2].description.as_deref(),
+        Some("Breaking out the auth logic.")
+    );
+    assert_eq!(candidates[2].state, "In Progress");
+    assert_eq!(candidates[2].priority, Some(0));
+
+    // Verify normalization: labels, blocked_by, branch_name, url are empty/null
+    for issue in &candidates {
+        assert!(issue.labels.is_empty());
+        assert!(issue.blocked_by.is_empty());
+        assert!(issue.branch_name.is_none());
+        assert!(issue.url.is_none());
+        assert!(issue.created_at.is_none());
+        assert!(issue.updated_at.is_none());
+    }
+}
+
+#[tokio::test]
+async fn test_todo_file_tracker_fetch_by_states() {
+    let dir = TempDir::new().unwrap();
+    let todo_path = dir.path().join("TODO.md");
+
+    std::fs::write(
+        &todo_path,
+        r#"## Todo
+- [A] Alpha
+
+## Done
+- [B] Beta
+
+## Blocked
+- [C] Charlie
+"#,
+    )
+    .unwrap();
+
+    let mut config = ServiceConfig::default();
+    config.tracker_kind = Some("todo_file".to_string());
+    config.tracker_path = todo_path;
+
+    let tracker = create_tracker(&config).unwrap();
+
+    // Fetch terminal states
+    let done = tracker
+        .fetch_issues_by_states(&["Done".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(done.len(), 1);
+    assert_eq!(done[0].identifier, "B");
+    assert_eq!(done[0].state, "Done");
+
+    // Fetch multiple states
+    let multi = tracker
+        .fetch_issues_by_states(&["Todo".to_string(), "Blocked".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(multi.len(), 2);
+    assert_eq!(multi[0].identifier, "A");
+    assert_eq!(multi[1].identifier, "C");
+}
+
+#[tokio::test]
+async fn test_todo_file_tracker_fetch_states_by_ids() {
+    let dir = TempDir::new().unwrap();
+    let todo_path = dir.path().join("TODO.md");
+
+    std::fs::write(
+        &todo_path,
+        r#"## Todo
+- [X-1] First
+
+## In Progress
+- [X-2] Second
+
+## Done
+- [X-3] Third
+"#,
+    )
+    .unwrap();
+
+    let mut config = ServiceConfig::default();
+    config.tracker_kind = Some("todo_file".to_string());
+    config.tracker_path = todo_path;
+
+    let tracker = create_tracker(&config).unwrap();
+
+    let issues = tracker
+        .fetch_issue_states_by_ids(&["X-1".to_string(), "X-3".to_string()])
+        .await
+        .unwrap();
+
+    assert_eq!(issues.len(), 2);
+    assert_eq!(issues[0].identifier, "X-1");
+    assert_eq!(issues[0].state, "Todo");
+    assert_eq!(issues[1].identifier, "X-3");
+    assert_eq!(issues[1].state, "Done");
+}
+
+#[tokio::test]
+async fn test_factory_rejects_unsupported_kind() {
+    let mut config = ServiceConfig::default();
+    config.tracker_kind = Some("jira".to_string());
+
+    let result = create_tracker(&config);
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_factory_rejects_missing_kind() {
+    let config = ServiceConfig::default();
+    let result = create_tracker(&config);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Implements Plan 2: the two built-in issue tracker backends and the factory function that wires them up from `ServiceConfig`.

- **TodoFileTracker** (`tracker/todo_file.rs`) — parses `## State` / `- [ID] Title` markdown, supports all three `IssueTracker` trait methods
- **GithubTracker** (`tracker/github.rs`) — GitHub Projects v2 GraphQL API with project-board discovery, cursor-based pagination, priority mapping, and label filtering; falls back to repo-mode when no project number is configured
- **Factory function** (`tracker/mod.rs`) — `create_tracker(&ServiceConfig)` dispatches on `tracker_kind`
- **Integration tests** (`tests/tracker_integration.rs`) — end-to-end tests exercising the factory → tracker → fetch pipeline

### Notable details

- GitHub tracker caches discovered project metadata (node ID, status field ID) to avoid redundant discovery queries
- `normalize_state_node` re-derives state from labels in repo-mode so reconciliation returns meaningful states instead of raw `open`/`closed`
- Generated slug identifiers include `state-position` prefix for uniqueness when issues lack explicit `[ID]` brackets
- All wiremock tests use `body_string_contains` matchers to distinguish GraphQL query types (wiremock v0.6 matches LIFO, not FIFO)

## Test plan

- [x] 129 tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Unit tests cover parsing, slug generation, state matching, pagination, error handling
- [x] Integration tests verify factory wiring with real `WORKFLOW.md` config parsing
- [x] wiremock tests cover GitHub GraphQL discovery, project items, repo issues, pagination, and priority mapping