### PR TITLE
feat: API, observability, CLI, and dashboard backend (Plan 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +114,61 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -129,6 +234,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +323,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deadpool"
@@ -237,12 +394,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ensemble-cli"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "clap",
+ "ensemble-core",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ensemble-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum",
  "chrono",
  "futures",
+ "futures-util",
  "libc",
  "liquid",
  "reqwest",
@@ -252,6 +422,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "wiremock",
@@ -432,13 +603,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -521,6 +704,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -775,6 +964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +1115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +1131,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -998,6 +1209,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -1149,6 +1366,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,9 +1404,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1420,6 +1681,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1714,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1513,6 +1796,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1704,6 +1993,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +2030,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1739,14 +2041,24 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1767,6 +2079,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1842,6 +2155,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +2182,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -1896,10 +2232,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -2341,6 +2689,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ reqwest = { version = "0.12", features = ["json"] }
 futures = "0.3"
 libc = "0.2"
 wiremock = "0.6"
+axum = "0.8"
+tower-http = { version = "0.6", features = ["cors"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ libc = "0.2"
 wiremock = "0.6"
 axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
+clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ wiremock = "0.6"
 axum = { version = "0.8", features = ["ws"] }
 futures-util = "0.3"
 tower-http = { version = "0.6", features = ["cors", "fs"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ libc = "0.2"
 wiremock = "0.6"
 axum = { version = "0.8", features = ["ws"] }
 futures-util = "0.3"
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "fs"] }
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ reqwest = { version = "0.12", features = ["json"] }
 futures = "0.3"
 libc = "0.2"
 wiremock = "0.6"
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
+futures-util = "0.3"
 tower-http = { version = "0.6", features = ["cors"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/ensemble-cli/Cargo.toml
+++ b/crates/ensemble-cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ensemble-cli"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "ensemble"
+path = "src/main.rs"
+
+[dependencies]
+ensemble-core = { path = "../ensemble-core" }
+tokio = { workspace = true }
+clap = { workspace = true }
+tracing = { workspace = true }
+axum = { workspace = true }

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -20,9 +20,12 @@ struct Cli {
     #[arg(default_value = "ensemble.yaml")]
     config_path: PathBuf,
 
+    /// HTTP server bind address.
+    #[arg(long, env = "HOST", default_value = "127.0.0.1")]
+    host: String,
+
     /// HTTP server port (enables API + dashboard).
-    /// CLI-only flag; not part of ensemble.yaml.
-    #[arg(long)]
+    #[arg(long, env = "PORT")]
     port: Option<u16>,
 }
 
@@ -100,7 +103,7 @@ async fn main() -> ExitCode {
         };
         let router = create_api_router(app_state);
 
-        let bind_addr = format!("127.0.0.1:{}", port);
+        let bind_addr = format!("{}:{}", cli.host, port);
         info!(addr = %bind_addr, "starting HTTP server");
 
         let listener = match tokio::net::TcpListener::bind(&bind_addr).await {
@@ -153,37 +156,115 @@ async fn main() -> ExitCode {
 mod tests {
     use super::*;
 
+    /// Helper: clear HOST/PORT env vars for test isolation, returning saved values.
+    fn clear_env() -> (Option<String>, Option<String>) {
+        let host = std::env::var("HOST").ok();
+        let port = std::env::var("PORT").ok();
+        std::env::remove_var("HOST");
+        std::env::remove_var("PORT");
+        (host, port)
+    }
+
+    /// Helper: restore previously saved HOST/PORT env vars.
+    fn restore_env(saved: (Option<String>, Option<String>)) {
+        match saved.0 {
+            Some(v) => std::env::set_var("HOST", v),
+            None => std::env::remove_var("HOST"),
+        }
+        match saved.1 {
+            Some(v) => std::env::set_var("PORT", v),
+            None => std::env::remove_var("PORT"),
+        }
+    }
+
     #[test]
     fn test_cli_parse_defaults() {
+        let saved = clear_env();
         let cli = Cli::parse_from(["ensemble"]);
         assert_eq!(cli.config_path, PathBuf::from("ensemble.yaml"));
+        assert_eq!(cli.host, "127.0.0.1");
         assert_eq!(cli.port, None);
+        restore_env(saved);
     }
 
     #[test]
     fn test_cli_parse_custom_path() {
+        let saved = clear_env();
         let cli = Cli::parse_from(["ensemble", "custom/ensemble.yaml"]);
         assert_eq!(cli.config_path, PathBuf::from("custom/ensemble.yaml"));
         assert_eq!(cli.port, None);
+        restore_env(saved);
     }
 
     #[test]
     fn test_cli_parse_with_port() {
+        let saved = clear_env();
         let cli = Cli::parse_from(["ensemble", "--port", "8080"]);
         assert_eq!(cli.config_path, PathBuf::from("ensemble.yaml"));
         assert_eq!(cli.port, Some(8080));
+        restore_env(saved);
+    }
+
+    #[test]
+    fn test_cli_parse_with_host() {
+        let saved = clear_env();
+        let cli = Cli::parse_from(["ensemble", "--host", "0.0.0.0", "--port", "3000"]);
+        assert_eq!(cli.host, "0.0.0.0");
+        assert_eq!(cli.port, Some(3000));
+        restore_env(saved);
     }
 
     #[test]
     fn test_cli_parse_all_options() {
-        let cli = Cli::parse_from(["ensemble", "--port", "3000", "my/ensemble.yaml"]);
+        let saved = clear_env();
+        let cli = Cli::parse_from([
+            "ensemble",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "3000",
+            "my/ensemble.yaml",
+        ]);
         assert_eq!(cli.config_path, PathBuf::from("my/ensemble.yaml"));
+        assert_eq!(cli.host, "0.0.0.0");
         assert_eq!(cli.port, Some(3000));
+        restore_env(saved);
     }
 
     #[test]
     fn test_cli_parse_ephemeral_port() {
+        let saved = clear_env();
         let cli = Cli::parse_from(["ensemble", "--port", "0"]);
         assert_eq!(cli.port, Some(0));
+        restore_env(saved);
+    }
+
+    #[test]
+    fn test_cli_env_host() {
+        let saved = clear_env();
+        std::env::set_var("HOST", "10.0.0.1");
+        let cli = Cli::parse_from(["ensemble"]);
+        assert_eq!(cli.host, "10.0.0.1");
+        restore_env(saved);
+    }
+
+    #[test]
+    fn test_cli_env_port() {
+        let saved = clear_env();
+        std::env::set_var("PORT", "9090");
+        let cli = Cli::parse_from(["ensemble"]);
+        assert_eq!(cli.port, Some(9090));
+        restore_env(saved);
+    }
+
+    #[test]
+    fn test_cli_flag_overrides_env() {
+        let saved = clear_env();
+        std::env::set_var("HOST", "10.0.0.1");
+        std::env::set_var("PORT", "9090");
+        let cli = Cli::parse_from(["ensemble", "--host", "0.0.0.0", "--port", "3000"]);
+        assert_eq!(cli.host, "0.0.0.0");
+        assert_eq!(cli.port, Some(3000));
+        restore_env(saved);
     }
 }

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -7,6 +7,7 @@ use tracing::{error, info};
 
 use ensemble_core::api::router::{create_api_router, AppState};
 use ensemble_core::config::ensemble::{load_config, validate_config};
+use ensemble_core::observability::events::EventBus;
 use ensemble_core::observability::logging::init_logging;
 use ensemble_core::orchestrator::state::OrchestratorState;
 use ensemble_core::pipeline::dag::build_dag;
@@ -82,20 +83,25 @@ async fn main() -> ExitCode {
 
     // 6. Optionally start HTTP server
     let server_handle = if let Some(port) = cli.port {
+        let workspace_root = config
+            .workspace
+            .root
+            .as_deref()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                std::env::temp_dir()
+                    .join("ensemble_workspaces")
+                    .display()
+                    .to_string()
+            });
+        let history_path =
+            std::path::PathBuf::from(&workspace_root).join("ensemble_history.jsonl");
         let app_state = AppState {
             orchestrator_state: orchestrator_state.clone(),
             refresh_requested: refresh_notify.clone(),
-            workspace_root: config
-                .workspace
-                .root
-                .as_deref()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| {
-                    std::env::temp_dir()
-                        .join("ensemble_workspaces")
-                        .display()
-                        .to_string()
-                }),
+            workspace_root,
+            history_path,
+            event_bus: EventBus::new(),
         };
         let router = create_api_router(app_state);
 

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -44,11 +44,7 @@ async fn main() -> ExitCode {
         Ok(cfg) => cfg,
         Err(e) => {
             error!(error = %e, path = %cli.config_path.display(), "failed to load config");
-            eprintln!(
-                "error: failed to load {}: {}",
-                cli.config_path.display(),
-                e
-            );
+            eprintln!("error: failed to load {}: {}", cli.config_path.display(), e);
             return ExitCode::FAILURE;
         }
     };
@@ -94,8 +90,7 @@ async fn main() -> ExitCode {
                     .display()
                     .to_string()
             });
-        let history_path =
-            std::path::PathBuf::from(&workspace_root).join("ensemble_history.jsonl");
+        let history_path = std::path::PathBuf::from(&workspace_root).join("ensemble_history.jsonl");
         let app_state = AppState {
             orchestrator_state: orchestrator_state.clone(),
             refresh_requested: refresh_notify.clone(),

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -1,0 +1,188 @@
+use clap::Parser;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{error, info};
+
+use ensemble_core::api::router::{create_api_router, AppState};
+use ensemble_core::config::ensemble::{load_config, validate_config};
+use ensemble_core::observability::logging::init_logging;
+use ensemble_core::orchestrator::state::OrchestratorState;
+use ensemble_core::pipeline::dag::build_dag;
+
+/// Ensemble: orchestrate coding agents to work on project issues.
+#[derive(Parser, Debug)]
+#[command(name = "ensemble", about = "Orchestrate coding agents")]
+struct Cli {
+    /// Path to ensemble.yaml
+    #[arg(default_value = "ensemble.yaml")]
+    config_path: PathBuf,
+
+    /// HTTP server port (enables API + dashboard).
+    /// CLI-only flag; not part of ensemble.yaml.
+    #[arg(long)]
+    port: Option<u16>,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    // 1. Parse CLI args
+    let cli = Cli::parse();
+
+    // 2. Init logging
+    init_logging();
+
+    info!(
+        config_path = %cli.config_path.display(),
+        "starting ensemble"
+    );
+
+    // 3. Load and validate ensemble.yaml
+    let config = match load_config(&cli.config_path) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            error!(error = %e, path = %cli.config_path.display(), "failed to load config");
+            eprintln!(
+                "error: failed to load {}: {}",
+                cli.config_path.display(),
+                e
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // 4. Validate config and build step DAG
+    if let Err(e) = validate_config(&config) {
+        error!(error = %e, "config validation failed");
+        eprintln!("error: config validation failed: {}", e);
+        return ExitCode::FAILURE;
+    }
+
+    if let Err(e) = build_dag(&config.steps) {
+        error!(error = %e, "step DAG validation failed");
+        eprintln!("error: step DAG validation failed: {}", e);
+        return ExitCode::FAILURE;
+    }
+
+    info!(
+        tracker_kind = %config.tracker.kind,
+        poll_interval_ms = config.polling.interval_ms,
+        max_concurrent = config.concurrency.max_concurrent_agents,
+        "config loaded successfully"
+    );
+
+    // 5. Create orchestrator state
+    let orchestrator_state = Arc::new(RwLock::new(OrchestratorState::new(
+        config.polling.interval_ms,
+        config.concurrency.max_concurrent_agents,
+    )));
+
+    let refresh_notify = Arc::new(tokio::sync::Notify::new());
+
+    // 6. Optionally start HTTP server
+    let server_handle = if let Some(port) = cli.port {
+        let app_state = AppState {
+            orchestrator_state: orchestrator_state.clone(),
+            refresh_requested: refresh_notify.clone(),
+            workspace_root: config
+                .workspace
+                .root
+                .as_deref()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| {
+                    std::env::temp_dir()
+                        .join("ensemble_workspaces")
+                        .display()
+                        .to_string()
+                }),
+        };
+        let router = create_api_router(app_state);
+
+        let bind_addr = format!("127.0.0.1:{}", port);
+        info!(addr = %bind_addr, "starting HTTP server");
+
+        let listener = match tokio::net::TcpListener::bind(&bind_addr).await {
+            Ok(l) => l,
+            Err(e) => {
+                error!(error = %e, addr = %bind_addr, "failed to bind HTTP server");
+                eprintln!("error: failed to bind HTTP server on {}: {}", bind_addr, e);
+                return ExitCode::FAILURE;
+            }
+        };
+
+        let actual_addr = listener.local_addr().unwrap();
+        info!(addr = %actual_addr, "HTTP server listening");
+
+        Some(tokio::spawn(async move {
+            if let Err(e) = axum::serve(listener, router).await {
+                error!(error = %e, "HTTP server error");
+            }
+        }))
+    } else {
+        info!("no HTTP port configured, skipping API server");
+        None
+    };
+
+    // 7. TODO: Start orchestrator poll loop (Plan 3 wires this up).
+    //    For now the CLI starts, optionally serves the API, and waits for shutdown.
+    info!("ensemble is running (orchestrator loop placeholder, press Ctrl+C to stop)");
+
+    // 8. Wait for shutdown signal (ctrl-c)
+    match tokio::signal::ctrl_c().await {
+        Ok(()) => {
+            info!("received shutdown signal");
+        }
+        Err(e) => {
+            error!(error = %e, "failed to listen for shutdown signal");
+        }
+    }
+
+    // 9. Clean shutdown
+    if let Some(handle) = server_handle {
+        handle.abort();
+        info!("HTTP server stopped");
+    }
+
+    info!("ensemble shut down cleanly");
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cli_parse_defaults() {
+        let cli = Cli::parse_from(["ensemble"]);
+        assert_eq!(cli.config_path, PathBuf::from("ensemble.yaml"));
+        assert_eq!(cli.port, None);
+    }
+
+    #[test]
+    fn test_cli_parse_custom_path() {
+        let cli = Cli::parse_from(["ensemble", "custom/ensemble.yaml"]);
+        assert_eq!(cli.config_path, PathBuf::from("custom/ensemble.yaml"));
+        assert_eq!(cli.port, None);
+    }
+
+    #[test]
+    fn test_cli_parse_with_port() {
+        let cli = Cli::parse_from(["ensemble", "--port", "8080"]);
+        assert_eq!(cli.config_path, PathBuf::from("ensemble.yaml"));
+        assert_eq!(cli.port, Some(8080));
+    }
+
+    #[test]
+    fn test_cli_parse_all_options() {
+        let cli = Cli::parse_from(["ensemble", "--port", "3000", "my/ensemble.yaml"]);
+        assert_eq!(cli.config_path, PathBuf::from("my/ensemble.yaml"));
+        assert_eq!(cli.port, Some(3000));
+    }
+
+    #[test]
+    fn test_cli_parse_ephemeral_port() {
+        let cli = Cli::parse_from(["ensemble", "--port", "0"]);
+        assert_eq!(cli.port, Some(0));
+    }
+}

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 
-use ensemble_core::api::router::{create_api_router, AppState};
+use ensemble_core::api::router::{create_api_router_with_static, AppState};
 use ensemble_core::config::ensemble::{load_config, validate_config};
 use ensemble_core::observability::events::EventBus;
 use ensemble_core::observability::logging::init_logging;
@@ -27,6 +27,10 @@ struct Cli {
     /// HTTP server port (enables API + dashboard).
     #[arg(long, env = "PORT")]
     port: Option<u16>,
+
+    /// Directory containing built dashboard assets to serve.
+    #[arg(long)]
+    static_dir: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -101,7 +105,7 @@ async fn main() -> ExitCode {
             history_path,
             event_bus: EventBus::new(),
         };
-        let router = create_api_router(app_state);
+        let router = create_api_router_with_static(app_state, cli.static_dir.clone());
 
         let bind_addr = format!("{}:{}", cli.host, port);
         info!(addr = %bind_addr, "starting HTTP server");
@@ -156,22 +160,33 @@ async fn main() -> ExitCode {
 mod tests {
     use super::*;
 
-    /// Helper: clear HOST/PORT env vars for test isolation, returning saved values.
-    fn clear_env() -> (Option<String>, Option<String>) {
+    use std::sync::Mutex;
+
+    // Mutex to serialize tests that manipulate HOST/PORT env vars.
+    // Env vars are process-global, so parallel tests would race.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Helper: lock env, clear HOST/PORT, return saved values + guard.
+    fn lock_and_clear_env() -> (
+        std::sync::MutexGuard<'static, ()>,
+        Option<String>,
+        Option<String>,
+    ) {
+        let guard = ENV_LOCK.lock().unwrap();
         let host = std::env::var("HOST").ok();
         let port = std::env::var("PORT").ok();
         std::env::remove_var("HOST");
         std::env::remove_var("PORT");
-        (host, port)
+        (guard, host, port)
     }
 
     /// Helper: restore previously saved HOST/PORT env vars.
-    fn restore_env(saved: (Option<String>, Option<String>)) {
-        match saved.0 {
+    fn restore_env(host: Option<String>, port: Option<String>) {
+        match host {
             Some(v) => std::env::set_var("HOST", v),
             None => std::env::remove_var("HOST"),
         }
-        match saved.1 {
+        match port {
             Some(v) => std::env::set_var("PORT", v),
             None => std::env::remove_var("PORT"),
         }
@@ -179,44 +194,44 @@ mod tests {
 
     #[test]
     fn test_cli_parse_defaults() {
-        let saved = clear_env();
+        let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble"]);
         assert_eq!(cli.config_path, PathBuf::from("ensemble.yaml"));
         assert_eq!(cli.host, "127.0.0.1");
         assert_eq!(cli.port, None);
-        restore_env(saved);
+        restore_env(host, port);
     }
 
     #[test]
     fn test_cli_parse_custom_path() {
-        let saved = clear_env();
+        let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "custom/ensemble.yaml"]);
         assert_eq!(cli.config_path, PathBuf::from("custom/ensemble.yaml"));
         assert_eq!(cli.port, None);
-        restore_env(saved);
+        restore_env(host, port);
     }
 
     #[test]
     fn test_cli_parse_with_port() {
-        let saved = clear_env();
+        let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "--port", "8080"]);
         assert_eq!(cli.config_path, PathBuf::from("ensemble.yaml"));
         assert_eq!(cli.port, Some(8080));
-        restore_env(saved);
+        restore_env(host, port);
     }
 
     #[test]
     fn test_cli_parse_with_host() {
-        let saved = clear_env();
+        let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "--host", "0.0.0.0", "--port", "3000"]);
         assert_eq!(cli.host, "0.0.0.0");
         assert_eq!(cli.port, Some(3000));
-        restore_env(saved);
+        restore_env(host, port);
     }
 
     #[test]
     fn test_cli_parse_all_options() {
-        let saved = clear_env();
+        let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from([
             "ensemble",
             "--host",
@@ -228,43 +243,43 @@ mod tests {
         assert_eq!(cli.config_path, PathBuf::from("my/ensemble.yaml"));
         assert_eq!(cli.host, "0.0.0.0");
         assert_eq!(cli.port, Some(3000));
-        restore_env(saved);
+        restore_env(host, port);
     }
 
     #[test]
     fn test_cli_parse_ephemeral_port() {
-        let saved = clear_env();
+        let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "--port", "0"]);
         assert_eq!(cli.port, Some(0));
-        restore_env(saved);
+        restore_env(host, port);
     }
 
     #[test]
     fn test_cli_env_host() {
-        let saved = clear_env();
+        let (_guard, host, port) = lock_and_clear_env();
         std::env::set_var("HOST", "10.0.0.1");
         let cli = Cli::parse_from(["ensemble"]);
         assert_eq!(cli.host, "10.0.0.1");
-        restore_env(saved);
+        restore_env(host, port);
     }
 
     #[test]
     fn test_cli_env_port() {
-        let saved = clear_env();
+        let (_guard, host, port) = lock_and_clear_env();
         std::env::set_var("PORT", "9090");
         let cli = Cli::parse_from(["ensemble"]);
         assert_eq!(cli.port, Some(9090));
-        restore_env(saved);
+        restore_env(host, port);
     }
 
     #[test]
     fn test_cli_flag_overrides_env() {
-        let saved = clear_env();
+        let (_guard, host, port) = lock_and_clear_env();
         std::env::set_var("HOST", "10.0.0.1");
         std::env::set_var("PORT", "9090");
         let cli = Cli::parse_from(["ensemble", "--host", "0.0.0.0", "--port", "3000"]);
         assert_eq!(cli.host, "0.0.0.0");
         assert_eq!(cli.port, Some(3000));
-        restore_env(saved);
+        restore_env(host, port);
     }
 }

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -21,6 +21,7 @@ futures = { workspace = true }
 libc = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
+futures-util = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -19,6 +19,8 @@ async-trait = { workspace = true }
 reqwest = { workspace = true }
 futures = { workspace = true }
 libc = { workspace = true }
+axum = { workspace = true }
+tower-http = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -201,7 +201,6 @@ mod tests {
     use crate::observability::events::EventBus;
     use crate::orchestrator::state::OrchestratorState;
     use crate::tracker::model::{Issue, RetryEntry};
-    use chrono::Utc;
     use std::path::PathBuf;
     use std::sync::Arc;
     use tokio::sync::RwLock;

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -137,10 +137,7 @@ pub async fn post_retry(
         Some(id) => id,
         None => {
             // Check if it's running instead
-            let is_running = lock
-                .running
-                .values()
-                .any(|e| e.identifier == identifier);
+            let is_running = lock.running.values().any(|e| e.identifier == identifier);
 
             if is_running {
                 return (

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -86,15 +86,23 @@ pub async fn post_stop(
     if let Some(entry) = lock.running.get(&issue_id) {
         if let Some(ref pid_str) = entry.agent_pid {
             if let Ok(pid) = pid_str.parse::<i32>() {
-                // Best-effort SIGTERM — don't fail the API call if the process is already gone
-                unsafe {
-                    libc::kill(pid, libc::SIGTERM);
+                if pid > 0 {
+                    let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+                    if rc == -1 {
+                        tracing::warn!(pid, issue_id = %issue_id, "failed to send SIGTERM");
+                    }
+                } else {
+                    tracing::warn!(pid, issue_id = %issue_id, "skipping SIGTERM for non-positive PID");
                 }
             }
         }
     }
 
-    // Remove from running state
+    // TODO: Once the orchestrator event loop exists (Plan 3), stop requests
+    // should be routed through a command channel instead of mutating state
+    // directly. This avoids a race where the orchestrator's WorkerExited
+    // handler processes a stale entry. For now, direct mutation is correct
+    // because the orchestrator loop is a placeholder.
     if let Some(entry) = lock.remove_running(&issue_id) {
         lock.add_runtime_seconds(&entry);
     }

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -1,0 +1,316 @@
+use crate::api::handlers::ApiError;
+use crate::api::router::AppState;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::Serialize;
+
+/// Response for a successful stop operation.
+#[derive(Debug, Serialize)]
+pub struct StopResponse {
+    pub stopped: bool,
+    pub issue_identifier: String,
+    pub message: String,
+}
+
+/// Response for a successful retry operation.
+#[derive(Debug, Serialize)]
+pub struct RetryResponse {
+    pub retried: bool,
+    pub issue_identifier: String,
+    pub message: String,
+}
+
+/// POST /api/v1/{identifier}/stop
+///
+/// Stops a running agent for the specified issue. Sends SIGTERM to the agent process
+/// and removes it from the running state. Returns 404 if not found, 409 if not running.
+pub async fn post_stop(
+    State(state): State<AppState>,
+    Path(identifier): Path<String>,
+) -> impl IntoResponse {
+    let mut lock = state.orchestrator_state.write().await;
+
+    // Find the running entry by identifier
+    let issue_id = lock
+        .running
+        .values()
+        .find(|e| e.identifier == identifier)
+        .map(|e| e.issue_id.clone());
+
+    let issue_id = match issue_id {
+        Some(id) => id,
+        None => {
+            // Check if it's retrying instead
+            let is_retrying = lock
+                .retry_attempts
+                .values()
+                .any(|e| e.identifier == identifier);
+
+            if is_retrying {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(
+                        serde_json::to_value(ApiError::new(
+                            "not_running",
+                            &format!(
+                                "issue '{}' is retrying, not running — use retry endpoint instead",
+                                identifier
+                            ),
+                        ))
+                        .unwrap(),
+                    ),
+                )
+                    .into_response();
+            }
+
+            return (
+                StatusCode::NOT_FOUND,
+                Json(
+                    serde_json::to_value(ApiError::new(
+                        "issue_not_found",
+                        &format!(
+                            "no running or retrying issue with identifier '{}'",
+                            identifier
+                        ),
+                    ))
+                    .unwrap(),
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    // Attempt to send SIGTERM to the agent process
+    if let Some(entry) = lock.running.get(&issue_id) {
+        if let Some(ref pid_str) = entry.agent_pid {
+            if let Ok(pid) = pid_str.parse::<i32>() {
+                // Best-effort SIGTERM — don't fail the API call if the process is already gone
+                unsafe {
+                    libc::kill(pid, libc::SIGTERM);
+                }
+            }
+        }
+    }
+
+    // Remove from running state
+    if let Some(entry) = lock.remove_running(&issue_id) {
+        lock.add_runtime_seconds(&entry);
+    }
+    lock.remove_claimed(&issue_id);
+    lock.remove_pipeline_run(&issue_id);
+    drop(lock);
+
+    (
+        StatusCode::OK,
+        Json(
+            serde_json::to_value(StopResponse {
+                stopped: true,
+                issue_identifier: identifier,
+                message: "agent stopped and issue released".to_string(),
+            })
+            .unwrap(),
+        ),
+    )
+        .into_response()
+}
+
+/// POST /api/v1/{identifier}/retry
+///
+/// Removes an issue from the retry queue, making it available for immediate re-dispatch.
+/// Returns 404 if not found, 409 if the issue is currently running (not retrying).
+pub async fn post_retry(
+    State(state): State<AppState>,
+    Path(identifier): Path<String>,
+) -> impl IntoResponse {
+    let mut lock = state.orchestrator_state.write().await;
+
+    // Find the retry entry by identifier
+    let issue_id = lock
+        .retry_attempts
+        .values()
+        .find(|e| e.identifier == identifier)
+        .map(|e| e.issue_id.clone());
+
+    let issue_id = match issue_id {
+        Some(id) => id,
+        None => {
+            // Check if it's running instead
+            let is_running = lock
+                .running
+                .values()
+                .any(|e| e.identifier == identifier);
+
+            if is_running {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(
+                        serde_json::to_value(ApiError::new(
+                            "not_retrying",
+                            &format!(
+                                "issue '{}' is currently running — use stop endpoint to interrupt",
+                                identifier
+                            ),
+                        ))
+                        .unwrap(),
+                    ),
+                )
+                    .into_response();
+            }
+
+            return (
+                StatusCode::NOT_FOUND,
+                Json(
+                    serde_json::to_value(ApiError::new(
+                        "issue_not_found",
+                        &format!(
+                            "no running or retrying issue with identifier '{}'",
+                            identifier
+                        ),
+                    ))
+                    .unwrap(),
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    // Remove from retry queue and release claim (allows next poll to re-pick it up)
+    lock.remove_retry(&issue_id);
+    lock.remove_claimed(&issue_id);
+    drop(lock);
+
+    // Signal the orchestrator to poll immediately so it picks up the now-unclaimed issue
+    state.refresh_requested.notify_one();
+
+    (
+        StatusCode::OK,
+        Json(
+            serde_json::to_value(RetryResponse {
+                retried: true,
+                issue_identifier: identifier,
+                message: "removed from retry queue, will be re-dispatched on next poll".to_string(),
+            })
+            .unwrap(),
+        ),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observability::events::EventBus;
+    use crate::orchestrator::state::OrchestratorState;
+    use crate::tracker::model::{Issue, RetryEntry};
+    use chrono::Utc;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn test_issue() -> Issue {
+        Issue {
+            id: "NODE_123".to_string(),
+            identifier: "my-repo#42".to_string(),
+            title: "Fix the bug".to_string(),
+            description: None,
+            priority: Some(2),
+            state: "In Progress".to_string(),
+            branch_name: None,
+            url: None,
+            labels: vec![],
+            blocked_by: vec![],
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn build_app_state_with_running() -> AppState {
+        let mut state = OrchestratorState::new(30000, 10);
+        state.add_running(&test_issue(), None);
+        AppState {
+            orchestrator_state: Arc::new(RwLock::new(state)),
+            refresh_requested: Arc::new(tokio::sync::Notify::new()),
+            workspace_root: "/tmp/workspaces".to_string(),
+            history_path: PathBuf::from("/tmp/history.jsonl"),
+            event_bus: EventBus::new(),
+        }
+    }
+
+    fn build_app_state_with_retry() -> AppState {
+        let mut state = OrchestratorState::new(30000, 10);
+        state.add_retry(RetryEntry {
+            issue_id: "NODE_456".to_string(),
+            identifier: "my-repo#99".to_string(),
+            attempt: 2,
+            due_at_ms: 999999,
+            error: Some("timeout".to_string()),
+        });
+        AppState {
+            orchestrator_state: Arc::new(RwLock::new(state)),
+            refresh_requested: Arc::new(tokio::sync::Notify::new()),
+            workspace_root: "/tmp/workspaces".to_string(),
+            history_path: PathBuf::from("/tmp/history.jsonl"),
+            event_bus: EventBus::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stop_running_issue() {
+        let state = build_app_state_with_running();
+        let response = post_stop(State(state.clone()), Path("my-repo#42".to_string())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Verify issue is no longer running
+        let lock = state.orchestrator_state.read().await;
+        assert!(lock.running.is_empty());
+        assert!(!lock.is_claimed("NODE_123"));
+    }
+
+    #[tokio::test]
+    async fn test_stop_not_found() {
+        let state = build_app_state_with_running();
+        let response = post_stop(State(state), Path("nonexistent#999".to_string())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_stop_retrying_issue_returns_conflict() {
+        let state = build_app_state_with_retry();
+        let response = post_stop(State(state), Path("my-repo#99".to_string())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_retry_retrying_issue() {
+        let state = build_app_state_with_retry();
+        let response = post_retry(State(state.clone()), Path("my-repo#99".to_string())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Verify issue is no longer in retry queue
+        let lock = state.orchestrator_state.read().await;
+        assert!(lock.retry_attempts.is_empty());
+        assert!(!lock.is_claimed("NODE_456"));
+    }
+
+    #[tokio::test]
+    async fn test_retry_not_found() {
+        let state = build_app_state_with_retry();
+        let response = post_retry(State(state), Path("nonexistent#999".to_string())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_retry_running_issue_returns_conflict() {
+        let state = build_app_state_with_running();
+        let response = post_retry(State(state), Path("my-repo#42".to_string())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+}

--- a/crates/ensemble-core/src/api/conversation.rs
+++ b/crates/ensemble-core/src/api/conversation.rs
@@ -49,11 +49,13 @@ pub async fn get_conversation(
         None => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::to_value(ApiError::new(
-                    "invalid_identifier",
-                    "identifier cannot be sanitized to a workspace key",
-                ))
-                .unwrap()),
+                Json(
+                    serde_json::to_value(ApiError::new(
+                        "invalid_identifier",
+                        "identifier cannot be sanitized to a workspace key",
+                    ))
+                    .unwrap(),
+                ),
             )
                 .into_response();
         }
@@ -69,12 +71,14 @@ pub async fn get_conversation(
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return (
                 StatusCode::OK,
-                Json(serde_json::to_value(ConversationResponse {
-                    messages: vec![],
-                    total: 0,
-                    next_cursor: None,
-                })
-                .unwrap()),
+                Json(
+                    serde_json::to_value(ConversationResponse {
+                        messages: vec![],
+                        total: 0,
+                        next_cursor: None,
+                    })
+                    .unwrap(),
+                ),
             )
                 .into_response();
         }
@@ -137,11 +141,13 @@ pub async fn get_conversation_message(
         None => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::to_value(ApiError::new(
-                    "invalid_identifier",
-                    "identifier cannot be sanitized to a workspace key",
-                ))
-                .unwrap()),
+                Json(
+                    serde_json::to_value(ApiError::new(
+                        "invalid_identifier",
+                        "identifier cannot be sanitized to a workspace key",
+                    ))
+                    .unwrap(),
+                ),
             )
                 .into_response();
         }

--- a/crates/ensemble-core/src/api/conversation.rs
+++ b/crates/ensemble-core/src/api/conversation.rs
@@ -104,7 +104,7 @@ pub async fn get_conversation(
 
     let total = all_messages.len();
     let cursor = query.cursor.unwrap_or(0);
-    let limit = query.limit.unwrap_or(50);
+    let limit = query.limit.unwrap_or(50).min(200);
 
     let page: Vec<ConversationMessage> =
         all_messages.into_iter().skip(cursor).take(limit).collect();

--- a/crates/ensemble-core/src/api/conversation.rs
+++ b/crates/ensemble-core/src/api/conversation.rs
@@ -1,0 +1,230 @@
+use crate::api::handlers::ApiError;
+use crate::api::router::AppState;
+use crate::tracker::model::sanitize_workspace_key;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+/// Query parameters for conversation pagination.
+#[derive(Debug, Default, Deserialize)]
+pub struct ConversationQuery {
+    /// Cursor-based pagination: skip messages before this 0-based index.
+    pub cursor: Option<usize>,
+    /// Maximum number of messages to return (default: 50).
+    pub limit: Option<usize>,
+}
+
+/// A single conversation message.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ConversationMessage {
+    pub index: u64,
+    pub role: String,
+    pub content: String,
+    #[serde(default)]
+    pub tool_calls: Option<serde_json::Value>,
+    #[serde(default)]
+    pub tool_output: Option<serde_json::Value>,
+}
+
+/// Response envelope for conversation queries.
+#[derive(Debug, Serialize)]
+pub struct ConversationResponse {
+    pub messages: Vec<ConversationMessage>,
+    pub total: usize,
+    pub next_cursor: Option<usize>,
+}
+
+/// GET /api/v1/{identifier}/conversation
+///
+/// Returns paginated conversation messages from the workspace's conversation.jsonl file.
+pub async fn get_conversation(
+    State(state): State<AppState>,
+    Path(identifier): Path<String>,
+    Query(query): Query<ConversationQuery>,
+) -> impl IntoResponse {
+    let workspace_key = match sanitize_workspace_key(&identifier) {
+        Some(key) => key,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::to_value(ApiError::new(
+                    "invalid_identifier",
+                    "identifier cannot be sanitized to a workspace key",
+                ))
+                .unwrap()),
+            )
+                .into_response();
+        }
+    };
+
+    let conversation_path = std::path::PathBuf::from(&state.workspace_root)
+        .join(&workspace_key)
+        .join(".ensemble")
+        .join("conversation.jsonl");
+
+    let contents = match tokio::fs::read_to_string(&conversation_path).await {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return (
+                StatusCode::OK,
+                Json(serde_json::to_value(ConversationResponse {
+                    messages: vec![],
+                    total: 0,
+                    next_cursor: None,
+                })
+                .unwrap()),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::to_value(ApiError::new(
+                        "conversation_read_error",
+                        &format!("failed to read conversation: {}", e),
+                    ))
+                    .unwrap(),
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    let all_messages: Vec<ConversationMessage> = contents
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect();
+
+    let total = all_messages.len();
+    let cursor = query.cursor.unwrap_or(0);
+    let limit = query.limit.unwrap_or(50);
+
+    let page: Vec<ConversationMessage> =
+        all_messages.into_iter().skip(cursor).take(limit).collect();
+
+    let next_cursor = if cursor + page.len() < total {
+        Some(cursor + page.len())
+    } else {
+        None
+    };
+
+    (
+        StatusCode::OK,
+        Json(
+            serde_json::to_value(ConversationResponse {
+                messages: page,
+                total,
+                next_cursor,
+            })
+            .unwrap(),
+        ),
+    )
+        .into_response()
+}
+
+/// GET /api/v1/{identifier}/conversation/{index}
+///
+/// Returns a single conversation message by its index.
+pub async fn get_conversation_message(
+    State(state): State<AppState>,
+    Path((identifier, index)): Path<(String, u64)>,
+) -> impl IntoResponse {
+    let workspace_key = match sanitize_workspace_key(&identifier) {
+        Some(key) => key,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::to_value(ApiError::new(
+                    "invalid_identifier",
+                    "identifier cannot be sanitized to a workspace key",
+                ))
+                .unwrap()),
+            )
+                .into_response();
+        }
+    };
+
+    let conversation_path = std::path::PathBuf::from(&state.workspace_root)
+        .join(&workspace_key)
+        .join(".ensemble")
+        .join("conversation.jsonl");
+
+    let contents = match tokio::fs::read_to_string(&conversation_path).await {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(
+                    serde_json::to_value(ApiError::new(
+                        "conversation_not_found",
+                        "no conversation file found for this issue",
+                    ))
+                    .unwrap(),
+                ),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::to_value(ApiError::new(
+                        "conversation_read_error",
+                        &format!("failed to read conversation: {}", e),
+                    ))
+                    .unwrap(),
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    let message = contents
+        .lines()
+        .filter_map(|line| serde_json::from_str::<ConversationMessage>(line).ok())
+        .find(|m| m.index == index);
+
+    match message {
+        Some(msg) => (StatusCode::OK, Json(serde_json::to_value(msg).unwrap())).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(
+                serde_json::to_value(ApiError::new(
+                    "message_not_found",
+                    &format!("no message at index {}", index),
+                ))
+                .unwrap(),
+            ),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_conversation_message_deserialize() {
+        let json = r#"{"index":0,"role":"user","content":"hello"}"#;
+        let msg: ConversationMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.index, 0);
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content, "hello");
+    }
+
+    #[test]
+    fn test_conversation_response_serialize() {
+        let response = ConversationResponse {
+            messages: vec![],
+            total: 0,
+            next_cursor: None,
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["total"], 0);
+        assert!(json["next_cursor"].is_null());
+    }
+}

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -125,9 +125,11 @@ pub async fn method_not_allowed() -> (StatusCode, Json<serde_json::Value>) {
 mod tests {
     use super::*;
     use crate::api::router::AppState;
+    use crate::observability::events::EventBus;
     use crate::orchestrator::state::OrchestratorState;
     use crate::tracker::model::{Issue, RetryEntry, RunningEntry};
     use chrono::Utc;
+    use std::path::PathBuf;
     use std::sync::Arc;
     use tokio::sync::RwLock;
 
@@ -199,6 +201,8 @@ mod tests {
             orchestrator_state: Arc::new(RwLock::new(state)),
             refresh_requested: Arc::new(tokio::sync::Notify::new()),
             workspace_root: "/tmp/workspaces".to_string(),
+            history_path: PathBuf::from("/tmp/history.jsonl"),
+            event_bus: EventBus::new(),
         }
     }
 
@@ -209,6 +213,8 @@ mod tests {
             orchestrator_state: Arc::new(RwLock::new(state)),
             refresh_requested: Arc::new(tokio::sync::Notify::new()),
             workspace_root: "/tmp/workspaces".to_string(),
+            history_path: PathBuf::from("/tmp/history.jsonl"),
+            event_bus: EventBus::new(),
         }
     }
 

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -1,0 +1,24 @@
+// API handlers — will be fleshed out in Task 4
+use crate::api::router::AppState;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+pub async fn get_state(State(_state): State<AppState>) -> impl IntoResponse {
+    StatusCode::NOT_IMPLEMENTED
+}
+
+pub async fn get_issue_detail(
+    State(_state): State<AppState>,
+    Path(_identifier): Path<String>,
+) -> impl IntoResponse {
+    StatusCode::NOT_IMPLEMENTED
+}
+
+pub async fn post_refresh(State(_state): State<AppState>) -> impl IntoResponse {
+    StatusCode::NOT_IMPLEMENTED
+}
+
+pub async fn method_not_allowed() -> impl IntoResponse {
+    StatusCode::METHOD_NOT_ALLOWED
+}

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -35,9 +35,7 @@ impl ApiError {
 ///
 /// Acquires a read lock on the orchestrator state, builds a RuntimeSnapshot,
 /// and returns it as JSON.
-pub async fn get_state(
-    State(state): State<AppState>,
-) -> (StatusCode, Json<RuntimeSnapshot>) {
+pub async fn get_state(State(state): State<AppState>) -> (StatusCode, Json<RuntimeSnapshot>) {
     let lock = state.orchestrator_state.read().await;
     let snapshot = build_state_snapshot(&lock);
     drop(lock);
@@ -58,11 +56,9 @@ pub async fn get_issue_detail(
     drop(lock);
 
     match detail {
-        Some(detail) => (
-            StatusCode::OK,
-            Json(serde_json::to_value(detail).unwrap()),
-        )
-            .into_response(),
+        Some(detail) => {
+            (StatusCode::OK, Json(serde_json::to_value(detail).unwrap())).into_response()
+        }
         None => {
             let error = ApiError::new(
                 "issue_not_found",
@@ -93,9 +89,7 @@ pub struct RefreshResponse {
 ///
 /// Signals the orchestrator to run an immediate tick (poll + reconcile).
 /// Returns 202 Accepted with a confirmation body.
-pub async fn post_refresh(
-    State(state): State<AppState>,
-) -> (StatusCode, Json<RefreshResponse>) {
+pub async fn post_refresh(State(state): State<AppState>) -> (StatusCode, Json<RefreshResponse>) {
     state.refresh_requested.notify_one();
 
     let response = RefreshResponse {
@@ -248,8 +242,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_issue_detail_found() {
         let app_state = build_populated_state();
-        let response =
-            get_issue_detail(State(app_state), Path("my-repo#42".to_string())).await;
+        let response = get_issue_detail(State(app_state), Path("my-repo#42".to_string())).await;
 
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::OK);
@@ -289,7 +282,10 @@ mod tests {
 
         assert!(json.get("error").is_some());
         let err = json.get("error").unwrap();
-        assert_eq!(err.get("code").unwrap().as_str().unwrap(), "issue_not_found");
+        assert_eq!(
+            err.get("code").unwrap().as_str().unwrap(),
+            "issue_not_found"
+        );
         assert_eq!(
             err.get("message").unwrap().as_str().unwrap(),
             "no such issue"
@@ -299,8 +295,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_issue_detail_retrying_issue() {
         let app_state = build_populated_state();
-        let response =
-            get_issue_detail(State(app_state), Path("my-repo#99".to_string())).await;
+        let response = get_issue_detail(State(app_state), Path("my-repo#99".to_string())).await;
 
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::OK);

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -1,24 +1,302 @@
-// API handlers — will be fleshed out in Task 4
 use crate::api::router::AppState;
+use crate::observability::snapshot::{build_issue_snapshot, build_state_snapshot, RuntimeSnapshot};
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use axum::Json;
+use chrono::Utc;
+use serde::Serialize;
 
-pub async fn get_state(State(_state): State<AppState>) -> impl IntoResponse {
-    StatusCode::NOT_IMPLEMENTED
+/// Standard JSON error envelope matching SPEC.md Section 13.7.2 error format.
+#[derive(Debug, Serialize)]
+pub struct ApiError {
+    pub error: ApiErrorDetail,
 }
 
+/// Inner detail of the error envelope.
+#[derive(Debug, Serialize)]
+pub struct ApiErrorDetail {
+    pub code: String,
+    pub message: String,
+}
+
+impl ApiError {
+    pub fn new(code: &str, message: &str) -> Self {
+        Self {
+            error: ApiErrorDetail {
+                code: code.to_string(),
+                message: message.to_string(),
+            },
+        }
+    }
+}
+
+/// GET /api/v1/state
+///
+/// Acquires a read lock on the orchestrator state, builds a RuntimeSnapshot,
+/// and returns it as JSON.
+pub async fn get_state(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<RuntimeSnapshot>) {
+    let lock = state.orchestrator_state.read().await;
+    let snapshot = build_state_snapshot(&lock);
+    drop(lock);
+
+    (StatusCode::OK, Json(snapshot))
+}
+
+/// GET /api/v1/{identifier}
+///
+/// Looks up an issue by its identifier (e.g. "my-repo#42") in running and retry maps.
+/// Returns the issue detail or 404 with a JSON error envelope.
 pub async fn get_issue_detail(
-    State(_state): State<AppState>,
-    Path(_identifier): Path<String>,
+    State(state): State<AppState>,
+    Path(identifier): Path<String>,
 ) -> impl IntoResponse {
-    StatusCode::NOT_IMPLEMENTED
+    let lock = state.orchestrator_state.read().await;
+    let detail = build_issue_snapshot(&lock, &identifier, &state.workspace_root);
+    drop(lock);
+
+    match detail {
+        Some(detail) => (
+            StatusCode::OK,
+            Json(serde_json::to_value(detail).unwrap()),
+        )
+            .into_response(),
+        None => {
+            let error = ApiError::new(
+                "issue_not_found",
+                &format!(
+                    "no running or retrying issue with identifier '{}'",
+                    identifier
+                ),
+            );
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::to_value(error).unwrap()),
+            )
+                .into_response()
+        }
+    }
 }
 
-pub async fn post_refresh(State(_state): State<AppState>) -> impl IntoResponse {
-    StatusCode::NOT_IMPLEMENTED
+/// Response body for POST /api/v1/refresh.
+#[derive(Debug, Serialize)]
+pub struct RefreshResponse {
+    pub queued: bool,
+    pub coalesced: bool,
+    pub requested_at: String,
+    pub operations: Vec<String>,
 }
 
-pub async fn method_not_allowed() -> impl IntoResponse {
-    StatusCode::METHOD_NOT_ALLOWED
+/// POST /api/v1/refresh
+///
+/// Signals the orchestrator to run an immediate tick (poll + reconcile).
+/// Returns 202 Accepted with a confirmation body.
+pub async fn post_refresh(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<RefreshResponse>) {
+    state.refresh_requested.notify_one();
+
+    let response = RefreshResponse {
+        queued: true,
+        coalesced: false,
+        requested_at: Utc::now().to_rfc3339(),
+        operations: vec!["poll".to_string(), "reconcile".to_string()],
+    };
+
+    (StatusCode::ACCEPTED, Json(response))
+}
+
+/// Handler for unsupported HTTP methods on defined routes.
+/// Returns 405 Method Not Allowed with a JSON error envelope.
+pub async fn method_not_allowed() -> (StatusCode, Json<serde_json::Value>) {
+    let error = ApiError::new(
+        "method_not_allowed",
+        "this HTTP method is not supported on this endpoint",
+    );
+    (
+        StatusCode::METHOD_NOT_ALLOWED,
+        Json(serde_json::to_value(error).unwrap()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::router::AppState;
+    use crate::orchestrator::state::OrchestratorState;
+    use crate::tracker::model::{Issue, RetryEntry, RunningEntry};
+    use chrono::Utc;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn test_issue() -> Issue {
+        Issue {
+            id: "NODE_123".to_string(),
+            identifier: "my-repo#42".to_string(),
+            title: "Fix the bug".to_string(),
+            description: Some("It is broken".to_string()),
+            priority: Some(2),
+            state: "In Progress".to_string(),
+            branch_name: None,
+            url: Some("https://github.com/acme/repo/issues/42".to_string()),
+            labels: vec!["bug".to_string()],
+            blocked_by: vec![],
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn test_running_entry() -> RunningEntry {
+        RunningEntry {
+            issue_id: "NODE_123".to_string(),
+            identifier: "my-repo#42".to_string(),
+            issue: test_issue(),
+            session_id: Some("session-abc".to_string()),
+            agent_pid: Some("12345".to_string()),
+            last_agent_event: Some("turn_completed".to_string()),
+            last_agent_timestamp: Some(Utc::now()),
+            last_agent_message: Some("Working on tests".to_string()),
+            agent_input_tokens: 1200,
+            agent_output_tokens: 800,
+            agent_total_tokens: 2000,
+            last_reported_input_tokens: 1200,
+            last_reported_output_tokens: 800,
+            last_reported_total_tokens: 2000,
+            turn_count: 7,
+            retry_attempt: None,
+            started_at: Utc::now(),
+        }
+    }
+
+    fn test_retry_entry() -> RetryEntry {
+        RetryEntry {
+            issue_id: "NODE_456".to_string(),
+            identifier: "my-repo#99".to_string(),
+            attempt: 3,
+            due_at_ms: 1711641600000,
+            error: Some("no available orchestrator slots".to_string()),
+        }
+    }
+
+    fn build_populated_state() -> AppState {
+        let mut state = OrchestratorState::new(30000, 10);
+        state
+            .running
+            .insert("NODE_123".to_string(), test_running_entry());
+        state
+            .retry_attempts
+            .insert("NODE_456".to_string(), test_retry_entry());
+        state.claimed.insert("NODE_123".to_string());
+        state.claimed.insert("NODE_456".to_string());
+        state.agent_totals.input_tokens = 5000;
+        state.agent_totals.output_tokens = 2400;
+        state.agent_totals.total_tokens = 7400;
+        state.agent_totals.seconds_running = 120.5;
+
+        AppState {
+            orchestrator_state: Arc::new(RwLock::new(state)),
+            refresh_requested: Arc::new(tokio::sync::Notify::new()),
+            workspace_root: "/tmp/workspaces".to_string(),
+        }
+    }
+
+    fn build_empty_state() -> AppState {
+        let state = OrchestratorState::new(30000, 10);
+
+        AppState {
+            orchestrator_state: Arc::new(RwLock::new(state)),
+            refresh_requested: Arc::new(tokio::sync::Notify::new()),
+            workspace_root: "/tmp/workspaces".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_state_returns_json() {
+        let app_state = build_populated_state();
+        let (status, Json(snapshot)) = get_state(State(app_state)).await;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let json = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(json["counts"]["running"], 1);
+        assert_eq!(json["counts"]["retrying"], 1);
+        assert_eq!(json["agent_totals"]["input_tokens"], 5000);
+        assert_eq!(json["agent_totals"]["output_tokens"], 2400);
+        assert_eq!(json["agent_totals"]["total_tokens"], 7400);
+    }
+
+    #[tokio::test]
+    async fn test_get_state_empty() {
+        let app_state = build_empty_state();
+        let (status, Json(snapshot)) = get_state(State(app_state)).await;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let json = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(json["counts"]["running"], 0);
+        assert_eq!(json["counts"]["retrying"], 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_issue_detail_found() {
+        let app_state = build_populated_state();
+        let response =
+            get_issue_detail(State(app_state), Path("my-repo#42".to_string())).await;
+
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_get_issue_detail_not_found() {
+        let app_state = build_populated_state();
+        let response =
+            get_issue_detail(State(app_state), Path("nonexistent#999".to_string())).await;
+
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_post_refresh_returns_202() {
+        let app_state = build_populated_state();
+        let (status, Json(body)) = post_refresh(State(app_state)).await;
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert!(body.queued);
+        assert!(!body.coalesced);
+        assert_eq!(body.operations, vec!["poll", "reconcile"]);
+    }
+
+    #[tokio::test]
+    async fn test_method_not_allowed_response() {
+        let (status, _) = method_not_allowed().await;
+        assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn test_error_envelope_json_shape() {
+        let error = ApiError::new("issue_not_found", "no such issue");
+        let json = serde_json::to_value(&error).unwrap();
+
+        assert!(json.get("error").is_some());
+        let err = json.get("error").unwrap();
+        assert_eq!(err.get("code").unwrap().as_str().unwrap(), "issue_not_found");
+        assert_eq!(
+            err.get("message").unwrap().as_str().unwrap(),
+            "no such issue"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_issue_detail_retrying_issue() {
+        let app_state = build_populated_state();
+        let response =
+            get_issue_detail(State(app_state), Path("my-repo#99".to_string())).await;
+
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }

--- a/crates/ensemble-core/src/api/history_handler.rs
+++ b/crates/ensemble-core/src/api/history_handler.rs
@@ -1,0 +1,97 @@
+use crate::api::router::AppState;
+use crate::history::reader::{read_history, HistoryQuery};
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+
+/// GET /api/v1/history
+///
+/// Returns paginated history records with optional filtering by outcome or step.
+pub async fn get_history(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> impl IntoResponse {
+    match read_history(&state.history_path, &query).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(e) => {
+            let error = crate::api::handlers::ApiError::new(
+                "history_read_error",
+                &format!("failed to read history: {}", e),
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::to_value(error).unwrap()),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::model::{HistoryRecord, TokenTotals};
+    use crate::history::writer::HistoryWriter;
+    use crate::observability::events::EventBus;
+    use crate::orchestrator::state::OrchestratorState;
+    use chrono::Utc;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn build_app_state(history_path: PathBuf) -> AppState {
+        AppState {
+            orchestrator_state: Arc::new(RwLock::new(OrchestratorState::new(30000, 10))),
+            refresh_requested: Arc::new(tokio::sync::Notify::new()),
+            workspace_root: "/tmp/workspaces".to_string(),
+            history_path,
+            event_bus: EventBus::new(),
+        }
+    }
+
+    fn sample_record(identifier: &str) -> HistoryRecord {
+        HistoryRecord {
+            issue_identifier: identifier.into(),
+            issue_id: format!("id-{}", identifier),
+            outcome: "succeeded".into(),
+            steps_traversed: vec!["build".into()],
+            attempts: 1,
+            tokens: TokenTotals {
+                input_tokens: 1000,
+                output_tokens: 500,
+                total_tokens: 1500,
+            },
+            duration_seconds: 60,
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+            last_error: None,
+            verdict: None,
+            workspace_path: format!("/tmp/{}", identifier),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_history_empty() {
+        let state = build_app_state(PathBuf::from("/tmp/nonexistent_test_history.jsonl"));
+        let response = get_history(State(state), Query(HistoryQuery::default())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_get_history_with_records() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::remove_file(&path).ok();
+
+        let writer = HistoryWriter::new(path.clone());
+        writer.append(&sample_record("MT-1")).await.unwrap();
+        writer.append(&sample_record("MT-2")).await.unwrap();
+
+        let state = build_app_state(path);
+        let response = get_history(State(state), Query(HistoryQuery::default())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/crates/ensemble-core/src/api/mod.rs
+++ b/crates/ensemble-core/src/api/mod.rs
@@ -1,0 +1,2 @@
+pub mod handlers;
+pub mod router;

--- a/crates/ensemble-core/src/api/mod.rs
+++ b/crates/ensemble-core/src/api/mod.rs
@@ -1,2 +1,5 @@
+pub mod controls;
+pub mod conversation;
 pub mod handlers;
+pub mod history_handler;
 pub mod router;

--- a/crates/ensemble-core/src/api/mod.rs
+++ b/crates/ensemble-core/src/api/mod.rs
@@ -3,3 +3,4 @@ pub mod conversation;
 pub mod handlers;
 pub mod history_handler;
 pub mod router;
+pub mod ws;

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -1,0 +1,72 @@
+use crate::api::handlers;
+use crate::orchestrator::state::OrchestratorState;
+use axum::routing::{get, post};
+use axum::Router;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Shared application state passed to all API handlers.
+#[derive(Clone)]
+pub struct AppState {
+    /// The orchestrator state, shared with the orchestrator task via RwLock.
+    pub orchestrator_state: Arc<RwLock<OrchestratorState>>,
+    /// Flag that signals the orchestrator to run an immediate tick.
+    /// The orchestrator polls this flag; setting it triggers a refresh.
+    pub refresh_requested: Arc<tokio::sync::Notify>,
+    /// The workspace root path, used for building issue detail paths.
+    pub workspace_root: String,
+}
+
+/// Create the axum router for the Ensemble HTTP API.
+///
+/// Endpoints:
+/// - `GET /api/v1/state` — runtime snapshot
+/// - `POST /api/v1/refresh` — trigger immediate poll+reconcile
+/// - `GET /api/v1/{identifier}` — issue-specific detail
+///
+/// Unsupported methods on these routes return 405.
+pub fn create_api_router(state: AppState) -> Router {
+    let api_routes = Router::new()
+        .route("/state", get(handlers::get_state))
+        .route(
+            "/refresh",
+            post(handlers::post_refresh)
+                .get(handlers::method_not_allowed)
+                .put(handlers::method_not_allowed)
+                .delete(handlers::method_not_allowed)
+                .patch(handlers::method_not_allowed),
+        )
+        .route(
+            "/{identifier}",
+            get(handlers::get_issue_detail)
+                .post(handlers::method_not_allowed)
+                .put(handlers::method_not_allowed)
+                .delete(handlers::method_not_allowed)
+                .patch(handlers::method_not_allowed),
+        );
+
+    Router::new()
+        .nest("/api/v1", api_routes)
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tracker::model::AgentTotals;
+
+    fn test_app_state() -> AppState {
+        let state = OrchestratorState::new(30000, 10);
+        AppState {
+            orchestrator_state: Arc::new(RwLock::new(state)),
+            refresh_requested: Arc::new(tokio::sync::Notify::new()),
+            workspace_root: "/tmp/workspaces".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_router_creation_does_not_panic() {
+        let state = test_app_state();
+        let _router = create_api_router(state);
+    }
+}

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -6,6 +6,7 @@ use axum::Router;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tower_http::services::{ServeDir, ServeFile};
 
 /// Shared application state passed to all API handlers.
 #[derive(Clone)]
@@ -34,9 +35,19 @@ pub struct AppState {
 /// - `GET /api/v1/{identifier}/conversation/{index}` — single conversation message
 /// - `POST /api/v1/{identifier}/stop` — stop a running agent
 /// - `POST /api/v1/{identifier}/retry` — retry a failed issue
+/// - `GET /ws/events/{identifier}` — WebSocket live event stream
 ///
-/// Unsupported methods on defined routes return 405.
+/// If `static_dir` is provided, unmatched routes serve static files from that
+/// directory with SPA fallback to `index.html`.
 pub fn create_api_router(state: AppState) -> Router {
+    create_api_router_with_static(state, None)
+}
+
+/// Create the API router with optional static file serving for the dashboard SPA.
+pub fn create_api_router_with_static(
+    state: AppState,
+    static_dir: Option<PathBuf>,
+) -> Router {
     let api_routes = Router::new()
         .route("/state", get(handlers::get_state))
         .route(
@@ -56,14 +67,8 @@ pub fn create_api_router(state: AppState) -> Router {
             "/{identifier}/conversation/{index}",
             get(conversation::get_conversation_message),
         )
-        .route(
-            "/{identifier}/stop",
-            post(controls::post_stop),
-        )
-        .route(
-            "/{identifier}/retry",
-            post(controls::post_retry),
-        )
+        .route("/{identifier}/stop", post(controls::post_stop))
+        .route("/{identifier}/retry", post(controls::post_retry))
         .route(
             "/{identifier}",
             get(handlers::get_issue_detail)
@@ -73,13 +78,17 @@ pub fn create_api_router(state: AppState) -> Router {
                 .patch(handlers::method_not_allowed),
         );
 
-    Router::new()
+    let mut router = Router::new()
         .nest("/api/v1", api_routes)
-        .route(
-            "/ws/events/{identifier}",
-            get(ws::ws_events),
-        )
-        .with_state(state)
+        .route("/ws/events/{identifier}", get(ws::ws_events))
+        .with_state(state);
+
+    if let Some(dir) = static_dir {
+        let serve = ServeDir::new(&dir).fallback(ServeFile::new(dir.join("index.html")));
+        router = router.fallback_service(serve);
+    }
+
+    router
 }
 
 #[cfg(test)]
@@ -101,5 +110,12 @@ mod tests {
     fn test_router_creation_does_not_panic() {
         let state = test_app_state();
         let _router = create_api_router(state);
+    }
+
+    #[test]
+    fn test_router_with_static_dir_does_not_panic() {
+        let state = test_app_state();
+        let _router =
+            create_api_router_with_static(state, Some(PathBuf::from("/tmp/dashboard")));
     }
 }

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -37,6 +37,10 @@ pub struct AppState {
 /// - `POST /api/v1/{identifier}/retry` — retry a failed issue
 /// - `GET /ws/events/{identifier}` — WebSocket live event stream
 ///
+/// **Security:** The API is unauthenticated. The CLI binds to `127.0.0.1` only,
+/// so access is limited to the local machine. This is appropriate for an operator
+/// dashboard; do not expose on `0.0.0.0` without adding authentication.
+///
 /// If `static_dir` is provided, unmatched routes serve static files from that
 /// directory with SPA fallback to `index.html`.
 pub fn create_api_router(state: AppState) -> Router {

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -1,7 +1,9 @@
-use crate::api::handlers;
+use crate::api::{controls, conversation, handlers, history_handler};
+use crate::observability::events::EventBus;
 use crate::orchestrator::state::OrchestratorState;
 use axum::routing::{get, post};
 use axum::Router;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -15,6 +17,10 @@ pub struct AppState {
     pub refresh_requested: Arc<tokio::sync::Notify>,
     /// The workspace root path, used for building issue detail paths.
     pub workspace_root: String,
+    /// Path to the history JSONL file.
+    pub history_path: PathBuf,
+    /// Event bus for pipeline event broadcasting.
+    pub event_bus: EventBus,
 }
 
 /// Create the axum router for the Ensemble HTTP API.
@@ -22,9 +28,14 @@ pub struct AppState {
 /// Endpoints:
 /// - `GET /api/v1/state` — runtime snapshot
 /// - `POST /api/v1/refresh` — trigger immediate poll+reconcile
+/// - `GET /api/v1/history` — query history records
 /// - `GET /api/v1/{identifier}` — issue-specific detail
+/// - `GET /api/v1/{identifier}/conversation` — paginated conversation
+/// - `GET /api/v1/{identifier}/conversation/{index}` — single conversation message
+/// - `POST /api/v1/{identifier}/stop` — stop a running agent
+/// - `POST /api/v1/{identifier}/retry` — retry a failed issue
 ///
-/// Unsupported methods on these routes return 405.
+/// Unsupported methods on defined routes return 405.
 pub fn create_api_router(state: AppState) -> Router {
     let api_routes = Router::new()
         .route("/state", get(handlers::get_state))
@@ -35,6 +46,23 @@ pub fn create_api_router(state: AppState) -> Router {
                 .put(handlers::method_not_allowed)
                 .delete(handlers::method_not_allowed)
                 .patch(handlers::method_not_allowed),
+        )
+        .route("/history", get(history_handler::get_history))
+        .route(
+            "/{identifier}/conversation",
+            get(conversation::get_conversation),
+        )
+        .route(
+            "/{identifier}/conversation/{index}",
+            get(conversation::get_conversation_message),
+        )
+        .route(
+            "/{identifier}/stop",
+            post(controls::post_stop),
+        )
+        .route(
+            "/{identifier}/retry",
+            post(controls::post_retry),
         )
         .route(
             "/{identifier}",
@@ -53,12 +81,15 @@ pub fn create_api_router(state: AppState) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     fn test_app_state() -> AppState {
         let state = OrchestratorState::new(30000, 10);
         AppState {
             orchestrator_state: Arc::new(RwLock::new(state)),
             refresh_requested: Arc::new(tokio::sync::Notify::new()),
             workspace_root: "/tmp/workspaces".to_string(),
+            history_path: PathBuf::from("/tmp/history.jsonl"),
+            event_bus: EventBus::new(),
         }
     }
 

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -1,4 +1,4 @@
-use crate::api::{controls, conversation, handlers, history_handler};
+use crate::api::{controls, conversation, handlers, history_handler, ws};
 use crate::observability::events::EventBus;
 use crate::orchestrator::state::OrchestratorState;
 use axum::routing::{get, post};
@@ -75,6 +75,10 @@ pub fn create_api_router(state: AppState) -> Router {
 
     Router::new()
         .nest("/api/v1", api_routes)
+        .route(
+            "/ws/events/{identifier}",
+            get(ws::ws_events),
+        )
         .with_state(state)
 }
 

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -53,8 +53,6 @@ pub fn create_api_router(state: AppState) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tracker::model::AgentTotals;
-
     fn test_app_state() -> AppState {
         let state = OrchestratorState::new(30000, 10);
         AppState {

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -1,8 +1,10 @@
 use crate::api::{controls, conversation, handlers, history_handler, ws};
 use crate::observability::events::EventBus;
 use crate::orchestrator::state::OrchestratorState;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use axum::routing::{get, post};
-use axum::Router;
+use axum::{Json, Router};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -41,14 +43,17 @@ pub struct AppState {
 /// so access is limited to the local machine. This is appropriate for an operator
 /// dashboard; do not expose on `0.0.0.0` without adding authentication.
 ///
-/// If `static_dir` is provided, unmatched routes serve static files from that
-/// directory with SPA fallback to `index.html`.
+/// If `static_dir` is provided, unmatched non-API, non-WS routes serve static
+/// files from that directory with SPA fallback to `index.html`. API and WS
+/// routes have their own 404 fallbacks so they never leak `index.html`.
 pub fn create_api_router(state: AppState) -> Router {
     create_api_router_with_static(state, None)
 }
 
 /// Create the API router with optional static file serving for the dashboard SPA.
 pub fn create_api_router_with_static(state: AppState, static_dir: Option<PathBuf>) -> Router {
+    // API routes get a JSON 404 fallback so unmatched /api/v1/* paths never
+    // fall through to the static file handler.
     let api_routes = Router::new()
         .route("/state", get(handlers::get_state))
         .route(
@@ -77,7 +82,8 @@ pub fn create_api_router_with_static(state: AppState, static_dir: Option<PathBuf
                 .put(handlers::method_not_allowed)
                 .delete(handlers::method_not_allowed)
                 .patch(handlers::method_not_allowed),
-        );
+        )
+        .fallback(api_not_found);
 
     let mut router = Router::new()
         .nest("/api/v1", api_routes)
@@ -90,6 +96,16 @@ pub fn create_api_router_with_static(state: AppState, static_dir: Option<PathBuf
     }
 
     router
+}
+
+/// Fallback handler for unmatched API routes. Returns a JSON 404 instead of
+/// falling through to the static file handler.
+async fn api_not_found() -> impl IntoResponse {
+    let error = handlers::ApiError::new("not_found", "API endpoint not found");
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::to_value(error).unwrap()),
+    )
 }
 
 #[cfg(test)]

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -39,9 +39,10 @@ pub struct AppState {
 /// - `POST /api/v1/{identifier}/retry` — retry a failed issue
 /// - `GET /ws/events/{identifier}` — WebSocket live event stream
 ///
-/// **Security:** The API is unauthenticated. The CLI binds to `127.0.0.1` only,
-/// so access is limited to the local machine. This is appropriate for an operator
-/// dashboard; do not expose on `0.0.0.0` without adding authentication.
+/// **Security:** The API is unauthenticated. The CLI binds to `127.0.0.1` by
+/// default, but callers can override the listen address via `--host` / `HOST`.
+/// Binding to a non-loopback address exposes this unauthenticated API to the
+/// network — only do so in trusted environments or behind a reverse proxy.
 ///
 /// If `static_dir` is provided, unmatched non-API, non-WS routes serve static
 /// files from that directory with SPA fallback to `index.html`. API and WS

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -44,10 +44,7 @@ pub fn create_api_router(state: AppState) -> Router {
 }
 
 /// Create the API router with optional static file serving for the dashboard SPA.
-pub fn create_api_router_with_static(
-    state: AppState,
-    static_dir: Option<PathBuf>,
-) -> Router {
+pub fn create_api_router_with_static(state: AppState, static_dir: Option<PathBuf>) -> Router {
     let api_routes = Router::new()
         .route("/state", get(handlers::get_state))
         .route(
@@ -115,7 +112,6 @@ mod tests {
     #[test]
     fn test_router_with_static_dir_does_not_panic() {
         let state = test_app_state();
-        let _router =
-            create_api_router_with_static(state, Some(PathBuf::from("/tmp/dashboard")));
+        let _router = create_api_router_with_static(state, Some(PathBuf::from("/tmp/dashboard")));
     }
 }

--- a/crates/ensemble-core/src/api/ws.rs
+++ b/crates/ensemble-core/src/api/ws.rs
@@ -1,0 +1,124 @@
+use crate::api::router::AppState;
+use crate::observability::events::PipelineEvent;
+use crate::observability::snapshot::build_issue_snapshot;
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::{Path, State, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use futures_util::stream::StreamExt;
+use futures_util::SinkExt;
+use tracing::{debug, warn};
+
+/// GET /ws/events/{identifier}
+///
+/// WebSocket upgrade handler for streaming live events for a specific issue.
+/// On connect: sends the current issue detail snapshot.
+/// Then streams matching PipelineEvents from the event bus.
+/// Closes on PipelineEvent::Complete or client disconnect.
+pub async fn ws_events(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    Path(identifier): Path<String>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_ws(socket, state, identifier))
+}
+
+async fn handle_ws(socket: WebSocket, state: AppState, identifier: String) {
+    let (mut sender, mut receiver) = socket.split();
+
+    // 1. Send initial snapshot on connect
+    {
+        let lock = state.orchestrator_state.read().await;
+        let snapshot = build_issue_snapshot(&lock, &identifier, &state.workspace_root);
+        drop(lock);
+
+        let initial_msg = serde_json::json!({
+            "type": "snapshot",
+            "data": snapshot,
+        });
+
+        if sender
+            .send(Message::Text(serde_json::to_string(&initial_msg).unwrap().into()))
+            .await
+            .is_err()
+        {
+            return; // Client disconnected
+        }
+    }
+
+    // 2. Subscribe to event bus
+    let mut rx = state.event_bus.subscribe();
+
+    // 3. Stream events, filtering by identifier
+    loop {
+        tokio::select! {
+            // Event from bus
+            event = rx.recv() => {
+                match event {
+                    Ok(event) if event.issue_identifier() == identifier => {
+                        let is_complete = matches!(event, PipelineEvent::Complete { .. });
+
+                        let msg = serde_json::json!({
+                            "type": "event",
+                            "data": event,
+                        });
+
+                        if sender
+                            .send(Message::Text(serde_json::to_string(&msg).unwrap().into()))
+                            .await
+                            .is_err()
+                        {
+                            debug!(identifier = %identifier, "WebSocket client disconnected");
+                            break;
+                        }
+
+                        if is_complete {
+                            debug!(identifier = %identifier, "pipeline complete, closing WebSocket");
+                            let _ = sender.send(Message::Close(None)).await;
+                            break;
+                        }
+                    }
+                    Ok(_) => {
+                        // Event for a different issue, skip
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(identifier = %identifier, lagged = n, "WebSocket subscriber lagged");
+                        // Continue receiving — some events were lost but that's acceptable
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        debug!(identifier = %identifier, "event bus closed, closing WebSocket");
+                        break;
+                    }
+                }
+            }
+            // Client message (ping/pong handled by axum, but we watch for close)
+            msg = receiver.next() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) | None => {
+                        debug!(identifier = %identifier, "WebSocket client closed connection");
+                        break;
+                    }
+                    Some(Err(_)) => {
+                        debug!(identifier = %identifier, "WebSocket error, closing");
+                        break;
+                    }
+                    _ => {
+                        // Ignore other client messages (text, binary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // WebSocket integration tests require a full server setup.
+    // Core logic is covered by the event bus tests and snapshot tests.
+    // Full WS integration testing is deferred to Plan 5's integration test suite.
+
+    #[test]
+    fn ws_handler_module_compiles() {
+        // This test exists to verify the ws module compiles correctly
+        // with all its dependencies.
+    }
+}

--- a/crates/ensemble-core/src/api/ws.rs
+++ b/crates/ensemble-core/src/api/ws.rs
@@ -37,7 +37,9 @@ async fn handle_ws(socket: WebSocket, state: AppState, identifier: String) {
         });
 
         if sender
-            .send(Message::Text(serde_json::to_string(&initial_msg).unwrap().into()))
+            .send(Message::Text(
+                serde_json::to_string(&initial_msg).unwrap().into(),
+            ))
             .await
             .is_err()
         {

--- a/crates/ensemble-core/src/history/mod.rs
+++ b/crates/ensemble-core/src/history/mod.rs
@@ -1,0 +1,3 @@
+pub mod model;
+pub mod reader;
+pub mod writer;

--- a/crates/ensemble-core/src/history/model.rs
+++ b/crates/ensemble-core/src/history/model.rs
@@ -1,0 +1,25 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HistoryRecord {
+    pub issue_identifier: String,
+    pub issue_id: String,
+    pub outcome: String,
+    pub steps_traversed: Vec<String>,
+    pub attempts: u32,
+    pub tokens: TokenTotals,
+    pub duration_seconds: u64,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: DateTime<Utc>,
+    pub last_error: Option<String>,
+    pub verdict: Option<String>,
+    pub workspace_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TokenTotals {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+}

--- a/crates/ensemble-core/src/history/reader.rs
+++ b/crates/ensemble-core/src/history/reader.rs
@@ -70,7 +70,7 @@ pub async fn read_history(
 
     let total = filtered.len();
     let cursor = query.cursor.unwrap_or(0);
-    let limit = query.limit.unwrap_or(50);
+    let limit = query.limit.unwrap_or(50).min(200);
 
     let page: Vec<HistoryRecord> = filtered.into_iter().skip(cursor).take(limit).collect();
 

--- a/crates/ensemble-core/src/history/reader.rs
+++ b/crates/ensemble-core/src/history/reader.rs
@@ -1,1 +1,236 @@
-// History reader — will be fleshed out in Task 9
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::model::HistoryRecord;
+
+/// Query parameters for filtering and paginating history records.
+#[derive(Debug, Default, Deserialize)]
+pub struct HistoryQuery {
+    /// Filter to records with this outcome (e.g. "succeeded", "failed").
+    pub outcome: Option<String>,
+    /// Filter to records that traversed a specific step name.
+    pub step: Option<String>,
+    /// Cursor-based pagination: skip records before this 0-based index.
+    pub cursor: Option<usize>,
+    /// Maximum number of records to return (default: 50).
+    pub limit: Option<usize>,
+}
+
+/// Response envelope for history queries.
+#[derive(Debug, Serialize)]
+pub struct HistoryResponse {
+    pub records: Vec<HistoryRecord>,
+    pub total: usize,
+    pub next_cursor: Option<usize>,
+}
+
+/// Read history records from a JSONL file with optional filtering and pagination.
+///
+/// Returns an empty response if the file does not exist.
+/// Malformed lines are silently skipped.
+pub async fn read_history(
+    path: &Path,
+    query: &HistoryQuery,
+) -> Result<HistoryResponse, std::io::Error> {
+    let contents = match tokio::fs::read_to_string(path).await {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(HistoryResponse {
+                records: vec![],
+                total: 0,
+                next_cursor: None,
+            });
+        }
+        Err(e) => return Err(e),
+    };
+
+    let all_records: Vec<HistoryRecord> = contents
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect();
+
+    // Apply filters
+    let filtered: Vec<HistoryRecord> = all_records
+        .into_iter()
+        .filter(|r| {
+            if let Some(ref outcome) = query.outcome {
+                if r.outcome != *outcome {
+                    return false;
+                }
+            }
+            if let Some(ref step) = query.step {
+                if !r.steps_traversed.contains(step) {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect();
+
+    let total = filtered.len();
+    let cursor = query.cursor.unwrap_or(0);
+    let limit = query.limit.unwrap_or(50);
+
+    let page: Vec<HistoryRecord> = filtered.into_iter().skip(cursor).take(limit).collect();
+
+    let next_cursor = if cursor + page.len() < total {
+        Some(cursor + page.len())
+    } else {
+        None
+    };
+
+    Ok(HistoryResponse {
+        records: page,
+        total,
+        next_cursor,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::model::TokenTotals;
+    use crate::history::writer::HistoryWriter;
+    use chrono::Utc;
+    use tempfile::NamedTempFile;
+
+    fn sample_record(identifier: &str, outcome: &str, steps: &[&str]) -> HistoryRecord {
+        HistoryRecord {
+            issue_identifier: identifier.into(),
+            issue_id: format!("id-{}", identifier),
+            outcome: outcome.into(),
+            steps_traversed: steps.iter().map(|s| s.to_string()).collect(),
+            attempts: 1,
+            tokens: TokenTotals {
+                input_tokens: 1000,
+                output_tokens: 500,
+                total_tokens: 1500,
+            },
+            duration_seconds: 60,
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+            last_error: None,
+            verdict: None,
+            workspace_path: format!("/tmp/{}", identifier),
+        }
+    }
+
+    async fn write_test_records(path: &std::path::Path) {
+        let writer = HistoryWriter::new(path.to_path_buf());
+        writer
+            .append(&sample_record("MT-1", "succeeded", &["build", "review"]))
+            .await
+            .unwrap();
+        writer
+            .append(&sample_record("MT-2", "failed", &["build"]))
+            .await
+            .unwrap();
+        writer
+            .append(&sample_record("MT-3", "succeeded", &["build", "review"]))
+            .await
+            .unwrap();
+        writer
+            .append(&sample_record("MT-4", "failed", &["build", "review"]))
+            .await
+            .unwrap();
+        writer
+            .append(&sample_record("MT-5", "succeeded", &["build"]))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn read_all() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::remove_file(&path).ok();
+        write_test_records(&path).await;
+
+        let response = read_history(&path, &HistoryQuery::default()).await.unwrap();
+        assert_eq!(response.total, 5);
+        assert_eq!(response.records.len(), 5);
+        assert!(response.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn filter_by_outcome() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::remove_file(&path).ok();
+        write_test_records(&path).await;
+
+        let query = HistoryQuery {
+            outcome: Some("succeeded".into()),
+            ..Default::default()
+        };
+        let response = read_history(&path, &query).await.unwrap();
+        assert_eq!(response.total, 3);
+        assert!(response.records.iter().all(|r| r.outcome == "succeeded"));
+    }
+
+    #[tokio::test]
+    async fn filter_by_step() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::remove_file(&path).ok();
+        write_test_records(&path).await;
+
+        let query = HistoryQuery {
+            step: Some("review".into()),
+            ..Default::default()
+        };
+        let response = read_history(&path, &query).await.unwrap();
+        assert_eq!(response.total, 3);
+        assert!(response
+            .records
+            .iter()
+            .all(|r| r.steps_traversed.contains(&"review".to_string())));
+    }
+
+    #[tokio::test]
+    async fn pagination() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::remove_file(&path).ok();
+        write_test_records(&path).await;
+
+        let query = HistoryQuery {
+            limit: Some(2),
+            ..Default::default()
+        };
+        let response = read_history(&path, &query).await.unwrap();
+        assert_eq!(response.total, 5);
+        assert_eq!(response.records.len(), 2);
+        assert_eq!(response.next_cursor, Some(2));
+
+        // Fetch next page
+        let query2 = HistoryQuery {
+            cursor: Some(2),
+            limit: Some(2),
+            ..Default::default()
+        };
+        let response2 = read_history(&path, &query2).await.unwrap();
+        assert_eq!(response2.records.len(), 2);
+        assert_eq!(response2.next_cursor, Some(4));
+
+        // Last page
+        let query3 = HistoryQuery {
+            cursor: Some(4),
+            limit: Some(2),
+            ..Default::default()
+        };
+        let response3 = read_history(&path, &query3).await.unwrap();
+        assert_eq!(response3.records.len(), 1);
+        assert!(response3.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn missing_file_returns_empty() {
+        let path = std::path::PathBuf::from("/tmp/nonexistent_history_file.jsonl");
+        let response = read_history(&path, &HistoryQuery::default()).await.unwrap();
+        assert_eq!(response.total, 0);
+        assert!(response.records.is_empty());
+        assert!(response.next_cursor.is_none());
+    }
+}

--- a/crates/ensemble-core/src/history/reader.rs
+++ b/crates/ensemble-core/src/history/reader.rs
@@ -1,0 +1,1 @@
+// History reader — will be fleshed out in Task 9

--- a/crates/ensemble-core/src/history/writer.rs
+++ b/crates/ensemble-core/src/history/writer.rs
@@ -1,0 +1,93 @@
+use std::path::{Path, PathBuf};
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+
+use super::model::HistoryRecord;
+
+#[derive(Debug, Clone)]
+pub struct HistoryWriter {
+    path: PathBuf,
+}
+
+impl HistoryWriter {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub async fn append(&self, record: &HistoryRecord) -> Result<(), std::io::Error> {
+        let mut line = serde_json::to_string(record)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        line.push('\n');
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .await?;
+
+        file.write_all(line.as_bytes()).await?;
+        file.flush().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::model::TokenTotals;
+    use chrono::Utc;
+    use tempfile::NamedTempFile;
+
+    fn sample_record() -> HistoryRecord {
+        HistoryRecord {
+            issue_identifier: "MT-648".into(),
+            issue_id: "abc123".into(),
+            outcome: "succeeded".into(),
+            steps_traversed: vec!["build".into(), "review".into()],
+            attempts: 1,
+            tokens: TokenTotals {
+                input_tokens: 180_000,
+                output_tokens: 104_000,
+                total_tokens: 284_000,
+            },
+            duration_seconds: 765,
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+            last_error: None,
+            verdict: Some("approved".into()),
+            workspace_path: "/tmp/ensemble_workspaces/MT-648".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn append_creates_file_and_writes_line() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::remove_file(&path).ok();
+        let writer = HistoryWriter::new(path.clone());
+        writer.append(&sample_record()).await.unwrap();
+        let contents = tokio::fs::read_to_string(&path).await.unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 1);
+        let parsed: HistoryRecord = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(parsed.issue_identifier, "MT-648");
+    }
+
+    #[tokio::test]
+    async fn append_multiple_records() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::remove_file(&path).ok();
+        let writer = HistoryWriter::new(path.clone());
+        writer.append(&sample_record()).await.unwrap();
+        let mut r2 = sample_record();
+        r2.issue_identifier = "MT-649".into();
+        writer.append(&r2).await.unwrap();
+        let contents = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(contents.lines().count(), 2);
+    }
+}

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod api;
 pub mod config;
 pub mod error;
 pub mod observability;

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod config;
 pub mod error;
+pub mod observability;
 pub mod orchestrator;
 pub mod pipeline;
 pub mod tracker;

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod api;
 pub mod config;
 pub mod error;
+pub mod history;
 pub mod observability;
 pub mod orchestrator;
 pub mod pipeline;

--- a/crates/ensemble-core/src/observability/events.rs
+++ b/crates/ensemble-core/src/observability/events.rs
@@ -1,0 +1,176 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tokio::sync::broadcast;
+
+/// A lightweight event emitted by the orchestrator at pipeline boundaries.
+/// These are broadcast to WebSocket subscribers and used for the event timeline.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event_type", rename_all = "snake_case")]
+pub enum PipelineEvent {
+    SessionStarted {
+        issue_identifier: String,
+        timestamp: DateTime<Utc>,
+        detail: String,
+    },
+    StepStarted {
+        issue_identifier: String,
+        timestamp: DateTime<Utc>,
+        step_name: String,
+        agent_name: String,
+        detail: String,
+    },
+    StepCompleted {
+        issue_identifier: String,
+        timestamp: DateTime<Utc>,
+        step_name: String,
+        verdict: Option<String>,
+        detail: String,
+    },
+    TurnCompleted {
+        issue_identifier: String,
+        timestamp: DateTime<Utc>,
+        turn: u32,
+        detail: String,
+        conversation_index: Option<u64>,
+        tokens_delta: TokensDelta,
+    },
+    ToolCall {
+        issue_identifier: String,
+        timestamp: DateTime<Utc>,
+        tool_name: String,
+        detail: String,
+    },
+    Error {
+        issue_identifier: String,
+        timestamp: DateTime<Utc>,
+        detail: String,
+    },
+    RetryScheduled {
+        issue_identifier: String,
+        timestamp: DateTime<Utc>,
+        attempt: u32,
+        detail: String,
+    },
+    Complete {
+        issue_identifier: String,
+        timestamp: DateTime<Utc>,
+        outcome: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TokensDelta {
+    pub input: u64,
+    pub output: u64,
+}
+
+impl PipelineEvent {
+    pub fn issue_identifier(&self) -> &str {
+        match self {
+            Self::SessionStarted {
+                issue_identifier, ..
+            }
+            | Self::StepStarted {
+                issue_identifier, ..
+            }
+            | Self::StepCompleted {
+                issue_identifier, ..
+            }
+            | Self::TurnCompleted {
+                issue_identifier, ..
+            }
+            | Self::ToolCall {
+                issue_identifier, ..
+            }
+            | Self::Error {
+                issue_identifier, ..
+            }
+            | Self::RetryScheduled {
+                issue_identifier, ..
+            }
+            | Self::Complete {
+                issue_identifier, ..
+            } => issue_identifier,
+        }
+    }
+
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        match self {
+            Self::SessionStarted { timestamp, .. }
+            | Self::StepStarted { timestamp, .. }
+            | Self::StepCompleted { timestamp, .. }
+            | Self::TurnCompleted { timestamp, .. }
+            | Self::ToolCall { timestamp, .. }
+            | Self::Error { timestamp, .. }
+            | Self::RetryScheduled { timestamp, .. }
+            | Self::Complete { timestamp, .. } => *timestamp,
+        }
+    }
+}
+
+const EVENT_BUS_CAPACITY: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub struct EventBus {
+    sender: broadcast::Sender<PipelineEvent>,
+}
+
+impl EventBus {
+    pub fn new() -> Self {
+        let (sender, _) = broadcast::channel(EVENT_BUS_CAPACITY);
+        Self { sender }
+    }
+
+    pub fn publish(&self, event: PipelineEvent) {
+        let _ = self.sender.send(event);
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<PipelineEvent> {
+        self.sender.subscribe()
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn publish_and_receive() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        bus.publish(PipelineEvent::SessionStarted {
+            issue_identifier: "MT-1".into(),
+            timestamp: Utc::now(),
+            detail: "test".into(),
+        });
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.issue_identifier(), "MT-1");
+    }
+
+    #[tokio::test]
+    async fn publish_with_no_subscribers_does_not_panic() {
+        let bus = EventBus::new();
+        bus.publish(PipelineEvent::Complete {
+            issue_identifier: "MT-2".into(),
+            timestamp: Utc::now(),
+            outcome: "succeeded".into(),
+        });
+    }
+
+    #[test]
+    fn issue_identifier_extraction() {
+        let event = PipelineEvent::ToolCall {
+            issue_identifier: "MT-99".into(),
+            timestamp: Utc::now(),
+            tool_name: "bash".into(),
+            detail: "ls".into(),
+        };
+        assert_eq!(event.issue_identifier(), "MT-99");
+    }
+}

--- a/crates/ensemble-core/src/observability/logging.rs
+++ b/crates/ensemble-core/src/observability/logging.rs
@@ -85,97 +85,84 @@ fn should_use_json() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serialize tests that mutate logging-related env vars.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn lock(vars: &[&'static str]) -> Self {
+            let guard = ENV_LOCK.lock().unwrap();
+            let saved: Vec<_> = vars.iter().map(|&k| (k, std::env::var(k).ok())).collect();
+            for &k in vars {
+                std::env::remove_var(k);
+            }
+            Self {
+                _guard: guard,
+                saved,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.saved {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    const LOG_VARS: &[&str] = &["ENSEMBLE_LOG", "RUST_LOG", "ENSEMBLE_LOG_FORMAT"];
 
     #[test]
     fn test_build_env_filter_default() {
-        // When neither ENSEMBLE_LOG nor RUST_LOG is set, default to info
-        let saved_ensemble = std::env::var("ENSEMBLE_LOG").ok();
-        let saved_rust = std::env::var("RUST_LOG").ok();
-        std::env::remove_var("ENSEMBLE_LOG");
-        std::env::remove_var("RUST_LOG");
-
+        let _env = EnvGuard::lock(LOG_VARS);
         let filter = build_env_filter();
         let _ = format!("{:?}", filter);
-
-        if let Some(val) = saved_ensemble {
-            std::env::set_var("ENSEMBLE_LOG", val);
-        }
-        if let Some(val) = saved_rust {
-            std::env::set_var("RUST_LOG", val);
-        }
     }
 
     #[test]
     fn test_build_env_filter_from_ensemble_log() {
-        let saved = std::env::var("ENSEMBLE_LOG").ok();
+        let _env = EnvGuard::lock(LOG_VARS);
         std::env::set_var("ENSEMBLE_LOG", "debug");
-
         let filter = build_env_filter();
         let _ = format!("{:?}", filter);
-
-        if let Some(val) = saved {
-            std::env::set_var("ENSEMBLE_LOG", val);
-        } else {
-            std::env::remove_var("ENSEMBLE_LOG");
-        }
     }
 
     #[test]
     fn test_build_env_filter_invalid_falls_back() {
-        let saved = std::env::var("ENSEMBLE_LOG").ok();
+        let _env = EnvGuard::lock(LOG_VARS);
         std::env::set_var("ENSEMBLE_LOG", "not a valid filter {{{}}}");
-
         let filter = build_env_filter();
-        // Should fall back to "info" without panicking
         let _ = format!("{:?}", filter);
-
-        if let Some(val) = saved {
-            std::env::set_var("ENSEMBLE_LOG", val);
-        } else {
-            std::env::remove_var("ENSEMBLE_LOG");
-        }
     }
 
     #[test]
     fn test_should_use_json_with_env_var() {
-        let saved = std::env::var("ENSEMBLE_LOG_FORMAT").ok();
+        let _env = EnvGuard::lock(LOG_VARS);
         std::env::set_var("ENSEMBLE_LOG_FORMAT", "json");
-
         assert!(should_use_json());
-
-        if let Some(val) = saved {
-            std::env::set_var("ENSEMBLE_LOG_FORMAT", val);
-        } else {
-            std::env::remove_var("ENSEMBLE_LOG_FORMAT");
-        }
     }
 
     #[test]
     fn test_should_use_json_case_insensitive() {
-        let saved = std::env::var("ENSEMBLE_LOG_FORMAT").ok();
+        let _env = EnvGuard::lock(LOG_VARS);
         std::env::set_var("ENSEMBLE_LOG_FORMAT", "JSON");
-
         assert!(should_use_json());
-
-        if let Some(val) = saved {
-            std::env::set_var("ENSEMBLE_LOG_FORMAT", val);
-        } else {
-            std::env::remove_var("ENSEMBLE_LOG_FORMAT");
-        }
     }
 
     #[test]
     fn test_should_not_use_json_with_text_format() {
-        let saved = std::env::var("ENSEMBLE_LOG_FORMAT").ok();
+        let _env = EnvGuard::lock(LOG_VARS);
         std::env::set_var("ENSEMBLE_LOG_FORMAT", "text");
-
-        // When format is not "json", terminal detection applies.
         let _ = should_use_json();
-
-        if let Some(val) = saved {
-            std::env::set_var("ENSEMBLE_LOG_FORMAT", val);
-        } else {
-            std::env::remove_var("ENSEMBLE_LOG_FORMAT");
-        }
     }
 }

--- a/crates/ensemble-core/src/observability/logging.rs
+++ b/crates/ensemble-core/src/observability/logging.rs
@@ -1,1 +1,181 @@
-// Logging setup — will be fleshed out in Task 2
+use tracing_subscriber::fmt;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
+
+/// Initialize structured logging for the Ensemble service.
+///
+/// Format selection:
+/// - JSON when `ENSEMBLE_LOG_FORMAT=json` or stdout is not a terminal
+/// - Human-readable (pretty) when stdout is a terminal
+///
+/// Filter selection (precedence order):
+/// 1. `ENSEMBLE_LOG` env var
+/// 2. `RUST_LOG` env var
+/// 3. Default: `info`
+///
+/// Key span fields used throughout the codebase:
+/// - `issue_id`, `issue_identifier` (per-issue spans)
+/// - `session_id` (per-session spans)
+/// - `hook` (hook execution spans)
+pub fn init_logging() {
+    let filter = build_env_filter();
+    let use_json = should_use_json();
+
+    if use_json {
+        let fmt_layer = fmt::layer()
+            .json()
+            .with_target(true)
+            .with_thread_ids(false)
+            .with_span_list(true);
+
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer)
+            .init();
+    } else {
+        let fmt_layer = fmt::layer()
+            .with_target(true)
+            .with_thread_ids(false)
+            .with_ansi(true);
+
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer)
+            .init();
+    }
+}
+
+/// Build an EnvFilter using ENSEMBLE_LOG, RUST_LOG, or the default "info" level.
+fn build_env_filter() -> EnvFilter {
+    if let Ok(ensemble_log) = std::env::var("ENSEMBLE_LOG") {
+        EnvFilter::try_new(&ensemble_log).unwrap_or_else(|_| {
+            eprintln!(
+                "warning: invalid ENSEMBLE_LOG filter '{}', falling back to 'info'",
+                ensemble_log
+            );
+            EnvFilter::new("info")
+        })
+    } else if let Ok(rust_log) = std::env::var("RUST_LOG") {
+        EnvFilter::try_new(&rust_log).unwrap_or_else(|_| {
+            eprintln!(
+                "warning: invalid RUST_LOG filter '{}', falling back to 'info'",
+                rust_log
+            );
+            EnvFilter::new("info")
+        })
+    } else {
+        EnvFilter::new("info")
+    }
+}
+
+/// Determine whether to use JSON output format.
+///
+/// Returns true if:
+/// - `ENSEMBLE_LOG_FORMAT=json` is set, OR
+/// - stdout is not a terminal (piped/redirected)
+fn should_use_json() -> bool {
+    if let Ok(format) = std::env::var("ENSEMBLE_LOG_FORMAT") {
+        if format.eq_ignore_ascii_case("json") {
+            return true;
+        }
+    }
+    !std::io::IsTerminal::is_terminal(&std::io::stdout())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_env_filter_default() {
+        // When neither ENSEMBLE_LOG nor RUST_LOG is set, default to info
+        let saved_ensemble = std::env::var("ENSEMBLE_LOG").ok();
+        let saved_rust = std::env::var("RUST_LOG").ok();
+        std::env::remove_var("ENSEMBLE_LOG");
+        std::env::remove_var("RUST_LOG");
+
+        let filter = build_env_filter();
+        let _ = format!("{:?}", filter);
+
+        if let Some(val) = saved_ensemble {
+            std::env::set_var("ENSEMBLE_LOG", val);
+        }
+        if let Some(val) = saved_rust {
+            std::env::set_var("RUST_LOG", val);
+        }
+    }
+
+    #[test]
+    fn test_build_env_filter_from_ensemble_log() {
+        let saved = std::env::var("ENSEMBLE_LOG").ok();
+        std::env::set_var("ENSEMBLE_LOG", "debug");
+
+        let filter = build_env_filter();
+        let _ = format!("{:?}", filter);
+
+        if let Some(val) = saved {
+            std::env::set_var("ENSEMBLE_LOG", val);
+        } else {
+            std::env::remove_var("ENSEMBLE_LOG");
+        }
+    }
+
+    #[test]
+    fn test_build_env_filter_invalid_falls_back() {
+        let saved = std::env::var("ENSEMBLE_LOG").ok();
+        std::env::set_var("ENSEMBLE_LOG", "not a valid filter {{{}}}");
+
+        let filter = build_env_filter();
+        // Should fall back to "info" without panicking
+        let _ = format!("{:?}", filter);
+
+        if let Some(val) = saved {
+            std::env::set_var("ENSEMBLE_LOG", val);
+        } else {
+            std::env::remove_var("ENSEMBLE_LOG");
+        }
+    }
+
+    #[test]
+    fn test_should_use_json_with_env_var() {
+        let saved = std::env::var("ENSEMBLE_LOG_FORMAT").ok();
+        std::env::set_var("ENSEMBLE_LOG_FORMAT", "json");
+
+        assert!(should_use_json());
+
+        if let Some(val) = saved {
+            std::env::set_var("ENSEMBLE_LOG_FORMAT", val);
+        } else {
+            std::env::remove_var("ENSEMBLE_LOG_FORMAT");
+        }
+    }
+
+    #[test]
+    fn test_should_use_json_case_insensitive() {
+        let saved = std::env::var("ENSEMBLE_LOG_FORMAT").ok();
+        std::env::set_var("ENSEMBLE_LOG_FORMAT", "JSON");
+
+        assert!(should_use_json());
+
+        if let Some(val) = saved {
+            std::env::set_var("ENSEMBLE_LOG_FORMAT", val);
+        } else {
+            std::env::remove_var("ENSEMBLE_LOG_FORMAT");
+        }
+    }
+
+    #[test]
+    fn test_should_not_use_json_with_text_format() {
+        let saved = std::env::var("ENSEMBLE_LOG_FORMAT").ok();
+        std::env::set_var("ENSEMBLE_LOG_FORMAT", "text");
+
+        // When format is not "json", terminal detection applies.
+        let _ = should_use_json();
+
+        if let Some(val) = saved {
+            std::env::set_var("ENSEMBLE_LOG_FORMAT", val);
+        } else {
+            std::env::remove_var("ENSEMBLE_LOG_FORMAT");
+        }
+    }
+}

--- a/crates/ensemble-core/src/observability/logging.rs
+++ b/crates/ensemble-core/src/observability/logging.rs
@@ -1,0 +1,1 @@
+// Logging setup — will be fleshed out in Task 2

--- a/crates/ensemble-core/src/observability/mod.rs
+++ b/crates/ensemble-core/src/observability/mod.rs
@@ -1,0 +1,2 @@
+pub mod logging;
+pub mod snapshot;

--- a/crates/ensemble-core/src/observability/mod.rs
+++ b/crates/ensemble-core/src/observability/mod.rs
@@ -1,2 +1,3 @@
+pub mod events;
 pub mod logging;
 pub mod snapshot;

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -70,9 +70,7 @@ pub struct AgentTotalsSnapshot {
 ///
 /// NOTE: Plan 5 (Dashboard) expects additional fields `logs` and `recent_events`
 /// in the API response. When implementing the dashboard integration, extend this
-/// struct with:
-///   - `logs: IssueLogInfo` (containing `agent_session_logs: Vec<AgentSessionLog>`)
-///   - `recent_events: Vec<RecentEvent>`
+/// struct with `logs` and `recent_events` fields.
 /// These are omitted here because Plan 4 does not yet have the event/log collection
 /// infrastructure, but the JSON shape should be forward-compatible.
 #[derive(Debug, Serialize)]
@@ -206,10 +204,8 @@ pub fn build_issue_snapshot(
 
     let current_retry_attempt = if let Some(entry) = running_entry {
         entry.retry_attempt
-    } else if let Some(entry) = retry_entry {
-        Some(entry.attempt)
     } else {
-        None
+        retry_entry.map(|entry| entry.attempt)
     };
 
     let restart_count = current_retry_attempt.unwrap_or(0);

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -312,8 +312,6 @@ mod tests {
     use crate::orchestrator::state::OrchestratorState;
     use crate::tracker::model::{AgentTotals, Issue, RetryEntry, RunningEntry};
     use chrono::Utc;
-    use std::collections::HashMap;
-
     fn test_issue() -> Issue {
         Issue {
             id: "NODE_123".to_string(),

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -170,10 +170,7 @@ pub fn build_issue_snapshot(
     workspace_root: &str,
 ) -> Option<IssueDetailSnapshot> {
     // Check running entries first
-    let running_entry = state
-        .running
-        .values()
-        .find(|e| e.identifier == identifier);
+    let running_entry = state.running.values().find(|e| e.identifier == identifier);
 
     // Check retry entries
     let retry_entry = state
@@ -359,8 +356,12 @@ mod tests {
 
     fn build_test_state() -> OrchestratorState {
         let mut state = OrchestratorState::new(30000, 10);
-        state.running.insert("NODE_123".to_string(), test_running_entry());
-        state.retry_attempts.insert("NODE_456".to_string(), test_retry_entry());
+        state
+            .running
+            .insert("NODE_123".to_string(), test_running_entry());
+        state
+            .retry_attempts
+            .insert("NODE_456".to_string(), test_retry_entry());
         state.claimed.insert("NODE_123".to_string());
         state.claimed.insert("NODE_456".to_string());
         state.agent_totals = AgentTotals {
@@ -410,7 +411,10 @@ mod tests {
         assert_eq!(row.issue_id, "NODE_456");
         assert_eq!(row.issue_identifier, "my-repo#99");
         assert_eq!(row.attempt, 3);
-        assert_eq!(row.error, Some("no available orchestrator slots".to_string()));
+        assert_eq!(
+            row.error,
+            Some("no available orchestrator slots".to_string())
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -1,0 +1,581 @@
+use crate::orchestrator::state::{OrchestratorState, RateLimitSnapshot};
+use crate::pipeline::engine::{PipelineRun, StepState};
+use crate::tracker::model::{RetryEntry, RunningEntry};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Top-level runtime snapshot matching SPEC.md Section 13.7.2 GET /api/v1/state shape.
+#[derive(Debug, Serialize)]
+pub struct RuntimeSnapshot {
+    pub generated_at: DateTime<Utc>,
+    pub counts: SnapshotCounts,
+    pub running: Vec<RunningSessionRow>,
+    pub retrying: Vec<RetryRow>,
+    pub agent_totals: AgentTotalsSnapshot,
+    pub rate_limits: Option<RateLimitSnapshot>,
+}
+
+/// Summary counts of running and retrying sessions.
+#[derive(Debug, Serialize)]
+pub struct SnapshotCounts {
+    pub running: usize,
+    pub retrying: usize,
+}
+
+/// A single row in the running sessions list.
+#[derive(Debug, Serialize)]
+pub struct RunningSessionRow {
+    pub issue_id: String,
+    pub issue_identifier: String,
+    pub state: String,
+    pub step_name: Option<String>,
+    pub session_id: Option<String>,
+    pub turn_count: u32,
+    pub last_event: Option<String>,
+    pub last_message: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub last_event_at: Option<DateTime<Utc>>,
+    pub tokens: TokenSnapshot,
+}
+
+/// Token counts for a single session.
+#[derive(Debug, Serialize)]
+pub struct TokenSnapshot {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+}
+
+/// A single row in the retry queue list.
+#[derive(Debug, Serialize)]
+pub struct RetryRow {
+    pub issue_id: String,
+    pub issue_identifier: String,
+    pub attempt: u32,
+    pub due_at_ms: u64,
+    pub error: Option<String>,
+}
+
+/// Aggregate token and runtime totals for the snapshot.
+#[derive(Debug, Serialize)]
+pub struct AgentTotalsSnapshot {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    pub seconds_running: f64,
+}
+
+/// Per-issue detail snapshot for GET /api/v1/{identifier}.
+///
+/// NOTE: Plan 5 (Dashboard) expects additional fields `logs` and `recent_events`
+/// in the API response. When implementing the dashboard integration, extend this
+/// struct with:
+///   - `logs: IssueLogInfo` (containing `agent_session_logs: Vec<AgentSessionLog>`)
+///   - `recent_events: Vec<RecentEvent>`
+/// These are omitted here because Plan 4 does not yet have the event/log collection
+/// infrastructure, but the JSON shape should be forward-compatible.
+#[derive(Debug, Serialize)]
+pub struct IssueDetailSnapshot {
+    pub issue_identifier: String,
+    pub issue_id: String,
+    pub status: String,
+    pub workspace: WorkspaceInfo,
+    pub attempts: AttemptInfo,
+    pub running: Option<RunningDetail>,
+    pub retry: Option<RetryRow>,
+    pub last_error: Option<String>,
+}
+
+/// Workspace path info for issue detail.
+#[derive(Debug, Serialize)]
+pub struct WorkspaceInfo {
+    pub path: String,
+}
+
+/// Attempt tracking for issue detail.
+#[derive(Debug, Serialize)]
+pub struct AttemptInfo {
+    pub restart_count: u32,
+    pub current_retry_attempt: Option<u32>,
+}
+
+/// Running session detail for issue detail.
+#[derive(Debug, Serialize)]
+pub struct RunningDetail {
+    pub session_id: Option<String>,
+    pub step_name: Option<String>,
+    pub turn_count: u32,
+    pub state: String,
+    pub started_at: DateTime<Utc>,
+    pub last_event: Option<String>,
+    pub last_message: Option<String>,
+    pub last_event_at: Option<DateTime<Utc>>,
+    pub tokens: TokenSnapshot,
+}
+
+/// Build a RuntimeSnapshot from the current OrchestratorState.
+///
+/// This computes `seconds_running` as the sum of cumulative ended-session runtime
+/// plus elapsed time for all currently active sessions (from their `started_at`).
+pub fn build_state_snapshot(state: &OrchestratorState) -> RuntimeSnapshot {
+    let now = Utc::now();
+
+    let running_rows: Vec<RunningSessionRow> = state
+        .running
+        .values()
+        .map(|entry| running_entry_to_row(entry, &state.pipeline_runs))
+        .collect();
+
+    let retry_rows: Vec<RetryRow> = state
+        .retry_attempts
+        .values()
+        .map(retry_entry_to_row)
+        .collect();
+
+    // Compute live seconds_running: cumulative from ended sessions + active elapsed
+    let active_elapsed: f64 = state
+        .running
+        .values()
+        .map(|entry| {
+            let elapsed = now.signed_duration_since(entry.started_at);
+            elapsed.num_milliseconds().max(0) as f64 / 1000.0
+        })
+        .sum();
+
+    let total_seconds = state.agent_totals.seconds_running + active_elapsed;
+
+    RuntimeSnapshot {
+        generated_at: now,
+        counts: SnapshotCounts {
+            running: running_rows.len(),
+            retrying: retry_rows.len(),
+        },
+        running: running_rows,
+        retrying: retry_rows,
+        agent_totals: AgentTotalsSnapshot {
+            input_tokens: state.agent_totals.input_tokens,
+            output_tokens: state.agent_totals.output_tokens,
+            total_tokens: state.agent_totals.total_tokens,
+            seconds_running: total_seconds,
+        },
+        rate_limits: state.agent_rate_limits.clone(),
+    }
+}
+
+/// Build an IssueDetailSnapshot for a specific issue by identifier.
+///
+/// Returns None if the identifier is not found in running or retry maps.
+pub fn build_issue_snapshot(
+    state: &OrchestratorState,
+    identifier: &str,
+    workspace_root: &str,
+) -> Option<IssueDetailSnapshot> {
+    // Check running entries first
+    let running_entry = state
+        .running
+        .values()
+        .find(|e| e.identifier == identifier);
+
+    // Check retry entries
+    let retry_entry = state
+        .retry_attempts
+        .values()
+        .find(|e| e.identifier == identifier);
+
+    if running_entry.is_none() && retry_entry.is_none() {
+        return None;
+    }
+
+    let (issue_id, issue_identifier) = if let Some(entry) = running_entry {
+        (entry.issue_id.clone(), entry.identifier.clone())
+    } else if let Some(entry) = retry_entry {
+        (entry.issue_id.clone(), entry.identifier.clone())
+    } else {
+        return None;
+    };
+
+    let workspace_key = crate::tracker::model::sanitize_workspace_key(identifier)?;
+    let workspace_path = format!("{}/{}", workspace_root, workspace_key);
+
+    let status = if running_entry.is_some() {
+        "running".to_string()
+    } else {
+        "retrying".to_string()
+    };
+
+    let current_retry_attempt = if let Some(entry) = running_entry {
+        entry.retry_attempt
+    } else if let Some(entry) = retry_entry {
+        Some(entry.attempt)
+    } else {
+        None
+    };
+
+    let restart_count = current_retry_attempt.unwrap_or(0);
+
+    let running_detail = running_entry.map(|entry| {
+        let step_name = state.pipeline_runs.get(&entry.issue_id).and_then(|run| {
+            run.step_states.iter().find_map(|(name, step_state)| {
+                if matches!(step_state, StepState::Running { .. }) {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+        });
+        RunningDetail {
+            session_id: entry.session_id.clone(),
+            step_name,
+            turn_count: entry.turn_count,
+            state: entry.issue.state.clone(),
+            started_at: entry.started_at,
+            last_event: entry.last_agent_event.clone(),
+            last_message: entry.last_agent_message.clone(),
+            last_event_at: entry.last_agent_timestamp,
+            tokens: TokenSnapshot {
+                input_tokens: entry.agent_input_tokens,
+                output_tokens: entry.agent_output_tokens,
+                total_tokens: entry.agent_total_tokens,
+            },
+        }
+    });
+
+    let retry_detail = retry_entry.map(retry_entry_to_row);
+
+    let last_error = retry_entry.and_then(|e| e.error.clone());
+
+    Some(IssueDetailSnapshot {
+        issue_identifier,
+        issue_id,
+        status,
+        workspace: WorkspaceInfo {
+            path: workspace_path,
+        },
+        attempts: AttemptInfo {
+            restart_count,
+            current_retry_attempt,
+        },
+        running: running_detail,
+        retry: retry_detail,
+        last_error,
+    })
+}
+
+/// Convert a RunningEntry to a RunningSessionRow for the snapshot.
+fn running_entry_to_row(
+    entry: &RunningEntry,
+    pipeline_runs: &HashMap<String, PipelineRun>,
+) -> RunningSessionRow {
+    let step_name = pipeline_runs.get(&entry.issue_id).and_then(|run| {
+        run.step_states.iter().find_map(|(name, state)| {
+            if matches!(state, StepState::Running { .. }) {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
+    });
+    RunningSessionRow {
+        issue_id: entry.issue_id.clone(),
+        issue_identifier: entry.identifier.clone(),
+        state: entry.issue.state.clone(),
+        step_name,
+        session_id: entry.session_id.clone(),
+        turn_count: entry.turn_count,
+        last_event: entry.last_agent_event.clone(),
+        last_message: entry.last_agent_message.clone(),
+        started_at: entry.started_at,
+        last_event_at: entry.last_agent_timestamp,
+        tokens: TokenSnapshot {
+            input_tokens: entry.agent_input_tokens,
+            output_tokens: entry.agent_output_tokens,
+            total_tokens: entry.agent_total_tokens,
+        },
+    }
+}
+
+/// Convert a RetryEntry to a RetryRow for the snapshot.
+fn retry_entry_to_row(entry: &RetryEntry) -> RetryRow {
+    RetryRow {
+        issue_id: entry.issue_id.clone(),
+        issue_identifier: entry.identifier.clone(),
+        attempt: entry.attempt,
+        due_at_ms: entry.due_at_ms,
+        error: entry.error.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orchestrator::state::OrchestratorState;
+    use crate::tracker::model::{AgentTotals, Issue, RetryEntry, RunningEntry};
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    fn test_issue() -> Issue {
+        Issue {
+            id: "NODE_123".to_string(),
+            identifier: "my-repo#42".to_string(),
+            title: "Fix the bug".to_string(),
+            description: Some("It is broken".to_string()),
+            priority: Some(2),
+            state: "In Progress".to_string(),
+            branch_name: None,
+            url: Some("https://github.com/acme/repo/issues/42".to_string()),
+            labels: vec!["bug".to_string()],
+            blocked_by: vec![],
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn test_running_entry() -> RunningEntry {
+        RunningEntry {
+            issue_id: "NODE_123".to_string(),
+            identifier: "my-repo#42".to_string(),
+            issue: test_issue(),
+            session_id: Some("session-abc".to_string()),
+            agent_pid: Some("12345".to_string()),
+            last_agent_event: Some("turn_completed".to_string()),
+            last_agent_timestamp: Some(Utc::now()),
+            last_agent_message: Some("Working on tests".to_string()),
+            agent_input_tokens: 1200,
+            agent_output_tokens: 800,
+            agent_total_tokens: 2000,
+            last_reported_input_tokens: 1200,
+            last_reported_output_tokens: 800,
+            last_reported_total_tokens: 2000,
+            turn_count: 7,
+            retry_attempt: None,
+            started_at: Utc::now(),
+        }
+    }
+
+    fn test_retry_entry() -> RetryEntry {
+        RetryEntry {
+            issue_id: "NODE_456".to_string(),
+            identifier: "my-repo#99".to_string(),
+            attempt: 3,
+            due_at_ms: 1711641600000,
+            error: Some("no available orchestrator slots".to_string()),
+        }
+    }
+
+    fn build_test_state() -> OrchestratorState {
+        let mut state = OrchestratorState::new(30000, 10);
+        state.running.insert("NODE_123".to_string(), test_running_entry());
+        state.retry_attempts.insert("NODE_456".to_string(), test_retry_entry());
+        state.claimed.insert("NODE_123".to_string());
+        state.claimed.insert("NODE_456".to_string());
+        state.agent_totals = AgentTotals {
+            input_tokens: 5000,
+            output_tokens: 2400,
+            total_tokens: 7400,
+            seconds_running: 120.5,
+        };
+        state
+    }
+
+    #[test]
+    fn test_build_snapshot_counts() {
+        let state = build_test_state();
+        let snapshot = build_state_snapshot(&state);
+
+        assert_eq!(snapshot.counts.running, 1);
+        assert_eq!(snapshot.counts.retrying, 1);
+    }
+
+    #[test]
+    fn test_build_snapshot_running_row() {
+        let state = build_test_state();
+        let snapshot = build_state_snapshot(&state);
+
+        assert_eq!(snapshot.running.len(), 1);
+        let row = &snapshot.running[0];
+        assert_eq!(row.issue_id, "NODE_123");
+        assert_eq!(row.issue_identifier, "my-repo#42");
+        assert_eq!(row.state, "In Progress");
+        assert_eq!(row.session_id, Some("session-abc".to_string()));
+        assert_eq!(row.turn_count, 7);
+        assert_eq!(row.last_event, Some("turn_completed".to_string()));
+        assert_eq!(row.last_message, Some("Working on tests".to_string()));
+        assert_eq!(row.tokens.input_tokens, 1200);
+        assert_eq!(row.tokens.output_tokens, 800);
+        assert_eq!(row.tokens.total_tokens, 2000);
+    }
+
+    #[test]
+    fn test_build_snapshot_retry_row() {
+        let state = build_test_state();
+        let snapshot = build_state_snapshot(&state);
+
+        assert_eq!(snapshot.retrying.len(), 1);
+        let row = &snapshot.retrying[0];
+        assert_eq!(row.issue_id, "NODE_456");
+        assert_eq!(row.issue_identifier, "my-repo#99");
+        assert_eq!(row.attempt, 3);
+        assert_eq!(row.error, Some("no available orchestrator slots".to_string()));
+    }
+
+    #[test]
+    fn test_build_snapshot_agent_totals() {
+        let state = build_test_state();
+        let snapshot = build_state_snapshot(&state);
+
+        assert_eq!(snapshot.agent_totals.input_tokens, 5000);
+        assert_eq!(snapshot.agent_totals.output_tokens, 2400);
+        assert_eq!(snapshot.agent_totals.total_tokens, 7400);
+        // seconds_running should be >= cumulative (120.5) because active sessions add elapsed
+        assert!(snapshot.agent_totals.seconds_running >= 120.5);
+    }
+
+    #[test]
+    fn test_build_snapshot_rate_limits_null() {
+        let state = build_test_state();
+        let snapshot = build_state_snapshot(&state);
+        assert!(snapshot.rate_limits.is_none());
+    }
+
+    #[test]
+    fn test_build_snapshot_json_shape() {
+        let state = build_test_state();
+        let snapshot = build_state_snapshot(&state);
+        let json = serde_json::to_value(&snapshot).unwrap();
+
+        // Verify top-level keys match SPEC.md Section 13.7.2
+        assert!(json.get("generated_at").is_some());
+        assert!(json.get("counts").is_some());
+        assert!(json.get("running").is_some());
+        assert!(json.get("retrying").is_some());
+        assert!(json.get("agent_totals").is_some());
+        assert!(json.get("rate_limits").is_some());
+
+        // Verify counts sub-keys
+        let counts = json.get("counts").unwrap();
+        assert!(counts.get("running").is_some());
+        assert!(counts.get("retrying").is_some());
+
+        // Verify running row sub-keys
+        let running = json.get("running").unwrap().as_array().unwrap();
+        assert_eq!(running.len(), 1);
+        let row = &running[0];
+        assert!(row.get("issue_id").is_some());
+        assert!(row.get("issue_identifier").is_some());
+        assert!(row.get("state").is_some());
+        assert!(row.get("session_id").is_some());
+        assert!(row.get("turn_count").is_some());
+        assert!(row.get("last_event").is_some());
+        assert!(row.get("last_message").is_some());
+        assert!(row.get("started_at").is_some());
+        assert!(row.get("last_event_at").is_some());
+        assert!(row.get("tokens").is_some());
+
+        // Verify tokens sub-keys
+        let tokens = row.get("tokens").unwrap();
+        assert!(tokens.get("input_tokens").is_some());
+        assert!(tokens.get("output_tokens").is_some());
+        assert!(tokens.get("total_tokens").is_some());
+
+        // Verify agent_totals sub-keys
+        let totals = json.get("agent_totals").unwrap();
+        assert!(totals.get("input_tokens").is_some());
+        assert!(totals.get("output_tokens").is_some());
+        assert!(totals.get("total_tokens").is_some());
+        assert!(totals.get("seconds_running").is_some());
+    }
+
+    #[test]
+    fn test_build_snapshot_empty_state() {
+        let state = OrchestratorState::new(30000, 10);
+
+        let snapshot = build_state_snapshot(&state);
+        assert_eq!(snapshot.counts.running, 0);
+        assert_eq!(snapshot.counts.retrying, 0);
+        assert!(snapshot.running.is_empty());
+        assert!(snapshot.retrying.is_empty());
+        assert_eq!(snapshot.agent_totals.seconds_running, 0.0);
+    }
+
+    #[test]
+    fn test_build_issue_snapshot_found_running() {
+        let state = build_test_state();
+        let detail = build_issue_snapshot(&state, "my-repo#42", "/tmp/workspaces");
+
+        assert!(detail.is_some());
+        let detail = detail.unwrap();
+        assert_eq!(detail.issue_identifier, "my-repo#42");
+        assert_eq!(detail.issue_id, "NODE_123");
+        assert_eq!(detail.status, "running");
+        assert_eq!(detail.workspace.path, "/tmp/workspaces/my-repo_42");
+        assert!(detail.running.is_some());
+        assert!(detail.retry.is_none());
+
+        let running = detail.running.unwrap();
+        assert_eq!(running.turn_count, 7);
+        assert_eq!(running.session_id, Some("session-abc".to_string()));
+    }
+
+    #[test]
+    fn test_build_issue_snapshot_found_retrying() {
+        let state = build_test_state();
+        let detail = build_issue_snapshot(&state, "my-repo#99", "/tmp/workspaces");
+
+        assert!(detail.is_some());
+        let detail = detail.unwrap();
+        assert_eq!(detail.issue_identifier, "my-repo#99");
+        assert_eq!(detail.issue_id, "NODE_456");
+        assert_eq!(detail.status, "retrying");
+        assert!(detail.running.is_none());
+        assert!(detail.retry.is_some());
+        assert_eq!(
+            detail.last_error,
+            Some("no available orchestrator slots".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_issue_snapshot_not_found() {
+        let state = build_test_state();
+        let detail = build_issue_snapshot(&state, "nonexistent#999", "/tmp/workspaces");
+        assert!(detail.is_none());
+    }
+
+    #[test]
+    fn test_issue_snapshot_json_shape() {
+        let state = build_test_state();
+        let detail = build_issue_snapshot(&state, "my-repo#42", "/tmp/workspaces").unwrap();
+        let json = serde_json::to_value(&detail).unwrap();
+
+        assert!(json.get("issue_identifier").is_some());
+        assert!(json.get("issue_id").is_some());
+        assert!(json.get("status").is_some());
+        assert!(json.get("workspace").is_some());
+        assert!(json.get("attempts").is_some());
+        assert!(json.get("running").is_some());
+        assert!(json.get("retry").is_some());
+        assert!(json.get("last_error").is_some());
+
+        let workspace = json.get("workspace").unwrap();
+        assert!(workspace.get("path").is_some());
+
+        let attempts = json.get("attempts").unwrap();
+        assert!(attempts.get("restart_count").is_some());
+        assert!(attempts.get("current_retry_attempt").is_some());
+    }
+
+    #[test]
+    fn test_retry_row_due_at_ms_passthrough() {
+        let entry = RetryEntry {
+            issue_id: "NODE_789".to_string(),
+            identifier: "test#1".to_string(),
+            attempt: 1,
+            due_at_ms: 1711641600000,
+            error: None,
+        };
+
+        let row = retry_entry_to_row(&entry);
+        assert_eq!(row.due_at_ms, 1711641600000);
+    }
+}

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -61,9 +61,7 @@ fn build_populated_app_state() -> AppState {
     };
 
     let mut state = OrchestratorState::new(30000, 10);
-    state
-        .running
-        .insert("NODE_123".to_string(), running_entry);
+    state.running.insert("NODE_123".to_string(), running_entry);
     state
         .retry_attempts
         .insert("NODE_456".to_string(), retry_entry);
@@ -121,10 +119,7 @@ async fn test_get_state_endpoint() {
     assert!(json.get("counts").is_some(), "missing counts");
     assert!(json.get("running").is_some(), "missing running");
     assert!(json.get("retrying").is_some(), "missing retrying");
-    assert!(
-        json.get("agent_totals").is_some(),
-        "missing agent_totals"
-    );
+    assert!(json.get("agent_totals").is_some(), "missing agent_totals");
     assert!(json.get("rate_limits").is_some(), "missing rate_limits");
 
     // Verify counts
@@ -198,10 +193,7 @@ async fn test_get_issue_detail_running() {
     // Verify workspace info
     let workspace = json.get("workspace").unwrap();
     assert!(workspace.get("path").is_some());
-    assert!(workspace["path"]
-        .as_str()
-        .unwrap()
-        .contains("my-repo_42"));
+    assert!(workspace["path"].as_str().unwrap().contains("my-repo_42"));
 
     // Verify attempts info
     let attempts = json.get("attempts").unwrap();
@@ -283,9 +275,7 @@ async fn test_post_refresh_endpoint() {
     assert!(json.get("requested_at").is_some());
     let ops = json["operations"].as_array().unwrap();
     assert!(ops.contains(&serde_json::Value::String("poll".to_string())));
-    assert!(ops.contains(&serde_json::Value::String(
-        "reconcile".to_string()
-    )));
+    assert!(ops.contains(&serde_json::Value::String("reconcile".to_string())));
 }
 
 #[tokio::test]

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -3,8 +3,10 @@
 
 use chrono::Utc;
 use ensemble_core::api::router::{create_api_router, AppState};
+use ensemble_core::observability::events::EventBus;
 use ensemble_core::orchestrator::state::OrchestratorState;
 use ensemble_core::tracker::model::{Issue, RetryEntry, RunningEntry};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -76,6 +78,8 @@ fn build_populated_app_state() -> AppState {
         orchestrator_state: Arc::new(RwLock::new(state)),
         refresh_requested: Arc::new(tokio::sync::Notify::new()),
         workspace_root: "/tmp/ensemble_workspaces".to_string(),
+        history_path: PathBuf::from("/tmp/ensemble_test_history.jsonl"),
+        event_bus: EventBus::new(),
     }
 }
 
@@ -311,6 +315,8 @@ async fn test_get_state_empty_system() {
         orchestrator_state: Arc::new(RwLock::new(state)),
         refresh_requested: Arc::new(tokio::sync::Notify::new()),
         workspace_root: "/tmp/workspaces".to_string(),
+        history_path: PathBuf::from("/tmp/ensemble_test_history.jsonl"),
+        event_bus: EventBus::new(),
     };
 
     let base_url = start_test_server(app_state).await;

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -92,9 +92,6 @@ async fn start_test_server(app_state: AppState) -> String {
         axum::serve(listener, router).await.unwrap();
     });
 
-    // Give the server a moment to start
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
     base_url
 }
 

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -2,7 +2,7 @@
 //! hit endpoints with reqwest, verify JSON shapes match SPEC.md Section 13.7.2.
 
 use chrono::Utc;
-use ensemble_core::api::router::{create_api_router, AppState};
+use ensemble_core::api::router::{create_api_router, create_api_router_with_static, AppState};
 use ensemble_core::observability::events::EventBus;
 use ensemble_core::orchestrator::state::OrchestratorState;
 use ensemble_core::tracker::model::{Issue, RetryEntry, RunningEntry};
@@ -330,4 +330,121 @@ async fn test_get_state_empty_system() {
     assert_eq!(json["agent_totals"]["total_tokens"], 0);
     assert_eq!(json["agent_totals"]["seconds_running"], 0.0);
     assert!(json["rate_limits"].is_null());
+}
+
+// --- Static serving and API 404 fallback tests ---
+
+fn build_empty_app_state() -> AppState {
+    let state = OrchestratorState::new(30000, 10);
+    AppState {
+        orchestrator_state: Arc::new(RwLock::new(state)),
+        refresh_requested: Arc::new(tokio::sync::Notify::new()),
+        workspace_root: "/tmp/workspaces".to_string(),
+        history_path: PathBuf::from("/tmp/ensemble_test_history.jsonl"),
+        event_bus: EventBus::new(),
+    }
+}
+
+async fn start_test_server_with_static(app_state: AppState, static_dir: Option<PathBuf>) -> String {
+    let router = create_api_router_with_static(app_state, static_dir);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{}", addr);
+
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    base_url
+}
+
+#[tokio::test]
+async fn test_api_unknown_route_returns_json_404() {
+    let base_url = start_test_server(build_empty_app_state()).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/api/v1/nonexistent/route", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 404);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    assert!(json.get("error").is_some(), "expected JSON error envelope");
+    assert_eq!(json["error"]["code"], "not_found");
+}
+
+#[tokio::test]
+async fn test_api_404_not_index_html_with_static_dir() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    std::fs::write(tmp_dir.path().join("index.html"), "<html>SPA</html>").unwrap();
+
+    let base_url =
+        start_test_server_with_static(build_empty_app_state(), Some(tmp_dir.path().to_path_buf()))
+            .await;
+    let client = reqwest::Client::new();
+
+    // API 404 should be JSON, not index.html
+    let response = client
+        .get(format!("{}/api/v1/nonexistent/route", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 404);
+    let body = response.text().await.unwrap();
+    assert!(
+        !body.contains("<html>"),
+        "API 404 should return JSON, not index.html; got: {}",
+        body
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["error"]["code"], "not_found");
+}
+
+#[tokio::test]
+async fn test_static_file_served() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    std::fs::write(tmp_dir.path().join("index.html"), "<html>SPA</html>").unwrap();
+    std::fs::write(tmp_dir.path().join("app.js"), "console.log('hi')").unwrap();
+
+    let base_url =
+        start_test_server_with_static(build_empty_app_state(), Some(tmp_dir.path().to_path_buf()))
+            .await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/app.js", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body = response.text().await.unwrap();
+    assert_eq!(body, "console.log('hi')");
+}
+
+#[tokio::test]
+async fn test_spa_fallback_returns_index_html() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    std::fs::write(tmp_dir.path().join("index.html"), "<html>SPA</html>").unwrap();
+
+    let base_url =
+        start_test_server_with_static(build_empty_app_state(), Some(tmp_dir.path().to_path_buf()))
+            .await;
+    let client = reqwest::Client::new();
+
+    // Unknown non-API path should get index.html (SPA routing)
+    let response = client
+        .get(format!("{}/dashboard/some/route", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body = response.text().await.unwrap();
+    assert_eq!(body, "<html>SPA</html>");
 }

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -1,0 +1,337 @@
+//! Integration test: start an axum server with pre-populated state,
+//! hit endpoints with reqwest, verify JSON shapes match SPEC.md Section 13.7.2.
+
+use chrono::Utc;
+use ensemble_core::api::router::{create_api_router, AppState};
+use ensemble_core::orchestrator::state::OrchestratorState;
+use ensemble_core::tracker::model::{Issue, RetryEntry, RunningEntry};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+fn test_issue(id: &str, identifier: &str, state: &str) -> Issue {
+    Issue {
+        id: id.to_string(),
+        identifier: identifier.to_string(),
+        title: format!("Issue {}", identifier),
+        description: Some(format!("Description for {}", identifier)),
+        priority: Some(1),
+        state: state.to_string(),
+        branch_name: None,
+        url: Some(format!(
+            "https://github.com/acme/repo/issues/{}",
+            identifier
+        )),
+        labels: vec!["bug".to_string()],
+        blocked_by: vec![],
+        created_at: None,
+        updated_at: None,
+    }
+}
+
+fn build_populated_app_state() -> AppState {
+    let issue1 = test_issue("NODE_123", "my-repo#42", "In Progress");
+    let running_entry = RunningEntry {
+        issue_id: "NODE_123".to_string(),
+        identifier: "my-repo#42".to_string(),
+        issue: issue1,
+        session_id: Some("session-abc".to_string()),
+        agent_pid: Some("12345".to_string()),
+        last_agent_event: Some("turn_completed".to_string()),
+        last_agent_timestamp: Some(Utc::now()),
+        last_agent_message: Some("Working on tests".to_string()),
+        agent_input_tokens: 1200,
+        agent_output_tokens: 800,
+        agent_total_tokens: 2000,
+        last_reported_input_tokens: 1200,
+        last_reported_output_tokens: 800,
+        last_reported_total_tokens: 2000,
+        turn_count: 7,
+        retry_attempt: None,
+        started_at: Utc::now(),
+    };
+
+    let retry_entry = RetryEntry {
+        issue_id: "NODE_456".to_string(),
+        identifier: "my-repo#99".to_string(),
+        attempt: 3,
+        due_at_ms: 1711641600000,
+        error: Some("no available orchestrator slots".to_string()),
+    };
+
+    let mut state = OrchestratorState::new(30000, 10);
+    state
+        .running
+        .insert("NODE_123".to_string(), running_entry);
+    state
+        .retry_attempts
+        .insert("NODE_456".to_string(), retry_entry);
+    state.claimed.insert("NODE_123".to_string());
+    state.claimed.insert("NODE_456".to_string());
+    state.agent_totals.input_tokens = 5000;
+    state.agent_totals.output_tokens = 2400;
+    state.agent_totals.total_tokens = 7400;
+    state.agent_totals.seconds_running = 120.5;
+
+    AppState {
+        orchestrator_state: Arc::new(RwLock::new(state)),
+        refresh_requested: Arc::new(tokio::sync::Notify::new()),
+        workspace_root: "/tmp/ensemble_workspaces".to_string(),
+    }
+}
+
+/// Start an axum test server and return the base URL.
+async fn start_test_server(app_state: AppState) -> String {
+    let router = create_api_router(app_state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{}", addr);
+
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    // Give the server a moment to start
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    base_url
+}
+
+#[tokio::test]
+async fn test_get_state_endpoint() {
+    let app_state = build_populated_app_state();
+    let base_url = start_test_server(app_state).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/api/v1/state", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+
+    // Verify top-level keys from SPEC.md Section 13.7.2
+    assert!(json.get("generated_at").is_some(), "missing generated_at");
+    assert!(json.get("counts").is_some(), "missing counts");
+    assert!(json.get("running").is_some(), "missing running");
+    assert!(json.get("retrying").is_some(), "missing retrying");
+    assert!(
+        json.get("agent_totals").is_some(),
+        "missing agent_totals"
+    );
+    assert!(json.get("rate_limits").is_some(), "missing rate_limits");
+
+    // Verify counts
+    let counts = json.get("counts").unwrap();
+    assert_eq!(counts["running"], 1);
+    assert_eq!(counts["retrying"], 1);
+
+    // Verify running array shape
+    let running = json.get("running").unwrap().as_array().unwrap();
+    assert_eq!(running.len(), 1);
+    let row = &running[0];
+    assert_eq!(row["issue_id"], "NODE_123");
+    assert_eq!(row["issue_identifier"], "my-repo#42");
+    assert_eq!(row["state"], "In Progress");
+    assert_eq!(row["session_id"], "session-abc");
+    assert_eq!(row["turn_count"], 7);
+    assert_eq!(row["last_event"], "turn_completed");
+    assert_eq!(row["last_message"], "Working on tests");
+    assert!(row.get("started_at").is_some());
+    assert!(row.get("last_event_at").is_some());
+
+    // Verify tokens sub-object
+    let tokens = row.get("tokens").unwrap();
+    assert_eq!(tokens["input_tokens"], 1200);
+    assert_eq!(tokens["output_tokens"], 800);
+    assert_eq!(tokens["total_tokens"], 2000);
+
+    // Verify retrying array shape
+    let retrying = json.get("retrying").unwrap().as_array().unwrap();
+    assert_eq!(retrying.len(), 1);
+    let retry = &retrying[0];
+    assert_eq!(retry["issue_id"], "NODE_456");
+    assert_eq!(retry["issue_identifier"], "my-repo#99");
+    assert_eq!(retry["attempt"], 3);
+    assert!(retry.get("due_at_ms").is_some());
+    assert_eq!(retry["error"], "no available orchestrator slots");
+
+    // Verify agent_totals shape
+    let totals = json.get("agent_totals").unwrap();
+    assert_eq!(totals["input_tokens"], 5000);
+    assert_eq!(totals["output_tokens"], 2400);
+    assert_eq!(totals["total_tokens"], 7400);
+    assert!(totals.get("seconds_running").is_some());
+    let secs = totals["seconds_running"].as_f64().unwrap();
+    assert!(
+        secs >= 120.5,
+        "seconds_running should be >= 120.5, got {}",
+        secs
+    );
+}
+
+#[tokio::test]
+async fn test_get_issue_detail_running() {
+    let app_state = build_populated_app_state();
+    let base_url = start_test_server(app_state).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/api/v1/my-repo%2342", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(json["issue_identifier"], "my-repo#42");
+    assert_eq!(json["issue_id"], "NODE_123");
+    assert_eq!(json["status"], "running");
+
+    // Verify workspace info
+    let workspace = json.get("workspace").unwrap();
+    assert!(workspace.get("path").is_some());
+    assert!(workspace["path"]
+        .as_str()
+        .unwrap()
+        .contains("my-repo_42"));
+
+    // Verify attempts info
+    let attempts = json.get("attempts").unwrap();
+    assert!(attempts.get("restart_count").is_some());
+    assert!(attempts.get("current_retry_attempt").is_some());
+
+    // Verify running detail is present
+    assert!(json.get("running").unwrap().is_object());
+
+    // Verify retry is null for a running issue
+    assert!(json.get("retry").unwrap().is_null());
+}
+
+#[tokio::test]
+async fn test_get_issue_detail_retrying() {
+    let app_state = build_populated_app_state();
+    let base_url = start_test_server(app_state).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/api/v1/my-repo%2399", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(json["issue_identifier"], "my-repo#99");
+    assert_eq!(json["status"], "retrying");
+
+    // Verify retry detail is present
+    assert!(json.get("retry").unwrap().is_object());
+
+    // Verify running is null for a retrying issue
+    assert!(json.get("running").unwrap().is_null());
+}
+
+#[tokio::test]
+async fn test_get_issue_detail_not_found() {
+    let app_state = build_populated_app_state();
+    let base_url = start_test_server(app_state).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/api/v1/nonexistent%23999", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 404);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+
+    // Verify error envelope
+    assert!(json.get("error").is_some(), "missing error envelope");
+    let error = json.get("error").unwrap();
+    assert_eq!(error["code"], "issue_not_found");
+    assert!(error.get("message").is_some());
+}
+
+#[tokio::test]
+async fn test_post_refresh_endpoint() {
+    let app_state = build_populated_app_state();
+    let base_url = start_test_server(app_state).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("{}/api/v1/refresh", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 202);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(json["queued"], true);
+    assert_eq!(json["coalesced"], false);
+    assert!(json.get("requested_at").is_some());
+    let ops = json["operations"].as_array().unwrap();
+    assert!(ops.contains(&serde_json::Value::String("poll".to_string())));
+    assert!(ops.contains(&serde_json::Value::String(
+        "reconcile".to_string()
+    )));
+}
+
+#[tokio::test]
+async fn test_get_refresh_returns_405() {
+    let app_state = build_populated_app_state();
+    let base_url = start_test_server(app_state).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/api/v1/refresh", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 405);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    assert!(json.get("error").is_some());
+    assert_eq!(json["error"]["code"], "method_not_allowed");
+}
+
+#[tokio::test]
+async fn test_get_state_empty_system() {
+    let state = OrchestratorState::new(30000, 10);
+
+    let app_state = AppState {
+        orchestrator_state: Arc::new(RwLock::new(state)),
+        refresh_requested: Arc::new(tokio::sync::Notify::new()),
+        workspace_root: "/tmp/workspaces".to_string(),
+    };
+
+    let base_url = start_test_server(app_state).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/api/v1/state", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(json["counts"]["running"], 0);
+    assert_eq!(json["counts"]["retrying"], 0);
+    assert!(json["running"].as_array().unwrap().is_empty());
+    assert!(json["retrying"].as_array().unwrap().is_empty());
+    assert_eq!(json["agent_totals"]["input_tokens"], 0);
+    assert_eq!(json["agent_totals"]["output_tokens"], 0);
+    assert_eq!(json["agent_totals"]["total_tokens"], 0);
+    assert_eq!(json["agent_totals"]["seconds_running"], 0.0);
+    assert!(json["rate_limits"].is_null());
+}


### PR DESCRIPTION
## Summary
- **Runtime observability**: snapshot types, structured logging (JSON/human auto-detection), event bus with broadcast channel
- **HTTP API** (axum): `GET /state`, `GET /{id}`, `POST /refresh`, `GET /history`, `GET /{id}/conversation`, `POST /{id}/stop`, `POST /{id}/retry`, `GET /ws/events/{id}` (WebSocket)
- **CLI binary** (`ensemble-cli`): arg parsing, config loading, optional HTTP server with `--host`/`--port`/`HOST`/`PORT` env var support, `--static-dir` for dashboard SPA
- **History log**: append-only JSONL writer + reader with filtering and cursor-based pagination
- **Static asset serving**: tower-http ServeDir with SPA fallback, API routes protected from leaking `index.html` via dedicated 404 fallback
- **294 tests** passing, clippy clean, fmt clean

## Test plan
- [x] `cargo test --workspace` — 294 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — no issues
- [x] `cargo fmt --all -- --check` — clean
- [x] CLI exits cleanly on missing `ensemble.yaml`
- [x] API integration tests verify JSON shapes against SPEC.md Section 13.7.2
- [x] Static serving tests verify API 404 returns JSON (not `index.html`), SPA fallback works