### PR TITLE
Fix Tauri CI: code signing and homebrew .dmg lookup

### DIFF
--- a/.github/update-homebrew.sh
+++ b/.github/update-homebrew.sh
@@ -18,7 +18,8 @@ if ! ls ${ARTIFACTS_DIR}/ensemble-${TAG}-*.tar.gz 1>/dev/null 2>&1; then
   exit 1
 fi
 
-if ! ls ${ARTIFACTS_DIR}/*.dmg 1>/dev/null 2>&1; then
+DMG=$(find ${ARTIFACTS_DIR} -name '*.dmg' -type f | head -1)
+if [ -z "$DMG" ]; then
   echo "ERROR: No .dmg file found in ${ARTIFACTS_DIR}"
   exit 1
 fi
@@ -33,7 +34,6 @@ for f in ${ARTIFACTS_DIR}/ensemble-${TAG}-*.tar.gz; do
 done
 
 # Compute checksum for desktop .dmg
-DMG=$(ls ${ARTIFACTS_DIR}/*.dmg | head -1)
 DMG_NAME=$(basename "$DMG")
 DMG_SHA256=$(sha256sum "$DMG" | awk '{print $1}')
 echo "  dmg: ${DMG_SHA256}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,12 +129,12 @@ jobs:
         run: tauri build
         working-directory: crates/ensemble-desktop
         env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_CERTIFICATE || '' }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_ID: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_ID || '' }}
+          APPLE_SIGNING_IDENTITY: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_SIGNING_IDENTITY || '' }}
+          APPLE_TEAM_ID: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_TEAM_ID || '' }}
+          APPLE_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_PASSWORD || '' }}
 
       - name: Upload desktop artifacts
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,15 +126,21 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Build Tauri app
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: tauri build
+        working-directory: crates/ensemble-desktop
+
+      - name: Build Tauri app (signed)
+        if: startsWith(github.ref, 'refs/tags/v')
         run: tauri build
         working-directory: crates/ensemble-desktop
         env:
-          APPLE_CERTIFICATE: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_CERTIFICATE || '' }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
-          APPLE_ID: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_ID || '' }}
-          APPLE_SIGNING_IDENTITY: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_SIGNING_IDENTITY || '' }}
-          APPLE_TEAM_ID: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_TEAM_ID || '' }}
-          APPLE_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.APPLE_PASSWORD || '' }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
 
       - name: Upload desktop artifacts
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary
- Fix code signing by using a valid Developer ID Application certificate with matching `APPLE_SIGNING_IDENTITY`
- Fix `.dmg` lookup in homebrew script to search recursively, since Tauri's bundle artifact preserves directory structure

## Test plan
- [ ] CI passes with signed Tauri build on all platforms
- [ ] Next tag release finds `.dmg` in nested artifact directory