### PR TITLE
Harden desktop config and smoke test handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,14 @@ jobs:
       - name: Install Tauri CLI
         run: pnpm install -g @tauri-apps/cli
 
-      - name: Run desktop unit tests
-        run: SKIP_UI_BUILD=1 cargo test -p ensemble-desktop --bin ensemble-desktop -- --nocapture
-
       - name: Install Tauri system dependencies (Linux)
         if: matrix.runner == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Run desktop unit tests
+        run: SKIP_UI_BUILD=1 cargo test -p ensemble-desktop --bin ensemble-desktop -- --nocapture
 
       - name: Build Tauri app
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
       - name: Install Tauri CLI
         run: pnpm install -g @tauri-apps/cli
 
+      - name: Run desktop unit tests
+        run: SKIP_UI_BUILD=1 cargo test -p ensemble-desktop --bin ensemble-desktop -- --nocapture
+
       - name: Install Tauri system dependencies (Linux)
         if: matrix.runner == 'ubuntu-latest'
         run: |
@@ -141,6 +144,10 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+
+      - name: Run E2E smoke test (verify app launches)
+        run: cargo test -p ensemble-desktop --test e2e app_launches_without_crash -- --ignored --nocapture
+        timeout-minutes: 2
 
       - name: Upload desktop artifacts
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,9 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Run desktop unit tests
-        run: SKIP_UI_BUILD=1 cargo test -p ensemble-desktop --bin ensemble-desktop -- --nocapture
+        run: cargo test -p ensemble-desktop --bin ensemble-desktop -- --nocapture
+        env:
+          SKIP_UI_BUILD: 1
 
       - name: Build Tauri app
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         if: matrix.runner == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xvfb
 
       - name: Run desktop unit tests
         run: cargo test -p ensemble-desktop --bin ensemble-desktop -- --nocapture
@@ -148,7 +148,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
 
       - name: Run E2E smoke test (verify app launches)
-        run: cargo test -p ensemble-desktop --test e2e app_launches_without_crash -- --ignored --nocapture
+        run: ${{ matrix.runner == 'ubuntu-latest' && 'xvfb-run -a' || '' }} cargo test -p ensemble-desktop --test e2e app_launches_without_crash -- --ignored --nocapture
         timeout-minutes: 2
 
       - name: Upload desktop artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/ensemble-desktop/Cargo.toml
+++ b/crates/ensemble-desktop/Cargo.toml
@@ -16,6 +16,10 @@ serde_json = { workspace = true }
 base64 = "0.22"
 mime_guess = "2"
 
+[dev-dependencies]
+tauri = { version = "2", features = ["test"] }
+tempfile = { workspace = true }
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/crates/ensemble-desktop/src/main.rs
+++ b/crates/ensemble-desktop/src/main.rs
@@ -72,3 +72,79 @@ fn serve_ui_file(path: String) -> Result<serde_json::Value, String> {
         "content_type": file.content_type,
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    /// Verify that tauri.conf.json is valid JSON and contains required fields
+    #[test]
+    fn tauri_config_is_valid() {
+        let config_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
+        let config_str = std::fs::read_to_string(&config_path)
+            .expect("tauri.conf.json should exist");
+        let config: serde_json::Value = serde_json::from_str(&config_str)
+            .expect("tauri.conf.json should be valid JSON");
+
+        // Check required fields exist
+        assert!(config.get("productName").is_some(), "productName is required");
+        assert!(config.get("version").is_some(), "version is required");
+        assert!(config.get("identifier").is_some(), "identifier is required");
+        assert!(config.get("build").is_some(), "build section is required");
+        assert!(config.get("app").is_some(), "app section is required");
+        
+        // Check windows configuration
+        let windows = config["app"]["windows"].as_array()
+            .expect("app.windows should be an array");
+        assert!(!windows.is_empty(), "at least one window should be defined");
+        
+        // Each window should have a url
+        for (i, window) in windows.iter().enumerate() {
+            assert!(
+                window.get("url").is_some(),
+                "window {} should have a url field (required for Tauri v2)",
+                i
+            );
+        }
+    }
+
+    /// Verify SPA assets directory exists (required for rust-embed)
+    #[test]
+    fn spa_assets_directory_exists() {
+        let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/spa");
+        
+        // In CI, this directory is created even if empty
+        // We just verify the path is valid, actual file checking happens at build time
+        let parent = assets_dir.parent().expect("assets directory should have parent");
+        assert!(parent.exists(), "assets/ directory should exist");
+    }
+
+    /// Verify embedded_ui module can be loaded
+    #[test]
+    fn embedded_ui_module_loads() {
+        // This just verifies the module compiles and can be referenced
+        // The actual embedding happens at build time
+        use crate::embedded_ui::spa_available;
+        
+        // We can't check spa_available() in tests without a full build,
+        // but we can verify the function signature exists
+        let _ = spa_available;
+    }
+
+    /// Verify orchestrator module can be constructed (without config)
+    #[tokio::test]
+    async fn orchestrator_module_loads() {
+        use crate::orchestrator::DesktopOrchestrator;
+        use std::path::PathBuf;
+
+        // Test that we can at least reference the struct and its methods
+        // Actual initialization would require a valid config file
+        let _ = DesktopOrchestrator::new;
+        let _ = DesktopOrchestrator::start;
+        let _ = DesktopOrchestrator::stop;
+        
+        // Verify the type implements Clone as expected
+        fn check_clone<T: Clone>() {}
+        check_clone::<DesktopOrchestrator>();
+    }
+}

--- a/crates/ensemble-desktop/src/main.rs
+++ b/crates/ensemble-desktop/src/main.rs
@@ -20,14 +20,24 @@ fn main() {
         eprintln!("Build with: cd ../ensemble-ui/src-ui && pnpm run build");
     }
 
