### PR TITLE
feat: worktree-based workspace isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ ensemble/
 │   └── ensemble-core/            # core library (domain model, config, workspace)
 │       ├── src/
 │       │   ├── lib.rs
-│       │   ├── error.rs          # EnsembleError, ConfigError, WorkspaceError, PipelineError
+│       │   ├── error.rs          # EnsembleError, ConfigError, WorkspaceError, WorktreeError, PipelineError
 │       │   ├── tracker/
 │       │   │   ├── mod.rs        # IssueTracker trait (read + write), TrackerError
 │       │   │   └── model.rs      # Issue, RunningEntry, RetryEntry, AgentTotals
@@ -26,7 +26,10 @@ ensemble/
 │       │   │   ├── engine.rs     # PipelineRun per-issue execution
 │       │   │   └── verdict.rs    # Verdict parsing (ACP + file fallback)
 │       │   └── workspace/
-│       │       ├── manager.rs    # WorkspaceManager (create/reuse/cleanup directories)
+│       │       ├── manager.rs    # WorkspaceManager (create/reuse/cleanup directories + worktrees)
+│       │       ├── coordinator.rs # WorktreeCoordinator (multi-repo worktree lifecycle)
+│       │       ├── worktree.rs   # Core git worktree operations (create/remove/exists/pull)
+│       │       ├── push_strategy.rs # PushStrategy enum (ask/auto_push/manual/pr_only)
 │       │       └── hooks.rs      # Async hook runner with timeouts
 │       └── tests/
 │           └── workflow_to_workspace.rs  # integration test

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -1,4 +1,5 @@
 use crate::error::PipelineError;
+use crate::workspace::push_strategy::PushStrategy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -25,6 +26,8 @@ pub struct EnsembleConfig {
     pub hooks: HooksConfig,
     #[serde(default)]
     pub agent: AgentRuntimeConfig,
+    #[serde(default)]
+    pub push_strategy: PushStrategy,
 }
 
 /// A repository to be managed by the workspace (path + branch).
@@ -32,6 +35,12 @@ pub struct EnsembleConfig {
 pub struct RepoConfig {
     pub path: String,
     pub branch: String,
+    #[serde(default = "default_git_remote")]
+    pub git_remote: String,
+}
+
+fn default_git_remote() -> String {
+    "origin".to_string()
 }
 
 fn default_max_cycles() -> u32 {

--- a/crates/ensemble-core/src/config/mod.rs
+++ b/crates/ensemble-core/src/config/mod.rs
@@ -1,2 +1,4 @@
 pub mod ensemble;
 pub mod template;
+
+pub use crate::workspace::push_strategy::PushStrategy;

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -7,6 +7,8 @@ pub enum EnsembleError {
     #[error(transparent)]
     Workspace(#[from] WorkspaceError),
     #[error(transparent)]
+    Worktree(#[from] WorktreeError),
+    #[error(transparent)]
     Tracker(#[from] crate::tracker::TrackerError),
     #[error(transparent)]
     Pipeline(#[from] PipelineError),
@@ -36,6 +38,24 @@ pub enum WorkspaceError {
     HookTimedOut { hook: String, timeout_ms: u64 },
     #[error("workspace path outside root: {path}")]
     PathOutsideRoot { path: String },
+}
+
+#[derive(Debug, Error)]
+pub enum WorktreeError {
+    #[error("worktree creation failed for repo {repo}: {reason}")]
+    CreationFailed { repo: String, reason: String },
+    #[error("worktree already exists at {path}")]
+    AlreadyExists { path: String },
+    #[error("worktree not found at {path}")]
+    NotFound { path: String },
+    #[error("git command failed: {command} — {reason}")]
+    GitCommandFailed { command: String, reason: String },
+    #[error("branch creation failed: {branch} — {reason}")]
+    BranchCreationFailed { branch: String, reason: String },
+    #[error("rollback failed during cleanup: {reason}")]
+    RollbackFailed { reason: String },
+    #[error("invalid repo path: {path}")]
+    InvalidRepoPath { path: String },
 }
 
 #[derive(Debug, Error)]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -213,7 +213,7 @@ impl Orchestrator {
                     state.release_claim(&issue.id);
                     state.remove_pipeline_run(&issue.id);
                     // Clean workspace
-                    if let Err(e) = self.workspace_mgr.remove_workspace(&entry.identifier) {
+                    if let Err(e) = self.workspace_mgr.remove_workspace(&entry.identifier).await {
                         warn!(
                             identifier = %entry.identifier,
                             error = %e,
@@ -374,7 +374,7 @@ impl Orchestrator {
 
         tokio::spawn(async move {
             // Prepare workspace
-            let workspace_result = workspace_mgr.prepare_workspace(&issue_clone.identifier);
+            let workspace_result = workspace_mgr.prepare_workspace(&issue_clone.identifier).await;
             let workspace_path = match workspace_result {
                 Ok(ws) => {
                     // Run after_create hook if newly created
@@ -384,7 +384,7 @@ impl Orchestrator {
                             if let Err(e) = crate::workspace::hooks::run_hook(
                                 "after_create",
                                 script,
-                                &ws.path,
+                                &ws.base_path,
                                 cfg.hooks.timeout_ms,
                             )
                             .await
@@ -403,7 +403,7 @@ impl Orchestrator {
                             }
                         }
                     }
-                    ws.path
+                    ws.base_path
                 }
                 Err(e) => {
                     let _ = event_tx
@@ -942,7 +942,7 @@ agent:
         });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 10 });
         let dir = tempfile::TempDir::new().unwrap();
-        let workspace_mgr = WorkspaceManager::new(dir.path()).unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator = Orchestrator::new(config, tracker, runner, workspace_mgr, shutdown_rx);
@@ -967,7 +967,7 @@ agent:
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 0 });
         let dir = tempfile::TempDir::new().unwrap();
-        let workspace_mgr = WorkspaceManager::new(dir.path()).unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator =
@@ -1009,7 +1009,7 @@ agent:
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 0 });
         let dir = tempfile::TempDir::new().unwrap();
-        let workspace_mgr = WorkspaceManager::new(dir.path()).unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator =
@@ -1058,7 +1058,7 @@ agent:
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 0 });
         let dir = tempfile::TempDir::new().unwrap();
-        let workspace_mgr = WorkspaceManager::new(dir.path()).unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator = Orchestrator::new(config, tracker, runner, workspace_mgr, shutdown_rx);
@@ -1122,7 +1122,7 @@ agent:
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 0 });
         let dir = tempfile::TempDir::new().unwrap();
-        let workspace_mgr = WorkspaceManager::new(dir.path()).unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator = Orchestrator::new(config, tracker, runner, workspace_mgr, shutdown_rx);
@@ -1166,7 +1166,7 @@ agent:
         });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 10 });
         let dir = tempfile::TempDir::new().unwrap();
