### PR TITLE
Fix PR #26 review feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ GitHub Actions runs on push to `main` and all PRs. Four parallel jobs: check, te
 
 - **Pluggable trackers**: `IssueTracker` is an async trait in `ensemble-core` with read methods and optional write methods (default no-ops). Tracker implementations (GitHub, todo_file) live in `ensemble-core` as sub-modules of `tracker/`.
 - **Config from ensemble.yaml**: All runtime config lives in `ensemble.yaml`. `EnsembleConfig` provides typed access with defaults and `$ENV_VAR` resolution. Agent definitions, step DAG, and prompt references are all defined here.
-- **Agent model discovery**: During `ensemble init`, acpx agent sessions are probed to discover available models and reasoning levels. These are stored as `model` and `reasoning_level` in `AgentConfig` and emitted in `ensemble.yaml`.
+- **Agent model discovery**: During `ensemble init`, acpx agent sessions are probed to discover available models. The selected model is stored as `model` in `AgentConfig` and emitted in `ensemble.yaml`.
 - **Multi-agent pipelines**: Named agents run through a step DAG (GitHub Actions-style: sequential by default, `depends` for parallelism). The orchestrator drives state transitions at step boundaries and collects verdicts from review agents.
 - **Workspace isolation**: Each issue gets a directory under a configurable root, keyed by sanitized identifier. Workspaces are reused across retries and cleaned up on completion.
 - **Hook lifecycle**: Shell hooks (after_create, before_run, after_run, before_remove) run in workspace directories with configurable timeouts. Non-fatal hooks use best-effort mode.

--- a/crates/ensemble-cli/src/commands/init/agents.rs
+++ b/crates/ensemble-cli/src/commands/init/agents.rs
@@ -71,19 +71,26 @@ pub fn discover_agents(existing: Option<&EnsembleConfig>) -> Result<Vec<AgentEnt
 
     println!();
 
-    // Compute default selection indices from existing config
+    // Compute default selection indices from existing config.
+    // If existing config exists but none of its agents match the available set,
+    // fall back to selecting all available agents (same as fresh-init behavior).
     let default_indices: Vec<usize> = if let Some(config) = existing {
         let existing_agents: Vec<&str> = config
             .agents
             .values()
             .filter_map(|a| a.acpx_agent.as_deref())
             .collect();
-        available
+        let indices: Vec<usize> = available
             .iter()
             .enumerate()
             .filter(|(_, name)| existing_agents.contains(&name.as_str()))
             .map(|(i, _)| i)
-            .collect()
+            .collect();
+        if indices.is_empty() {
+            (0..available.len()).collect()
+        } else {
+            indices
+        }
     } else {
         (0..available.len()).collect()
     };
@@ -336,6 +343,10 @@ fn probe_agent_capabilities(agent_name: &str) -> AgentCapabilities {
 }
 
 /// Read capabilities from a session JSON file.
