### PR TITLE
Fix init wizard: tilde expansion, remote branches, acpx install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/ensemble-cli/Cargo.toml
+++ b/crates/ensemble-cli/Cargo.toml
@@ -22,3 +22,6 @@ serde_json = { workspace = true }
 rust-embed = { workspace = true }
 mime_guess = "2"
 reqwest = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/ensemble-cli/src/commands/init/agents.rs
+++ b/crates/ensemble-cli/src/commands/init/agents.rs
@@ -122,7 +122,11 @@ fn try_acpx_version() -> Option<String> {
 
     if output.status.success() {
         let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if v.is_empty() { None } else { Some(v) }
+        if v.is_empty() {
+            None
+        } else {
+            Some(v)
+        }
     } else {
         None
     }

--- a/crates/ensemble-cli/src/commands/init/agents.rs
+++ b/crates/ensemble-cli/src/commands/init/agents.rs
@@ -96,13 +96,19 @@ fn check_acpx() -> Result<String, String> {
         return Err("acpx is required to continue".to_string());
     }
 
-    let cmd = format!("{choice} install -g acpx@latest");
+    let (program, args): (&str, Vec<&str>) = if choice == "yarn" {
+        ("yarn", vec!["global", "add", "acpx@latest"])
+    } else {
+        (choice, vec!["install", "-g", "acpx@latest"])
+    };
+
+    let cmd = format!("{program} {}", args.join(" "));
     println!("\nRunning: {cmd}\n");
 
-    let status = std::process::Command::new(choice)
-        .args(["install", "-g", "acpx@latest"])
+    let status = std::process::Command::new(program)
+        .args(&args)
         .status()
-        .map_err(|e| format!("{choice} failed: {e}"))?;
+        .map_err(|e| format!("{program} failed: {e}"))?;
 
     if !status.success() {
         return Err(format!("{cmd} exited with {status}"));

--- a/crates/ensemble-cli/src/commands/init/agents.rs
+++ b/crates/ensemble-cli/src/commands/init/agents.rs
@@ -96,11 +96,7 @@ fn check_acpx() -> Result<String, String> {
         return Err("acpx is required to continue".to_string());
     }
 
-    let (program, args): (&str, Vec<&str>) = if choice == "yarn" {
-        ("yarn", vec!["global", "add", "acpx@latest"])
-    } else {
-        (choice, vec!["install", "-g", "acpx@latest"])
-    };
+    let (program, args) = install_command(choice);
 
     let cmd = format!("{program} {}", args.join(" "));
     println!("\nRunning: {cmd}\n");
@@ -158,5 +154,48 @@ fn get_agent_version(name: &str) -> String {
             }
         }
         _ => String::new(),
+    }
+}
+
+/// Build the (program, args) pair for installing acpx globally with the
+/// given package manager. Yarn uses `global add` instead of `install -g`.
+fn install_command(manager: &str) -> (&str, Vec<&str>) {
+    if manager == "yarn" {
+        ("yarn", vec!["global", "add", "acpx@latest"])
+    } else {
+        (manager, vec!["install", "-g", "acpx@latest"])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_command_npm() {
+        let (prog, args) = install_command("npm");
+        assert_eq!(prog, "npm");
+        assert_eq!(args, &["install", "-g", "acpx@latest"]);
+    }
+
+    #[test]
+    fn install_command_pnpm() {
+        let (prog, args) = install_command("pnpm");
+        assert_eq!(prog, "pnpm");
+        assert_eq!(args, &["install", "-g", "acpx@latest"]);
+    }
+
+    #[test]
+    fn install_command_bun() {
+        let (prog, args) = install_command("bun");
+        assert_eq!(prog, "bun");
+        assert_eq!(args, &["install", "-g", "acpx@latest"]);
+    }
+
+    #[test]
+    fn install_command_yarn() {
+        let (prog, args) = install_command("yarn");
+        assert_eq!(prog, "yarn");
+        assert_eq!(args, &["global", "add", "acpx@latest"]);
     }
 }

--- a/crates/ensemble-cli/src/commands/init/agents.rs
+++ b/crates/ensemble-cli/src/commands/init/agents.rs
@@ -79,22 +79,50 @@ fn ask_roles(selected: Vec<String>) -> Result<Vec<AgentEntry>, String> {
 }
 
 fn check_acpx() -> Result<String, String> {
+    if let Some(version) = try_acpx_version() {
+        return Ok(version);
+    }
+
+    println!("acpx is not installed.\n");
+    println!("Ensemble requires acpx for agent communication.");
+    println!("See: https://github.com/openclaw/acpx\n");
+
+    let options = vec!["npm", "pnpm", "bun", "yarn", "Skip (exit)"];
+    let choice = inquire::Select::new("Install acpx with:", options)
+        .prompt()
+        .map_err(|e| e.to_string())?;
+
+    if choice == "Skip (exit)" {
+        return Err("acpx is required to continue".to_string());
+    }
+
+    let cmd = format!("{choice} install -g acpx@latest");
+    println!("\nRunning: {cmd}\n");
+
+    let status = std::process::Command::new(choice)
+        .args(["install", "-g", "acpx@latest"])
+        .status()
+        .map_err(|e| format!("{choice} failed: {e}"))?;
+
+    if !status.success() {
+        return Err(format!("{cmd} exited with {status}"));
+    }
+
+    // Verify it's now available
+    try_acpx_version().ok_or_else(|| "acpx installed but not found on PATH".to_string())
+}
+
+fn try_acpx_version() -> Option<String> {
     let output = std::process::Command::new("acpx")
         .arg("--version")
         .output()
-        .map_err(|_| {
-            "acpx is not installed.\n\n\
-             Ensemble requires acpx for agent communication.\n\
-             Install: npm install -g acpx@latest\n\
-             See: https://github.com/openclaw/acpx"
-                .to_string()
-        })?;
+        .ok()?;
 
     if output.status.success() {
-        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        Ok(version)
+        let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if v.is_empty() { None } else { Some(v) }
     } else {
-        Err("acpx --version failed".to_string())
+        None
     }
 }
 

--- a/crates/ensemble-cli/src/commands/init/repos.rs
+++ b/crates/ensemble-cli/src/commands/init/repos.rs
@@ -1,6 +1,16 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+/// Expand a leading `~` or `~/` to the user's home directory.
+fn expand_tilde(path: &str) -> String {
+    if path == "~" || path.starts_with("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return path.replacen('~', &home, 1);
+        }
+    }
+    path.to_string()
+}
+
 #[derive(Debug)]
 pub struct RepoEntry {
     pub path: PathBuf,
@@ -128,7 +138,8 @@ pub fn ask_repos() -> Result<Vec<RepoEntry>, inquire::InquireError> {
             break;
         }
 
-        let input_path = PathBuf::from(&trimmed);
+        let expanded = expand_tilde(&trimmed);
+        let input_path = PathBuf::from(&expanded);
 
         // Canonicalize the path so we store an absolute, normalized path.
         let canonical = match std::fs::canonicalize(&input_path) {

--- a/crates/ensemble-cli/src/commands/init/repos.rs
+++ b/crates/ensemble-cli/src/commands/init/repos.rs
@@ -1,6 +1,15 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+/// Strip a leading `origin/` (or `<remote>/`) prefix from a branch name so
+/// that user input like `origin/main` is normalised to `main`.
+fn strip_remote_prefix(branch: &str) -> String {
+    branch
+        .strip_prefix("origin/")
+        .unwrap_or(branch)
+        .to_string()
+}
+
 /// Expand a leading `~` or `~/` to the user's home directory.
 fn expand_tilde(path: &str) -> String {
     if path == "~" || path.starts_with("~/") {
@@ -94,7 +103,7 @@ fn ask_branch_with_retry(repo_path: &PathBuf, initial_branch: &str) -> Option<St
 
     let retry_prompt = format!("Retry branch for '{}'", repo_path.display());
     let retry_input = inquire::Text::new(&retry_prompt).prompt().ok()?;
-    let retry_branch = retry_input.trim().to_string();
+    let retry_branch = strip_remote_prefix(retry_input.trim());
 
     if retry_branch.is_empty() {
         return None;
@@ -171,7 +180,7 @@ pub fn ask_repos() -> Result<Vec<RepoEntry>, inquire::InquireError> {
         let branch_input = inquire::Text::new(&branch_prompt)
             .with_default(&branch_default_text)
             .prompt()?;
-        let branch = branch_input.trim().to_string();
+        let branch = strip_remote_prefix(branch_input.trim());
 
         // Validate the branch exists. Offer one retry on failure.
         match ask_branch_with_retry(&canonical, &branch) {

--- a/crates/ensemble-cli/src/commands/init/repos.rs
+++ b/crates/ensemble-cli/src/commands/init/repos.rs
@@ -197,7 +197,10 @@ mod tests {
     #[test]
     fn expand_tilde_with_slash() {
         let home = std::env::var("HOME").unwrap();
-        assert_eq!(expand_tilde("~/dev/ensemble"), format!("{home}/dev/ensemble"));
+        assert_eq!(
+            expand_tilde("~/dev/ensemble"),
+            format!("{home}/dev/ensemble")
+        );
     }
 
     #[test]
@@ -228,7 +231,11 @@ mod tests {
         let repo = tmp.path();
 
         // Init a repo with a commit so HEAD and main exist.
-        Command::new("git").args(["init"]).current_dir(repo).output().unwrap();
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
         Command::new("git")
             .args(["commit", "--allow-empty", "-m", "init"])
             .current_dir(repo)

--- a/crates/ensemble-cli/src/commands/init/repos.rs
+++ b/crates/ensemble-cli/src/commands/init/repos.rs
@@ -189,3 +189,110 @@ pub fn ask_repos() -> Result<Vec<RepoEntry>, inquire::InquireError> {
 
     Ok(repos)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_tilde_with_slash() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(expand_tilde("~/dev/ensemble"), format!("{home}/dev/ensemble"));
+    }
+
+    #[test]
+    fn expand_tilde_bare() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(expand_tilde("~"), home);
+    }
+
+    #[test]
+    fn expand_tilde_no_tilde() {
+        assert_eq!(expand_tilde("/usr/local/bin"), "/usr/local/bin");
+    }
+
+    #[test]
+    fn expand_tilde_mid_path_unchanged() {
+        assert_eq!(expand_tilde("/home/~user/foo"), "/home/~user/foo");
+    }
+
+    #[test]
+    fn expand_tilde_tilde_user_unchanged() {
+        // ~otheruser should NOT be expanded (we only handle ~/...)
+        assert_eq!(expand_tilde("~otheruser/foo"), "~otheruser/foo");
+    }
+
+    #[test]
+    fn branch_exists_local_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+
+        // Init a repo with a commit so HEAD and main exist.
+        Command::new("git").args(["init"]).current_dir(repo).output().unwrap();
+        Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+
+        let repo_path = PathBuf::from(repo);
+        // Default branch should exist (could be main or master depending on config).
+        let default = Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        let branch_name = String::from_utf8_lossy(&default.stdout).trim().to_string();
+
+        assert!(branch_exists(&repo_path, &branch_name));
+        assert!(!branch_exists(&repo_path, "nonexistent-branch-xyz"));
+    }
+
+    #[test]
+    fn branch_exists_remote_qualified() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Create a bare "remote" and clone it so we get origin refs.
+        let bare = tmp.path().join("bare.git");
+        Command::new("git")
+            .args(["init", "--bare"])
+            .arg(&bare)
+            .output()
+            .unwrap();
+
+        let clone = tmp.path().join("clone");
+        Command::new("git")
+            .args(["clone"])
+            .arg(&bare)
+            .arg(&clone)
+            .output()
+            .unwrap();
+
+        // Create initial commit and push so origin/main exists.
+        Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(&clone)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["push", "origin", "HEAD"])
+            .current_dir(&clone)
+            .output()
+            .unwrap();
+
+        let clone_path = PathBuf::from(&clone);
+        let default = Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&clone)
+            .output()
+            .unwrap();
+        let branch_name = String::from_utf8_lossy(&default.stdout).trim().to_string();
+
+        // "origin/main" should resolve via refs/remotes/origin/main
+        let remote_qualified = format!("origin/{branch_name}");
+        assert!(branch_exists(&clone_path, &remote_qualified));
+
+        // Bare name should also work
+        assert!(branch_exists(&clone_path, &branch_name));
+    }
+}

--- a/crates/ensemble-cli/src/commands/init/repos.rs
+++ b/crates/ensemble-cli/src/commands/init/repos.rs
@@ -1,15 +1,6 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-/// Strip a leading `origin/` (or `<remote>/`) prefix from a branch name so
-/// that user input like `origin/main` is normalised to `main`.
-fn strip_remote_prefix(branch: &str) -> String {
-    branch
-        .strip_prefix("origin/")
-        .unwrap_or(branch)
-        .to_string()
-}
-
 /// Expand a leading `~` or `~/` to the user's home directory.
 fn expand_tilde(path: &str) -> String {
     if path == "~" || path.starts_with("~/") {
@@ -66,28 +57,27 @@ fn is_git_repo(repo_path: &PathBuf) -> bool {
         .unwrap_or(false)
 }
 
-/// Check whether a branch exists in the given repository (checks local and remote refs).
+/// Check whether a branch exists in the given repository.
+///
+/// Accepts bare names (`main`), remote-qualified names (`origin/main`), or
+/// full refnames (`refs/heads/main`). Checks local refs, remote refs under
+/// `origin/`, and `refs/remotes/` directly so that `origin/main` resolves
+/// to `refs/remotes/origin/main`.
 fn branch_exists(repo_path: &PathBuf, branch: &str) -> bool {
-    // Check local refs first
-    let local_ref = format!("refs/heads/{}", branch);
-    if Command::new("git")
-        .args(["rev-parse", "--verify", &local_ref])
-        .current_dir(repo_path)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-    {
-        return true;
-    }
+    let candidates = [
+        format!("refs/heads/{}", branch),
+        format!("refs/remotes/origin/{}", branch),
+        format!("refs/remotes/{}", branch),
+    ];
 
-    // Check remote refs
-    let remote_ref = format!("refs/remotes/origin/{}", branch);
-    Command::new("git")
-        .args(["rev-parse", "--verify", &remote_ref])
-        .current_dir(repo_path)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    candidates.iter().any(|r| {
+        Command::new("git")
+            .args(["rev-parse", "--verify", r])
+            .current_dir(repo_path)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    })
 }
 
 fn ask_branch_with_retry(repo_path: &PathBuf, initial_branch: &str) -> Option<String> {
@@ -103,7 +93,7 @@ fn ask_branch_with_retry(repo_path: &PathBuf, initial_branch: &str) -> Option<St
 
     let retry_prompt = format!("Retry branch for '{}'", repo_path.display());
     let retry_input = inquire::Text::new(&retry_prompt).prompt().ok()?;
-    let retry_branch = strip_remote_prefix(retry_input.trim());
+    let retry_branch = retry_input.trim().to_string();
 
     if retry_branch.is_empty() {
         return None;
@@ -180,7 +170,7 @@ pub fn ask_repos() -> Result<Vec<RepoEntry>, inquire::InquireError> {
         let branch_input = inquire::Text::new(&branch_prompt)
             .with_default(&branch_default_text)
             .prompt()?;
-        let branch = strip_remote_prefix(branch_input.trim());
+        let branch = branch_input.trim().to_string();
 
         // Validate the branch exists. Offer one retry on failure.
         match ask_branch_with_retry(&canonical, &branch) {

--- a/crates/ensemble-cli/src/commands/init/repos.rs
+++ b/crates/ensemble-cli/src/commands/init/repos.rs
@@ -225,17 +225,31 @@ mod tests {
         assert_eq!(expand_tilde("~otheruser/foo"), "~otheruser/foo");
     }
 
+    /// Configure git user in a repo so commits work on CI runners without global config.
+    fn git_config_user(dir: &std::path::Path) {
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+    }
+
     #[test]
     fn branch_exists_local_branch() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path();
 
-        // Init a repo with a commit so HEAD and main exist.
         Command::new("git")
             .args(["init"])
             .current_dir(repo)
             .output()
             .unwrap();
+        git_config_user(repo);
         Command::new("git")
             .args(["commit", "--allow-empty", "-m", "init"])
             .current_dir(repo)
@@ -243,7 +257,6 @@ mod tests {
             .unwrap();
 
         let repo_path = PathBuf::from(repo);
-        // Default branch should exist (could be main or master depending on config).
         let default = Command::new("git")
             .args(["branch", "--show-current"])
             .current_dir(repo)
@@ -259,7 +272,6 @@ mod tests {
     fn branch_exists_remote_qualified() {
         let tmp = tempfile::tempdir().unwrap();
 
-        // Create a bare "remote" and clone it so we get origin refs.
         let bare = tmp.path().join("bare.git");
         Command::new("git")
             .args(["init", "--bare"])
@@ -275,7 +287,7 @@ mod tests {
             .output()
             .unwrap();
 
-        // Create initial commit and push so origin/main exists.
+        git_config_user(&clone);
         Command::new("git")
             .args(["commit", "--allow-empty", "-m", "init"])
             .current_dir(&clone)


### PR DESCRIPTION
## Summary
- Fix `~/path` input in repo path prompt — `PathBuf` treats `~` as a literal directory, now expanded to `$HOME` before canonicalization
- Fix `origin/main` branch validation — `branch_exists` now checks `refs/remotes/{branch}` directly so remote-qualified names resolve correctly
- Offer interactive acpx installation when missing — picker for npm/pnpm/bun/yarn with correct command per manager (yarn uses `global add`)

## Test plan
- [x] Unit tests for `expand_tilde` (5 cases: `~/path`, bare `~`, absolute, mid-path, `~user`)
- [x] Unit tests for `branch_exists` with local and remote-qualified branches (using tempfile repos)
- [x] Unit tests for `install_command` per package manager (npm, pnpm, bun, yarn)
- [ ] Manual: run `ensemble init`, enter `~/dev/somerepo` as repo path
- [ ] Manual: enter `origin/main` as target branch
- [ ] Manual: test acpx install flow with acpx not on PATH