-        let workspace_mgr = WorkspaceManager::new(dir.path()).unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let mut orchestrator =

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -374,7 +374,9 @@ impl Orchestrator {
 
         tokio::spawn(async move {
             // Prepare workspace
-            let workspace_result = workspace_mgr.prepare_workspace(&issue_clone.identifier).await;
+            let workspace_result = workspace_mgr
+                .prepare_workspace(&issue_clone.identifier)
+                .await;
             let workspace_path = match workspace_result {
                 Ok(ws) => {
                     // Run after_create hook if newly created

--- a/crates/ensemble-core/src/orchestrator/reconciler.rs
+++ b/crates/ensemble-core/src/orchestrator/reconciler.rs
@@ -186,7 +186,7 @@ pub async fn startup_terminal_cleanup(
     match tracker.fetch_issues_by_states(terminal_states).await {
         Ok(terminal_issues) => {
             for issue in &terminal_issues {
-                match workspace_mgr.remove_workspace(&issue.identifier) {
+                match workspace_mgr.remove_workspace(&issue.identifier).await {
                     Ok(()) => {
                         debug!(
                             identifier = %issue.identifier,
@@ -487,10 +487,10 @@ mod tests {
     #[tokio::test]
     async fn test_startup_terminal_cleanup() {
         let dir = tempfile::TempDir::new().unwrap();
-        let workspace_mgr = WorkspaceManager::new(dir.path()).unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
 
         // Create a workspace
-        workspace_mgr.prepare_workspace("repo#42").unwrap();
+        workspace_mgr.prepare_workspace("repo#42").await.unwrap();
         assert!(dir.path().join("repo_42").exists());
 
         let tracker = MockTrackerForReconcile {
@@ -507,7 +507,7 @@ mod tests {
     #[tokio::test]
     async fn test_startup_terminal_cleanup_failure_continues() {
         let dir = tempfile::TempDir::new().unwrap();
-        let workspace_mgr = WorkspaceManager::new(dir.path()).unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
 
         let tracker = MockTrackerForReconcile {
             issues: vec![],

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -1,7 +1,8 @@
 use crate::config::ensemble::RepoConfig;
 use crate::error::WorktreeError;
 use crate::workspace::worktree::{
-    create_worktree, pull_worktree, remove_worktree, sanitize_branch_name, worktree_exists,
+    branch_exists, create_worktree, pull_worktree, remove_orphaned_worktree, remove_worktree,
+    sanitize_branch_name, worktree_exists,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -57,50 +58,73 @@ impl WorktreeCoordinator {
             let worktree_path_str = worktree_path.to_string_lossy().to_string();
             let repo_path_str = &repo_config.path;
 
-            match worktree_exists(repo_path_str, &worktree_path_str).await? {
-                true => {
-                    info!(repo = repo_name, "reusing existing worktree");
+            let wt_registered = worktree_exists(repo_path_str, &worktree_path_str).await?;
+            let dir_exists = worktree_path.exists();
+            let br_exists = branch_exists(repo_path_str, &branch).await.unwrap_or(false);
 
-                    if let Err(e) = pull_worktree(
-                        &worktree_path_str,
-                        &repo_config.branch,
-                        &repo_config.git_remote,
-                    )
-                    .await
-                    {
-                        warn!(repo = repo_name, error = %e, "failed to pull, continuing");
-                    }
+            if wt_registered && br_exists {
+                // Happy path: worktree registered and branch exists — reuse it
+                info!(repo = repo_name, "reusing existing worktree");
 
-                    created.insert(
-                        repo_name.clone(),
-                        WorktreeInfo {
-                            path: worktree_path,
-                            branch: branch.clone(),
-                            created_now: false,
-                        },
-                    );
+                if let Err(e) = pull_worktree(
+                    &worktree_path_str,
+                    &repo_config.branch,
+                    &repo_config.git_remote,
+                )
+                .await
+                {
+                    warn!(repo = repo_name, error = %e, "failed to pull, continuing");
                 }
-                false => {
-                    info!(repo = repo_name, path = %worktree_path.display(), "creating new worktree");
 
+                created.insert(
+                    repo_name.clone(),
+                    WorktreeInfo {
+                        path: worktree_path,
+                        branch: branch.clone(),
+                        created_now: false,
+                    },
+                );
+            } else {
+                // Stale worktree: directory exists but branch/registration is gone
+                if dir_exists && !wt_registered {
+                    warn!(
+                        repo = repo_name,
+                        "stale worktree detected, cleaning up orphaned directory"
+                    );
                     if let Err(e) =
-                        create_worktree(repo_path_str, &worktree_path_str, &branch).await
+                        remove_orphaned_worktree(repo_path_str, &worktree_path_str).await
                     {
-                        error!(repo = repo_name, error = %e, "failed to create worktree");
+                        error!(repo = repo_name, error = %e, "failed to remove orphaned worktree");
                         self.rollback(&created, &newly_created).await;
-                        return Err(e);
+                        return Err(WorktreeError::RollbackFailed {
+                            reason: format!("cannot remove orphaned worktree: {e}"),
+                        });
                     }
-
-                    newly_created.push(repo_name.clone());
-                    created.insert(
-                        repo_name.clone(),
-                        WorktreeInfo {
-                            path: worktree_path,
-                            branch: branch.clone(),
-                            created_now: true,
-                        },
+                } else if wt_registered && !br_exists {
+                    warn!(
+                        repo = repo_name,
+                        "worktree registered but branch deleted, cleaning up"
                     );
+                    let _ = remove_worktree(repo_path_str, &worktree_path_str, &branch).await;
                 }
+
+                info!(repo = repo_name, path = %worktree_path.display(), "creating new worktree");
+
+                if let Err(e) = create_worktree(repo_path_str, &worktree_path_str, &branch).await {
+                    error!(repo = repo_name, error = %e, "failed to create worktree");
+                    self.rollback(&created, &newly_created).await;
+                    return Err(e);
+                }
+
+                newly_created.push(repo_name.clone());
+                created.insert(
+                    repo_name.clone(),
+                    WorktreeInfo {
+                        path: worktree_path,
+                        branch: branch.clone(),
+                        created_now: true,
+                    },
+                );
             }
         }
 
@@ -178,6 +202,6 @@ mod tests {
         let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
 
         let branch = coordinator.format_branch_name("my-repo#42");
-        assert_eq!(branch, "ensemble-2026-03-30-my-repo#42");
+        assert_eq!(branch, "ensemble-2026-03-30-my-repo-42");
     }
 }

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -1,8 +1,8 @@
 use crate::config::ensemble::RepoConfig;
 use crate::error::WorktreeError;
 use crate::workspace::worktree::{
-    branch_exists, create_worktree, pull_worktree, remove_orphaned_worktree, remove_worktree,
-    sanitize_branch_name, worktree_exists,
+    attach_worktree, branch_exists, create_worktree, pull_worktree, remove_orphaned_worktree,
+    remove_worktree, sanitize_branch_name, worktree_exists,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -60,7 +60,7 @@ impl WorktreeCoordinator {
 
             let wt_registered = worktree_exists(repo_path_str, &worktree_path_str).await?;
             let dir_exists = worktree_path.exists();
-            let br_exists = branch_exists(repo_path_str, &branch).await.unwrap_or(false);
+            let br_exists = branch_exists(repo_path_str, &branch).await?;
 
             if wt_registered && br_exists {
                 // Happy path: worktree registered and branch exists — reuse it
@@ -84,8 +84,43 @@ impl WorktreeCoordinator {
                         created_now: false,
                     },
                 );
+            } else if br_exists && !wt_registered {
+                // Branch exists but worktree is missing — attach without -b
+                if dir_exists {
+                    warn!(
+                        repo = repo_name,
+                        "orphaned directory for existing branch, removing"
+                    );
+                    if let Err(e) =
+                        remove_orphaned_worktree(repo_path_str, &worktree_path_str).await
+                    {
+                        error!(repo = repo_name, error = %e, "failed to remove orphaned dir");
+                        self.rollback(&created, &newly_created).await;
+                        return Err(WorktreeError::RollbackFailed {
+                            reason: format!("cannot remove orphaned worktree: {e}"),
+                        });
+                    }
+                }
+
+                info!(repo = repo_name, "attaching worktree to existing branch");
+
+                if let Err(e) = attach_worktree(repo_path_str, &worktree_path_str, &branch).await {
+                    error!(repo = repo_name, error = %e, "failed to attach worktree");
+                    self.rollback(&created, &newly_created).await;
+                    return Err(e);
+                }
+
+                newly_created.push(repo_name.clone());
+                created.insert(
+                    repo_name.clone(),
+                    WorktreeInfo {
+                        path: worktree_path,
+                        branch: branch.clone(),
+                        created_now: false, // branch existed, not truly new
+                    },
+                );
             } else {
-                // Stale worktree: directory exists but branch/registration is gone
+                // Clean up stale state before creating fresh
                 if dir_exists && !wt_registered {
                     warn!(
                         repo = repo_name,
@@ -110,7 +145,14 @@ impl WorktreeCoordinator {
 
                 info!(repo = repo_name, path = %worktree_path.display(), "creating new worktree");
 
-                if let Err(e) = create_worktree(repo_path_str, &worktree_path_str, &branch).await {
+                if let Err(e) = create_worktree(
+                    repo_path_str,
+                    &worktree_path_str,
+                    &branch,
+                    Some(&repo_config.branch),
+                )
+                .await
+                {
                     error!(repo = repo_name, error = %e, "failed to create worktree");
                     self.rollback(&created, &newly_created).await;
                     return Err(e);

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -1,0 +1,181 @@
+use crate::config::ensemble::RepoConfig;
+use crate::error::WorktreeError;
+use crate::workspace::worktree::{
+    create_worktree, pull_worktree, remove_worktree, sanitize_branch_name, worktree_exists,
+};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tracing::{error, info, warn};
+
+/// Information about a created/found worktree.
+#[derive(Debug, Clone)]
+pub struct WorktreeInfo {
+    /// Absolute path to the worktree directory.
+    pub path: PathBuf,
+    /// The branch name used for this worktree.
+    pub branch: String,
+    /// Whether this worktree was created in this call (false = reused existing).
+    pub created_now: bool,
+}
+
+/// Coordinates worktree lifecycle across multiple repositories.
+pub struct WorktreeCoordinator {
+    repos: HashMap<String, RepoConfig>,
+    base_date: String,
+}
+
+impl WorktreeCoordinator {
+    pub fn new(repos: HashMap<String, RepoConfig>, base_date: String) -> Self {
+        Self { repos, base_date }
+    }
+
+    /// Prepare worktrees for all configured repos for the given issue.
+    ///
+    /// All-or-nothing: if any creation fails, already-created worktrees are rolled back.
+    pub async fn prepare_worktrees(
+        &self,
+        issue_id: &str,
+    ) -> Result<HashMap<String, WorktreeInfo>, WorktreeError> {
+        let branch = self.format_branch_name(issue_id);
+        let mut created = HashMap::new();
+        let mut newly_created = Vec::new();
+
+        info!(issue_id, branch, "preparing worktrees for issue");
+
+        for (repo_name, repo_config) in &self.repos {
+            let repo_path = Path::new(&repo_config.path);
+
+            if !repo_path.exists() {
+                error!(repo = %repo_path.display(), "repo path does not exist");
+                self.rollback(&created, &newly_created).await;
+                return Err(WorktreeError::InvalidRepoPath {
+                    path: repo_config.path.clone(),
+                });
+            }
+
+            let worktree_path = repo_path.join(".worktrees").join(&branch);
+            let worktree_path_str = worktree_path.to_string_lossy().to_string();
+            let repo_path_str = &repo_config.path;
+
+            match worktree_exists(repo_path_str, &worktree_path_str).await? {
+                true => {
+                    info!(repo = repo_name, "reusing existing worktree");
+
+                    if let Err(e) =
+                        pull_worktree(&worktree_path_str, &repo_config.branch).await
+                    {
+                        warn!(repo = repo_name, error = %e, "failed to pull, continuing");
+                    }
+
+                    created.insert(
+                        repo_name.clone(),
+                        WorktreeInfo {
+                            path: worktree_path,
+                            branch: branch.clone(),
+                            created_now: false,
+                        },
+                    );
+                }
+                false => {
+                    info!(repo = repo_name, path = %worktree_path.display(), "creating new worktree");
+
+                    if let Err(e) =
+                        create_worktree(repo_path_str, &worktree_path_str, &branch).await
+                    {
+                        error!(repo = repo_name, error = %e, "failed to create worktree");
+                        self.rollback(&created, &newly_created).await;
+                        return Err(e);
+                    }
+
+                    newly_created.push(repo_name.clone());
+                    created.insert(
+                        repo_name.clone(),
+                        WorktreeInfo {
+                            path: worktree_path,
+                            branch: branch.clone(),
+                            created_now: true,
+                        },
+                    );
+                }
+            }
+        }
+
+        info!(count = created.len(), "worktrees prepared successfully");
+        Ok(created)
+    }
+
+    /// Clean up worktrees and delete branches for the given issue.
+    pub async fn cleanup_worktrees(&self, issue_id: &str) -> Result<(), WorktreeError> {
+        let branch = self.format_branch_name(issue_id);
+
+        info!(issue_id, branch, "cleaning up worktrees");
+
+        for (repo_name, repo_config) in &self.repos {
+            let repo_path = Path::new(&repo_config.path);
+            let worktree_path = repo_path.join(".worktrees").join(&branch);
+            let worktree_path_str = worktree_path.to_string_lossy().to_string();
+
+            if let Err(e) =
+                remove_worktree(&repo_config.path, &worktree_path_str, &branch).await
+            {
+                warn!(repo = repo_name, error = %e, "failed to cleanup worktree (continuing)");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// List expected worktree paths for an issue without creating them.
+    pub fn list_worktree_paths(&self, issue_id: &str) -> HashMap<String, PathBuf> {
+        let branch = self.format_branch_name(issue_id);
+        let mut paths = HashMap::new();
+
+        for (repo_name, repo_config) in &self.repos {
+            let repo_path = Path::new(&repo_config.path);
+            let worktree_path = repo_path.join(".worktrees").join(&branch);
+            paths.insert(repo_name.clone(), worktree_path);
+        }
+
+        paths
+    }
+
+    fn format_branch_name(&self, issue_id: &str) -> String {
+        let sanitized = sanitize_branch_name(issue_id);
+        format!("ensemble-{}-{}", self.base_date, sanitized)
+    }
+
+    async fn rollback(
+        &self,
+        all_worktrees: &HashMap<String, WorktreeInfo>,
+        newly_created: &[String],
+    ) {
+        info!("rolling back partially created worktrees");
+
+        for repo_name in newly_created {
+            if let Some(info) = all_worktrees.get(repo_name) {
+                if let Some(repo_config) = self.repos.get(repo_name) {
+                    let worktree_path_str = info.path.to_string_lossy().to_string();
+                    if let Err(e) =
+                        remove_worktree(&repo_config.path, &worktree_path_str, &info.branch).await
+                    {
+                        error!(repo = %repo_name, error = %e, "rollback cleanup failed");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_branch_name() {
+        let repos = HashMap::new();
+        let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+
+        let branch = coordinator.format_branch_name("my-repo#42");
+        assert_eq!(branch, "ensemble-2026-03-30-my-repo#42");
+    }
+}

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -61,8 +61,12 @@ impl WorktreeCoordinator {
                 true => {
                     info!(repo = repo_name, "reusing existing worktree");
 
-                    if let Err(e) =
-                        pull_worktree(&worktree_path_str, &repo_config.branch, &repo_config.git_remote).await
+                    if let Err(e) = pull_worktree(
+                        &worktree_path_str,
+                        &repo_config.branch,
+                        &repo_config.git_remote,
+                    )
+                    .await
                     {
                         warn!(repo = repo_name, error = %e, "failed to pull, continuing");
                     }
@@ -115,9 +119,7 @@ impl WorktreeCoordinator {
             let worktree_path = repo_path.join(".worktrees").join(&branch);
             let worktree_path_str = worktree_path.to_string_lossy().to_string();
 
-            if let Err(e) =
-                remove_worktree(&repo_config.path, &worktree_path_str, &branch).await
-            {
+            if let Err(e) = remove_worktree(&repo_config.path, &worktree_path_str, &branch).await {
                 warn!(repo = repo_name, error = %e, "failed to cleanup worktree (continuing)");
             }
         }

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -62,7 +62,7 @@ impl WorktreeCoordinator {
                     info!(repo = repo_name, "reusing existing worktree");
 
                     if let Err(e) =
-                        pull_worktree(&worktree_path_str, &repo_config.branch).await
+                        pull_worktree(&worktree_path_str, &repo_config.branch, &repo_config.git_remote).await
                     {
                         warn!(repo = repo_name, error = %e, "failed to pull, continuing");
                     }

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -27,7 +27,10 @@ impl WorkspaceManager {
     /// Create a new WorkspaceManager with the given workspace root.
     /// The root is normalized to an absolute path.
     /// Pass `repos` to enable worktree-based workspace isolation.
-    pub fn new(root: &Path, repos: Option<HashMap<String, RepoConfig>>) -> Result<Self, WorkspaceError> {
+    pub fn new(
+        root: &Path,
+        repos: Option<HashMap<String, RepoConfig>>,
+    ) -> Result<Self, WorkspaceError> {
         let root = if root.is_absolute() {
             root.to_path_buf()
         } else {

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -27,10 +27,8 @@ impl WorkspaceManager {
     /// Create a new WorkspaceManager with the given workspace root.
     /// The root is normalized to an absolute path.
     /// Pass `repos` to enable worktree-based workspace isolation.
-    pub fn new(
-        root: &Path,
-        repos: Option<HashMap<String, RepoConfig>>,
-    ) -> Result<Self, WorkspaceError> {
+    /// Repo names are derived from path basenames.
+    pub fn new(root: &Path, repos: Option<Vec<RepoConfig>>) -> Result<Self, WorkspaceError> {
         let root = if root.is_absolute() {
             root.to_path_buf()
         } else {
@@ -41,7 +39,16 @@ impl WorkspaceManager {
                 .join(root)
         };
 
-        let worktree_coordinator = repos.map(|repos_map| {
+        let worktree_coordinator = repos.filter(|r| !r.is_empty()).map(|repo_list| {
+            let mut repos_map = HashMap::new();
+            for (index, repo) in repo_list.into_iter().enumerate() {
+                let name = Path::new(&repo.path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| format!("repo-{index}"));
+                repos_map.insert(name, repo);
+            }
             let today = chrono::Local::now().format("%Y-%m-%d").to_string();
             WorktreeCoordinator::new(repos_map, today)
         });

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -1,11 +1,16 @@
+use crate::config::ensemble::RepoConfig;
 use crate::error::WorkspaceError;
 use crate::tracker::model::sanitize_workspace_key;
+use crate::workspace::coordinator::{WorktreeCoordinator, WorktreeInfo};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 /// Result of preparing a workspace for an issue.
 pub struct WorkspaceResult {
-    /// Absolute path to the workspace directory.
-    pub path: PathBuf,
+    /// Absolute path to the base workspace directory (logs, artifacts).
+    pub base_path: PathBuf,
+    /// Map of repo name to worktree info (if repos configured).
+    pub worktrees: HashMap<String, WorktreeInfo>,
     /// The sanitized workspace key used as the directory name.
     pub workspace_key: String,
     /// True if the directory was newly created (not reused).
@@ -15,12 +20,14 @@ pub struct WorkspaceResult {
 /// Manage per-issue workspace directories.
 pub struct WorkspaceManager {
     root: PathBuf,
+    worktree_coordinator: Option<WorktreeCoordinator>,
 }
 
 impl WorkspaceManager {
     /// Create a new WorkspaceManager with the given workspace root.
     /// The root is normalized to an absolute path.
-    pub fn new(root: &Path) -> Result<Self, WorkspaceError> {
+    /// Pass `repos` to enable worktree-based workspace isolation.
+    pub fn new(root: &Path, repos: Option<HashMap<String, RepoConfig>>) -> Result<Self, WorkspaceError> {
         let root = if root.is_absolute() {
             root.to_path_buf()
         } else {
@@ -30,7 +37,16 @@ impl WorkspaceManager {
                 })?
                 .join(root)
         };
-        Ok(Self { root })
+
+        let worktree_coordinator = repos.map(|repos_map| {
+            let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+            WorktreeCoordinator::new(repos_map, today)
+        });
+
+        Ok(Self {
+            root,
+            worktree_coordinator,
+        })
     }
 
     /// Get the absolute workspace root path.
@@ -45,57 +61,82 @@ impl WorkspaceManager {
     }
 
     /// Prepare (create or reuse) a workspace for the given issue identifier.
-    pub fn prepare_workspace(&self, identifier: &str) -> Result<WorkspaceResult, WorkspaceError> {
+    pub async fn prepare_workspace(
+        &self,
+        identifier: &str,
+    ) -> Result<WorkspaceResult, WorkspaceError> {
         let workspace_key =
             sanitize_workspace_key(identifier).ok_or_else(|| WorkspaceError::CreationFailed {
                 reason: format!("unsafe workspace key from identifier: {identifier:?}"),
             })?;
-        let workspace_path = self.root.join(&workspace_key);
+        let base_path = self.root.join(&workspace_key);
 
         // Safety: ensure workspace path is inside root
-        self.validate_path_inside_root(&workspace_path)?;
+        self.validate_path_inside_root(&base_path)?;
 
-        let created_now = if workspace_path.exists() {
-            if !workspace_path.is_dir() {
+        let base_created = if base_path.exists() {
+            if !base_path.is_dir() {
                 return Err(WorkspaceError::CreationFailed {
                     reason: format!(
                         "path exists but is not a directory: {}",
-                        workspace_path.display()
+                        base_path.display()
                     ),
                 });
             }
             false
         } else {
-            std::fs::create_dir_all(&workspace_path).map_err(|e| {
-                WorkspaceError::CreationFailed {
-                    reason: format!("mkdir failed: {e}"),
-                }
+            std::fs::create_dir_all(&base_path).map_err(|e| WorkspaceError::CreationFailed {
+                reason: format!("mkdir failed: {e}"),
             })?;
             true
         };
 
+        // Prepare worktrees if coordinator is configured
+        let worktrees = if let Some(coordinator) = &self.worktree_coordinator {
+            coordinator
+                .prepare_worktrees(identifier)
+                .await
+                .map_err(|e| WorkspaceError::CreationFailed {
+                    reason: format!("worktree preparation failed: {e}"),
+                })?
+        } else {
+            HashMap::new()
+        };
+
+        let created_now = base_created || worktrees.values().any(|w| w.created_now);
+
         Ok(WorkspaceResult {
-            path: workspace_path,
+            base_path,
+            worktrees,
             workspace_key,
             created_now,
         })
     }
 
-    /// Remove a workspace directory for the given issue identifier.
-    pub fn remove_workspace(&self, identifier: &str) -> Result<(), WorkspaceError> {
+    /// Remove a workspace directory and its worktrees for the given issue identifier.
+    pub async fn remove_workspace(&self, identifier: &str) -> Result<(), WorkspaceError> {
         let workspace_key =
             sanitize_workspace_key(identifier).ok_or_else(|| WorkspaceError::CreationFailed {
                 reason: format!("unsafe workspace key from identifier: {identifier:?}"),
             })?;
-        let workspace_path = self.root.join(&workspace_key);
+        let base_path = self.root.join(&workspace_key);
 
-        self.validate_path_inside_root(&workspace_path)?;
+        self.validate_path_inside_root(&base_path)?;
 
-        if workspace_path.exists() {
-            std::fs::remove_dir_all(&workspace_path).map_err(|e| {
-                WorkspaceError::CreationFailed {
-                    reason: format!("remove failed: {e}"),
-                }
+        // Clean up worktrees first
+        if let Some(coordinator) = &self.worktree_coordinator {
+            coordinator
+                .cleanup_worktrees(identifier)
+                .await
+                .map_err(|e| WorkspaceError::CreationFailed {
+                    reason: format!("worktree cleanup failed: {e}"),
+                })?;
+        }
+
+        // Remove base workspace
+        if base_path.exists() {
+            std::fs::remove_dir_all(&base_path).map_err(|e| WorkspaceError::CreationFailed {
+                reason: format!("remove failed: {e}"),
             })?;
         }
         Ok(())
@@ -110,9 +151,6 @@ impl WorkspaceManager {
     /// When `path` does not yet exist (pre-creation), its parent is canonicalized
     /// and the final component is re-appended, preserving the intended semantics.
     fn validate_path_inside_root(&self, path: &Path) -> Result<(), WorkspaceError> {
-        // Resolve the root to its canonical form. Canonicalize can fail if
-        // permissions prevent stat — fall back to the raw path, which is safe
-        // because a non-canonical path only makes the starts_with check stricter.
         let canonical_root = if self.root.exists() {
             self.root
                 .canonicalize()
@@ -121,8 +159,6 @@ impl WorkspaceManager {
             self.root.clone()
         };
 
-        // Resolve the candidate path. If it does not exist yet, resolve its parent
-        // and append the final component so we still get a canonical form.
         let canonical_path = if path.exists() {
             path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
         } else if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
@@ -154,99 +190,97 @@ mod tests {
 
     fn setup() -> (TempDir, WorkspaceManager) {
         let dir = TempDir::new().unwrap();
-        let mgr = WorkspaceManager::new(dir.path()).unwrap();
+        let mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         (dir, mgr)
     }
 
-    #[test]
-    fn test_prepare_creates_new_workspace() {
+    #[tokio::test]
+    async fn test_prepare_creates_new_workspace() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace("my-repo#42").unwrap();
+        let result = mgr.prepare_workspace("my-repo#42").await.unwrap();
         assert!(result.created_now);
         assert_eq!(result.workspace_key, "my-repo_42");
-        assert!(result.path.is_dir());
+        assert!(result.base_path.is_dir());
     }
 
-    #[test]
-    fn test_prepare_reuses_existing_workspace() {
+    #[tokio::test]
+    async fn test_prepare_reuses_existing_workspace() {
         let (_dir, mgr) = setup();
-        let first = mgr.prepare_workspace("my-repo#42").unwrap();
+        let first = mgr.prepare_workspace("my-repo#42").await.unwrap();
         assert!(first.created_now);
 
-        let second = mgr.prepare_workspace("my-repo#42").unwrap();
+        let second = mgr.prepare_workspace("my-repo#42").await.unwrap();
         assert!(!second.created_now);
-        assert_eq!(first.path, second.path);
+        assert_eq!(first.base_path, second.base_path);
     }
 
-    #[test]
-    fn test_prepare_sanitizes_identifier() {
+    #[tokio::test]
+    async fn test_prepare_sanitizes_identifier() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace("acme/repo 123!@#").unwrap();
+        let result = mgr.prepare_workspace("acme/repo 123!@#").await.unwrap();
         assert_eq!(result.workspace_key, "acme_repo_123___");
-        assert!(result.path.is_dir());
+        assert!(result.base_path.is_dir());
     }
 
-    #[test]
-    fn test_prepare_deterministic_path() {
+    #[tokio::test]
+    async fn test_prepare_deterministic_path() {
         let (_dir, mgr) = setup();
-        let r1 = mgr.prepare_workspace("test-issue").unwrap();
-        let r2 = mgr.prepare_workspace("test-issue").unwrap();
-        assert_eq!(r1.path, r2.path);
+        let r1 = mgr.prepare_workspace("test-issue").await.unwrap();
+        let r2 = mgr.prepare_workspace("test-issue").await.unwrap();
+        assert_eq!(r1.base_path, r2.base_path);
     }
 
-    #[test]
-    fn test_remove_workspace() {
+    #[tokio::test]
+    async fn test_remove_workspace() {
         let (_dir, mgr) = setup();
-        mgr.prepare_workspace("my-repo#42").unwrap();
+        mgr.prepare_workspace("my-repo#42").await.unwrap();
 
         let ws_path = mgr.root().join("my-repo_42");
         assert!(ws_path.exists());
 
-        mgr.remove_workspace("my-repo#42").unwrap();
+        mgr.remove_workspace("my-repo#42").await.unwrap();
         assert!(!ws_path.exists());
     }
 
-    #[test]
-    fn test_remove_nonexistent_is_ok() {
+    #[tokio::test]
+    async fn test_remove_nonexistent_is_ok() {
         let (_dir, mgr) = setup();
-        assert!(mgr.remove_workspace("nonexistent").is_ok());
+        assert!(mgr.remove_workspace("nonexistent").await.is_ok());
     }
 
-    #[test]
-    fn test_path_inside_root_validation() {
+    #[tokio::test]
+    async fn test_path_inside_root_validation() {
         let (_dir, mgr) = setup();
-        // Normal path should be fine
-        let result = mgr.prepare_workspace("normal-issue");
+        let result = mgr.prepare_workspace("normal-issue").await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_file_at_workspace_path_errors() {
+    #[tokio::test]
+    async fn test_file_at_workspace_path_errors() {
         let (dir, mgr) = setup();
-        // Create a file where the workspace dir would be
         let file_path = dir.path().join("my-repo_42");
         std::fs::write(&file_path, "not a directory").unwrap();
 
-        let result = mgr.prepare_workspace("my-repo#42");
+        let result = mgr.prepare_workspace("my-repo#42").await;
         assert!(matches!(result, Err(WorkspaceError::CreationFailed { .. })));
     }
 
-    #[test]
-    fn test_dot_identifier_rejected() {
+    #[tokio::test]
+    async fn test_dot_identifier_rejected() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace(".");
+        let result = mgr.prepare_workspace(".").await;
         assert!(matches!(result, Err(WorkspaceError::CreationFailed { .. })));
     }
 
-    #[test]
-    fn test_dotdot_identifier_rejected() {
+    #[tokio::test]
+    async fn test_dotdot_identifier_rejected() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace("..");
+        let result = mgr.prepare_workspace("..").await;
         assert!(matches!(result, Err(WorkspaceError::CreationFailed { .. })));
     }
 
-    #[test]
-    fn test_workspace_root_accessor() {
+    #[tokio::test]
+    async fn test_workspace_root_accessor() {
         let (dir, mgr) = setup();
         assert_eq!(mgr.root(), dir.path());
     }

--- a/crates/ensemble-core/src/workspace/mod.rs
+++ b/crates/ensemble-core/src/workspace/mod.rs
@@ -1,2 +1,3 @@
 pub mod hooks;
 pub mod manager;
+pub mod worktree;

--- a/crates/ensemble-core/src/workspace/mod.rs
+++ b/crates/ensemble-core/src/workspace/mod.rs
@@ -1,4 +1,5 @@
 pub mod coordinator;
 pub mod hooks;
 pub mod manager;
+pub mod push_strategy;
 pub mod worktree;

--- a/crates/ensemble-core/src/workspace/mod.rs
+++ b/crates/ensemble-core/src/workspace/mod.rs
@@ -1,3 +1,4 @@
+pub mod coordinator;
 pub mod hooks;
 pub mod manager;
 pub mod worktree;

--- a/crates/ensemble-core/src/workspace/push_strategy.rs
+++ b/crates/ensemble-core/src/workspace/push_strategy.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+
+/// Strategy for handling branch pushes at the end of a successful pipeline.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PushStrategy {
+    /// Prompt user interactively (CLI mode only, blocks until response).
+    Ask,
+    /// Automatically push branch to origin.
+    AutoPush,
+    /// Leave local, user handles manually.
+    #[default]
+    Manual,
+    /// Only create PR (implicit push).
+    PrOnly,
+}
+
+impl PushStrategy {
+    /// Returns true if this strategy requires interactive user input.
+    pub fn is_interactive(&self) -> bool {
+        matches!(self, PushStrategy::Ask)
+    }
+
+    /// Returns true if this strategy will push to remote.
+    pub fn will_push(&self) -> bool {
+        matches!(self, PushStrategy::AutoPush | PushStrategy::PrOnly)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_strategy_is_interactive() {
+        assert!(PushStrategy::Ask.is_interactive());
+        assert!(!PushStrategy::AutoPush.is_interactive());
+        assert!(!PushStrategy::Manual.is_interactive());
+        assert!(!PushStrategy::PrOnly.is_interactive());
+    }
+
+    #[test]
+    fn test_push_strategy_will_push() {
+        assert!(!PushStrategy::Ask.will_push());
+        assert!(PushStrategy::AutoPush.will_push());
+        assert!(!PushStrategy::Manual.will_push());
+        assert!(PushStrategy::PrOnly.will_push());
+    }
+
+    #[test]
+    fn test_push_strategy_default() {
+        assert_eq!(PushStrategy::default(), PushStrategy::Manual);
+    }
+
+    #[test]
+    fn test_push_strategy_deserialization() {
+        let yaml = r#""ask""#;
+        let strategy: PushStrategy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(strategy, PushStrategy::Ask);
+
+        let yaml = r#""auto_push""#;
+        let strategy: PushStrategy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(strategy, PushStrategy::AutoPush);
+    }
+}

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -28,10 +28,15 @@ pub fn sanitize_branch_name(identifier: &str) -> String {
     result
 }
 
+/// Create a worktree with a new branch, optionally based on a start point.
+///
+/// If `start_point` is provided (e.g. "main"), the new branch is created from
+/// that ref instead of HEAD.
 pub async fn create_worktree(
     repo_path: &str,
     worktree_path: &str,
     branch: &str,
+    start_point: Option<&str>,
 ) -> Result<(), WorktreeError> {
     let repo = Path::new(repo_path);
     if !repo.join(".git").exists() {
@@ -52,11 +57,17 @@ pub async fn create_worktree(
         repo_path = %repo_path,
         worktree_path = %worktree_path,
         branch = %branch,
+        start_point = ?start_point,
         "Creating worktree with new branch"
     );
 
+    let mut args = vec!["worktree", "add", "-b", branch, worktree_path];
+    if let Some(sp) = start_point {
+        args.push(sp);
+    }
+
     let output = Command::new("git")
-        .args(["worktree", "add", "-b", branch, worktree_path])
+        .args(&args)
         .current_dir(repo_path)
         .output()
         .await
@@ -85,6 +96,44 @@ pub async fn create_worktree(
     }
 
     debug!(worktree_path = %worktree_path, "Worktree created successfully");
+    Ok(())
+}
+
+/// Attach a worktree to an existing branch (no `-b`).
+///
+/// Use this when the branch already exists but the worktree directory is missing.
+pub async fn attach_worktree(
+    repo_path: &str,
+    worktree_path: &str,
+    branch: &str,
+) -> Result<(), WorktreeError> {
+    info!(
+        repo_path = %repo_path,
+        worktree_path = %worktree_path,
+        branch = %branch,
+        "Attaching worktree to existing branch"
+    );
+
+    let output = Command::new("git")
+        .args(["worktree", "add", worktree_path, branch])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .map_err(|e| WorktreeError::GitCommandFailed {
+            command: format!("git worktree add {} {}", worktree_path, branch),
+            reason: e.to_string(),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!(stderr = %stderr, "Git worktree attach failed");
+        return Err(WorktreeError::CreationFailed {
+            repo: repo_path.to_string(),
+            reason: stderr.to_string(),
+        });
+    }
+
+    debug!(worktree_path = %worktree_path, "Worktree attached successfully");
     Ok(())
 }
 
@@ -211,7 +260,7 @@ pub async fn remove_worktree(
     }
 
     let output = Command::new("git")
-        .args(["worktree", "remove", worktree_path])
+        .args(["worktree", "remove", "--force", worktree_path])
         .current_dir(repo_path)
         .output()
         .await

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -190,10 +190,15 @@ pub async fn remove_worktree(
     Ok(())
 }
 
-pub async fn pull_worktree(worktree_path: &str, branch: &str) -> Result<(), WorktreeError> {
+pub async fn pull_worktree(
+    worktree_path: &str,
+    branch: &str,
+    remote: &str,
+) -> Result<(), WorktreeError> {
     info!(
         worktree_path = %worktree_path,
         branch = %branch,
+        remote = %remote,
         "Pulling latest changes"
     );
 
@@ -206,14 +211,14 @@ pub async fn pull_worktree(worktree_path: &str, branch: &str) -> Result<(), Work
     }
 
     let output = Command::new("git")
-        .args(["pull", "origin", branch])
+        .args(["pull", remote, branch])
         .current_dir(worktree_path)
         .output()
         .await
         .map_err(|e| {
             error!(error = %e, "Failed to spawn git pull command");
             WorktreeError::GitCommandFailed {
-                command: format!("git pull origin {}", branch),
+                command: format!("git pull {} {}", remote, branch),
                 reason: e.to_string(),
             }
         })?;
@@ -222,7 +227,7 @@ pub async fn pull_worktree(worktree_path: &str, branch: &str) -> Result<(), Work
         let stderr = String::from_utf8_lossy(&output.stderr);
         error!(stderr = %stderr, "Git pull command failed");
         return Err(WorktreeError::GitCommandFailed {
-            command: format!("git pull origin {}", branch),
+            command: format!("git pull {} {}", remote, branch),
             reason: stderr.to_string(),
         });
     }

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -4,8 +4,7 @@ use tokio::process::Command;
 use tracing::{debug, error, info, warn};
 
 pub fn sanitize_branch_name(identifier: &str) -> String {
-    identifier
-        .replace(['/', ':', ' ', '\t'], "-")
+    identifier.replace(['/', ':', ' ', '\t'], "-")
 }
 
 pub async fn create_worktree(
@@ -36,13 +35,7 @@ pub async fn create_worktree(
     );
 
     let output = Command::new("git")
-        .args([
-            "worktree",
-            "add",
-            "-b",
-            branch,
-            worktree_path,
-        ])
+        .args(["worktree", "add", "-b", branch, worktree_path])
         .current_dir(repo_path)
         .output()
         .await
@@ -57,13 +50,13 @@ pub async fn create_worktree(
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         error!(stderr = %stderr, "Git worktree add command failed");
-        
+
         if stderr.contains("already exists") {
             return Err(WorktreeError::AlreadyExists {
                 path: worktree_path.to_string(),
             });
         }
-        
+
         return Err(WorktreeError::CreationFailed {
             repo: repo_path.to_string(),
             reason: stderr.to_string(),
@@ -104,15 +97,17 @@ pub async fn worktree_exists(repo_path: &str, worktree_path: &str) -> Result<boo
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let worktree_path_normalized = Path::new(worktree_path).canonicalize()
+    let worktree_path_normalized = Path::new(worktree_path)
+        .canonicalize()
         .unwrap_or_else(|_| Path::new(worktree_path).to_path_buf());
-    
+
     for line in stdout.lines() {
         if line.starts_with("worktree ") {
             let listed_path = line.strip_prefix("worktree ").unwrap_or(line);
-            let listed_path_normalized = Path::new(listed_path).canonicalize()
+            let listed_path_normalized = Path::new(listed_path)
+                .canonicalize()
                 .unwrap_or_else(|_| Path::new(listed_path).to_path_buf());
-            
+
             if listed_path_normalized == worktree_path_normalized {
                 debug!(worktree_path = %worktree_path, "Worktree found in list");
                 return Ok(true);
@@ -259,7 +254,10 @@ mod tests {
 
     #[test]
     fn test_sanitize_branch_name_no_change() {
-        assert_eq!(sanitize_branch_name("valid-branch-name"), "valid-branch-name");
+        assert_eq!(
+            sanitize_branch_name("valid-branch-name"),
+            "valid-branch-name"
+        );
         assert_eq!(sanitize_branch_name("issue_123"), "issue_123");
     }
 }

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -1,0 +1,263 @@
+use crate::error::WorktreeError;
+use std::path::Path;
+use tokio::process::Command;
+use tracing::{debug, error, info, warn};
+
+pub fn sanitize_branch_name(identifier: &str) -> String {
+    identifier
+        .replace('/', "-")
+        .replace(':', "-")
+        .replace(' ', "-")
+        .replace('\t', "-")
+}
+
+pub async fn create_worktree(
+    repo_path: &str,
+    worktree_path: &str,
+    branch: &str,
+) -> Result<(), WorktreeError> {
+    let repo = Path::new(repo_path);
+    if !repo.join(".git").exists() {
+        error!(repo_path = %repo_path, "Invalid repo path - no .git directory");
+        return Err(WorktreeError::InvalidRepoPath {
+            path: repo_path.to_string(),
+        });
+    }
+
+    if worktree_exists(repo_path, worktree_path).await? {
+        warn!(worktree_path = %worktree_path, "Worktree already exists");
+        return Err(WorktreeError::AlreadyExists {
+            path: worktree_path.to_string(),
+        });
+    }
+
+    info!(
+        repo_path = %repo_path,
+        worktree_path = %worktree_path,
+        branch = %branch,
+        "Creating worktree with new branch"
+    );
+
+    let output = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            worktree_path,
+        ])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .map_err(|e| {
+            error!(error = %e, "Failed to spawn git worktree add command");
+            WorktreeError::GitCommandFailed {
+                command: format!("git worktree add -b {} {}", branch, worktree_path),
+                reason: e.to_string(),
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!(stderr = %stderr, "Git worktree add command failed");
+        
+        if stderr.contains("already exists") {
+            return Err(WorktreeError::AlreadyExists {
+                path: worktree_path.to_string(),
+            });
+        }
+        
+        return Err(WorktreeError::CreationFailed {
+            repo: repo_path.to_string(),
+            reason: stderr.to_string(),
+        });
+    }
+
+    debug!(worktree_path = %worktree_path, "Worktree created successfully");
+    Ok(())
+}
+
+pub async fn worktree_exists(repo_path: &str, worktree_path: &str) -> Result<bool, WorktreeError> {
+    debug!(
+        repo_path = %repo_path,
+        worktree_path = %worktree_path,
+        "Checking if worktree exists"
+    );
+
+    let output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .map_err(|e| {
+            error!(error = %e, "Failed to spawn git worktree list command");
+            WorktreeError::GitCommandFailed {
+                command: "git worktree list --porcelain".to_string(),
+                reason: e.to_string(),
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!(stderr = %stderr, "Git worktree list command failed");
+        return Err(WorktreeError::GitCommandFailed {
+            command: "git worktree list --porcelain".to_string(),
+            reason: stderr.to_string(),
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let worktree_path_normalized = Path::new(worktree_path).canonicalize()
+        .unwrap_or_else(|_| Path::new(worktree_path).to_path_buf());
+    
+    for line in stdout.lines() {
+        if line.starts_with("worktree ") {
+            let listed_path = line.strip_prefix("worktree ").unwrap_or(line);
+            let listed_path_normalized = Path::new(listed_path).canonicalize()
+                .unwrap_or_else(|_| Path::new(listed_path).to_path_buf());
+            
+            if listed_path_normalized == worktree_path_normalized {
+                debug!(worktree_path = %worktree_path, "Worktree found in list");
+                return Ok(true);
+            }
+        }
+    }
+
+    debug!(worktree_path = %worktree_path, "Worktree not found in list");
+    Ok(false)
+}
+
+pub async fn remove_worktree(
+    repo_path: &str,
+    worktree_path: &str,
+    branch: &str,
+) -> Result<(), WorktreeError> {
+    info!(
+        repo_path = %repo_path,
+        worktree_path = %worktree_path,
+        branch = %branch,
+        "Removing worktree"
+    );
+
+    if !worktree_exists(repo_path, worktree_path).await? {
+        warn!(worktree_path = %worktree_path, "Worktree does not exist");
+        return Err(WorktreeError::NotFound {
+            path: worktree_path.to_string(),
+        });
+    }
+
+    let output = Command::new("git")
+        .args(["worktree", "remove", worktree_path])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .map_err(|e| {
+            error!(error = %e, "Failed to spawn git worktree remove command");
+            WorktreeError::GitCommandFailed {
+                command: format!("git worktree remove {}", worktree_path),
+                reason: e.to_string(),
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!(stderr = %stderr, "Git worktree remove command failed");
+        return Err(WorktreeError::GitCommandFailed {
+            command: format!("git worktree remove {}", worktree_path),
+            reason: stderr.to_string(),
+        });
+    }
+
+    debug!(worktree_path = %worktree_path, "Worktree removed successfully");
+
+    let branch_output = Command::new("git")
+        .args(["branch", "-D", branch])
+        .current_dir(repo_path)
+        .output()
+        .await;
+
+    match branch_output {
+        Ok(output) => {
+            if output.status.success() {
+                debug!(branch = %branch, "Branch deleted successfully");
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                warn!(stderr = %stderr, branch = %branch, "Failed to delete branch");
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, branch = %branch, "Failed to spawn branch delete command");
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn pull_worktree(worktree_path: &str, branch: &str) -> Result<(), WorktreeError> {
+    info!(
+        worktree_path = %worktree_path,
+        branch = %branch,
+        "Pulling latest changes"
+    );
+
+    let worktree = Path::new(worktree_path);
+    if !worktree.join(".git").exists() {
+        error!(worktree_path = %worktree_path, "Invalid worktree path - no .git file");
+        return Err(WorktreeError::NotFound {
+            path: worktree_path.to_string(),
+        });
+    }
+
+    let output = Command::new("git")
+        .args(["pull", "origin", branch])
+        .current_dir(worktree_path)
+        .output()
+        .await
+        .map_err(|e| {
+            error!(error = %e, "Failed to spawn git pull command");
+            WorktreeError::GitCommandFailed {
+                command: format!("git pull origin {}", branch),
+                reason: e.to_string(),
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!(stderr = %stderr, "Git pull command failed");
+        return Err(WorktreeError::GitCommandFailed {
+            command: format!("git pull origin {}", branch),
+            reason: stderr.to_string(),
+        });
+    }
+
+    debug!(worktree_path = %worktree_path, "Pull completed successfully");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_branch_name_basic() {
+        assert_eq!(sanitize_branch_name("issue-123"), "issue-123");
+        assert_eq!(sanitize_branch_name("feature/test"), "feature-test");
+        assert_eq!(sanitize_branch_name("bug: fix"), "bug--fix");
+        assert_eq!(sanitize_branch_name("with space"), "with-space");
+        assert_eq!(sanitize_branch_name("with\ttab"), "with-tab");
+    }
+
+    #[test]
+    fn test_sanitize_branch_name_multiple_special() {
+        assert_eq!(
+            sanitize_branch_name("feat/JIRA-123: add feature"),
+            "feat-JIRA-123--add-feature"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_branch_name_no_change() {
+        assert_eq!(sanitize_branch_name("valid-branch-name"), "valid-branch-name");
+        assert_eq!(sanitize_branch_name("issue_123"), "issue_123");
+    }
+}

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -5,10 +5,7 @@ use tracing::{debug, error, info, warn};
 
 pub fn sanitize_branch_name(identifier: &str) -> String {
     identifier
-        .replace('/', "-")
-        .replace(':', "-")
-        .replace(' ', "-")
-        .replace('\t', "-")
+        .replace(['/', ':', ' ', '\t'], "-")
 }
 
 pub async fn create_worktree(

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -3,8 +3,29 @@ use std::path::Path;
 use tokio::process::Command;
 use tracing::{debug, error, info, warn};
 
+/// Sanitize an issue identifier for use in git branch names.
+///
+/// Rules (per spec): all non-alphanumeric chars → `-`, collapse consecutive
+/// dashes, strip leading/trailing dashes, lowercase everything.
 pub fn sanitize_branch_name(identifier: &str) -> String {
-    identifier.replace(['/', ':', ' ', '\t'], "-")
+    let mut result = String::with_capacity(identifier.len());
+    let mut last_was_dash = true; // true to strip leading dashes
+
+    for c in identifier.chars() {
+        if c.is_alphanumeric() {
+            result.push(c.to_ascii_lowercase());
+            last_was_dash = false;
+        } else if !last_was_dash {
+            result.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    if result.ends_with('-') {
+        result.pop();
+    }
+
+    result
 }
 
 pub async fn create_worktree(
@@ -117,6 +138,57 @@ pub async fn worktree_exists(repo_path: &str, worktree_path: &str) -> Result<boo
 
     debug!(worktree_path = %worktree_path, "Worktree not found in list");
     Ok(false)
+}
+
+/// Check if a local branch exists in the repo.
+pub async fn branch_exists(repo_path: &str, branch: &str) -> Result<bool, WorktreeError> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", &format!("refs/heads/{branch}")])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .map_err(|e| WorktreeError::GitCommandFailed {
+            command: "git rev-parse".to_string(),
+            reason: e.to_string(),
+        })?;
+
+    Ok(output.status.success())
+}
+
+/// Remove an orphaned worktree directory that is not registered in git.
+///
+/// This handles the case where the directory exists but `git worktree list`
+/// doesn't know about it (e.g. branch was deleted, or previous cleanup was
+/// interrupted).
+pub async fn remove_orphaned_worktree(
+    repo_path: &str,
+    worktree_path: &str,
+) -> Result<(), WorktreeError> {
+    warn!(
+        repo_path = %repo_path,
+        worktree_path = %worktree_path,
+        "Removing orphaned worktree directory"
+    );
+
+    // Try git worktree prune first to clean stale entries
+    let _ = Command::new("git")
+        .args(["worktree", "prune"])
+        .current_dir(repo_path)
+        .output()
+        .await;
+
+    // Remove the directory
+    let path = Path::new(worktree_path);
+    if path.exists() {
+        tokio::fs::remove_dir_all(path)
+            .await
+            .map_err(|e| WorktreeError::GitCommandFailed {
+                command: format!("remove orphaned dir {}", worktree_path),
+                reason: e.to_string(),
+            })?;
+    }
+
+    Ok(())
 }
 
 pub async fn remove_worktree(
@@ -239,7 +311,7 @@ mod tests {
     fn test_sanitize_branch_name_basic() {
         assert_eq!(sanitize_branch_name("issue-123"), "issue-123");
         assert_eq!(sanitize_branch_name("feature/test"), "feature-test");
-        assert_eq!(sanitize_branch_name("bug: fix"), "bug--fix");
+        assert_eq!(sanitize_branch_name("bug: fix"), "bug-fix");
         assert_eq!(sanitize_branch_name("with space"), "with-space");
         assert_eq!(sanitize_branch_name("with\ttab"), "with-tab");
     }
@@ -248,7 +320,7 @@ mod tests {
     fn test_sanitize_branch_name_multiple_special() {
         assert_eq!(
             sanitize_branch_name("feat/JIRA-123: add feature"),
-            "feat-JIRA-123--add-feature"
+            "feat-jira-123-add-feature"
         );
     }
 
@@ -258,6 +330,18 @@ mod tests {
             sanitize_branch_name("valid-branch-name"),
             "valid-branch-name"
         );
-        assert_eq!(sanitize_branch_name("issue_123"), "issue_123");
+        // underscores are non-alphanumeric, so they become dashes
+        assert_eq!(sanitize_branch_name("issue_123"), "issue-123");
+    }
+
+    #[test]
+    fn test_sanitize_branch_name_spec_examples() {
+        assert_eq!(sanitize_branch_name("my-repo#42"), "my-repo-42");
+        assert_eq!(sanitize_branch_name("acme/api#123"), "acme-api-123");
+        assert_eq!(
+            sanitize_branch_name("FEATURE_Add Dark Mode!!!"),
+            "feature-add-dark-mode"
+        );
+        assert_eq!(sanitize_branch_name("--test--"), "test");
     }
 }

--- a/crates/ensemble-core/tests/coordinator_tests.rs
+++ b/crates/ensemble-core/tests/coordinator_tests.rs
@@ -33,6 +33,7 @@ fn setup_repo(name: &str) -> (TempDir, RepoConfig) {
     let config = RepoConfig {
         path: dir.path().to_string_lossy().to_string(),
         branch: "main".to_string(),
+        git_remote: "origin".to_string(),
     };
 
     (dir, config)

--- a/crates/ensemble-core/tests/coordinator_tests.rs
+++ b/crates/ensemble-core/tests/coordinator_tests.rs
@@ -1,0 +1,108 @@
+use ensemble_core::config::ensemble::RepoConfig;
+use ensemble_core::workspace::coordinator::WorktreeCoordinator;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+fn setup_repo(name: &str) -> (TempDir, RepoConfig) {
+    let dir = TempDir::new().unwrap();
+
+    // Initialize git repo
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+
+    // Create initial commit
+    std::fs::write(dir.path().join("README.md"), format!("# {}", name)).unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(&dir)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .output()
+        .unwrap();
+
+    let config = RepoConfig {
+        path: dir.path().to_string_lossy().to_string(),
+        branch: "main".to_string(),
+    };
+
+    (dir, config)
+}
+
+#[tokio::test]
+async fn test_prepare_worktrees_creates_all() {
+    let (_repo1_dir, repo1_config) = setup_repo("repo1");
+    let (_repo2_dir, repo2_config) = setup_repo("repo2");
+
+    let repos = HashMap::from([
+        ("frontend".to_string(), repo1_config),
+        ("api".to_string(), repo2_config),
+    ]);
+
+    let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+
+    let result = coordinator.prepare_worktrees("my-issue-42").await;
+
+    assert!(result.is_ok());
+    let worktrees = result.unwrap();
+
+    assert_eq!(worktrees.len(), 2);
+    assert!(worktrees.contains_key("frontend"));
+    assert!(worktrees.contains_key("api"));
+
+    // Verify directories exist
+    let frontend_path = &worktrees["frontend"].path;
+    let api_path = &worktrees["api"].path;
+
+    assert!(frontend_path.exists());
+    assert!(api_path.exists());
+    assert!(worktrees["frontend"].created_now);
+    assert!(worktrees["api"].created_now);
+}
+
+#[tokio::test]
+async fn test_prepare_worktrees_reuses_existing() {
+    let (_repo1_dir, repo1_config) = setup_repo("repo1");
+
+    let repos = HashMap::from([("frontend".to_string(), repo1_config)]);
+
+    let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+
+    // First call creates
+    let result1 = coordinator.prepare_worktrees("my-issue-42").await.unwrap();
+    assert!(result1["frontend"].created_now);
+
+    // Second call reuses
+    let result2 = coordinator.prepare_worktrees("my-issue-42").await.unwrap();
+    assert!(!result2["frontend"].created_now);
+    assert_eq!(result1["frontend"].path, result2["frontend"].path);
+}
+
+#[tokio::test]
+async fn test_cleanup_worktrees() {
+    let (_repo1_dir, repo1_config) = setup_repo("repo1");
+
+    let repos = HashMap::from([("frontend".to_string(), repo1_config)]);
+
+    let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+
+    // Create worktree
+    let worktrees = coordinator.prepare_worktrees("my-issue-42").await.unwrap();
+    let path = worktrees["frontend"].path.clone();
+    assert!(path.exists());
+
+    // Cleanup
+    coordinator.cleanup_worktrees("my-issue-42").await.unwrap();
+
+    // Verify removed
+    assert!(!path.exists());
+}

--- a/crates/ensemble-core/tests/coordinator_tests.rs
+++ b/crates/ensemble-core/tests/coordinator_tests.rs
@@ -8,7 +8,7 @@ fn setup_repo(name: &str) -> (TempDir, RepoConfig) {
 
     // Initialize git repo
     std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();

--- a/crates/ensemble-core/tests/workflow_to_workspace.rs
+++ b/crates/ensemble-core/tests/workflow_to_workspace.rs
@@ -128,7 +128,7 @@ async fn test_hook_in_workspace() {
 fn setup_git_repo(name: &str) -> TempDir {
     let dir = TempDir::new().unwrap();
     std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();

--- a/crates/ensemble-core/tests/workflow_to_workspace.rs
+++ b/crates/ensemble-core/tests/workflow_to_workspace.rs
@@ -5,7 +5,6 @@ use ensemble_core::config::template::render_prompt;
 use ensemble_core::tracker::model::{sanitize_workspace_key, Issue};
 use ensemble_core::workspace::hooks::run_hook;
 use ensemble_core::workspace::manager::WorkspaceManager;
-use std::collections::HashMap;
 use tempfile::TempDir;
 
 fn sample_issue() -> Issue {
@@ -156,14 +155,11 @@ async fn test_workflow_with_worktrees() {
     let ws_dir = TempDir::new().unwrap();
     let repo_dir = setup_git_repo("test-repo");
 
-    let repos = HashMap::from([(
-        "test-repo".to_string(),
-        RepoConfig {
-            path: repo_dir.path().to_string_lossy().to_string(),
-            branch: "main".to_string(),
-            git_remote: "origin".to_string(),
-        },
-    )]);
+    let repos = vec![RepoConfig {
+        path: repo_dir.path().to_string_lossy().to_string(),
+        branch: "main".to_string(),
+        git_remote: "origin".to_string(),
+    }];
 
     let mgr = WorkspaceManager::new(ws_dir.path(), Some(repos)).unwrap();
     let issue = sample_issue();
@@ -174,10 +170,8 @@ async fn test_workflow_with_worktrees() {
     assert!(ws.base_path.is_dir());
     assert!(!ws.worktrees.is_empty());
 
-    let worktree_info = ws
-        .worktrees
-        .get("test-repo")
-        .expect("worktree should exist");
+    assert_eq!(ws.worktrees.len(), 1);
+    let (repo_key, worktree_info) = ws.worktrees.iter().next().unwrap();
     assert!(worktree_info.path.exists());
     assert!(worktree_info.created_now);
     assert!(worktree_info.path.join("README.md").exists());
@@ -185,7 +179,7 @@ async fn test_workflow_with_worktrees() {
     // Reuse workspace
     let ws2 = mgr.prepare_workspace(&issue.identifier).await.unwrap();
     assert!(!ws2.created_now);
-    let worktree_info2 = ws2.worktrees.get("test-repo").unwrap();
+    let worktree_info2 = ws2.worktrees.get(repo_key).unwrap();
     assert!(!worktree_info2.created_now);
     assert_eq!(worktree_info.path, worktree_info2.path);
 

--- a/crates/ensemble-core/tests/workflow_to_workspace.rs
+++ b/crates/ensemble-core/tests/workflow_to_workspace.rs
@@ -174,7 +174,10 @@ async fn test_workflow_with_worktrees() {
     assert!(ws.base_path.is_dir());
     assert!(!ws.worktrees.is_empty());
 
-    let worktree_info = ws.worktrees.get("test-repo").expect("worktree should exist");
+    let worktree_info = ws
+        .worktrees
+        .get("test-repo")
+        .expect("worktree should exist");
     assert!(worktree_info.path.exists());
     assert!(worktree_info.created_now);
     assert!(worktree_info.path.join("README.md").exists());

--- a/crates/ensemble-core/tests/workflow_to_workspace.rs
+++ b/crates/ensemble-core/tests/workflow_to_workspace.rs
@@ -1,10 +1,11 @@
 //! Integration test: load ensemble.yaml -> parse config -> create workspace -> run hooks
 
-use ensemble_core::config::ensemble::{parse_config, EnsembleConfig};
+use ensemble_core::config::ensemble::{parse_config, EnsembleConfig, RepoConfig};
 use ensemble_core::config::template::render_prompt;
 use ensemble_core::tracker::model::{sanitize_workspace_key, Issue};
 use ensemble_core::workspace::hooks::run_hook;
 use ensemble_core::workspace::manager::WorkspaceManager;
+use std::collections::HashMap;
 use tempfile::TempDir;
 
 fn sample_issue() -> Issue {
@@ -123,4 +124,71 @@ async fn test_hook_in_workspace() {
     assert!(marker.exists());
     let content = std::fs::read_to_string(&marker).unwrap();
     assert_eq!(content.trim(), "initialized");
+}
+
+fn setup_git_repo(name: &str) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    std::fs::write(dir.path().join("README.md"), format!("# {}", name)).unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(&dir)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .output()
+        .unwrap();
+    dir
+}
+
+#[tokio::test]
+async fn test_workflow_with_worktrees() {
+    let ws_dir = TempDir::new().unwrap();
+    let repo_dir = setup_git_repo("test-repo");
+
+    let repos = HashMap::from([(
+        "test-repo".to_string(),
+        RepoConfig {
+            path: repo_dir.path().to_string_lossy().to_string(),
+            branch: "main".to_string(),
+            git_remote: "origin".to_string(),
+        },
+    )]);
+
+    let mgr = WorkspaceManager::new(ws_dir.path(), Some(repos)).unwrap();
+    let issue = sample_issue();
+
+    // Create workspace with worktrees
+    let ws = mgr.prepare_workspace(&issue.identifier).await.unwrap();
+    assert!(ws.created_now);
+    assert!(ws.base_path.is_dir());
+    assert!(!ws.worktrees.is_empty());
+
+    let worktree_info = ws.worktrees.get("test-repo").expect("worktree should exist");
+    assert!(worktree_info.path.exists());
+    assert!(worktree_info.created_now);
+    assert!(worktree_info.path.join("README.md").exists());
+
+    // Reuse workspace
+    let ws2 = mgr.prepare_workspace(&issue.identifier).await.unwrap();
+    assert!(!ws2.created_now);
+    let worktree_info2 = ws2.worktrees.get("test-repo").unwrap();
+    assert!(!worktree_info2.created_now);
+    assert_eq!(worktree_info.path, worktree_info2.path);
+
+    // Cleanup
+    let wt_path = worktree_info.path.clone();
+    mgr.remove_workspace(&issue.identifier).await.unwrap();
+    assert!(!ws.base_path.exists());
+    assert!(!wt_path.exists());
 }

--- a/crates/ensemble-core/tests/workflow_to_workspace.rs
+++ b/crates/ensemble-core/tests/workflow_to_workspace.rs
@@ -55,8 +55,8 @@ hooks:
     parse_config(&yaml).unwrap()
 }
 
-#[test]
-fn test_full_config_flow() {
+#[tokio::test]
+async fn test_full_config_flow() {
     let dir = TempDir::new().unwrap();
     let ws_root = dir.path().join("workspaces");
 
@@ -84,42 +84,42 @@ fn test_full_config_flow() {
     assert!(prompt.contains("Add dark mode"));
 
     // 3. Create workspace
-    let mgr = WorkspaceManager::new(&ws_root).unwrap();
-    let ws = mgr.prepare_workspace(&issue.identifier).unwrap();
+    let mgr = WorkspaceManager::new(&ws_root, None).unwrap();
+    let ws = mgr.prepare_workspace(&issue.identifier).await.unwrap();
     assert!(ws.created_now);
-    assert!(ws.path.is_dir());
+    assert!(ws.base_path.is_dir());
     assert_eq!(
         ws.workspace_key,
         sanitize_workspace_key(&issue.identifier).unwrap()
     );
 
     // 4. Reuse workspace
-    let ws2 = mgr.prepare_workspace(&issue.identifier).unwrap();
+    let ws2 = mgr.prepare_workspace(&issue.identifier).await.unwrap();
     assert!(!ws2.created_now);
-    assert_eq!(ws.path, ws2.path);
+    assert_eq!(ws.base_path, ws2.base_path);
 
     // 5. Cleanup
-    mgr.remove_workspace(&issue.identifier).unwrap();
-    assert!(!ws.path.exists());
+    mgr.remove_workspace(&issue.identifier).await.unwrap();
+    assert!(!ws.base_path.exists());
 }
 
 #[tokio::test]
 async fn test_hook_in_workspace() {
     let dir = TempDir::new().unwrap();
-    let mgr = WorkspaceManager::new(dir.path()).unwrap();
-    let ws = mgr.prepare_workspace("hook-test#1").unwrap();
+    let mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+    let ws = mgr.prepare_workspace("hook-test#1").await.unwrap();
 
     // Run a hook that creates a file
     run_hook(
         "after_create",
         "echo 'initialized' > .ensemble-init",
-        &ws.path,
+        &ws.base_path,
         5000,
     )
     .await
     .unwrap();
 
-    let marker = ws.path.join(".ensemble-init");
+    let marker = ws.base_path.join(".ensemble-init");
     assert!(marker.exists());
     let content = std::fs::read_to_string(&marker).unwrap();
     assert_eq!(content.trim(), "initialized");

--- a/crates/ensemble-core/tests/worktree_tests.rs
+++ b/crates/ensemble-core/tests/worktree_tests.rs
@@ -1,0 +1,149 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+fn setup_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    std::fs::write(dir.path().join("README.md"), "# Test").unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(&dir)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .output()
+        .unwrap();
+    dir
+}
+
+#[tokio::test]
+async fn test_sanitize_branch_name_basic() {
+    use ensemble_core::workspace::worktree::sanitize_branch_name;
+    
+    assert_eq!(sanitize_branch_name("issue-123"), "issue-123");
+    assert_eq!(sanitize_branch_name("feature/test"), "feature-test");
+    assert_eq!(sanitize_branch_name("bug: fix"), "bug--fix");
+}
+
+#[tokio::test]
+async fn test_create_worktree_creates_directory() {
+    use ensemble_core::workspace::worktree::create_worktree;
+    
+    let repo = setup_repo();
+    let worktree_path = repo.path().join("worktrees/test-branch");
+    
+    create_worktree(
+        repo.path().to_str().unwrap(),
+        worktree_path.to_str().unwrap(),
+        "test-branch",
+    )
+    .await
+    .unwrap();
+    
+    assert!(worktree_path.exists());
+    assert!(worktree_path.join(".git").exists());
+}
+
+#[tokio::test]
+async fn test_worktree_exists_returns_true_for_existing() {
+    use ensemble_core::workspace::worktree::{create_worktree, worktree_exists};
+    
+    let repo = setup_repo();
+    let worktree_path = repo.path().join("worktrees/existing");
+    
+    create_worktree(
+        repo.path().to_str().unwrap(),
+        worktree_path.to_str().unwrap(),
+        "existing-branch",
+    )
+    .await
+    .unwrap();
+    
+    let exists = worktree_exists(repo.path().to_str().unwrap(), worktree_path.to_str().unwrap())
+        .await
+        .unwrap();
+    
+    assert!(exists);
+}
+
+#[tokio::test]
+async fn test_worktree_exists_returns_false_for_nonexistent() {
+    use ensemble_core::workspace::worktree::worktree_exists;
+    
+    let repo = setup_repo();
+    let worktree_path = repo.path().join("worktrees/nonexistent");
+    
+    let exists = worktree_exists(repo.path().to_str().unwrap(), worktree_path.to_str().unwrap())
+        .await
+        .unwrap();
+    
+    assert!(!exists);
+}
+
+#[tokio::test]
+async fn test_remove_worktree_deletes_directory() {
+    use ensemble_core::workspace::worktree::{create_worktree, remove_worktree, worktree_exists};
+    
+    let repo = setup_repo();
+    let worktree_path = repo.path().join("worktrees/to-remove");
+    let branch = "to-remove-branch";
+    
+    create_worktree(
+        repo.path().to_str().unwrap(),
+        worktree_path.to_str().unwrap(),
+        branch,
+    )
+    .await
+    .unwrap();
+    
+    remove_worktree(
+        repo.path().to_str().unwrap(),
+        worktree_path.to_str().unwrap(),
+        branch,
+    )
+    .await
+    .unwrap();
+    
+    assert!(!worktree_path.exists());
+    let exists = worktree_exists(repo.path().to_str().unwrap(), worktree_path.to_str().unwrap())
+        .await
+        .unwrap();
+    assert!(!exists);
+}
+
+#[tokio::test]
+async fn test_create_worktree_fails_if_already_exists() {
+    use ensemble_core::workspace::worktree::create_worktree;
+    use ensemble_core::error::WorktreeError;
+    
+    let repo = setup_repo();
+    let worktree_path = repo.path().join("worktrees/duplicate");
+    let branch = "duplicate-branch";
+    
+    create_worktree(
+        repo.path().to_str().unwrap(),
+        worktree_path.to_str().unwrap(),
+        branch,
+    )
+    .await
+    .unwrap();
+    
+    let result = create_worktree(
+        repo.path().to_str().unwrap(),
+        worktree_path.to_str().unwrap(),
+        branch,
+    )
+    .await;
+    
+    assert!(matches!(result, Err(WorktreeError::AlreadyExists { .. })));
+}

--- a/crates/ensemble-core/tests/worktree_tests.rs
+++ b/crates/ensemble-core/tests/worktree_tests.rs
@@ -32,7 +32,7 @@ async fn test_sanitize_branch_name_basic() {
 
     assert_eq!(sanitize_branch_name("issue-123"), "issue-123");
     assert_eq!(sanitize_branch_name("feature/test"), "feature-test");
-    assert_eq!(sanitize_branch_name("bug: fix"), "bug--fix");
+    assert_eq!(sanitize_branch_name("bug: fix"), "bug-fix");
 }
 
 #[tokio::test]

--- a/crates/ensemble-core/tests/worktree_tests.rs
+++ b/crates/ensemble-core/tests/worktree_tests.rs
@@ -4,7 +4,7 @@ use tempfile::TempDir;
 fn setup_repo() -> TempDir {
     let dir = TempDir::new().unwrap();
     Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();

--- a/crates/ensemble-core/tests/worktree_tests.rs
+++ b/crates/ensemble-core/tests/worktree_tests.rs
@@ -46,6 +46,7 @@ async fn test_create_worktree_creates_directory() {
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
         "test-branch",
+        None,
     )
     .await
     .unwrap();
@@ -65,6 +66,7 @@ async fn test_worktree_exists_returns_true_for_existing() {
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
         "existing-branch",
+        None,
     )
     .await
     .unwrap();
@@ -108,6 +110,7 @@ async fn test_remove_worktree_deletes_directory() {
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
         branch,
+        None,
     )
     .await
     .unwrap();
@@ -143,6 +146,7 @@ async fn test_create_worktree_fails_if_already_exists() {
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
         branch,
+        None,
     )
     .await
     .unwrap();
@@ -151,6 +155,7 @@ async fn test_create_worktree_fails_if_already_exists() {
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
         branch,
+        None,
     )
     .await;
 

--- a/crates/ensemble-core/tests/worktree_tests.rs
+++ b/crates/ensemble-core/tests/worktree_tests.rs
@@ -29,7 +29,7 @@ fn setup_repo() -> TempDir {
 #[tokio::test]
 async fn test_sanitize_branch_name_basic() {
     use ensemble_core::workspace::worktree::sanitize_branch_name;
-    
+
     assert_eq!(sanitize_branch_name("issue-123"), "issue-123");
     assert_eq!(sanitize_branch_name("feature/test"), "feature-test");
     assert_eq!(sanitize_branch_name("bug: fix"), "bug--fix");
@@ -38,10 +38,10 @@ async fn test_sanitize_branch_name_basic() {
 #[tokio::test]
 async fn test_create_worktree_creates_directory() {
     use ensemble_core::workspace::worktree::create_worktree;
-    
+
     let repo = setup_repo();
     let worktree_path = repo.path().join("worktrees/test-branch");
-    
+
     create_worktree(
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
@@ -49,7 +49,7 @@ async fn test_create_worktree_creates_directory() {
     )
     .await
     .unwrap();
-    
+
     assert!(worktree_path.exists());
     assert!(worktree_path.join(".git").exists());
 }
@@ -57,10 +57,10 @@ async fn test_create_worktree_creates_directory() {
 #[tokio::test]
 async fn test_worktree_exists_returns_true_for_existing() {
     use ensemble_core::workspace::worktree::{create_worktree, worktree_exists};
-    
+
     let repo = setup_repo();
     let worktree_path = repo.path().join("worktrees/existing");
-    
+
     create_worktree(
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
@@ -68,36 +68,42 @@ async fn test_worktree_exists_returns_true_for_existing() {
     )
     .await
     .unwrap();
-    
-    let exists = worktree_exists(repo.path().to_str().unwrap(), worktree_path.to_str().unwrap())
-        .await
-        .unwrap();
-    
+
+    let exists = worktree_exists(
+        repo.path().to_str().unwrap(),
+        worktree_path.to_str().unwrap(),
+    )
+    .await
+    .unwrap();
+
     assert!(exists);
 }
 
 #[tokio::test]
 async fn test_worktree_exists_returns_false_for_nonexistent() {
     use ensemble_core::workspace::worktree::worktree_exists;
-    
+
     let repo = setup_repo();
     let worktree_path = repo.path().join("worktrees/nonexistent");
-    
-    let exists = worktree_exists(repo.path().to_str().unwrap(), worktree_path.to_str().unwrap())
-        .await
-        .unwrap();
-    
+
+    let exists = worktree_exists(
+        repo.path().to_str().unwrap(),
+        worktree_path.to_str().unwrap(),
+    )
+    .await
+    .unwrap();
+
     assert!(!exists);
 }
 
 #[tokio::test]
 async fn test_remove_worktree_deletes_directory() {
     use ensemble_core::workspace::worktree::{create_worktree, remove_worktree, worktree_exists};
-    
+
     let repo = setup_repo();
     let worktree_path = repo.path().join("worktrees/to-remove");
     let branch = "to-remove-branch";
-    
+
     create_worktree(
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
@@ -105,7 +111,7 @@ async fn test_remove_worktree_deletes_directory() {
     )
     .await
     .unwrap();
-    
+
     remove_worktree(
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
@@ -113,23 +119,26 @@ async fn test_remove_worktree_deletes_directory() {
     )
     .await
     .unwrap();
-    
+
     assert!(!worktree_path.exists());
-    let exists = worktree_exists(repo.path().to_str().unwrap(), worktree_path.to_str().unwrap())
-        .await
-        .unwrap();
+    let exists = worktree_exists(
+        repo.path().to_str().unwrap(),
+        worktree_path.to_str().unwrap(),
+    )
+    .await
+    .unwrap();
     assert!(!exists);
 }
 
 #[tokio::test]
 async fn test_create_worktree_fails_if_already_exists() {
-    use ensemble_core::workspace::worktree::create_worktree;
     use ensemble_core::error::WorktreeError;
-    
+    use ensemble_core::workspace::worktree::create_worktree;
+
     let repo = setup_repo();
     let worktree_path = repo.path().join("worktrees/duplicate");
     let branch = "duplicate-branch";
-    
+
     create_worktree(
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
@@ -137,13 +146,13 @@ async fn test_create_worktree_fails_if_already_exists() {
     )
     .await
     .unwrap();
-    
+
     let result = create_worktree(
         repo.path().to_str().unwrap(),
         worktree_path.to_str().unwrap(),
         branch,
     )
     .await;
-    
+
     assert!(matches!(result, Err(WorktreeError::AlreadyExists { .. })));
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -97,8 +97,14 @@ Important boundary:
 6. `Workspace Manager`
    - Maps issue identifiers to workspace paths.
    - Ensures per-issue workspace directories exist.
+   - Optionally creates git worktrees for configured repositories via `WorktreeCoordinator`.
+   - All-or-nothing worktree creation with rollback on partial failure.
+   - Worktrees stored in `.worktrees/<branch>` within each repo, with branch naming
+     `ensemble-YYYY-MM-DD-<sanitized-issue-id>`.
+   - Reuses existing worktrees on retry cycles (pulls latest changes).
    - Runs workspace lifecycle hooks.
-   - Cleans workspaces for terminal issues.
+   - Cleans workspaces and worktrees for terminal issues.
+   - Push strategy (ask, auto_push, manual, pr_only) controls branch handling after success.
 
 7. `Agent Runner`
    - Creates workspace.

--- a/docs/superpowers/plans/2026-03-30-worktree-workspaces-plan.md
+++ b/docs/superpowers/plans/2026-03-30-worktree-workspaces-plan.md
@@ -1,0 +1,1425 @@
+# Worktree-Based Workspaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace plain workspace directories with git worktrees, enabling multi-agent collaboration across configured repositories with proper isolation, persistence across retries, and lifecycle management.
+
+**Architecture:** Add `WorktreeCoordinator` to manage worktree lifecycle across repos, enhance `WorkspaceManager` to coordinate between base directories and worktrees, add `PushStrategy` configuration, and update orchestrator to pass worktree paths to agents.
+
+**Tech Stack:** Rust, git CLI (via std::process::Command), tokio for async, thiserror for error handling, serde for config
+
+---
+
+## File Structure
+
+**New Files:**
+- `crates/ensemble-core/src/workspace/worktree.rs` - Core worktree operations (create, remove, list, branch management)
+- `crates/ensemble-core/src/workspace/coordinator.rs` - Multi-repo worktree coordination with rollback
+- `crates/ensemble-core/src/workspace/push_strategy.rs` - PushStrategy enum and logic
+- `crates/ensemble-core/tests/worktree_tests.rs` - Unit tests for worktree operations
+
+**Modified Files:**
+- `crates/ensemble-core/src/error.rs` - Add WorktreeError variants
+- `crates/ensemble-core/src/workspace/mod.rs` - Export new modules
+- `crates/ensemble-core/src/workspace/manager.rs` - Integrate worktree coordinator
+- `crates/ensemble-core/src/config/ensemble.rs` - Add PushStrategy and git_remote to RepoConfig
+- `crates/ensemble-core/src/config/mod.rs` - Re-export PushStrategy
+- `crates/ensemble-core/src/orchestrator/mod.rs` - Pass worktree paths to agents
+- `crates/ensemble-core/src/agent/mod.rs` - Update AgentRunner trait with worktree context
+
+---
+
+## Phase 1: Core Worktree Operations
+
+### Task 1: Add Worktree Error Types
+
+**Files:**
+- Modify: `crates/ensemble-core/src/error.rs:29-39`
+
+- [ ] **Step 1: Add WorktreeError enum to error.rs**
+
+Add after `WorkspaceError`:
+
+```rust
+#[derive(Debug, Error)]
+pub enum WorktreeError {
+    #[error("worktree creation failed for repo {repo}: {reason}")]
+    CreationFailed { repo: String, reason: String },
+    #[error("worktree already exists at {path}")]
+    AlreadyExists { path: String },
+    #[error("worktree not found at {path}")]
+    NotFound { path: String },
+    #[error("git command failed: {command} — {reason}")]
+    GitCommandFailed { command: String, reason: String },
+    #[error("branch creation failed: {branch} — {reason}")]
+    BranchCreationFailed { branch: String, reason: String },
+    #[error("rollback failed during cleanup: {reason}")]
+    RollbackFailed { reason: String },
+    #[error("invalid repo path: {path}")]
+    InvalidRepoPath { path: String },
+}
+```
+
+- [ ] **Step 2: Add WorktreeError to EnsembleError**
+
+Add variant to `EnsembleError`:
+
+```rust
+#[derive(Debug, Error)]
+pub enum EnsembleError {
+    // ... existing variants
+    #[error(transparent)]
+    Worktree(#[from] WorktreeError),
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/ensemble-core/src/error.rs
+git commit -m "feat: add WorktreeError enum for worktree operations"
+```
+
+---
+
+### Task 2: Create Core Worktree Module
+
+**Files:**
+- Create: `crates/ensemble-core/src/workspace/worktree.rs`
+- Test: `crates/ensemble-core/tests/worktree_tests.rs`
+
+- [ ] **Step 1: Write failing test for worktree creation**
+
+Create `crates/ensemble-core/tests/worktree_tests.rs`:
+
+```rust
+use ensemble_core::workspace::worktree::{create_worktree, remove_worktree, worktree_exists};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn setup_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    // Initialize a git repo for testing
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&dir)
+        .output()
+        .expect("git init failed");
+    
+    // Create initial commit
+    std::fs::write(dir.path().join("README.md"), "# Test").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(&dir)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .output()
+        .unwrap();
+    
+    dir
+}
+
+#[tokio::test]
+async fn test_create_worktree_success() {
+    let repo = setup_repo();
+    let worktree_path = repo.path().join(".worktrees").join("test-issue");
+    let branch = "ensemble-2026-03-30-test-issue";
+    
+    let result = create_worktree(repo.path(), &worktree_path, branch).await;
+    
+    assert!(result.is_ok());
+    assert!(worktree_path.exists());
+    assert!(worktree_path.join("README.md").exists()); // Should have repo contents
+}
+
+#[tokio::test]
+async fn test_worktree_exists_detection() {
+    let repo = setup_repo();
+    let worktree_path = repo.path().join(".worktrees").join("test-issue");
+    let branch = "ensemble-2026-03-30-test-issue";
+    
+    // Initially not exists
+    assert!(!worktree_exists(repo.path(), &worktree_path).await.unwrap());
+    
+    // Create it
+    create_worktree(repo.path(), &worktree_path, branch).await.unwrap();
+    
+    // Now exists
+    assert!(worktree_exists(repo.path(), &worktree_path).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_remove_worktree() {
+    let repo = setup_repo();
+    let worktree_path = repo.path().join(".worktrees").join("test-issue");
+    let branch = "ensemble-2026-03-30-test-issue";
+    
+    create_worktree(repo.path(), &worktree_path, branch).await.unwrap();
+    assert!(worktree_path.exists());
+    
+    remove_worktree(repo.path(), &worktree_path, branch).await.unwrap();
+    
+    assert!(!worktree_path.exists());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p ensemble-core worktree_tests -- --nocapture
+```
+
+Expected: FAIL with "module not found" or similar
+
+- [ ] **Step 3: Create worktree.rs module**
+
+Create `crates/ensemble-core/src/workspace/worktree.rs`:
+
+```rust
+use crate::error::WorktreeError;
+use std::path::Path;
+use std::process::Command;
+use tokio::process::Command as TokioCommand;
+use tracing::{debug, error, info, warn};
+
+/// Create a git worktree at the specified path with a new branch.
+pub async fn create_worktree(
+    repo_path: &Path,
+    worktree_path: &Path,
+    branch: &str,
+) -> Result<(), WorktreeError> {
+    info!(
+        repo = %repo_path.display(),
+        worktree = %worktree_path.display(),
+        branch,
+        "creating worktree"
+    );
+    
+    // Ensure parent directory exists
+    if let Some(parent) = worktree_path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            WorktreeError::CreationFailed {
+                repo: repo_path.display().to_string(),
+                reason: format!("failed to create parent dir: {e}"),
+            }
+        })?;
+    }
+    
+    // Create worktree with new branch
+    let output = TokioCommand::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            &worktree_path.to_string_lossy(),
+        ])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .map_err(|e| WorktreeError::GitCommandFailed {
+            command: "git worktree add".to_string(),
+            reason: e.to_string(),
+        })?;
+    
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!(%stderr, "git worktree add failed");
+        
+        // Check if worktree already exists
+        if stderr.contains("already exists") {
+            return Err(WorktreeError::AlreadyExists {
+                path: worktree_path.display().to_string(),
+            });
+        }
+        
+        return Err(WorktreeError::CreationFailed {
+            repo: repo_path.display().to_string(),
+            reason: stderr.to_string(),
+        });
+    }
+    
+    info!("worktree created successfully");
+    Ok(())
+}
+
+/// Check if a worktree exists at the given path.
+pub async fn worktree_exists(repo_path: &Path, worktree_path: &Path) -> Result<bool, WorktreeError> {
+    let output = TokioCommand::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .map_err(|e| WorktreeError::GitCommandFailed {
+            command: "git worktree list".to_string(),
+            reason: e.to_string(),
+        })?;
+    
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(WorktreeError::GitCommandFailed {
+            command: "git worktree list".to_string(),
+            reason: stderr.to_string(),
+        });
+    }
+    
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let worktree_str = worktree_path.to_string_lossy();
+    
+    // Check if any worktree path matches
+    for line in stdout.lines() {
+        if line.starts_with("worktree ") {
+            let path = line.trim_start_matches("worktree ");
+            if path == worktree_str.as_ref() {
+                return Ok(true);
+            }
+        }
+    }
+    
+    // Also check if directory exists (orphaned worktree)
+    if worktree_path.exists() {
+        warn!("worktree directory exists but not registered in git");
+        return Ok(true);
+    }
+    
+    Ok(false)
+}
+
+/// Remove a worktree and delete its branch.
+pub async fn remove_worktree(
+    repo_path: &Path,
+    worktree_path: &Path,
+    branch: &str,
+) -> Result<(), WorktreeError> {
+    info!(
+        worktree = %worktree_path.display(),
+        branch,
+        "removing worktree"
+    );
+    
+    // Remove worktree
+    let output = TokioCommand::new("git")
+        .args([
+            "worktree",
+            "remove",
+            "--force",
+            &worktree_path.to_string_lossy(),
+        ])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .map_err(|e| WorktreeError::GitCommandFailed {
+            command: "git worktree remove".to_string(),
+            reason: e.to_string(),
+        })?;
+    
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // If worktree doesn't exist, that's ok
+        if stderr.contains("not a working tree") {
+            debug!("worktree already removed");
+        } else {
+            return Err(WorktreeError::GitCommandFailed {
+                command: "git worktree remove".to_string(),
+                reason: stderr.to_string(),
+            });
+        }
+    }
+    
+    // Delete the branch (local)
+    let _ = TokioCommand::new("git")
+        .args(["branch", "-D", branch])
+        .current_dir(repo_path)
+        .output()
+        .await;
+    
+    info!("worktree removed successfully");
+    Ok(())
+}
+
+/// Pull latest changes from remote in a worktree.
+pub async fn pull_worktree(worktree_path: &Path, branch: &str) -> Result<(), WorktreeError> {
+    info!(worktree = %worktree_path.display(), "pulling latest changes");
+    
+    let output = TokioCommand::new("git")
+        .args(["pull", "origin", branch])
+        .current_dir(worktree_path)
+        .output()
+        .await
+        .map_err(|e| WorktreeError::GitCommandFailed {
+            command: "git pull".to_string(),
+            reason: e.to_string(),
+        })?;
+    
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Pull may fail if branch doesn't exist on remote yet - that's ok
+        if !stderr.contains("couldn't find remote ref") {
+            warn!(%stderr, "git pull had issues, but continuing");
+        }
+    }
+    
+    Ok(())
+}
+
+/// Sanitize an issue identifier for use in branch names.
+/// Replaces non-alphanumeric chars with `-`, collapses multiple `-`, strips leading/trailing.
+pub fn sanitize_branch_name(identifier: &str) -> String {
+    let mut result = String::with_capacity(identifier.len());
+    let mut last_was_dash = true; // Start true to strip leading dashes
+    
+    for c in identifier.chars() {
+        if c.is_alphanumeric() {
+            result.push(c.to_ascii_lowercase());
+            last_was_dash = false;
+        } else if !last_was_dash {
+            result.push('-');
+            last_was_dash = true;
+        }
+        // Skip consecutive non-alphanumeric
+    }
+    
+    // Strip trailing dash
+    if result.ends_with('-') {
+        result.pop();
+    }
+    
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_sanitize_branch_name() {
+        assert_eq!(
+            sanitize_branch_name("my-repo#42"),
+            "my-repo-42"
+        );
+        assert_eq!(
+            sanitize_branch_name("acme/api#123"),
+            "acme-api-123"
+        );
+        assert_eq!(
+            sanitize_branch_name("FEATURE_Add Dark Mode!!!"),
+            "feature-add-dark-mode"
+        );
+        assert_eq!(
+            sanitize_branch_name("--test--"),
+            "test"
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Export worktree module**
+
+Modify `crates/ensemble-core/src/workspace/mod.rs`:
+
+```rust
+pub mod hooks;
+pub mod manager;
+pub mod worktree;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cargo test -p ensemble-core worktree_tests -- --nocapture
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/workspace/
+git add crates/ensemble-core/tests/worktree_tests.rs
+git commit -m "feat: add core worktree operations module"
+```
+
+---
+
+### Task 3: Create WorktreeCoordinator
+
+**Files:**
+- Create: `crates/ensemble-core/src/workspace/coordinator.rs`
+- Test: `crates/ensemble-core/tests/coordinator_tests.rs`
+
+- [ ] **Step 1: Write failing test for coordinator**
+
+Create `crates/ensemble-core/tests/coordinator_tests.rs`:
+
+```rust
+use ensemble_core::config::ensemble::RepoConfig;
+use ensemble_core::workspace::coordinator::WorktreeCoordinator;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+fn setup_repo(name: &str) -> (TempDir, RepoConfig) {
+    let dir = TempDir::new().unwrap();
+    
+    // Initialize git repo
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    
+    // Create initial commit
+    std::fs::write(dir.path().join("README.md"), format!("# {}", name)).unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(&dir)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .output()
+        .unwrap();
+    
+    let config = RepoConfig {
+        path: dir.path().to_string_lossy().to_string(),
+        branch: "main".to_string(),
+        git_remote: None,
+    };
+    
+    (dir, config)
+}
+
+#[tokio::test]
+async fn test_prepare_worktrees_creates_all() {
+    let (repo1_dir, repo1_config) = setup_repo("repo1");
+    let (repo2_dir, repo2_config) = setup_repo("repo2");
+    
+    let repos = HashMap::from([
+        ("frontend".to_string(), repo1_config),
+        ("api".to_string(), repo2_config),
+    ]);
+    
+    let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+    
+    let result = coordinator.prepare_worktrees("my-issue-42").await;
+    
+    assert!(result.is_ok());
+    let worktrees = result.unwrap();
+    
+    assert_eq!(worktrees.len(), 2);
+    assert!(worktrees.contains_key("frontend"));
+    assert!(worktrees.contains_key("api"));
+    
+    // Verify directories exist
+    let frontend_path = &worktrees["frontend"].path;
+    let api_path = &worktrees["api"].path;
+    
+    assert!(frontend_path.exists());
+    assert!(api_path.exists());
+    assert!(worktrees["frontend"].created_now);
+    assert!(worktrees["api"].created_now);
+}
+
+#[tokio::test]
+async fn test_prepare_worktrees_reuses_existing() {
+    let (repo1_dir, repo1_config) = setup_repo("repo1");
+    
+    let repos = HashMap::from([
+        ("frontend".to_string(), repo1_config),
+    ]);
+    
+    let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+    
+    // First call creates
+    let result1 = coordinator.prepare_worktrees("my-issue-42").await.unwrap();
+    assert!(result1["frontend"].created_now);
+    
+    // Second call reuses
+    let result2 = coordinator.prepare_worktrees("my-issue-42").await.unwrap();
+    assert!(!result2["frontend"].created_now);
+    assert_eq!(result1["frontend"].path, result2["frontend"].path);
+}
+
+#[tokio::test]
+async fn test_cleanup_worktrees() {
+    let (repo1_dir, repo1_config) = setup_repo("repo1");
+    
+    let repos = HashMap::from([
+        ("frontend".to_string(), repo1_config),
+    ]);
+    
+    let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+    
+    // Create worktree
+    let worktrees = coordinator.prepare_worktrees("my-issue-42").await.unwrap();
+    let path = worktrees["frontend"].path.clone();
+    assert!(path.exists());
+    
+    // Cleanup
+    coordinator.cleanup_worktrees("my-issue-42").await.unwrap();
+    
+    // Verify removed
+    assert!(!path.exists());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p ensemble-core coordinator_tests -- --nocapture
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Create coordinator.rs module**
+
+Create `crates/ensemble-core/src/workspace/coordinator.rs`:
+
+```rust
+use crate::config::ensemble::RepoConfig;
+use crate::error::WorktreeError;
+use crate::workspace::worktree::{create_worktree, remove_worktree, sanitize_branch_name, worktree_exists, pull_worktree};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tracing::{error, info, warn};
+
+/// Information about a created/found worktree.
+#[derive(Debug, Clone)]
+pub struct WorktreeInfo {
+    /// Absolute path to the worktree directory
+    pub path: PathBuf,
+    /// The branch name used for this worktree
+    pub branch: String,
+    /// Whether this worktree was created in this call (false = reused existing)
+    pub created_now: bool,
+}
+
+/// Coordinates worktree lifecycle across multiple repositories.
+pub struct WorktreeCoordinator {
+    /// Map of repo name to RepoConfig
+    repos: HashMap<String, RepoConfig>,
+    /// Base date string for branch naming (YYYY-MM-DD)
+    base_date: String,
+}
+
+impl WorktreeCoordinator {
+    /// Create a new coordinator with the given repo configurations.
+    pub fn new(repos: HashMap<String, RepoConfig>, base_date: String) -> Self {
+        Self { repos, base_date }
+    }
+    
+    /// Prepare worktrees for all configured repos for the given issue.
+    /// 
+    /// This is an all-or-nothing operation. If any worktree creation fails,
+    /// all already-created worktrees are rolled back and cleaned up.
+    pub async fn prepare_worktrees(
+        &self,
+        issue_id: &str,
+    ) -> Result<HashMap<String, WorktreeInfo>, WorktreeError> {
+        let branch = self.format_branch_name(issue_id);
+        let mut created = HashMap::new();
+        
+        info!(issue_id, branch, "preparing worktrees for issue");
+        
+        // Track repos that were newly created for rollback
+        let mut newly_created = Vec::new();
+        
+        for (repo_name, repo_config) in &self.repos {
+            let repo_path = Path::new(&repo_config.path);
+            
+            // Validate repo path
+            if !repo_path.exists() {
+                error!(repo = %repo_path.display(), "repo path does not exist");
+                // Rollback any already created worktrees
+                self.rollback(&created, &newly_created).await;
+                return Err(WorktreeError::InvalidRepoPath {
+                    path: repo_config.path.clone(),
+                });
+            }
+            
+            let worktree_path = repo_path.join(".worktrees").join(&branch);
+            
+            // Check if worktree already exists
+            match worktree_exists(repo_path, &worktree_path).await? {
+                true => {
+                    info!(repo = repo_name, "reusing existing worktree");
+                    
+                    // Pull latest changes to refresh
+                    if let Err(e) = pull_worktree(&worktree_path, &repo_config.branch).await {
+                        warn!(repo = repo_name, error = %e, "failed to pull latest changes, continuing");
+                    }
+                    
+                    created.insert(
+                        repo_name.clone(),
+                        WorktreeInfo {
+                            path: worktree_path,
+                            branch: branch.clone(),
+                            created_now: false,
+                        },
+                    );
+                }
+                false => {
+                    info!(repo = repo_name, path = %worktree_path.display(), "creating new worktree");
+                    
+                    if let Err(e) = create_worktree(repo_path, &worktree_path, &branch).await {
+                        error!(repo = repo_name, error = %e, "failed to create worktree");
+                        // Rollback any already created worktrees
+                        self.rollback(&created, &newly_created).await;
+                        return Err(e);
+                    }
+                    
+                    newly_created.push(repo_name.clone());
+                    created.insert(
+                        repo_name.clone(),
+                        WorktreeInfo {
+                            path: worktree_path,
+                            branch: branch.clone(),
+                            created_now: true,
+                        },
+                    );
+                }
+            }
+        }
+        
+        info!(count = created.len(), "worktrees prepared successfully");
+        Ok(created)
+    }
+    
+    /// Clean up worktrees and delete branches for the given issue.
+    pub async fn cleanup_worktrees(&self, issue_id: &str) -> Result<(), WorktreeError> {
+        let branch = self.format_branch_name(issue_id);
+        
+        info!(issue_id, branch, "cleaning up worktrees");
+        
+        for (repo_name, repo_config) in &self.repos {
+            let repo_path = Path::new(&repo_config.path);
+            let worktree_path = repo_path.join(".worktrees").join(&branch);
+            
+            if let Err(e) = remove_worktree(repo_path, &worktree_path, &branch).await {
+                warn!(repo = repo_name, error = %e, "failed to cleanup worktree (continuing)");
+            }
+        }
+        
+        Ok(())
+    }
+    
+    /// List worktree paths for an issue without creating them.
+    pub fn list_worktrees(&self, issue_id: &str) -> HashMap<String, PathBuf> {
+        let branch = self.format_branch_name(issue_id);
+        let mut paths = HashMap::new();
+        
+        for (repo_name, repo_config) in &self.repos {
+            let repo_path = Path::new(&repo_config.path);
+            let worktree_path = repo_path.join(".worktrees").join(&branch);
+            paths.insert(repo_name.clone(), worktree_path);
+        }
+        
+        paths
+    }
+    
+    /// Format branch name for an issue.
+    fn format_branch_name(&self, issue_id: &str) -> String {
+        let sanitized = sanitize_branch_name(issue_id);
+        format!("ensemble-{}-{}", self.base_date, sanitized)
+    }
+    
+    /// Rollback worktrees that were created during a failed prepare operation.
+    async fn rollback(
+        &self,
+        all_worktrees: &HashMap<String, WorktreeInfo>,
+        newly_created: &[String],
+    ) {
+        info!("rolling back partially created worktrees");
+        
+        for repo_name in newly_created {
+            if let Some(info) = all_worktrees.get(repo_name) {
+                if let Some(repo_config) = self.repos.get(repo_name) {
+                    let repo_path = Path::new(&repo_config.path);
+                    if let Err(e) = remove_worktree(repo_path, &info.path, &info.branch).await {
+                        error!(repo = repo_name, error = %e, "rollback cleanup failed");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_format_branch_name() {
+        let repos = HashMap::new();
+        let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+        
+        let branch = coordinator.format_branch_name("my-repo#42");
+        assert_eq!(branch, "ensemble-2026-03-30-my-repo-42");
+    }
+}
+```
+
+- [ ] **Step 4: Export coordinator module**
+
+Modify `crates/ensemble-core/src/workspace/mod.rs`:
+
+```rust
+pub mod coordinator;
+pub mod hooks;
+pub mod manager;
+pub mod worktree;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cargo test -p ensemble-core coordinator_tests -- --nocapture
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/workspace/
+git add crates/ensemble-core/tests/coordinator_tests.rs
+git commit -m "feat: add WorktreeCoordinator for multi-repo worktree management"
+```
+
+---
+
+### Task 4: Add PushStrategy Configuration
+
+**Files:**
+- Create: `crates/ensemble-core/src/workspace/push_strategy.rs`
+- Modify: `crates/ensemble-core/src/config/ensemble.rs`
+- Modify: `crates/ensemble-core/src/config/mod.rs`
+- Modify: `crates/ensemble-core/src/workspace/mod.rs`
+
+- [ ] **Step 1: Create PushStrategy enum**
+
+Create `crates/ensemble-core/src/workspace/push_strategy.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+/// Strategy for handling branch pushes at the end of a successful pipeline.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PushStrategy {
+    /// Prompt user interactively (CLI mode only, blocks until response)
+    Ask,
+    /// Automatically push branch to origin
+    AutoPush,
+    /// Leave local, user handles manually
+    Manual,
+    /// Only create PR (implicit push)
+    PrOnly,
+}
+
+impl Default for PushStrategy {
+    fn default() -> Self {
+        PushStrategy::Manual
+    }
+}
+
+impl PushStrategy {
+    /// Returns true if this strategy requires interactive user input.
+    pub fn is_interactive(&self) -> bool {
+        matches!(self, PushStrategy::Ask)
+    }
+    
+    /// Returns true if this strategy will push to remote.
+    pub fn will_push(&self) -> bool {
+        matches!(self, PushStrategy::AutoPush | PushStrategy::PrOnly)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_push_strategy_is_interactive() {
+        assert!(PushStrategy::Ask.is_interactive());
+        assert!(!PushStrategy::AutoPush.is_interactive());
+        assert!(!PushStrategy::Manual.is_interactive());
+        assert!(!PushStrategy::PrOnly.is_interactive());
+    }
+    
+    #[test]
+    fn test_push_strategy_will_push() {
+        assert!(!PushStrategy::Ask.will_push());
+        assert!(PushStrategy::AutoPush.will_push());
+        assert!(!PushStrategy::Manual.will_push());
+        assert!(PushStrategy::PrOnly.will_push());
+    }
+    
+    #[test]
+    fn test_push_strategy_default() {
+        assert_eq!(PushStrategy::default(), PushStrategy::Manual);
+    }
+    
+    #[test]
+    fn test_push_strategy_deserialization() {
+        let yaml = r#""ask""#;
+        let strategy: PushStrategy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(strategy, PushStrategy::Ask);
+        
+        let yaml = r#""auto_push""#;
+        let strategy: PushStrategy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(strategy, PushStrategy::AutoPush);
+    }
+}
+```
+
+- [ ] **Step 2: Export PushStrategy from workspace mod**
+
+Modify `crates/ensemble-core/src/workspace/mod.rs`:
+
+```rust
+pub mod coordinator;
+pub mod hooks;
+pub mod manager;
+pub mod push_strategy;
+pub mod worktree;
+```
+
+- [ ] **Step 3: Add PushStrategy to EnsembleConfig**
+
+Modify `crates/ensemble-core/src/config/ensemble.rs`:
+
+Add import at top:
+```rust
+use crate::workspace::push_strategy::PushStrategy;
+```
+
+Add to `EnsembleConfig` struct after `agent` field:
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct EnsembleConfig {
+    // ... existing fields
+    #[serde(default)]
+    pub agent: AgentRuntimeConfig,
+    #[serde(default)]
+    pub push_strategy: PushStrategy,
+}
+```
+
+- [ ] **Step 4: Add git_remote to RepoConfig**
+
+Modify `RepoConfig` struct in `crates/ensemble-core/src/config/ensemble.rs`:
+
+```rust
+/// A repository to be managed by the workspace (path + branch).
+#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct RepoConfig {
+    pub path: String,
+    pub branch: String,
+    #[serde(default = "default_git_remote")]
+    pub git_remote: String,
+}
+
+fn default_git_remote() -> String {
+    "origin".to_string()
+}
+```
+
+- [ ] **Step 5: Re-export PushStrategy from config mod**
+
+Modify `crates/ensemble-core/src/config/mod.rs`:
+
+Add re-export:
+```rust
+pub use crate::workspace::push_strategy::PushStrategy;
+```
+
+- [ ] **Step 6: Run tests to verify config changes**
+
+```bash
+cargo test -p ensemble-core push_strategy -- --nocapture
+cargo test -p ensemble-core test_parse_config -- --nocapture
+```
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-core/src/workspace/push_strategy.rs
+git add crates/ensemble-core/src/config/
+git add crates/ensemble-core/src/workspace/mod.rs
+git commit -m "feat: add PushStrategy configuration and git_remote to RepoConfig"
+```
+
+---
+
+## Phase 2: Integration
+
+### Task 5: Enhance WorkspaceManager with Worktree Support
+
+**Files:**
+- Modify: `crates/ensemble-core/src/workspace/manager.rs`
+- Modify: `crates/ensemble-core/src/workspace/coordinator.rs` (minor update for git_remote usage)
+
+- [ ] **Step 1: Update WorkspaceManager to integrate coordinator**
+
+Modify `crates/ensemble-core/src/workspace/manager.rs`:
+
+Add imports:
+```rust
+use crate::config::ensemble::RepoConfig;
+use crate::workspace::coordinator::{WorktreeCoordinator, WorktreeInfo};
+use std::collections::HashMap;
+```
+
+Update `WorkspaceManager` struct:
+```rust
+/// Manage per-issue workspace directories.
+pub struct WorkspaceManager {
+    root: PathBuf,
+    worktree_coordinator: Option<WorktreeCoordinator>,
+}
+```
+
+Update `WorkspaceResult`:
+```rust
+/// Result of preparing a workspace for an issue.
+pub struct WorkspaceResult {
+    /// Absolute path to the base workspace directory (logs, artifacts).
+    pub base_path: PathBuf,
+    /// Map of repo name to worktree info (if repos configured).
+    pub worktrees: HashMap<String, WorktreeInfo>,
+    /// The sanitized workspace key used as the directory name.
+    pub workspace_key: String,
+    /// True if the directory was newly created (not reused).
+    pub created_now: bool,
+}
+```
+
+Update `WorkspaceManager::new`:
+```rust
+impl WorkspaceManager {
+    /// Create a new WorkspaceManager with the given workspace root.
+    /// The root is normalized to an absolute path.
+    pub fn new(root: &Path, repos: Option<Vec<RepoConfig>>) -> Result<Self, WorkspaceError> {
+        let root = if root.is_absolute() {
+            root.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map_err(|e| WorkspaceError::CreationFailed {
+                    reason: format!("cannot resolve relative root: {e}"),
+                })?
+                .join(root)
+        };
+        
+        // Initialize worktree coordinator if repos are configured
+        let worktree_coordinator = repos.map(|repo_configs| {
+            let mut repos_map = HashMap::new();
+            for (index, repo) in repo_configs.into_iter().enumerate() {
+                // Use path basename as name if not specified, or index-based
+                let name = Path::new(&repo.path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| format!("repo-{}", index));
+                repos_map.insert(name, repo);
+            }
+            
+            let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+            WorktreeCoordinator::new(repos_map, today)
+        });
+        
+        Ok(Self {
+            root,
+            worktree_coordinator,
+        })
+    }
+    // ...
+}
+```
+
+Update `prepare_workspace` to be async and handle worktrees:
+```rust
+/// Prepare (create or reuse) a workspace for the given issue identifier.
+pub async fn prepare_workspace(
+    &self,
+    identifier: &str,
+) -> Result<WorkspaceResult, WorkspaceError> {
+    let workspace_key =
+        sanitize_workspace_key(identifier).ok_or_else(|| WorkspaceError::CreationFailed {
+            reason: format!("unsafe workspace key from identifier: {identifier:?}"),
+        })?;
+    let base_path = self.root.join(&workspace_key);
+    
+    // Safety: ensure workspace path is inside root
+    self.validate_path_inside_root(&base_path)?;
+    
+    // Create base workspace directory
+    let base_created = if base_path.exists() {
+        if !base_path.is_dir() {
+            return Err(WorkspaceError::CreationFailed {
+                reason: format!("path exists but is not a directory: {}", base_path.display()),
+            });
+        }
+        false
+    } else {
+        std::fs::create_dir_all(&base_path).map_err(|e| WorkspaceError::CreationFailed {
+            reason: format!("mkdir failed: {e}"),
+        })?;
+        true
+    };
+    
+    // Prepare worktrees if coordinator is configured
+    let worktrees = if let Some(coordinator) = &self.worktree_coordinator {
+        coordinator
+            .prepare_worktrees(identifier)
+            .await
+            .map_err(|e| WorkspaceError::CreationFailed {
+                reason: format!("worktree preparation failed: {e}"),
+            })?
+    } else {
+        HashMap::new()
+    };
+    
+    let created_now = base_created || worktrees.values().any(|w| w.created_now);
+    
+    Ok(WorkspaceResult {
+        base_path,
+        worktrees,
+        workspace_key,
+        created_now,
+    })
+}
+```
+
+Update `remove_workspace`:
+```rust
+/// Remove a workspace directory and its worktrees for the given issue identifier.
+pub async fn remove_workspace(&self, identifier: &str) -> Result<(), WorkspaceError> {
+    let workspace_key =
+        sanitize_workspace_key(identifier).ok_or_else(|| WorkspaceError::CreationFailed {
+            reason: format!("unsafe workspace key from identifier: {identifier:?}"),
+        })?;
+    let base_path = self.root.join(&workspace_key);
+    
+    self.validate_path_inside_root(&base_path)?;
+    
+    // Clean up worktrees first
+    if let Some(coordinator) = &self.worktree_coordinator {
+        coordinator
+            .cleanup_worktrees(identifier)
+            .await
+            .map_err(|e| WorkspaceError::CreationFailed {
+                reason: format!("worktree cleanup failed: {e}"),
+            })?;
+    }
+    
+    // Remove base workspace
+    if base_path.exists() {
+        std::fs::remove_dir_all(&base_path).map_err(|e| WorkspaceError::CreationFailed {
+            reason: format!("remove failed: {e}"),
+        })?;
+    }
+    
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Add chrono dependency**
+
+Check if chrono is already in Cargo.toml, if not add it to workspace dependencies.
+
+- [ ] **Step 3: Update coordinator to use git_remote**
+
+Modify `pull_worktree` in `worktree.rs` to accept remote name:
+
+```rust
+/// Pull latest changes from remote in a worktree.
+pub async fn pull_worktree(
+    worktree_path: &Path,
+    branch: &str,
+    remote: &str,
+) -> Result<(), WorktreeError> {
+    info!(worktree = %worktree_path.display(), remote, "pulling latest changes");
+    
+    let output = TokioCommand::new("git")
+        .args(["pull", remote, branch])
+        .current_dir(worktree_path)
+        .output()
+        .await
+        .map_err(|e| WorktreeError::GitCommandFailed {
+            command: "git pull".to_string(),
+            reason: e.to_string(),
+        })?;
+    
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Pull may fail if branch doesn't exist on remote yet - that's ok
+        if !stderr.contains("couldn't find remote ref") {
+            warn!(%stderr, "git pull had issues, but continuing");
+        }
+    }
+    
+    Ok(())
+}
+```
+
+Update coordinator usage:
+```rust
+if let Err(e) = pull_worktree(&worktree_path, &repo_config.branch, &repo_config.git_remote).await {
+    warn!(repo = repo_name, error = %e, "failed to pull latest changes, continuing");
+}
+```
+
+- [ ] **Step 4: Update existing tests**
+
+Modify tests in `manager.rs` to handle the new signature. Most tests don't use repos, so they'll pass `None` for repos.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test -p ensemble-core workspace::manager -- --nocapture
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/workspace/manager.rs
+git add crates/ensemble-core/src/workspace/worktree.rs
+git add crates/ensemble-core/src/workspace/coordinator.rs
+git commit -m "feat: integrate WorktreeCoordinator into WorkspaceManager"
+```
+
+---
+
+### Task 6: Update Orchestrator Integration
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/reconciler.rs`
+
+- [ ] **Step 1: Update orchestrator to use async workspace preparation**
+
+Find where `WorkspaceManager::new` is called and update to pass repos:
+
+In `orchestrator/mod.rs` around line 48:
+```rust
+pub fn new(
+    config: Arc<RwLock<EnsembleConfig>>,
+    tracker: Arc<dyn IssueTracker>,
+    agent_runner: Arc<dyn AgentRunner>,
+    workspace_mgr: WorkspaceManager,
+    shutdown_rx: mpsc::Receiver<()>,
+) -> Self {
+```
+
+The workspace_mgr is passed in, so we need to update the caller.
+
+Update startup_terminal_cleanup call to be async:
+
+```rust
+// Startup terminal workspace cleanup
+{
+    let config = self.config.read().await;
+    startup_terminal_cleanup(
+        self.tracker.as_ref(),
+        &config.tracker.terminal_states,
+        &self.workspace_mgr,
+    )
+    .await;
+}
+```
+
+- [ ] **Step 2: Update workspace preparation call**
+
+Find where `prepare_workspace` is called (around line 377) and make it async:
+
+```rust
+let workspace_result = workspace_mgr
+    .prepare_workspace(&issue_clone.identifier)
+    .await;
+```
+
+- [ ] **Step 3: Update reconciler to use async workspace operations**
+
+In `orchestrator/reconciler.rs`, find where workspace operations are called and add `.await`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/ensemble-core/src/orchestrator/
+git commit -m "feat: update orchestrator for async workspace with worktrees"
+```
+
+---
+
+## Phase 3: Testing and Documentation
+
+### Task 7: Integration Tests
+
+**Files:**
+- Modify: `crates/ensemble-core/tests/workflow_to_workspace.rs`
+- Create: Additional integration test for multi-repo scenario
+
+- [ ] **Step 1: Add worktree test to workflow_to_workspace.rs**
+
+Add a test that includes repos configuration:
+
+```rust
+#[tokio::test]
+async fn test_workflow_with_worktrees() {
+    let dir = TempDir::new().unwrap();
+    let ws_root = dir.path().join("workspaces");
+    
+    // Setup a git repo
+    let repo_dir = dir.path().join("test-repo");
+    std::fs::create_dir(&repo_dir).unwrap();
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    std::fs::write(repo_dir.join("README.md"), "# Test").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(&repo_dir)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .output()
+        .unwrap();
+    
+    let yaml = format!(
+        r#"
+tracker:
+  kind: github
+  repository: acme/test-repo
+  api_key: fake-token
+workspace:
+  root: {}
+repos:
+  - path: {}
+    branch: main
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: "Build the thing."
+steps:
+  - name: build
+    agent: build
+on_success: Done
+on_failure: Failed
+"#,
+        ws_root.display(),
+        repo_dir.display()
+    );
+    
+    let config = parse_config(&yaml).unwrap();
+    assert_eq!(config.repos.len(), 1);
+    
+    // Create workspace manager with repos
+    let mgr = WorkspaceManager::new(&ws_root, Some(config.repos.clone())).unwrap();
+    
+    let issue = sample_issue();
+    let ws = mgr.prepare_workspace(&issue.identifier).await.unwrap();
+    
+    // Verify worktree was created
+    assert!(!ws.worktrees.is_empty());
+    let worktree_info = ws.worktrees.get("test-repo").expect("worktree should exist");
+    assert!(worktree_info.path.exists());
+    assert!(worktree_info.created_now);
+    
+    // Verify worktree has repo contents
+    assert!(worktree_info.path.join("README.md").exists());
+    
+    // Cleanup
+    mgr.remove_workspace(&issue.identifier).await.unwrap();
+    assert!(!worktree_info.path.exists());
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+cargo test -p ensemble-core --test workflow_to_workspace -- --nocapture
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/ensemble-core/tests/
+git commit -m "test: add integration tests for worktree-based workspaces"
+```
+
+---
+
+### Task 8: Documentation Updates
+
+**Files:**
+- Modify: `SPEC.md` (workspace section)
+- Modify: `README.md` (if applicable)
+
+- [ ] **Step 1: Update SPEC.md workspace section**
+
+Find the workspace section in SPEC.md and update to describe worktree behavior.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add SPEC.md
+git commit -m "docs: update SPEC with worktree-based workspace behavior"
+```
+
+---
+
+## Summary
+
+This implementation plan provides:
+
+1. **Phase 1**: Core worktree infrastructure
+   - Error types for worktree operations
+   - Low-level git worktree commands
+   - Multi-repo coordinator with rollback
+   - PushStrategy configuration
+
+2. **Phase 2**: Integration
+   - WorkspaceManager enhanced with worktree support
+   - Async workspace preparation
+   - Orchestrator integration
+
+3. **Phase 3**: Testing and documentation
+   - Unit tests for all components
+   - Integration tests
+   - Documentation updates
+
+**Key Design Decisions:**
+- All-or-nothing worktree creation with rollback
+- Date-based branch naming for chronological ordering
+- Worktrees created in `.worktrees/` subdirectory of each repo
+- Async throughout for non-blocking I/O
+- Backward compatible (repos config optional)
+
+**Testing Strategy:**
+- Unit tests: Individual worktree operations
+- Coordinator tests: Multi-repo scenarios, rollback
+- Integration tests: Full pipeline with worktrees
+- Mock git repos in temp directories for isolation

--- a/docs/superpowers/specs/2026-03-30-worktree-workspaces-design.md
+++ b/docs/superpowers/specs/2026-03-30-worktree-workspaces-design.md
@@ -1,0 +1,358 @@
+# Worktree-Based Workspaces Design
+
+Date: 2026-03-30
+
+## Overview
+
+Ensemble orchestrates multi-agent pipelines where agents collaborate on the same codebase to complete issues. This design replaces plain workspace directories with git worktrees, enabling agents to work in isolated branches while sharing state across pipeline steps.
+
+## Problem Statement
+
+The current `WorkspaceManager` creates empty directories per issue. This doesn't work for git-based development where:
+- Agents need to modify actual code
+- Changes must persist across pipeline steps (e.g., implement → review)
+- Parallel agents (multiple reviewers) need to see the same code state
+- Changes should eventually be merged back to the main branch
+
+## Design Goals
+
+- **Isolation**: Each issue gets its own branch in each configured repository
+- **Collaboration**: All agents for an issue share the same worktrees
+- **Persistence**: Changes survive across retry cycles
+- **Cleanup**: Automatic cleanup when work is merged
+- **Multi-repo**: Support issues that span multiple repositories
+
+## Architecture
+
+### High-Level Flow
+
+```
+Pipeline Start (Issue #42)
+    │
+    ├─ For each RepoConfig:
+    │   ├─ Check if worktree exists at .worktrees/ensemble-{date}-42
+    │   ├─ If exists: git pull to refresh
+    │   └─ If not: git worktree add -b ensemble-{date}-42
+    │
+    ├─ All-or-nothing: rollback on failure
+    └─ Store worktree paths in PipelineRun context
+
+Agent Execution
+    │
+    ├─ Agent receives {"repo-name": "/path/to/worktree", ...}
+    └─ All agents share same worktrees across steps
+
+Pipeline End (Success)
+    │
+    ├─ Based on push_strategy:
+    │   ├─ ask: prompt user
+    │   ├─ auto_push: push branch
+    │   ├─ manual: leave local
+    │   └─ pr_only: create PR
+    └─ Cleanup worktrees on merge
+```
+
+### Components
+
+#### 1. WorktreeCoordinator
+
+A new component that manages worktree lifecycle across multiple repos:
+
+```rust
+pub struct WorktreeCoordinator {
+    /// Map of repo name to RepoConfig
+    repos: HashMap<String, RepoConfig>,
+    /// Base date for branch naming (set at pipeline start)
+    base_date: String,
+}
+
+pub struct WorktreeInfo {
+    /// Absolute path to worktree
+    pub path: PathBuf,
+    /// Branch name (e.g., "ensemble-2026-03-30-my-repo-42")
+    pub branch: String,
+    /// Whether this was newly created
+    pub created_now: bool,
+}
+
+impl WorktreeCoordinator {
+    /// Prepare worktrees for all repos atomically
+    pub fn prepare_worktrees(&self, issue_id: &str) -> Result<HashMap<String, WorktreeInfo>, WorktreeError>;
+    
+    /// Remove worktrees and delete branches
+    pub fn cleanup_worktrees(&self, issue_id: &str) -> Result<(), WorktreeError>;
+    
+    /// List existing worktrees for an issue
+    pub fn list_worktrees(&self, issue_id: &str) -> HashMap<String, PathBuf>;
+}
+```
+
+#### 2. Enhanced WorkspaceManager
+
+The existing `WorkspaceManager` gains worktree awareness:
+
+```rust
+pub struct WorkspaceManager {
+    /// Base workspace root (for non-git work, logs, etc.)
+    root: PathBuf,
+    /// Worktree coordinator for multi-repo management
+    worktree_coordinator: Option<WorktreeCoordinator>,
+}
+
+pub struct WorkspaceResult {
+    /// Base workspace path (logs, artifacts)
+    pub base_path: PathBuf,
+    /// Map of repo name to worktree path
+    pub worktrees: HashMap<String, PathBuf>,
+    /// Whether any worktrees were newly created
+    pub created_now: bool,
+}
+```
+
+#### 3. PushStrategy Configuration
+
+New enum added to `EnsembleConfig`:
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PushStrategy {
+    /// Prompt user interactively (CLI mode only, blocks until response)
+    Ask,
+    /// Automatically push branch to origin
+    AutoPush,
+    /// Leave local, user handles manually
+    Manual,
+    /// Only create PR (implicit push)
+    PrOnly,
+}
+```
+
+**Note on "ask" mode:** This is intended for CLI/interactive usage where the user is present to respond. In daemon/server mode, "ask" should be treated as "manual" (log a warning that interactive mode is not available). The desktop GUI can implement its own prompting mechanism via the API.
+
+YAML usage:
+```yaml
+push_strategy: ask  # or auto_push, manual, pr_only
+```
+
+### Branch Naming
+
+Format: `ensemble-{YYYY-MM-DD}-{sanitized-issue-id}`
+
+**Sanitization rules:**
+- Replace all non-alphanumeric characters with `-`
+- Collapse multiple consecutive `-` into single `-`
+- Strip leading/trailing `-`
+- Lowercase all characters
+
+Examples:
+- Issue "my-repo#42" → `ensemble-2026-03-30-my-repo-42`
+- Issue "acme/api#123" → `ensemble-2026-03-30-acme-api-123`
+- Issue "FEATURE_Add Dark Mode" → `ensemble-2026-03-30-feature-add-dark-mode`
+
+The date prefix ensures chronological ordering and helps identify stale branches.
+
+### Worktree Location
+
+Worktrees are created within each repo under `.worktrees/`:
+
+```
+/Users/chris/code/acme-frontend/
+├── .git/                    # main git repo
+├── .worktrees/
+│   └── ensemble-2026-03-30-my-repo-42/  # worktree for issue #42
+│       └── (code files)
+└── src/
+    └── ...
+```
+
+This keeps worktrees:
+- Near the original repo for easy access
+- Hidden from normal directory listings
+- Automatically ignored by git (`.worktrees/` in gitignore)
+
+### Multi-Repo Coordination
+
+For an issue spanning multiple repos:
+
+```yaml
+repos:
+  - path: /Users/chris/code/acme-frontend
+    branch: main
+  - path: /Users/chris/code/acme-api
+    branch: develop
+```
+
+Worktrees created:
+- `/Users/chris/code/acme-frontend/.worktrees/ensemble-2026-03-30-issue-42/`
+- `/Users/chris/code/acme-api/.worktrees/ensemble-2026-03-30-issue-42/`
+
+All agents receive both paths and can work across repos.
+
+### Error Handling
+
+**All-or-Nothing Creation**: If creating worktrees for 3 repos and the 3rd fails:
+1. Roll back by removing already-created worktrees
+2. Delete partially-created branches
+3. Return error to orchestrator
+4. Pipeline fails before any agent runs
+
+**Stale Worktree Detection**: If a worktree exists but the branch doesn't (corrupted state):
+1. Log warning about corrupted state
+2. Remove the orphaned worktree directory
+3. Create fresh worktree
+
+**Permission Errors**: If git commands fail due to permissions:
+1. Return clear error with repo path
+2. Suggest checking git credentials
+
+### Retry Behavior
+
+Retry cycles reuse existing worktrees:
+
+```
+Cycle 1:
+  - Create worktrees
+  - Agent implements feature
+  - Review rejects → Retry scheduled
+
+Cycle 2 (retry):
+  - Reuse same worktrees (found at .worktrees/ensemble-{date}-42)
+  - Changes from Cycle 1 still present
+  - Agent continues from where we left off
+```
+
+This preserves partial progress across retries.
+
+### Cleanup Lifecycle
+
+Worktrees persist until the issue reaches a terminal success state:
+
+```
+Active States (Todo, In Progress):
+  └─ Worktrees exist and are used
+
+Failure (non-retryable):
+  └─ Worktrees kept for debugging
+  └─ Manual cleanup required
+
+Success / Merged:
+  └─ Remove worktrees
+  └─ Delete ensemble-* branches (local and remote)
+```
+
+**Remote branch deletion:** Uses default remote (typically "origin"). Configurable via `git_remote` setting in `RepoConfig` (defaults to "origin").
+
+Cleanup is triggered by tracker state transitions to `terminal_states`.
+
+### Integration Points
+
+#### Orchestrator Changes
+
+1. **Pipeline Start**: Call `prepare_workspace()` which coordinates worktree creation
+2. **Agent Dispatch**: Pass worktree paths to `AgentRunner`
+3. **Pipeline End**: Based on `PushStrategy`, either prompt, push, or leave local
+4. **Terminal Cleanup**: Remove worktrees when issue reaches terminal state
+
+#### Agent Runner Changes
+
+`AgentRunner::run()` signature updated:
+
+```rust
+async fn run(
+    &self,
+    issue: &Issue,
+    agent_config: &AgentConfig,
+    workspace: &WorkspaceResult,  // Now includes worktree paths
+    prompt: &str,
+) -> Result<Verdict, AgentError>;
+```
+
+Agent receives worktree paths via the prompt template or ACP context.
+
+#### Template Variables
+
+New template variable available:
+- `repos.frontend` → `/path/to/frontend/worktree`
+- `repos.api` → `/path/to/api/worktree`
+
+Template usage:
+```liquid
+You are working on {{ issue.identifier }}: {{ issue.title }}
+
+Code locations:
+{% for repo in repos %}- {{ repo.name }}: {{ repo.path }}
+{% endfor %}
+```
+
+## Implementation Phases
+
+### Phase 1: Core Worktree Management
+- Add `WorktreeCoordinator` struct
+- Implement worktree creation and cleanup
+- Add `PushStrategy` to config
+- Update `WorkspaceManager` integration
+
+### Phase 2: Orchestrator Integration
+- Modify pipeline start to prepare worktrees
+- Pass worktree paths to agents
+- Implement push strategy logic
+- Add terminal state cleanup
+
+### Phase 3: Template and Agent Integration
+- Add repo paths to template variables
+- Update agent runner to pass worktree context
+- Test with acpx agent protocol
+
+### Phase 4: Testing and Edge Cases
+- Test multi-repo scenarios
+- Test retry cycles
+- Test cleanup on various states
+- Error handling validation
+
+## Migration Path
+
+Existing configs without `repos` field continue using plain directories (backward compatible). When no `repos` are configured:
+- `WorkspaceManager` creates plain directories as before
+- Worktree coordination is skipped entirely
+- Agents work in empty directories (useful for non-git workflows)
+
+To enable worktrees, users add:
+
+```yaml
+repos:
+  - path: /path/to/repo
+    branch: main
+```
+
+**Mid-pipeline migration:** If a user adds `repos` while pipelines are running:
+- Existing plain-directory workspaces continue to completion
+- New issues use worktree mode
+- No automatic migration of in-flight issues (manual retry required)
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Large repos, slow worktree creation | Async creation with timeout; show progress |
+| Git version compatibility | Document minimum git version (2.5+ for worktrees) |
+| Disk space from many worktrees | Cleanup on merge; configurable retention |
+| Branch name collisions | Date prefix + sanitized issue ID |
+| Partial worktree creation failure | All-or-nothing with rollback |
+
+## Testing Strategy
+
+- **Unit tests**: `WorktreeCoordinator` worktree creation/cleanup
+- **Integration tests**: Full pipeline with worktrees across multiple repos
+- **Edge cases**: Retry cycles, stale worktrees, permission errors
+- **E2E tests**: Real git repos in temp directories
+
+## Success Criteria
+
+- [ ] Agents can modify code in worktrees
+- [ ] Changes persist across pipeline steps
+- [ ] Retry cycles reuse existing worktrees
+- [ ] Worktrees cleaned up on merge
+- [ ] Multi-repo issues work correctly
+- [ ] All-or-nothing creation prevents partial states
+- [ ] Push strategy respects user preference


### PR DESCRIPTION
## Summary
- Add git worktree support for per-issue branch isolation across configured repositories
- `WorktreeCoordinator` manages multi-repo worktree lifecycle with all-or-nothing creation and rollback
- `PushStrategy` enum (ask/auto_push/manual/pr_only) controls branch handling after pipeline success
- `WorkspaceManager` now async, integrates coordinator when repos are configured, backward-compatible when not
- Stale worktree detection recovers from orphaned directories and deleted branches
- Branch naming: `ensemble-YYYY-MM-DD-<sanitized-issue-id>` with full spec-compliant sanitization

## Test plan
- [x] Unit tests for branch name sanitization (including spec examples)
- [x] Unit tests for PushStrategy enum behavior and deserialization
- [x] Integration tests for worktree create/remove/exists/pull operations
- [x] Integration tests for multi-repo coordinator (create all, reuse, cleanup, rollback)
- [x] Integration test for full workflow with worktrees (create, reuse, cleanup)
- [x] All 316 existing tests pass, clippy clean, fmt clean