+///
+/// Returns as soon as the session JSON is parseable and contains an `acpx`
+/// object (with or without models), rather than always blocking for the full
+/// timeout when an agent never populates `available_models`.
 fn read_session_capabilities(session_id: &str) -> AgentCapabilities {
     let acpx_dir = dirs::home_dir()
         .map(|h| h.join(".acpx").join("sessions"))
@@ -343,13 +354,15 @@ fn read_session_capabilities(session_id: &str) -> AgentCapabilities {
 
     let session_file = acpx_dir.join(format!("{session_id}.json"));
 
-    // Wait briefly for the session file to be populated with capabilities
+    // Wait for the session file to appear and become parseable
     for _ in 0..20 {
         if let Ok(content) = std::fs::read_to_string(&session_file) {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-                let caps = AgentCapabilities::from_session_json(&json);
-                if !caps.available_models.is_empty() {
-                    return caps;
+                // Once the acpx object is present, return whatever we have.
+                // Agents that never populate available_models will have an
+                // empty list rather than blocking for the full 10s timeout.
+                if json.get("acpx").is_some() {
+                    return AgentCapabilities::from_session_json(&json);
                 }
             }
         }

--- a/crates/ensemble-cli/src/commands/init/tracker.rs
+++ b/crates/ensemble-cli/src/commands/init/tracker.rs
@@ -48,7 +48,7 @@ pub async fn ask_tracker(
                 .with_default(&default_path)
                 .prompt()?;
 
-            println!("Creating TODO.md with a sample issue...");
+            println!("Creating {} with a sample issue...", path_str);
             Ok(TrackerChoice::TodoFile {
                 path: PathBuf::from(path_str),
             })
@@ -132,7 +132,8 @@ async fn ask_github_tracker(
         default_statuses()
     };
 
-    let (active_states, on_success, on_failure) = ask_status_mapping(&available_statuses)?;
+    let (active_states, on_success, on_failure) =
+        ask_status_mapping(&available_statuses, existing)?;
 
     // terminal_states = the success state (and failure if present on the board)
     let mut terminal_states = vec![on_success.clone()];
@@ -163,29 +164,58 @@ fn default_statuses() -> Vec<String> {
 
 /// Prompt the user to select active states and map success/failure statuses.
 ///
+/// When `existing` config is provided, defaults are seeded from the existing
+/// tracker's `active_states`, `on_success`, and `on_failure` values.
+///
 /// Returns `(active_states, on_success, on_failure)`.
 pub fn ask_status_mapping(
     available_statuses: &[String],
+    existing: Option<&EnsembleConfig>,
 ) -> Result<(Vec<String>, String, String), inquire::InquireError> {
+    // Compute default indices for active states from existing config
+    let default_active_indices: Vec<usize> = existing
+        .map(|c| {
+            c.tracker
+                .active_states
+                .iter()
+                .filter_map(|s| available_statuses.iter().position(|a| a == s))
+                .collect()
+        })
+        .unwrap_or_default();
+    let default_active_indices = if default_active_indices.is_empty() {
+        vec![0]
+    } else {
+        default_active_indices
+    };
+
     // Multi-select active states
     let active_states: Vec<String> = MultiSelect::new(
         "Which statuses should Ensemble pick up work from? (space to toggle)",
         available_statuses.to_vec(),
     )
-    .with_default(&[0]) // default: first item selected
+    .with_default(&default_active_indices)
     .prompt()?;
+
+    // Compute default cursor for success state from existing config
+    let success_default_idx = existing
+        .and_then(|c| available_statuses.iter().position(|s| s == &c.on_success))
+        .unwrap_or(0);
 
     // Select success state
     let on_success = Select::new(
         "Which status means work is complete?",
         available_statuses.to_vec(),
     )
+    .with_starting_cursor(success_default_idx)
     .prompt()?
     .to_string();
 
-    // Free-text failure state (with default "Failed")
+    // Default failure state from existing config
+    let default_failure = existing.map(|c| c.on_failure.as_str()).unwrap_or("Failed");
+
+    // Free-text failure state
     let on_failure = Text::new("Which status means work failed? (press enter to use \"Failed\")")
-        .with_default("Failed")
+        .with_default(default_failure)
         .prompt()?;
 
     Ok((active_states, on_success, on_failure))

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -98,20 +98,39 @@ impl AcpAgentRunner {
     }
 }
 
+/// POSIX-compatible single-quote escaping for shell arguments.
+///
+/// Wraps the argument in single quotes and escapes any embedded single-quote
+/// characters. This prevents shell metacharacter injection when arguments are
+/// interpolated into commands executed via `bash -lc`.
+fn shell_escape(arg: &str) -> String {
+    let mut escaped = String::with_capacity(arg.len() + 2);
+    escaped.push('\'');
+    for ch in arg.chars() {
+        if ch == '\'' {
+            escaped.push_str("'\\''");
+        } else {
+            escaped.push(ch);
+        }
+    }
+    escaped.push('\'');
+    escaped
+}
+
 /// Build the ACP spawn command for an agent.
 ///
 /// When `acpx_agent` is set, uses `acpx --agent <name>` with `--model` if
-/// configured. acpx speaks ACP over stdin/stdout and handles model selection
-/// natively. Falls back to `executor` if set, then to the global default.
+/// configured. Arguments are shell-escaped because the command is executed
+/// via `bash -lc`. Falls back to `executor` if set, then to the global default.
 fn resolve_agent_command(
     agent_config: Option<&crate::config::ensemble::AgentConfig>,
     default_command: &str,
 ) -> String {
     if let Some(ac) = agent_config {
         if let Some(ref acpx_name) = ac.acpx_agent {
-            let mut cmd = format!("acpx --agent {acpx_name}");
+            let mut cmd = format!("acpx --agent {}", shell_escape(acpx_name));
             if let Some(ref model) = ac.model {
-                cmd.push_str(&format!(" --model {model}"));
+                cmd.push_str(&format!(" --model {}", shell_escape(model)));
             }
             return cmd;
         }
@@ -407,5 +426,54 @@ mod tests {
 
         assert!(result.is_err());
         assert!(matches!(result, Err(AgentError::TurnFailed { .. })));
+    }
+
+    #[test]
+    fn test_shell_escape_simple() {
+        assert_eq!(shell_escape("claude"), "'claude'");
+    }
+
+    #[test]
+    fn test_shell_escape_with_single_quote() {
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn test_shell_escape_with_metacharacters() {
+        assert_eq!(shell_escape("a; rm -rf /"), "'a; rm -rf /'");
+    }
+
+    #[test]
+    fn test_resolve_agent_command_escapes_acpx_name() {
+        let config = crate::config::ensemble::AgentConfig {
+            acpx_agent: Some("claude".to_string()),
+            model: Some("sonnet".to_string()),
+            executor: None,
+            prompt: None,
+            prompt_template: None,
+            reasoning_level: None,
+        };
+        let cmd = resolve_agent_command(Some(&config), "default-cmd");
+        assert_eq!(cmd, "acpx --agent 'claude' --model 'sonnet'");
+    }
+
+    #[test]
+    fn test_resolve_agent_command_no_model() {
+        let config = crate::config::ensemble::AgentConfig {
+            acpx_agent: Some("claude".to_string()),
+            model: None,
+            executor: None,
+            prompt: None,
+            prompt_template: None,
+            reasoning_level: None,
+        };
+        let cmd = resolve_agent_command(Some(&config), "default-cmd");
+        assert_eq!(cmd, "acpx --agent 'claude'");
+    }
+
+    #[test]
+    fn test_resolve_agent_command_falls_back_to_default() {
+        let cmd = resolve_agent_command(None, "default-cmd");
+        assert_eq!(cmd, "default-cmd");
     }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -533,7 +533,7 @@ Named agent definitions. Each key is the agent role name, each value is an objec
 - `reasoning_level` (string, optional)
   - Reasoning/thinking level for agents that support it (for example `high`, `low`).
   - When omitted, the agent uses its default reasoning level.
-  - Discovered automatically during `ensemble init` by probing acpx agent capabilities.
+  - Currently set manually in `ensemble.yaml`; reserved for future tooling that may auto-detect supported reasoning levels.
 - `prompt` (string, optional)
   - Inline prompt text. Mutually exclusive with `prompt_template`.
 - `prompt_template` (path string, optional)

--- a/docs/superpowers/specs/2026-03-31-init-defaults-and-model-selection-design.md
+++ b/docs/superpowers/specs/2026-03-31-init-defaults-and-model-selection-design.md
@@ -4,7 +4,7 @@
 
 Two improvements to `ensemble init`:
 1. Load an existing `ensemble.yaml` and use its values as defaults throughout the wizard
-2. After selecting acpx agents, probe each for available models and reasoning levels, then ask the user to configure them
+2. After selecting acpx agents, probe each for available models, then ask the user to configure them (reasoning-level discovery/prompting is future work)
 
 ## Change 1: Existing Config as Defaults
 
@@ -76,11 +76,7 @@ During the role-naming loop, after naming each agent's role:
    - Default: existing config value, or `"default"` if no existing config
    - If user picks `"default"`, store `None` (omit from YAML)
 
-2. **Reasoning level** (if `config_options` includes a `thought_level` select):
-   - `Select` prompt: "Reasoning level for <agent>?"
-   - Options: extracted from the config option's selectable values, plus a "default" option
-   - Default: existing config value, or `"default"`
-   - If user picks `"default"`, store `None` (omit from YAML)
+2. **Reasoning level** — *future work*. The `reasoning_level` field exists in `AgentConfig` for forward compatibility, but discovery/prompting is not yet implemented. When acpx exposes `config_options` with a `thought_level` category, this section can be revisited.
 
 ### Data model changes
 


### PR DESCRIPTION
## Summary

Follow-up to #26 addressing all 8 review comments from Copilot:

- **Shell injection fix**: Shell-escape `acpx_agent` and `model` arguments in `resolve_agent_command` using POSIX single-quote escaping, preventing command injection via crafted `ensemble.yaml` values
- **TODO tracker message**: Print the actual selected file path instead of hardcoded "TODO.md"
- **Status mapping defaults**: Thread existing config into `ask_status_mapping` so re-running `ensemble init` preserves `active_states`, `on_success`, and `on_failure` selections
- **Agent selection fallback**: When existing config has no matching `acpx_agent` entries, fall back to selecting all available agents instead of an empty selection
- **Session probe timeout**: Return early from `read_session_capabilities` once the `acpx` object is present in the session JSON, avoiding a 10s block for agents that never populate `available_models`
- **Doc corrections**: Update SPEC.md, AGENTS.md, and design doc to accurately describe `reasoning_level` as manually configured / future work (not yet auto-discovered)

## Test plan
- [x] `cargo test -p ensemble-core` passes (320 tests)
- [x] `cargo clippy -p ensemble-core -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] New unit tests for `shell_escape` and `resolve_agent_command`