-    let config_path = PathBuf::from("ensemble.yaml");
+    let config_path = resolve_config_path();
     if !config_path.exists() {
         eprintln!("Error: Config file not found: {}", config_path.display());
         eprintln!("Please create an ensemble.yaml file or run ensemble init to generate one.");
-        
+
         #[cfg(not(test))]
         show_config_missing_dialog(&config_path);
-        
+
+        std::process::exit(1);
+    }
+
+    let config_path = normalize_config_path(config_path);
+    if let Err(error) = change_to_config_directory(&config_path) {
+        eprintln!(
+            "Error: Failed to switch to config directory for {}: {}",
+            config_path.display(),
+            error
+        );
         std::process::exit(1);
     }
 
@@ -59,35 +69,66 @@ fn main() {
         .expect("error while running tauri application");
 }
 
+fn resolve_config_path() -> PathBuf {
+    std::env::var_os("ENSEMBLE_CONFIG")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("ensemble.yaml"))
+}
+
+fn normalize_config_path(config_path: PathBuf) -> PathBuf {
+    std::fs::canonicalize(&config_path).unwrap_or(config_path)
+}
+
+fn change_to_config_directory(config_path: &std::path::Path) -> std::io::Result<()> {
+    let config_dir = config_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."));
+    std::env::set_current_dir(config_dir)
+}
+
 #[cfg(not(test))]
 fn show_config_missing_dialog(config_path: &std::path::Path) {
     let message = format!(
         "Configuration file not found: {}. Please create an ensemble.yaml file or run ensemble init to generate one.",
         config_path.display()
     );
-    
+
     #[cfg(target_os = "macos")]
     {
         use std::process::Command;
         let _ = Command::new("osascript")
-            .args(["-e", &format!("display dialog \"{}\" buttons {{\"OK\"}} with icon stop", message)])
+            .args([
+                "-e",
+                &format!(
+                    "display dialog \"{}\" buttons {{\"OK\"}} with icon stop",
+                    message
+                ),
+            ])
             .output();
     }
-    
+
     #[cfg(target_os = "linux")]
     {
         use std::process::Command;
         let _ = Command::new("zenity")
-            .args(["--error", "--title=Ensemble", &format!("--text={}", message)])
+            .args([
+                "--error",
+                "--title=Ensemble",
+                &format!("--text={}", message),
+            ])
             .output()
             .or_else(|_| {
-                Command::new("kdialog").args(["--error", &message, "--title=Ensemble"]).output()
+                Command::new("kdialog")
+                    .args(["--error", &message, "--title=Ensemble"])
+                    .output()
             })
             .or_else(|_| {
-                Command::new("xmessage").args(["-center", &message]).output()
+                Command::new("xmessage")
+                    .args(["-center", &message])
+                    .output()
             });
     }
-    
+
     #[cfg(target_os = "windows")]
     {
         use std::process::Command;
@@ -107,26 +148,32 @@ fn serve_ui_file(path: String) -> Result<serde_json::Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use crate::resolve_config_path;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, OnceLock};
 
     #[test]
     fn tauri_config_is_valid() {
         let config_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
-        let config_str = std::fs::read_to_string(&config_path)
-            .expect("tauri.conf.json should exist");
-        let config: serde_json::Value = serde_json::from_str(&config_str)
-            .expect("tauri.conf.json should be valid JSON");
+        let config_str =
+            std::fs::read_to_string(&config_path).expect("tauri.conf.json should exist");
+        let config: serde_json::Value =
+            serde_json::from_str(&config_str).expect("tauri.conf.json should be valid JSON");
 
-        assert!(config.get("productName").is_some(), "productName is required");
+        assert!(
+            config.get("productName").is_some(),
+            "productName is required"
+        );
         assert!(config.get("version").is_some(), "version is required");
         assert!(config.get("identifier").is_some(), "identifier is required");
         assert!(config.get("build").is_some(), "build section is required");
         assert!(config.get("app").is_some(), "app section is required");
-        
-        let windows = config["app"]["windows"].as_array()
+
+        let windows = config["app"]["windows"]
+            .as_array()
             .expect("app.windows should be an array");
         assert!(!windows.is_empty(), "at least one window should be defined");
-        
+
         for (i, window) in windows.iter().enumerate() {
             assert!(
                 window.get("url").is_some(),
@@ -139,7 +186,9 @@ mod tests {
     #[test]
     fn spa_assets_directory_exists() {
         let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/spa");
-        let parent = assets_dir.parent().expect("assets directory should have parent");
+        let parent = assets_dir
+            .parent()
+            .expect("assets directory should have parent");
         assert!(parent.exists(), "assets/ directory should exist");
     }
 
@@ -149,11 +198,61 @@ mod tests {
         let _ = spa_available;
     }
 
+    #[test]
+    fn resolve_config_path_defaults_to_workspace_file() {
+        let _guard = env_lock().lock().unwrap();
+        let env_value = std::env::var_os("ENSEMBLE_CONFIG");
+        std::env::remove_var("ENSEMBLE_CONFIG");
+
+        let resolved = resolve_config_path();
+
+        restore_env("ENSEMBLE_CONFIG", env_value);
+        assert_eq!(resolved, PathBuf::from("ensemble.yaml"));
+    }
+
+    #[test]
+    fn resolve_config_path_prefers_env_override() {
+        let _guard = env_lock().lock().unwrap();
+        let env_value = std::env::var_os("ENSEMBLE_CONFIG");
+        let override_path = PathBuf::from("custom/ensemble.yaml");
+        std::env::set_var("ENSEMBLE_CONFIG", &override_path);
+
+        let resolved = resolve_config_path();
+
+        restore_env("ENSEMBLE_CONFIG", env_value);
+        assert_eq!(resolved, override_path);
+    }
+
     #[tokio::test]
     async fn orchestrator_module_loads() {
         use crate::orchestrator::DesktopOrchestrator;
         let _ = DesktopOrchestrator::new;
         fn check_clone<T: Clone>() {}
         check_clone::<DesktopOrchestrator>();
+    }
+
+    #[test]
+    fn resolve_config_path_returns_relative_override_unchanged() {
+        let _guard = env_lock().lock().unwrap();
+        let env_value = std::env::var_os("ENSEMBLE_CONFIG");
+        let override_path = PathBuf::from("configs/dev/ensemble.yaml");
+        std::env::set_var("ENSEMBLE_CONFIG", &override_path);
+
+        let resolved = resolve_config_path();
+
+        restore_env("ENSEMBLE_CONFIG", env_value);
+        assert_eq!(resolved, override_path);
+    }
+
+    fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK.get_or_init(|| Mutex::new(()))
     }
 }

--- a/crates/ensemble-desktop/src/main.rs
+++ b/crates/ensemble-desktop/src/main.rs
@@ -25,8 +25,10 @@ fn main() {
         eprintln!("Error: Config file not found: {}", config_path.display());
         eprintln!("Please create an ensemble.yaml file or run ensemble init to generate one.");
 
-        #[cfg(not(test))]
-        show_config_missing_dialog(&config_path);
+        if should_show_config_missing_dialog() {
+            #[cfg(not(test))]
+            show_config_missing_dialog(&config_path);
+        }
 
         std::process::exit(1);
     }
@@ -84,6 +86,13 @@ fn change_to_config_directory(config_path: &std::path::Path) -> std::io::Result<
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."));
     std::env::set_current_dir(config_dir)
+}
+
+fn should_show_config_missing_dialog() -> bool {
+    !matches!(
+        std::env::var("ENSEMBLE_SUPPRESS_CONFIG_DIALOG").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE")
+    )
 }
 
 #[cfg(not(test))]
@@ -148,7 +157,7 @@ fn serve_ui_file(path: String) -> Result<serde_json::Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::resolve_config_path;
+    use crate::{resolve_config_path, should_show_config_missing_dialog};
     use std::path::{Path, PathBuf};
     use std::sync::{Mutex, OnceLock};
 
@@ -242,6 +251,18 @@ mod tests {
 
         restore_env("ENSEMBLE_CONFIG", env_value);
         assert_eq!(resolved, override_path);
+    }
+
+    #[test]
+    fn suppresses_config_missing_dialog_for_automation() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = std::env::var_os("ENSEMBLE_SUPPRESS_CONFIG_DIALOG");
+        std::env::set_var("ENSEMBLE_SUPPRESS_CONFIG_DIALOG", "1");
+
+        let should_show = should_show_config_missing_dialog();
+
+        restore_env("ENSEMBLE_SUPPRESS_CONFIG_DIALOG", previous);
+        assert!(!should_show);
     }
 
     fn restore_env(key: &str, value: Option<std::ffi::OsString>) {

--- a/crates/ensemble-desktop/src/main.rs
+++ b/crates/ensemble-desktop/src/main.rs
@@ -12,15 +12,23 @@ use embedded_ui::{resolve_path, spa_available};
 use orchestrator::{get_state, trigger_refresh, DesktopOrchestrator};
 
 fn main() {
-    // Initialize logging
     ensemble_core::observability::logging::init_logging();
-
     info!("Starting Ensemble Desktop");
 
-    // Check SPA availability
     if !spa_available() {
         eprintln!("Warning: SPA assets not found. UI may not display correctly.");
         eprintln!("Build with: cd ../ensemble-ui/src-ui && pnpm run build");
+    }
+
+    let config_path = PathBuf::from("ensemble.yaml");
+    if !config_path.exists() {
+        eprintln!("Error: Config file not found: {}", config_path.display());
+        eprintln!("Please create an ensemble.yaml file or run ensemble init to generate one.");
+        
+        #[cfg(not(test))]
+        show_config_missing_dialog(&config_path);
+        
+        std::process::exit(1);
     }
 
     tauri::Builder::default()
@@ -30,17 +38,12 @@ fn main() {
             serve_ui_file,
         ])
         .setup(|app| {
-            // Get config path (use default or from args)
-            let config_path = PathBuf::from("ensemble.yaml");
-
-            // Initialize orchestrator
             let rt = tokio::runtime::Runtime::new().unwrap();
             let orchestrator =
                 rt.block_on(async { DesktopOrchestrator::new(config_path).await })?;
 
             app.manage(orchestrator);
 
-            // Start orchestrator
             let orchestrator_ref = app.state::<DesktopOrchestrator>().inner().clone();
             rt.spawn(async move {
                 if let Err(e) = orchestrator_ref.start().await {
@@ -48,10 +51,7 @@ fn main() {
                 }
             });
 
-            // Store runtime in app state to prevent it from being dropped.
-            // Dropping a tokio Runtime cancels all spawned tasks.
             app.manage(rt);
-
             info!("Ensemble Desktop initialized successfully");
             Ok(())
         })
@@ -59,14 +59,46 @@ fn main() {
         .expect("error while running tauri application");
 }
 
-/// Tauri command to serve UI files
+#[cfg(not(test))]
+fn show_config_missing_dialog(config_path: &std::path::Path) {
+    let message = format!(
+        "Configuration file not found: {}. Please create an ensemble.yaml file or run ensemble init to generate one.",
+        config_path.display()
+    );
+    
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+        let _ = Command::new("osascript")
+            .args(["-e", &format!("display dialog \"{}\" buttons {{\"OK\"}} with icon stop", message)])
+            .output();
+    }
+    
+    #[cfg(target_os = "linux")]
+    {
+        use std::process::Command;
+        let _ = Command::new("zenity")
+            .args(["--error", "--title=Ensemble", &format!("--text={}", message)])
+            .output()
+            .or_else(|_| {
+                Command::new("kdialog").args(["--error", &message, "--title=Ensemble"]).output()
+            })
+            .or_else(|_| {
+                Command::new("xmessage").args(["-center", &message]).output()
+            });
+    }
+    
+    #[cfg(target_os = "windows")]
+    {
+        use std::process::Command;
+        let _ = Command::new("msg").args(["*", &message]).output();
+    }
+}
+
 #[tauri::command]
 fn serve_ui_file(path: String) -> Result<serde_json::Value, String> {
     let file = resolve_path(&path).ok_or_else(|| format!("File not found: {}", path))?;
-
-    // Encode binary data as base64 for JSON serialization
     let data_b64 = STANDARD.encode(&file.data);
-
     Ok(serde_json::json!({
         "data": data_b64,
         "content_type": file.content_type,
@@ -77,7 +109,6 @@ fn serve_ui_file(path: String) -> Result<serde_json::Value, String> {
 mod tests {
     use std::path::Path;
 
-    /// Verify that tauri.conf.json is valid JSON and contains required fields
     #[test]
     fn tauri_config_is_valid() {
         let config_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
@@ -86,64 +117,42 @@ mod tests {
         let config: serde_json::Value = serde_json::from_str(&config_str)
             .expect("tauri.conf.json should be valid JSON");
 
-        // Check required fields exist
         assert!(config.get("productName").is_some(), "productName is required");
         assert!(config.get("version").is_some(), "version is required");
         assert!(config.get("identifier").is_some(), "identifier is required");
         assert!(config.get("build").is_some(), "build section is required");
         assert!(config.get("app").is_some(), "app section is required");
         
-        // Check windows configuration
         let windows = config["app"]["windows"].as_array()
             .expect("app.windows should be an array");
         assert!(!windows.is_empty(), "at least one window should be defined");
         
-        // Each window should have a url
         for (i, window) in windows.iter().enumerate() {
             assert!(
                 window.get("url").is_some(),
-                "window {} should have a url field (required for Tauri v2)",
+                "window {} should have a url field",
                 i
             );
         }
     }
 
-    /// Verify SPA assets directory exists (required for rust-embed)
     #[test]
     fn spa_assets_directory_exists() {
         let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/spa");
-        
-        // In CI, this directory is created even if empty
-        // We just verify the path is valid, actual file checking happens at build time
         let parent = assets_dir.parent().expect("assets directory should have parent");
         assert!(parent.exists(), "assets/ directory should exist");
     }
 
-    /// Verify embedded_ui module can be loaded
     #[test]
     fn embedded_ui_module_loads() {
-        // This just verifies the module compiles and can be referenced
-        // The actual embedding happens at build time
         use crate::embedded_ui::spa_available;
-        
-        // We can't check spa_available() in tests without a full build,
-        // but we can verify the function signature exists
         let _ = spa_available;
     }
 
-    /// Verify orchestrator module can be constructed (without config)
     #[tokio::test]
     async fn orchestrator_module_loads() {
         use crate::orchestrator::DesktopOrchestrator;
-        use std::path::PathBuf;
-
-        // Test that we can at least reference the struct and its methods
-        // Actual initialization would require a valid config file
         let _ = DesktopOrchestrator::new;
-        let _ = DesktopOrchestrator::start;
-        let _ = DesktopOrchestrator::stop;
-        
-        // Verify the type implements Clone as expected
         fn check_clone<T: Clone>() {}
         check_clone::<DesktopOrchestrator>();
     }

--- a/crates/ensemble-desktop/tauri.conf.json
+++ b/crates/ensemble-desktop/tauri.conf.json
@@ -19,7 +19,8 @@
         "width": 1280,
         "height": 800,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "url": "index.html"
       }
     ]
   }

--- a/crates/ensemble-desktop/tests/e2e.rs
+++ b/crates/ensemble-desktop/tests/e2e.rs
@@ -183,6 +183,7 @@ fn app_shows_error_when_config_missing() {
     let mut child = Command::new(&binary_path)
         .current_dir(workspace_root)
         .env("ENSEMBLE_CONFIG", &missing_config)
+        .env("ENSEMBLE_SUPPRESS_CONFIG_DIALOG", "1")
         .env("RUST_BACKTRACE", "1")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/ensemble-desktop/tests/e2e.rs
+++ b/crates/ensemble-desktop/tests/e2e.rs
@@ -149,30 +149,99 @@ on_failure: "Failed"
     }
 }
 
-/// Verify the app binary exists in the expected location.
+/// Verify the app shows a helpful error and exits gracefully when config is missing.
 #[test]
-fn app_binary_exists_in_target() {
-    // This test runs without --ignored flag
-    // It just verifies the binary structure exists
-    let target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+#[ignore = "Requires compiled app binary - run with: cargo build --release -p ensemble-desktop first"]
+fn app_shows_error_when_config_missing() {
+    // Find the compiled binary
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
 
-    // In CI, we verify the structure is set up correctly
-    // The actual launch test is ignored and runs separately
-    let debug_binary = std::path::Path::new(&target_dir)
-        .join("debug")
-        .join("ensemble-desktop");
-    let release_binary = std::path::Path::new(&target_dir)
-        .join("release")
-        .join("ensemble-desktop");
+    let possible_paths = vec![
+        manifest_dir
+            .join("target")
+            .join(profile)
+            .join("ensemble-desktop"),
+        workspace_root
+            .join("target")
+            .join(profile)
+            .join("ensemble-desktop"),
+        std::env::var("CARGO_TARGET_DIR")
+            .map(|d| {
+                std::path::PathBuf::from(d)
+                    .join(profile)
+                    .join("ensemble-desktop")
+            })
+            .unwrap_or_default(),
+    ];
 
-    // At least one should exist (or be buildable)
-    let exists = debug_binary.exists() || release_binary.exists();
+    #[cfg(target_os = "windows")]
+    let binary_path = possible_paths
+        .iter()
+        .map(|p| p.with_extension("exe"))
+        .find(|p| p.exists());
 
-    if !exists {
-        // Don't fail in normal test runs - this is just informational
-        println!("Note: App binary not found. Build with: cargo build -p ensemble-desktop");
+    #[cfg(not(target_os = "windows"))]
+    let binary_path = possible_paths.iter().find(|p| p.exists());
+
+    let binary_path = binary_path.cloned().expect("App binary not found");
+
+    // Ensure no ensemble.yaml exists in workspace
+    let workspace_config = workspace_root.join("ensemble.yaml");
+    let config_existed = workspace_config.exists();
+    if config_existed {
+        // Temporarily rename it
+        let backup = workspace_root.join("ensemble.yaml.bak");
+        std::fs::rename(&workspace_config, &backup).expect("Failed to backup config");
     }
 
-    // Always pass - this is a smoke check
-    assert!(true);
+    // Launch the app without config
+    let mut child = Command::new(&binary_path)
+        .current_dir(workspace_root)
+        .env("RUST_BACKTRACE", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to launch app binary");
+
+    // Wait for it to exit
+    let status = child.wait().expect("Failed to wait for app");
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut out) = child.stdout.take() {
+        use std::io::Read;
+        out.read_to_string(&mut stdout).ok();
+    }
+    if let Some(mut err) = child.stderr.take() {
+        use std::io::Read;
+        err.read_to_string(&mut stderr).ok();
+    }
+
+    // Restore config if it existed
+    if config_existed {
+        let backup = workspace_root.join("ensemble.yaml.bak");
+        std::fs::rename(&backup, &workspace_config).ok();
+    }
+
+    // Verify the app exited with error code 1 and showed helpful message
+    assert!(
+        !status.success(),
+        "App should exit with error when config is missing"
+    );
+
+    let combined_output = format!("{} {}", stdout, stderr);
+    assert!(
+        combined_output.contains("Config file not found")
+            || combined_output.contains("ensemble.yaml"),
+        "App should show helpful error message about missing config. Got:\n{}",
+        combined_output
+    );
+
+    println!("✓ App correctly exits with error when config is missing");
 }

--- a/crates/ensemble-desktop/tests/e2e.rs
+++ b/crates/ensemble-desktop/tests/e2e.rs
@@ -1,0 +1,126 @@
+//! WebDriver-based E2E tests for the Tauri desktop app.
+//!
+//! These tests launch the actual compiled app and verify it:
+//! 1. Opens without crashing
+//! 2. Loads the UI successfully
+//!
+//! To run these tests:
+//!   SKIP_UI_BUILD=1 cargo test -p ensemble-desktop --test e2e -- --ignored
+//!
+//! Note: The app must be built first for these tests to work.
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// Launch the app and verify it doesn't immediately crash.
+///
+/// This is a smoke test that checks the app can initialize
+/// and run for a few seconds without panicking.
+#[test]
+#[ignore = "Requires compiled app binary - run with: cargo build --release -p ensemble-desktop first"]
+fn app_launches_without_crash() {
+    // Find the compiled binary
+    let target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+
+    #[cfg(target_os = "macos")]
+    let binary_path = format!("{}/{}/ensemble-desktop", target_dir, profile);
+
+    #[cfg(target_os = "linux")]
+    let binary_path = format!("{}/{}/ensemble-desktop", target_dir, profile);
+
+    #[cfg(target_os = "windows")]
+    let binary_path = format!("{}/{}/ensemble-desktop.exe", target_dir, profile);
+
+    let binary_path = std::path::Path::new(&binary_path);
+
+    if !binary_path.exists() {
+        // Try to find it in the workspace root
+        let workspace_binary = std::path::Path::new(&target_dir)
+            .join(profile)
+            .join("ensemble-desktop");
+
+        if !workspace_binary.exists() {
+            panic!(
+                "App binary not found at {}. Build with: cargo build --release -p ensemble-desktop",
+                binary_path.display()
+            );
+        }
+    }
+
+    // Launch the app with a short timeout to see if it crashes on startup
+    let mut child = Command::new(&binary_path)
+        .env("TAURI_WEBVIEW_AUTOMATION", "1") // Enable automation mode
+        .env("RUST_BACKTRACE", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to launch app binary");
+
+    // Give the app a few seconds to initialize
+    std::thread::sleep(Duration::from_secs(3));
+
+    // Check if the process is still running
+    match child.try_wait() {
+        Ok(Some(status)) => {
+            // Process exited - this is a failure
+            let mut stdout = String::new();
+            let mut stderr = String::new();
+
+            if let Some(mut out) = child.stdout.take() {
+                use std::io::Read;
+                out.read_to_string(&mut stdout).ok();
+            }
+            if let Some(mut err) = child.stderr.take() {
+                use std::io::Read;
+                err.read_to_string(&mut stderr).ok();
+            }
+
+            panic!(
+                "App crashed on startup!\nExit status: {:?}\n\nSTDOUT:\n{}\n\nSTDERR:\n{}",
+                status, stdout, stderr
+            );
+        }
+        Ok(None) => {
+            // Process is still running - success!
+            // Kill it gracefully
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        Err(e) => {
+            panic!("Failed to check app status: {}", e);
+        }
+    }
+}
+
+/// Verify the app binary exists in the expected location.
+#[test]
+fn app_binary_exists_in_target() {
+    // This test runs without --ignored flag
+    // It just verifies the binary structure exists
+    let target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+
+    // In CI, we verify the structure is set up correctly
+    // The actual launch test is ignored and runs separately
+    let debug_binary = std::path::Path::new(&target_dir)
+        .join("debug")
+        .join("ensemble-desktop");
+    let release_binary = std::path::Path::new(&target_dir)
+        .join("release")
+        .join("ensemble-desktop");
+
+    // At least one should exist (or be buildable)
+    let exists = debug_binary.exists() || release_binary.exists();
+
+    if !exists {
+        // Don't fail in normal test runs - this is just informational
+        println!("Note: App binary not found. Build with: cargo build -p ensemble-desktop");
+    }
+
+    // Always pass - this is a smoke check
+    assert!(true);
+}

--- a/crates/ensemble-desktop/tests/e2e.rs
+++ b/crates/ensemble-desktop/tests/e2e.rs
@@ -9,6 +9,7 @@
 //!
 //! Note: The app must be built first for these tests to work.
 
+use std::io::Write;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -19,41 +20,85 @@ use std::time::Duration;
 #[test]
 #[ignore = "Requires compiled app binary - run with: cargo build --release -p ensemble-desktop first"]
 fn app_launches_without_crash() {
-    // Find the compiled binary
-    let target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+    // Find the compiled binary - look in multiple locations
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
     let profile = if cfg!(debug_assertions) {
         "debug"
     } else {
         "release"
     };
 
-    #[cfg(target_os = "macos")]
-    let binary_path = format!("{}/{}/ensemble-desktop", target_dir, profile);
-
-    #[cfg(target_os = "linux")]
-    let binary_path = format!("{}/{}/ensemble-desktop", target_dir, profile);
+    // Try multiple possible locations for the binary
+    let possible_paths = vec![
+        // From crate directory
+        manifest_dir
+            .join("target")
+            .join(profile)
+            .join("ensemble-desktop"),
+        // From workspace root
+        workspace_root
+            .join("target")
+            .join(profile)
+            .join("ensemble-desktop"),
+        // From CARGO_TARGET_DIR if set
+        std::env::var("CARGO_TARGET_DIR")
+            .map(|d| {
+                std::path::PathBuf::from(d)
+                    .join(profile)
+                    .join("ensemble-desktop")
+            })
+            .unwrap_or_default(),
+    ];
 
     #[cfg(target_os = "windows")]
-    let binary_path = format!("{}/{}/ensemble-desktop.exe", target_dir, profile);
+    let binary_path = possible_paths
+        .iter()
+        .map(|p| p.with_extension("exe"))
+        .find(|p| p.exists());
 
-    let binary_path = std::path::Path::new(&binary_path);
+    #[cfg(not(target_os = "windows"))]
+    let binary_path = possible_paths.iter().find(|p| p.exists());
 
-    if !binary_path.exists() {
-        // Try to find it in the workspace root
-        let workspace_binary = std::path::Path::new(&target_dir)
-            .join(profile)
-            .join("ensemble-desktop");
+    let binary_path = binary_path.cloned().unwrap_or_else(|| {
+        panic!(
+            "App binary not found. Tried: {:?}\nBuild with: cargo build -p ensemble-desktop",
+            possible_paths
+        )
+    });
 
-        if !workspace_binary.exists() {
-            panic!(
-                "App binary not found at {}. Build with: cargo build --release -p ensemble-desktop",
-                binary_path.display()
-            );
-        }
-    }
+    println!("Launching app binary: {}", binary_path.display());
+
+    // Create a minimal ensemble.yaml config file in a temp directory
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("ensemble.yaml");
+    let minimal_config = r#"
+tracker:
+  kind: todo_file
+  file: issues.json
+agents:
+  coder:
+    model: claude-sonnet-4-20250514
+    prompt: "You are a helpful coding assistant."
+    executor: local
+steps:
+  - name: build
+    agent: coder
+    prompt: "Build the code"
+on_success: "Done"
+on_failure: "Failed"
+"#;
+    std::fs::File::create(&config_path)
+        .and_then(|mut f| f.write_all(minimal_config.as_bytes()))
+        .expect("Failed to write test config file");
+
+    // Copy the config to workspace root so the app can find it
+    let workspace_config = workspace_root.join("ensemble.yaml");
+    std::fs::copy(&config_path, &workspace_config).ok();
 
     // Launch the app with a short timeout to see if it crashes on startup
     let mut child = Command::new(&binary_path)
+        .current_dir(workspace_root) // Run from workspace root
         .env("TAURI_WEBVIEW_AUTOMATION", "1") // Enable automation mode
         .env("RUST_BACKTRACE", "1")
         .stdout(Stdio::piped())
@@ -65,7 +110,7 @@ fn app_launches_without_crash() {
     std::thread::sleep(Duration::from_secs(3));
 
     // Check if the process is still running
-    match child.try_wait() {
+    let result = match child.try_wait() {
         Ok(Some(status)) => {
             // Process exited - this is a failure
             let mut stdout = String::new();
@@ -80,20 +125,27 @@ fn app_launches_without_crash() {
                 err.read_to_string(&mut stderr).ok();
             }
 
-            panic!(
+            Err(format!(
                 "App crashed on startup!\nExit status: {:?}\n\nSTDOUT:\n{}\n\nSTDERR:\n{}",
                 status, stdout, stderr
-            );
+            ))
         }
         Ok(None) => {
             // Process is still running - success!
+            println!("App launched successfully and is still running after 3 seconds");
             // Kill it gracefully
             let _ = child.kill();
             let _ = child.wait();
+            Ok(())
         }
-        Err(e) => {
-            panic!("Failed to check app status: {}", e);
-        }
+        Err(e) => Err(format!("Failed to check app status: {}", e)),
+    };
+
+    // Clean up the temp config file
+    let _ = std::fs::remove_file(&workspace_config);
+
+    if let Err(msg) = result {
+        panic!("{}", msg);
     }
 }
 

--- a/crates/ensemble-desktop/tests/e2e.rs
+++ b/crates/ensemble-desktop/tests/e2e.rs
@@ -10,8 +10,72 @@
 //! Note: The app must be built first for these tests to work.
 
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
+
+#[test]
+fn resolve_binary_path_prefers_explicit_env_override() {
+    let _guard = env_lock().lock().unwrap();
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let binary_name = binary_name();
+    let env_binary = temp_dir.path().join(binary_name);
+    std::fs::write(&env_binary, b"test-binary").expect("Failed to write binary fixture");
+
+    let previous = std::env::var_os("ENSEMBLE_DESKTOP_BIN");
+    std::env::set_var("ENSEMBLE_DESKTOP_BIN", &env_binary);
+
+    let resolved = resolve_binary_path(&[PathBuf::from("missing-binary")])
+        .expect("Expected env override to resolve");
+
+    restore_env("ENSEMBLE_DESKTOP_BIN", previous);
+    assert_eq!(resolved, env_binary);
+}
+
+#[test]
+fn resolve_binary_path_prefers_first_existing_candidate() {
+    let _guard = env_lock().lock().unwrap();
+    let previous = std::env::var_os("ENSEMBLE_DESKTOP_BIN");
+    std::env::remove_var("ENSEMBLE_DESKTOP_BIN");
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let binary_name = binary_name();
+    let debug_binary = temp_dir.path().join("debug").join(binary_name);
+    let release_binary = temp_dir.path().join("release").join(binary_name);
+
+    std::fs::create_dir_all(debug_binary.parent().expect("debug dir")).expect("create debug dir");
+    std::fs::write(&debug_binary, b"debug").expect("write debug fixture");
+    std::fs::create_dir_all(release_binary.parent().expect("release dir"))
+        .expect("create release dir");
+    std::fs::write(&release_binary, b"release").expect("write release fixture");
+
+    let resolved = resolve_binary_path(&[debug_binary.clone(), release_binary])
+        .expect("Expected first existing candidate to resolve");
+
+    restore_env("ENSEMBLE_DESKTOP_BIN", previous);
+    assert_eq!(resolved, debug_binary);
+}
+
+#[test]
+fn resolve_binary_path_rejects_missing_explicit_override() {
+    let _guard = env_lock().lock().unwrap();
+    let previous = std::env::var_os("ENSEMBLE_DESKTOP_BIN");
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let missing_override = temp_dir.path().join("does-not-exist").join(binary_name());
+    let fallback_binary = temp_dir.path().join("debug").join(binary_name());
+    std::fs::create_dir_all(fallback_binary.parent().expect("debug dir"))
+        .expect("create debug dir");
+    std::fs::write(&fallback_binary, b"debug").expect("write debug fixture");
+
+    std::env::set_var("ENSEMBLE_DESKTOP_BIN", &missing_override);
+
+    let resolved = resolve_binary_path(&[fallback_binary]);
+
+    restore_env("ENSEMBLE_DESKTOP_BIN", previous);
+    assert_eq!(resolved, None);
+}
 
 /// Launch the app and verify it doesn't immediately crash.
 ///
@@ -20,47 +84,10 @@ use std::time::Duration;
 #[test]
 #[ignore = "Requires compiled app binary - run with: cargo build --release -p ensemble-desktop first"]
 fn app_launches_without_crash() {
-    // Find the compiled binary - look in multiple locations
     let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-
-    // Try multiple possible locations for the binary
-    let possible_paths = vec![
-        // From crate directory
-        manifest_dir
-            .join("target")
-            .join(profile)
-            .join("ensemble-desktop"),
-        // From workspace root
-        workspace_root
-            .join("target")
-            .join(profile)
-            .join("ensemble-desktop"),
-        // From CARGO_TARGET_DIR if set
-        std::env::var("CARGO_TARGET_DIR")
-            .map(|d| {
-                std::path::PathBuf::from(d)
-                    .join(profile)
-                    .join("ensemble-desktop")
-            })
-            .unwrap_or_default(),
-    ];
-
-    #[cfg(target_os = "windows")]
-    let binary_path = possible_paths
-        .iter()
-        .map(|p| p.with_extension("exe"))
-        .find(|p| p.exists());
-
-    #[cfg(not(target_os = "windows"))]
-    let binary_path = possible_paths.iter().find(|p| p.exists());
-
-    let binary_path = binary_path.cloned().unwrap_or_else(|| {
+    let possible_paths = candidate_binary_paths(manifest_dir, workspace_root);
+    let binary_path = resolve_binary_path(&possible_paths).unwrap_or_else(|| {
         panic!(
             "App binary not found. Tried: {:?}\nBuild with: cargo build -p ensemble-desktop",
             possible_paths
@@ -92,14 +119,10 @@ on_failure: "Failed"
         .and_then(|mut f| f.write_all(minimal_config.as_bytes()))
         .expect("Failed to write test config file");
 
-    // Copy the config to workspace root so the app can find it
-    let workspace_config = workspace_root.join("ensemble.yaml");
-    std::fs::copy(&config_path, &workspace_config).ok();
-
-    // Launch the app with a short timeout to see if it crashes on startup
     let mut child = Command::new(&binary_path)
-        .current_dir(workspace_root) // Run from workspace root
-        .env("TAURI_WEBVIEW_AUTOMATION", "1") // Enable automation mode
+        .current_dir(workspace_root)
+        .env("ENSEMBLE_CONFIG", &config_path)
+        .env("TAURI_WEBVIEW_AUTOMATION", "1")
         .env("RUST_BACKTRACE", "1")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -141,9 +164,6 @@ on_failure: "Failed"
         Err(e) => Err(format!("Failed to check app status: {}", e)),
     };
 
-    // Clean up the temp config file
-    let _ = std::fs::remove_file(&workspace_config);
-
     if let Err(msg) = result {
         panic!("{}", msg);
     }
@@ -153,56 +173,16 @@ on_failure: "Failed"
 #[test]
 #[ignore = "Requires compiled app binary - run with: cargo build --release -p ensemble-desktop first"]
 fn app_shows_error_when_config_missing() {
-    // Find the compiled binary
     let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
+    let possible_paths = candidate_binary_paths(manifest_dir, workspace_root);
+    let binary_path = resolve_binary_path(&possible_paths).expect("App binary not found");
+    let missing_config_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let missing_config = missing_config_dir.path().join("missing-ensemble.yaml");
 
-    let possible_paths = vec![
-        manifest_dir
-            .join("target")
-            .join(profile)
-            .join("ensemble-desktop"),
-        workspace_root
-            .join("target")
-            .join(profile)
-            .join("ensemble-desktop"),
-        std::env::var("CARGO_TARGET_DIR")
-            .map(|d| {
-                std::path::PathBuf::from(d)
-                    .join(profile)
-                    .join("ensemble-desktop")
-            })
-            .unwrap_or_default(),
-    ];
-
-    #[cfg(target_os = "windows")]
-    let binary_path = possible_paths
-        .iter()
-        .map(|p| p.with_extension("exe"))
-        .find(|p| p.exists());
-
-    #[cfg(not(target_os = "windows"))]
-    let binary_path = possible_paths.iter().find(|p| p.exists());
-
-    let binary_path = binary_path.cloned().expect("App binary not found");
-
-    // Ensure no ensemble.yaml exists in workspace
-    let workspace_config = workspace_root.join("ensemble.yaml");
-    let config_existed = workspace_config.exists();
-    if config_existed {
-        // Temporarily rename it
-        let backup = workspace_root.join("ensemble.yaml.bak");
-        std::fs::rename(&workspace_config, &backup).expect("Failed to backup config");
-    }
-
-    // Launch the app without config
     let mut child = Command::new(&binary_path)
         .current_dir(workspace_root)
+        .env("ENSEMBLE_CONFIG", &missing_config)
         .env("RUST_BACKTRACE", "1")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -223,13 +203,6 @@ fn app_shows_error_when_config_missing() {
         err.read_to_string(&mut stderr).ok();
     }
 
-    // Restore config if it existed
-    if config_existed {
-        let backup = workspace_root.join("ensemble.yaml.bak");
-        std::fs::rename(&backup, &workspace_config).ok();
-    }
-
-    // Verify the app exited with error code 1 and showed helpful message
     assert!(
         !status.success(),
         "App should exit with error when config is missing"
@@ -244,4 +217,70 @@ fn app_shows_error_when_config_missing() {
     );
 
     println!("✓ App correctly exits with error when config is missing");
+}
+
+fn candidate_binary_paths(manifest_dir: &Path, workspace_root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        let target_dir = PathBuf::from(target_dir);
+        paths.push(target_dir.join("debug").join(binary_name()));
+        paths.push(target_dir.join("release").join(binary_name()));
+    }
+
+    paths.push(
+        workspace_root
+            .join("target")
+            .join("debug")
+            .join(binary_name()),
+    );
+    paths.push(
+        manifest_dir
+            .join("target")
+            .join("debug")
+            .join(binary_name()),
+    );
+    paths.push(
+        workspace_root
+            .join("target")
+            .join("release")
+            .join(binary_name()),
+    );
+    paths.push(
+        manifest_dir
+            .join("target")
+            .join("release")
+            .join(binary_name()),
+    );
+
+    paths
+}
+
+fn resolve_binary_path(candidates: &[PathBuf]) -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("ENSEMBLE_DESKTOP_BIN") {
+        let path = PathBuf::from(path);
+        return path.exists().then_some(path);
+    }
+
+    candidates.iter().find(|path| path.exists()).cloned()
+}
+
+fn binary_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "ensemble-desktop.exe"
+    } else {
+        "ensemble-desktop"
+    }
+}
+
+fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
+    match value {
+        Some(value) => std::env::set_var(key, value),
+        None => std::env::remove_var(key),
+    }
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
 }


### PR DESCRIPTION
## Summary
- harden desktop startup when config files are missing or supplied via `ENSEMBLE_CONFIG`, including preserving relative config paths
- add and refine desktop E2E smoke tests so they use explicit binary/config selection and avoid mutating repo config files
- tighten desktop CI by installing Linux Tauri dependencies before tests, using workflow `env` for `SKIP_UI_BUILD`, and running a desktop smoke test step

## Test Plan
- [x] `SKIP_UI_BUILD=1 cargo test -p ensemble-desktop --bin ensemble-desktop -- --nocapture`
- [x] `SKIP_UI_BUILD=1 cargo build -p ensemble-desktop && SKIP_UI_BUILD=1 cargo test -p ensemble-desktop --test e2e -- --ignored --nocapture`
- [x] `cargo fmt --all -- --check && SKIP_UI_BUILD=1 cargo clippy -p ensemble-desktop --tests -- -D warnings`