### PR TITLE
Migrate Ensemble to config-dir based configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Ensemble
 
-Ensemble is a long-running Rust service that orchestrates multi-agent pipelines against an issue tracker. It reads work from trackers (GitHub Projects, todo files), creates isolated per-issue workspaces, runs named agents through a step DAG (build, review, etc.), collects verdicts, and drives tracker state transitions. Configuration lives in `ensemble.yaml`.
+Ensemble is a long-running Rust service that orchestrates multi-agent pipelines against an issue tracker. It reads work from trackers (GitHub Projects, todo files), creates isolated per-issue workspaces, runs named agents through a step DAG (build, review, etc.), collects verdicts, and drives tracker state transitions. Configuration lives in a configuration directory containing `config.yaml`.
 
 See `docs/SPEC.md` for the full specification. See `docs/superpowers/plans/` for implementation plans.
 
@@ -18,7 +18,8 @@ ensemble/
 │   │   │   │   ├── mod.rs        # IssueTracker trait (read + write), TrackerError
 │   │   │   │   └── model.rs      # Issue, RunningEntry, RetryEntry, AgentTotals
 │   │   │   ├── config/
-│   │   │   │   ├── ensemble.rs   # ensemble.yaml loader (EnsembleConfig)
+│   │   │   │   ├── ensemble.rs   # config.yaml loader (EnsembleConfig)
+│   │   │   │   ├── location.rs   # config directory resolution
 │   │   │   │   └── template.rs   # Liquid prompt template renderer
 │   │   │   ├── pipeline/
 │   │   │   │   ├── mod.rs        # re-exports
@@ -93,7 +94,7 @@ This bumps versions in `Cargo.toml` + `tauri.conf.json`, commits, tags, and push
 - **Rust 2021 edition**, minimum rust-version 1.80
 - **Error handling**: `thiserror` enums (`EnsembleError`, `ConfigError`, `WorkspaceError`, `TrackerError`). Use `?` propagation, not `.unwrap()` in library code. Tests may unwrap.
 - **Async runtime**: `tokio` with `features = ["full"]`. Async tests use `#[tokio::test]`.
-- **Serialization**: `serde` + `serde_json` for domain types, `serde_yaml` for `ensemble.yaml`.
+- **Serialization**: `serde` + `serde_json` for domain types, `serde_yaml` for `config.yaml`.
 - **Templates**: `liquid` crate for prompt rendering. Variables available: `issue.*` and optionally `attempt`.
 - **Logging**: `tracing` crate. Use `info!`/`warn!`/`error!` with structured fields.
 - **Tests**: Unit tests in `#[cfg(test)] mod tests` within each file. Integration tests in `crates/*/tests/`. Use `tempfile` for filesystem tests.
@@ -109,7 +110,7 @@ This bumps versions in `Cargo.toml` + `tauri.conf.json`, commits, tags, and push
 ## Key design decisions
 
 - **Pluggable trackers**: `IssueTracker` is an async trait in `ensemble-core` with read methods and optional write methods (default no-ops). Tracker implementations (GitHub, todo_file) live in `ensemble-core` as sub-modules of `tracker/`.
-- **Config from ensemble.yaml**: All runtime config lives in `ensemble.yaml`. `EnsembleConfig` provides typed access with defaults and `$ENV_VAR` resolution. Agent definitions, step DAG, and prompt references are all defined here.
+- **Config directory based**: All runtime config lives in a configuration directory containing `config.yaml`. `EnsembleConfig` provides typed access with defaults and `$ENV_VAR` resolution. The config directory is resolved via `--config-dir`, `ENSEMBLE_CONFIG_DIR`, or platform defaults. Agent definitions, step DAG, and prompt references are all defined in `config.yaml`. Relative paths are resolved from the config directory.
 - **Agent model discovery**: During `ensemble init`, acpx agent sessions are probed to discover available models. The selected model is stored as `model` in `AgentConfig` and emitted in `ensemble.yaml`.
 - **Multi-agent pipelines**: Named agents run through a step DAG (GitHub Actions-style: sequential by default, `depends` for parallelism). The orchestrator drives state transitions at step boundaries and collects verdicts from review agents.
 - **Workspace isolation**: Each issue gets a directory under a configurable root, keyed by sanitized identifier. Workspaces are reused across retries and cleaned up on completion.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,6 +881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +984,8 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "dirs",
+ "dotenvy",
  "futures",
  "futures-util",
  "libc",
@@ -986,6 +994,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shellexpand",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3982,6 +3991,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ inquire = "0.7"
 utoipa = { version = "5.3", features = ["axum_extras", "chrono"] }
 rust-embed = { version = "8", features = ["axum"] }
 dirs = "6"
+dotenvy = "0.15"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ensemble is a service that orchestrates coding agents against your issue tracker
 
 Ensemble reads issues from a tracker (GitHub Projects or a local TODO file), creates a workspace directory for each one, and runs a pipeline of named agents against it. Each agent gets a prompt rendered from the issue context. Agents report verdicts (approve/reject), and Ensemble transitions the issue state accordingly. Failed issues retry with exponential backoff.
 
-All behavior is configured in a single `ensemble.yaml` file that lives in your repository.
+All behavior is configured in a `config.yaml` file that lives in a configuration directory (default: `~/.config/ensemble/` on Linux, `~/Library/Application Support/ensemble/` on macOS).
 
 ## Install
 
@@ -24,20 +24,26 @@ cargo install --path crates/ensemble-cli
 
 ## Quick start
 
-**1. Create a config file:**
+**1. Create a configuration directory:**
 
 ```sh
 ensemble init
 ```
 
-This walks you through setting up your tracker, agents, and pipeline. It generates an `ensemble.yaml` and any prompt templates you need.
+This walks you through setting up your tracker, agents, and pipeline. It creates a configuration directory containing:
+- `config.yaml` — main configuration file
+- `templates/` — prompt templates
+- `.env` — environment variables (auto-loaded)
+- `~/ensemble/TODO.md` — default TODO tracker state (if using todo_file)
 
 **2. Or write one by hand:**
+
+Create a directory for your config (e.g., `~/.config/ensemble/`) and add a `config.yaml`:
 
 ```yaml
 tracker:
   kind: todo_file
-  path: TODO.md
+  # path defaults to ~/ensemble/TODO.md if not specified
 
 agents:
   builder:
@@ -68,9 +74,30 @@ ensemble web --port 3000
 
 Then open `http://localhost:3000` in your browser.
 
+## Configuration location
+
+By default, Ensemble looks for configuration in your system's config directory:
+- **Linux:** `~/.config/ensemble/`
+- **macOS:** `~/Library/Application Support/ensemble/`
+- **Windows:** `%APPDATA%\ensemble\`
+
+You can override this with:
+- `--config-dir <path>` flag
+- `ENSEMBLE_CONFIG_DIR` environment variable
+
+**Open the config directory:**
+
+```sh
+ensemble open-config-dir
+```
+
+This opens the resolved configuration directory in your system's file manager. If the directory doesn't exist, it will suggest running `ensemble init`.
+
+**Legacy note:** The old `ENSEMBLE_CONFIG` environment variable and `--config` flag are no longer supported. Use `ENSEMBLE_CONFIG_DIR` and `--config-dir` instead.
+
 ## Core concepts
 
-**Trackers** connect Ensemble to your issue source. Supported: GitHub Projects (`github`) and local TODO files (`todo_file`). The tracker defines which states are active (pollable) and terminal (done).
+**Trackers** connect Ensemble to your issue source. Supported: GitHub Projects (`github`) and local TODO files (`todo_file`). The tracker defines which states are active (pollable) and terminal (done). For `todo_file`, the default path is `~/ensemble/TODO.md`.
 
 **Agents** are named definitions that pair an executor (like `claude-code`) with a prompt. Prompts can be inline strings or [Liquid](https://shopify.github.io/liquid/) template files with access to issue context.
 
@@ -82,7 +109,7 @@ Then open `http://localhost:3000` in your browser.
 
 ## Documentation
 
-- [Configuration Reference](docs/configuration.md) — every `ensemble.yaml` field
+- [Configuration Reference](docs/configuration.md) — every `config.yaml` field
 - [Pipeline Guide](docs/pipelines.md) — steps, DAGs, verdicts, retries
 - [Contributing](docs/contributing.md) — building, testing, project structure
 - [Roadmap](docs/roadmap.md) — what's built, what's coming

--- a/crates/ensemble-cli/src/commands/init.rs
+++ b/crates/ensemble-cli/src/commands/init.rs
@@ -43,14 +43,20 @@ pub async fn execute(args: InitArgs) -> ExitCode {
     // Check for legacy ensemble.yaml and warn
     let legacy_path = resolved.config_dir.join("ensemble.yaml");
     if legacy_path.exists() && !resolved.config_path.exists() {
-        eprintln!("found legacy ensemble.yaml at {} - rename it to config.yaml", legacy_path.display());
+        eprintln!(
+            "found legacy ensemble.yaml at {} - rename it to config.yaml",
+            legacy_path.display()
+        );
     }
 
     // Try to load existing config for defaults
     let existing: Option<EnsembleConfig> = if resolved.config_path.exists() {
-        let overwrite = match inquire::Confirm::new(&format!("{} already exists. Overwrite?", resolved.config_path.display()))
-            .with_default(false)
-            .prompt()
+        let overwrite = match inquire::Confirm::new(&format!(
+            "{} already exists. Overwrite?",
+            resolved.config_path.display()
+        ))
+        .with_default(false)
+        .prompt()
         {
             Ok(v) => v,
             Err(_) => return ExitCode::FAILURE,
@@ -144,7 +150,10 @@ pub async fn execute(args: InitArgs) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    println!("\n✓ Configuration written to {}", resolved.config_dir.display());
+    println!(
+        "\n✓ Configuration written to {}",
+        resolved.config_dir.display()
+    );
     println!("  - config.yaml: main configuration file");
     println!("  - .env: environment variables (auto-loaded)");
     println!("  - templates/: prompt templates");

--- a/crates/ensemble-cli/src/commands/init.rs
+++ b/crates/ensemble-cli/src/commands/init.rs
@@ -1,4 +1,6 @@
 use ensemble_core::config::ensemble::{load_config, EnsembleConfig};
+use ensemble_core::config::location::resolve_config_dir_for_cli;
+use std::path::PathBuf;
 use std::process::ExitCode;
 
 pub mod agents;
@@ -9,15 +11,44 @@ pub mod tracker;
 pub mod validate;
 
 #[derive(Debug, Clone)]
-pub struct InitArgs;
+pub struct InitArgs {
+    pub config_dir: Option<PathBuf>,
+}
 
 /// Run the interactive initialization wizard
-pub async fn execute(_args: InitArgs) -> ExitCode {
+pub async fn execute(args: InitArgs) -> ExitCode {
     println!();
 
+    // Resolve config directory
+    let cwd = match std::env::current_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            eprintln!("error: failed to get current directory: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let resolved = match resolve_config_dir_for_cli(
+        args.config_dir.as_deref(),
+        std::env::var_os("ENSEMBLE_CONFIG_DIR"),
+        &cwd,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: failed to resolve config directory: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Check for legacy ensemble.yaml and warn
+    let legacy_path = resolved.config_dir.join("ensemble.yaml");
+    if legacy_path.exists() && !resolved.config_path.exists() {
+        eprintln!("found legacy ensemble.yaml at {} - rename it to config.yaml", legacy_path.display());
+    }
+
     // Try to load existing config for defaults
-    let existing: Option<EnsembleConfig> = if std::path::Path::new("ensemble.yaml").exists() {
-        let overwrite = match inquire::Confirm::new("ensemble.yaml already exists. Overwrite?")
+    let existing: Option<EnsembleConfig> = if resolved.config_path.exists() {
+        let overwrite = match inquire::Confirm::new(&format!("{} already exists. Overwrite?", resolved.config_path.display()))
             .with_default(false)
             .prompt()
         {
@@ -28,7 +59,7 @@ pub async fn execute(_args: InitArgs) -> ExitCode {
             println!("Aborted.");
             return ExitCode::SUCCESS;
         }
-        match load_config(std::path::Path::new("ensemble.yaml")) {
+        match load_config(&resolved.config_path) {
             Ok(config) => {
                 println!("  (using existing values as defaults)\n");
                 Some(config)
@@ -101,6 +132,7 @@ pub async fn execute(_args: InitArgs) -> ExitCode {
     };
 
     if let Err(e) = generate::write_files(
+        &resolved.config_dir,
         &tracker_result,
         &repos,
         &discovered_agents,
@@ -110,6 +142,14 @@ pub async fn execute(_args: InitArgs) -> ExitCode {
     ) {
         eprintln!("error writing files: {e}");
         return ExitCode::FAILURE;
+    }
+
+    println!("\n✓ Configuration written to {}", resolved.config_dir.display());
+    println!("  - config.yaml: main configuration file");
+    println!("  - .env: environment variables (auto-loaded)");
+    println!("  - templates/: prompt templates");
+    if let tracker::TrackerChoice::TodoFile { path } = &tracker_result {
+        println!("  - TODO state: {}", path.display());
     }
 
     ExitCode::SUCCESS

--- a/crates/ensemble-cli/src/commands/init/generate.rs
+++ b/crates/ensemble-cli/src/commands/init/generate.rs
@@ -137,6 +137,7 @@ pub fn generate_todo_md() -> String {
 }
 
 pub fn write_files(
+    config_dir: &std::path::Path,
     tracker: &TrackerChoice,
     repos: &[RepoEntry],
     agents: &[AgentEntry],
@@ -146,64 +147,83 @@ pub fn write_files(
 ) -> Result<(), std::io::Error> {
     println!("Writing configuration...");
 
-    let yaml = generate_yaml(tracker, repos, agents, steps, on_success, on_failure);
-    std::fs::write("ensemble.yaml", &yaml)?;
-    println!("  ✓ ensemble.yaml");
+    // Create config directory if it doesn't exist
+    std::fs::create_dir_all(config_dir)?;
 
-    std::fs::create_dir_all("templates")?;
+    let yaml = generate_yaml(tracker, repos, agents, steps, on_success, on_failure);
+    let config_path = config_dir.join("config.yaml");
+    std::fs::write(&config_path, &yaml)?;
+    println!("  ✓ {}", config_path.display());
+
+    let templates_dir = config_dir.join("templates");
+    std::fs::create_dir_all(&templates_dir)?;
     for step in steps {
         let template = generate_template(&step.name);
-        let path = format!("templates/{}.liquid", step.name);
-        if std::path::Path::new(&path).exists() {
-            match inquire::Confirm::new(&format!("Template '{}' already exists. Overwrite?", path))
-                .with_default(true)
-                .prompt()
+        let path = templates_dir.join(format!("{}.liquid", step.name));
+        if path.exists() {
+            match inquire::Confirm::new(&format!(
+                "Template '{}' already exists. Overwrite?",
+                path.display()
+            ))
+            .with_default(true)
+            .prompt()
             {
                 Ok(true) => {}
                 Ok(false) => {
-                    println!("  Skipping {path}");
+                    println!("  Skipping {}", path.display());
                     continue;
                 }
                 Err(_) => return Ok(()),
             }
         }
         std::fs::write(&path, &template)?;
-        println!("  ✓ {path}");
+        println!("  ✓ {}", path.display());
     }
 
-    if let TrackerChoice::TodoFile { .. } = tracker {
-        std::fs::write("TODO.md", generate_todo_md())?;
-        println!("  ✓ TODO.md");
+    if let TrackerChoice::TodoFile { path } = tracker {
+        // Create parent directories for TODO file if needed
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, generate_todo_md())?;
+        println!("  ✓ {}", path.display());
     }
 
     // Write .env file with GitHub token if provided interactively
     if let TrackerChoice::GitHub {
         api_token: Some(token),
+        api_key_env,
         ..
     } = tracker
     {
-        if std::path::Path::new(".env").exists() {
-            match inquire::Confirm::new(".env already exists. Overwrite?")
-                .with_default(false)
-                .prompt()
+        let env_path = config_dir.join(".env");
+        if env_path.exists() {
+            match inquire::Confirm::new(&format!(
+                "{} already exists. Overwrite?",
+                env_path.display()
+            ))
+            .with_default(false)
+            .prompt()
             {
                 Ok(true) => {}
                 Ok(false) => {
-                    println!("  Skipping .env (token not saved)");
+                    println!("  Skipping {} (token not saved)", env_path.display());
                 }
                 Err(_) => return Ok(()),
             }
         }
-        std::fs::write(".env", format!("GITHUB_TOKEN={}\n", token))?;
+        std::fs::write(&env_path, format!("{}={}\n", api_key_env, token))?;
         // Set restrictive permissions (user read/write only)
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(".env", perms)?;
+            std::fs::set_permissions(&env_path, perms)?;
         }
-        println!("  ✓ .env");
-        println!("  Note: Run `source .env` or export GITHUB_TOKEN before `ensemble run`");
+        println!(
+            "  ✓ {} (auto-loaded from config directory)",
+            env_path.display()
+        );
     }
 
     println!("\nDone! Run `ensemble` to start processing issues.");

--- a/crates/ensemble-cli/src/commands/init/tracker.rs
+++ b/crates/ensemble-cli/src/commands/init/tracker.rs
@@ -1,4 +1,5 @@
 use ensemble_core::config::ensemble::EnsembleConfig;
+use ensemble_core::config::location::default_todo_state_path;
 use std::path::PathBuf;
 
 use inquire::{MultiSelect, Password, Select, Text};
@@ -42,7 +43,11 @@ pub async fn ask_tracker(
             let default_path = existing
                 .and_then(|c| c.tracker.path.as_ref())
                 .map(|p| p.to_string_lossy().into_owned())
-                .unwrap_or_else(|| "TODO.md".to_string());
+                .unwrap_or_else(|| {
+                    default_todo_state_path()
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .unwrap_or_else(|_| "~/ensemble/TODO.md".to_string())
+                });
 
             let path_str = Text::new("TODO file path:")
                 .with_default(&default_path)

--- a/crates/ensemble-cli/src/commands/mod.rs
+++ b/crates/ensemble-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod init;
+pub mod open_config_dir;
 pub mod run;
 pub mod web;

--- a/crates/ensemble-cli/src/commands/open_config_dir.rs
+++ b/crates/ensemble-cli/src/commands/open_config_dir.rs
@@ -1,0 +1,132 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+use tracing::{error, info};
+
+use ensemble_core::config::location::resolve_config_dir_for_cli;
+
+#[derive(Debug, Clone)]
+pub struct OpenConfigDirArgs {
+    pub config_dir: Option<PathBuf>,
+}
+
+/// Open the configuration directory in the system file manager
+pub async fn execute(args: OpenConfigDirArgs) -> ExitCode {
+    let cwd = match std::env::current_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            error!(error = %e, "failed to get current directory");
+            eprintln!("error: failed to get current directory: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let resolved = match resolve_config_dir_for_cli(
+        args.config_dir.as_deref(),
+        std::env::var_os("ENSEMBLE_CONFIG_DIR"),
+        &cwd,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            error!(error = %e, "failed to resolve config directory");
+            eprintln!("error: failed to resolve config directory: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if !resolved.config_dir.exists() {
+        eprintln!("error: config directory does not exist: {}", resolved.config_dir.display());
+        eprintln!("run `ensemble init` to create it");
+        return ExitCode::FAILURE;
+    }
+
+    info!(config_dir = %resolved.config_dir.display(), "opening config directory");
+
+    match open_in_system_file_manager(&resolved.config_dir) {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(e) => {
+            error!(error = %e, "failed to open config directory");
+            eprintln!("error: failed to open config directory: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Open a path in the system file manager
+#[cfg(target_os = "macos")]
+fn open_in_system_file_manager(path: &std::path::Path) -> Result<(), String> {
+    use std::process::Command;
+    
+    let status = Command::new("open")
+        .arg(path)
+        .status()
+        .map_err(|e| format!("failed to execute open command: {}", e))?;
+    
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("open command failed with status: {:?}", status.code()))
+    }
+}
+
+/// Open a path in the system file manager
+#[cfg(target_os = "windows")]
+fn open_in_system_file_manager(path: &std::path::Path) -> Result<(), String> {
+    use std::process::Command;
+    
+    let status = Command::new("explorer")
+        .arg(path)
+        .status()
+        .map_err(|e| format!("failed to execute explorer command: {}", e))?;
+    
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("explorer command failed with status: {:?}", status.code()))
+    }
+}
+
+/// Open a path in the system file manager
+#[cfg(target_os = "linux")]
+fn open_in_system_file_manager(path: &std::path::Path) -> Result<(), String> {
+    use std::process::Command;
+    
+    // Try xdg-open first, then fallback to common file managers
+    let result = Command::new("xdg-open")
+        .arg(path)
+        .status();
+    
+    match result {
+        Ok(status) if status.success() => return Ok(()),
+        _ => {}
+    }
+    
+    // Fallback to nautilus (GNOME) or dolphin (KDE)
+    for cmd in ["nautilus", "dolphin", "thunar", "nemo"] {
+        if let Ok(status) = Command::new(cmd).arg(path).status() {
+            if status.success() {
+                return Ok(());
+            }
+        }
+    }
+    
+    Err("failed to open file manager. Please install xdg-open or a file manager (nautilus, dolphin, thunar, or nemo)".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_open_config_dir_args() {
+        let args = OpenConfigDirArgs {
+            config_dir: Some(PathBuf::from("/tmp/test")),
+        };
+        assert_eq!(args.config_dir, Some(PathBuf::from("/tmp/test")));
+    }
+
+    #[test]
+    fn test_open_config_dir_args_none() {
+        let args = OpenConfigDirArgs { config_dir: None };
+        assert!(args.config_dir.is_none());
+    }
+}

--- a/crates/ensemble-cli/src/commands/open_config_dir.rs
+++ b/crates/ensemble-cli/src/commands/open_config_dir.rs
@@ -34,7 +34,10 @@ pub async fn execute(args: OpenConfigDirArgs) -> ExitCode {
     };
 
     if !resolved.config_dir.exists() {
-        eprintln!("error: config directory does not exist: {}", resolved.config_dir.display());
+        eprintln!(
+            "error: config directory does not exist: {}",
+            resolved.config_dir.display()
+        );
         eprintln!("run `ensemble init` to create it");
         return ExitCode::FAILURE;
     }
@@ -55,16 +58,19 @@ pub async fn execute(args: OpenConfigDirArgs) -> ExitCode {
 #[cfg(target_os = "macos")]
 fn open_in_system_file_manager(path: &std::path::Path) -> Result<(), String> {
     use std::process::Command;
-    
+
     let status = Command::new("open")
         .arg(path)
         .status()
         .map_err(|e| format!("failed to execute open command: {}", e))?;
-    
+
     if status.success() {
         Ok(())
     } else {
-        Err(format!("open command failed with status: {:?}", status.code()))
+        Err(format!(
+            "open command failed with status: {:?}",
+            status.code()
+        ))
     }
 }
 
@@ -72,16 +78,19 @@ fn open_in_system_file_manager(path: &std::path::Path) -> Result<(), String> {
 #[cfg(target_os = "windows")]
 fn open_in_system_file_manager(path: &std::path::Path) -> Result<(), String> {
     use std::process::Command;
-    
+
     let status = Command::new("explorer")
         .arg(path)
         .status()
         .map_err(|e| format!("failed to execute explorer command: {}", e))?;
-    
+
     if status.success() {
         Ok(())
     } else {
-        Err(format!("explorer command failed with status: {:?}", status.code()))
+        Err(format!(
+            "explorer command failed with status: {:?}",
+            status.code()
+        ))
     }
 }
 
@@ -89,17 +98,15 @@ fn open_in_system_file_manager(path: &std::path::Path) -> Result<(), String> {
 #[cfg(target_os = "linux")]
 fn open_in_system_file_manager(path: &std::path::Path) -> Result<(), String> {
     use std::process::Command;
-    
+
     // Try xdg-open first, then fallback to common file managers
-    let result = Command::new("xdg-open")
-        .arg(path)
-        .status();
-    
+    let result = Command::new("xdg-open").arg(path).status();
+
     match result {
         Ok(status) if status.success() => return Ok(()),
         _ => {}
     }
-    
+
     // Fallback to nautilus (GNOME) or dolphin (KDE)
     for cmd in ["nautilus", "dolphin", "thunar", "nemo"] {
         if let Ok(status) = Command::new(cmd).arg(path).status() {
@@ -108,7 +115,7 @@ fn open_in_system_file_manager(path: &std::path::Path) -> Result<(), String> {
             }
         }
     }
-    
+
     Err("failed to open file manager. Please install xdg-open or a file manager (nautilus, dolphin, thunar, or nemo)".to_string())
 }
 

--- a/crates/ensemble-cli/src/commands/run.rs
+++ b/crates/ensemble-cli/src/commands/run.rs
@@ -5,29 +5,53 @@ use tokio::sync::RwLock;
 use tracing::{error, info};
 
 use ensemble_core::config::ensemble::{load_config, validate_config};
+use ensemble_core::config::location::resolve_config_dir_for_cli;
 use ensemble_core::orchestrator::state::OrchestratorState;
 use ensemble_core::pipeline::dag::build_dag;
 
 #[derive(Debug, Clone)]
 pub struct RunArgs {
-    pub config_path: PathBuf,
+    pub config_dir: Option<PathBuf>,
 }
 
 /// Run the orchestrator in headless mode (terminal output only)
 pub async fn execute(args: RunArgs) -> ExitCode {
+    let cwd = match std::env::current_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            error!(error = %e, "failed to get current directory");
+            eprintln!("error: failed to get current directory: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let resolved = match resolve_config_dir_for_cli(
+        args.config_dir.as_deref(),
+        std::env::var_os("ENSEMBLE_CONFIG_DIR"),
+        &cwd,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            error!(error = %e, "failed to resolve config directory");
+            eprintln!("error: failed to resolve config directory: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
     info!(
-        config_path = %args.config_path.display(),
+        config_dir = %resolved.config_dir.display(),
+        config_path = %resolved.config_path.display(),
         "starting ensemble in headless mode"
     );
 
-    // Load and validate ensemble.yaml
-    let config = match load_config(&args.config_path) {
+    // Load and validate config.yaml
+    let config = match load_config(&resolved.config_path) {
         Ok(cfg) => cfg,
         Err(e) => {
-            error!(error = %e, path = %args.config_path.display(), "failed to load config");
+            error!(error = %e, path = %resolved.config_path.display(), "failed to load config");
             eprintln!(
                 "error: failed to load {}: {}",
-                args.config_path.display(),
+                resolved.config_path.display(),
                 e
             );
             return ExitCode::FAILURE;
@@ -76,4 +100,23 @@ pub async fn execute(args: RunArgs) -> ExitCode {
 
     info!("ensemble shut down cleanly");
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_args() {
+        let args = RunArgs {
+            config_dir: Some(PathBuf::from("/tmp/test")),
+        };
+        assert_eq!(args.config_dir, Some(PathBuf::from("/tmp/test")));
+    }
+
+    #[test]
+    fn test_run_args_none() {
+        let args = RunArgs { config_dir: None };
+        assert!(args.config_dir.is_none());
+    }
 }

--- a/crates/ensemble-cli/src/commands/web.rs
+++ b/crates/ensemble-cli/src/commands/web.rs
@@ -6,6 +6,7 @@ use tracing::{error, info, warn};
 
 use ensemble_core::api::router::{create_api_router, AppState};
 use ensemble_core::config::ensemble::{load_config, validate_config};
+use ensemble_core::config::location::resolve_config_dir_for_cli;
 use ensemble_core::observability::events::EventBus;
 use ensemble_core::orchestrator::state::OrchestratorState;
 use ensemble_core::pipeline::dag::build_dag;
@@ -14,28 +15,51 @@ use crate::embedded_ui::spa_router;
 
 #[derive(Debug, Clone)]
 pub struct WebArgs {
-    pub config_path: PathBuf,
+    pub config_dir: Option<PathBuf>,
     pub host: String,
     pub port: Option<u16>,
 }
 
 /// Run the orchestrator with web UI (SPA + API server)
 pub async fn execute(args: WebArgs) -> ExitCode {
+    let cwd = match std::env::current_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            error!(error = %e, "failed to get current directory");
+            eprintln!("error: failed to get current directory: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let resolved = match resolve_config_dir_for_cli(
+        args.config_dir.as_deref(),
+        std::env::var_os("ENSEMBLE_CONFIG_DIR"),
+        &cwd,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            error!(error = %e, "failed to resolve config directory");
+            eprintln!("error: failed to resolve config directory: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
     info!(
-        config_path = %args.config_path.display(),
+        config_dir = %resolved.config_dir.display(),
+        config_path = %resolved.config_path.display(),
         host = %args.host,
         port = ?args.port,
         "starting ensemble in web mode"
     );
 
-    // Load and validate ensemble.yaml
-    let config = match load_config(&args.config_path) {
+    // Load and validate config.yaml
+    let config = match load_config(&resolved.config_path) {
         Ok(cfg) => cfg,
         Err(e) => {
-            error!(error = %e, path = %args.config_path.display(), "failed to load config");
+            error!(error = %e, path = %resolved.config_path.display(), "failed to load config");
             eprintln!(
                 "error: failed to load {}: {}",
-                args.config_path.display(),
+                resolved.config_path.display(),
                 e
             );
             return ExitCode::FAILURE;
@@ -89,7 +113,7 @@ pub async fn execute(args: WebArgs) -> ExitCode {
         history_path,
         event_bus: EventBus::new(),
         config: Arc::new(config.clone()),
-        config_path: args.config_path.display().to_string(),
+        config_path: resolved.config_path.display().to_string(),
     };
 
     // Create combined router: API routes + SPA fallback
@@ -159,4 +183,33 @@ pub async fn execute(args: WebArgs) -> ExitCode {
 
     info!("ensemble shut down cleanly");
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_web_args() {
+        let args = WebArgs {
+            config_dir: Some(PathBuf::from("/tmp/test")),
+            host: "0.0.0.0".to_string(),
+            port: Some(8080),
+        };
+        assert_eq!(args.config_dir, Some(PathBuf::from("/tmp/test")));
+        assert_eq!(args.host, "0.0.0.0");
+        assert_eq!(args.port, Some(8080));
+    }
+
+    #[test]
+    fn test_web_args_defaults() {
+        let args = WebArgs {
+            config_dir: None,
+            host: "127.0.0.1".to_string(),
+            port: None,
+        };
+        assert!(args.config_dir.is_none());
+        assert_eq!(args.host, "127.0.0.1");
+        assert_eq!(args.port, None);
+    }
 }

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -131,10 +131,7 @@ async fn main() -> ExitCode {
 
     match cli.command {
         Some(Command::Init) => {
-            commands::init::execute(commands::init::InitArgs {
-                config_dir,
-            })
-            .await
+            commands::init::execute(commands::init::InitArgs { config_dir }).await
         }
         Some(Command::Run) => commands::run::execute(commands::run::RunArgs { config_dir }).await,
         Some(Command::Web { host, port }) => {
@@ -209,7 +206,9 @@ mod tests {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "run", "--config-dir", "/tmp/ensemble"]);
         match cli.command {
-            Some(Command::Run) => assert_eq!(cli.config.config_dir, Some(PathBuf::from("/tmp/ensemble"))),
+            Some(Command::Run) => {
+                assert_eq!(cli.config.config_dir, Some(PathBuf::from("/tmp/ensemble")))
+            }
             other => panic!("expected Run subcommand, got {:?}", other),
         }
         restore_env(host, port);
@@ -340,7 +339,9 @@ mod tests {
             "/tmp/ensemble",
         ]);
         match cli.command {
-            Some(Command::OpenConfigDir) => assert_eq!(cli.config.config_dir, Some(PathBuf::from("/tmp/ensemble"))),
+            Some(Command::OpenConfigDir) => {
+                assert_eq!(cli.config.config_dir, Some(PathBuf::from("/tmp/ensemble")))
+            }
             other => panic!("expected OpenConfigDir subcommand, got {:?}", other),
         }
         restore_env(host, port);

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -63,7 +63,7 @@ enum Command {
 /// Check for legacy config override arguments and print migration error.
 fn reject_legacy_config_overrides(args: impl Iterator<Item = OsString>) -> Result<(), String> {
     let args_vec: Vec<_> = args.collect();
-    
+
     // Check for deprecated --config flag
     if args_vec.iter().any(|a| a == "--config" || a == "-c") {
         return Err(
@@ -72,15 +72,16 @@ fn reject_legacy_config_overrides(args: impl Iterator<Item = OsString>) -> Resul
              example: ENSEMBLE_CONFIG_DIR=/path/to/config ensemble run".to_string()
         );
     }
-    
+
     // Check for ENSEMBLE_CONFIG (old env var)
     if std::env::var_os("ENSEMBLE_CONFIG").is_some() {
         return Err(
             "error: ENSEMBLE_CONFIG is no longer supported. Use ENSEMBLE_CONFIG_DIR instead.\n\
-             example: ENSEMBLE_CONFIG_DIR=/path/to/config ensemble run".to_string()
+             example: ENSEMBLE_CONFIG_DIR=/path/to/config ensemble run"
+                .to_string(),
         );
     }
-    
+
     Ok(())
 }
 
@@ -91,20 +92,24 @@ async fn main() -> ExitCode {
         eprintln!("{}", msg);
         return ExitCode::FAILURE;
     }
-    
+
     let cli = Cli::parse();
     init_logging();
 
     match cli.command {
-        Some(Command::Init { config }) => commands::init::execute(commands::init::InitArgs { config_dir: config.config_dir }).await,
-        Some(Command::Run { config }) => {
-            commands::run::execute(commands::run::RunArgs { config_dir: config.config_dir }).await
+        Some(Command::Init { config }) => {
+            commands::init::execute(commands::init::InitArgs {
+                config_dir: config.config_dir,
+            })
+            .await
         }
-        Some(Command::Web {
-            config,
-            host,
-            port,
-        }) => {
+        Some(Command::Run { config }) => {
+            commands::run::execute(commands::run::RunArgs {
+                config_dir: config.config_dir,
+            })
+            .await
+        }
+        Some(Command::Web { config, host, port }) => {
             commands::web::execute(commands::web::WebArgs {
                 config_dir: config.config_dir,
                 host,
@@ -317,7 +322,12 @@ mod tests {
     #[test]
     fn test_cli_parse_open_config_dir_with_config_dir() {
         let (_guard, host, port) = lock_and_clear_env();
-        let cli = Cli::parse_from(["ensemble", "open-config-dir", "--config-dir", "/tmp/ensemble"]);
+        let cli = Cli::parse_from([
+            "ensemble",
+            "open-config-dir",
+            "--config-dir",
+            "/tmp/ensemble",
+        ]);
         match cli.command {
             Some(Command::OpenConfigDir { config }) => {
                 assert_eq!(config.config_dir, Some(PathBuf::from("/tmp/ensemble")));
@@ -331,24 +341,30 @@ mod tests {
 
     #[test]
     fn test_cli_rejects_legacy_config_flag() {
-        let result = reject_legacy_config_overrides([
-            OsString::from("ensemble"),
-            OsString::from("run"),
-            OsString::from("--config"),
-            OsString::from("old.yaml"),
-        ].into_iter());
+        let result = reject_legacy_config_overrides(
+            [
+                OsString::from("ensemble"),
+                OsString::from("run"),
+                OsString::from("--config"),
+                OsString::from("old.yaml"),
+            ]
+            .into_iter(),
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("--config-dir"));
     }
 
     #[test]
     fn test_cli_rejects_legacy_short_config_flag() {
-        let result = reject_legacy_config_overrides([
-            OsString::from("ensemble"),
-            OsString::from("run"),
-            OsString::from("-c"),
-            OsString::from("old.yaml"),
-        ].into_iter());
+        let result = reject_legacy_config_overrides(
+            [
+                OsString::from("ensemble"),
+                OsString::from("run"),
+                OsString::from("-c"),
+                OsString::from("old.yaml"),
+            ]
+            .into_iter(),
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("--config-dir"));
     }

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -12,39 +12,29 @@ use ensemble_core::observability::logging::init_logging;
 #[derive(Parser, Debug)]
 #[command(name = "ensemble", about = "Orchestrate coding agents")]
 struct Cli {
+    #[command(flatten)]
+    config: ConfigDirArgs,
+
     /// Subcommand is optional: bare `ensemble` defaults to headless `run`.
     #[command(subcommand)]
     command: Option<Command>,
-
-    /// Config directory path (deprecated: use subcommand-specific --config-dir instead)
-    #[arg(default_value = None, hide = true)]
-    _legacy_config_path: Option<PathBuf>,
 }
 
 #[derive(Args, Debug, Clone)]
 struct ConfigDirArgs {
     /// Path to the ensemble configuration directory (contains config.yaml)
-    #[arg(long, env = "ENSEMBLE_CONFIG_DIR")]
+    #[arg(long, env = "ENSEMBLE_CONFIG_DIR", global = true)]
     config_dir: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]
 enum Command {
     /// Interactively create an ensemble configuration directory.
-    Init {
-        #[command(flatten)]
-        config: ConfigDirArgs,
-    },
+    Init,
     /// Start the ensemble orchestrator in headless mode.
-    Run {
-        #[command(flatten)]
-        config: ConfigDirArgs,
-    },
+    Run,
     /// Start the ensemble orchestrator with web UI.
     Web {
-        #[command(flatten)]
-        config: ConfigDirArgs,
-
         /// HTTP server bind address.
         #[arg(long, env = "HOST", default_value = "127.0.0.1")]
         host: String,
@@ -54,10 +44,7 @@ enum Command {
         port: Option<u16>,
     },
     /// Open the ensemble configuration directory in the system file manager.
-    OpenConfigDir {
-        #[command(flatten)]
-        config: ConfigDirArgs,
-    },
+    OpenConfigDir,
 }
 
 /// Check for legacy config override arguments and print migration error.
@@ -82,6 +69,50 @@ fn reject_legacy_config_overrides(args: impl Iterator<Item = OsString>) -> Resul
         );
     }
 
+    let mut expect_value_for_flag = false;
+    let mut saw_subcommand = false;
+
+    for arg in args_vec.iter().skip(1) {
+        let arg = arg.to_string_lossy();
+
+        if expect_value_for_flag {
+            expect_value_for_flag = false;
+            continue;
+        }
+
+        if arg == "--" {
+            break;
+        }
+
+        if arg == "--config-dir" || arg == "--host" || arg == "--port" {
+            expect_value_for_flag = true;
+            continue;
+        }
+
+        if arg.starts_with("--config-dir=")
+            || arg.starts_with("--host=")
+            || arg.starts_with("--port=")
+        {
+            continue;
+        }
+
+        if arg.starts_with('-') {
+            continue;
+        }
+
+        if !saw_subcommand && matches!(arg.as_ref(), "init" | "run" | "web" | "open-config-dir") {
+            saw_subcommand = true;
+            continue;
+        }
+
+        return Err(
+            "error: positional config paths are no longer supported. Use --config-dir or ENSEMBLE_CONFIG_DIR instead.\n\
+             example: ensemble run --config-dir /path/to/config\n\
+             example: ensemble --config-dir /path/to/config"
+                .to_string(),
+        );
+    }
+
     Ok(())
 }
 
@@ -96,37 +127,31 @@ async fn main() -> ExitCode {
     let cli = Cli::parse();
     init_logging();
 
+    let config_dir = cli.config.config_dir;
+
     match cli.command {
-        Some(Command::Init { config }) => {
+        Some(Command::Init) => {
             commands::init::execute(commands::init::InitArgs {
-                config_dir: config.config_dir,
+                config_dir,
             })
             .await
         }
-        Some(Command::Run { config }) => {
-            commands::run::execute(commands::run::RunArgs {
-                config_dir: config.config_dir,
-            })
-            .await
-        }
-        Some(Command::Web { config, host, port }) => {
+        Some(Command::Run) => commands::run::execute(commands::run::RunArgs { config_dir }).await,
+        Some(Command::Web { host, port }) => {
             commands::web::execute(commands::web::WebArgs {
-                config_dir: config.config_dir,
+                config_dir,
                 host,
                 port,
             })
             .await
         }
-        Some(Command::OpenConfigDir { config }) => {
+        Some(Command::OpenConfigDir) => {
             commands::open_config_dir::execute(commands::open_config_dir::OpenConfigDirArgs {
-                config_dir: config.config_dir,
+                config_dir,
             })
             .await
         }
-        None => {
-            // No subcommand: default to headless run with default config dir
-            commands::run::execute(commands::run::RunArgs { config_dir: None }).await
-        }
+        None => commands::run::execute(commands::run::RunArgs { config_dir }).await,
     }
 }
 
@@ -173,7 +198,7 @@ mod tests {
     fn test_cli_parse_init_subcommand() {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "init"]);
-        assert!(matches!(cli.command, Some(Command::Init { .. })));
+        assert!(matches!(cli.command, Some(Command::Init)));
         restore_env(host, port);
     }
 
@@ -184,9 +209,7 @@ mod tests {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "run", "--config-dir", "/tmp/ensemble"]);
         match cli.command {
-            Some(Command::Run { config }) => {
-                assert_eq!(config.config_dir, Some(PathBuf::from("/tmp/ensemble")));
-            }
+            Some(Command::Run) => assert_eq!(cli.config.config_dir, Some(PathBuf::from("/tmp/ensemble"))),
             other => panic!("expected Run subcommand, got {:?}", other),
         }
         restore_env(host, port);
@@ -197,9 +220,7 @@ mod tests {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "run"]);
         match cli.command {
-            Some(Command::Run { config }) => {
-                assert_eq!(config.config_dir, None);
-            }
+            Some(Command::Run) => assert_eq!(cli.config.config_dir, None),
             other => panic!("expected Run subcommand, got {:?}", other),
         }
         restore_env(host, port);
@@ -212,13 +233,8 @@ mod tests {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "web"]);
         match cli.command {
-            Some(Command::Web {
-                config,
-                host: h,
-                port: p,
-                ..
-            }) => {
-                assert_eq!(config.config_dir, None);
+            Some(Command::Web { host: h, port: p }) => {
+                assert_eq!(cli.config.config_dir, None);
                 assert_eq!(h, "127.0.0.1");
                 assert_eq!(p, None);
             }
@@ -241,13 +257,8 @@ mod tests {
             "8080",
         ]);
         match cli.command {
-            Some(Command::Web {
-                config,
-                host: h,
-                port: p,
-                ..
-            }) => {
-                assert_eq!(config.config_dir, Some(PathBuf::from("/tmp/ensemble")));
+            Some(Command::Web { host: h, port: p }) => {
+                assert_eq!(cli.config.config_dir, Some(PathBuf::from("/tmp/ensemble")));
                 assert_eq!(h, "0.0.0.0");
                 assert_eq!(p, Some(8080));
             }
@@ -315,7 +326,7 @@ mod tests {
     fn test_cli_parse_open_config_dir_subcommand() {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "open-config-dir"]);
-        assert!(matches!(cli.command, Some(Command::OpenConfigDir { .. })));
+        assert!(matches!(cli.command, Some(Command::OpenConfigDir)));
         restore_env(host, port);
     }
 
@@ -329,9 +340,7 @@ mod tests {
             "/tmp/ensemble",
         ]);
         match cli.command {
-            Some(Command::OpenConfigDir { config }) => {
-                assert_eq!(config.config_dir, Some(PathBuf::from("/tmp/ensemble")));
-            }
+            Some(Command::OpenConfigDir) => assert_eq!(cli.config.config_dir, Some(PathBuf::from("/tmp/ensemble"))),
             other => panic!("expected OpenConfigDir subcommand, got {:?}", other),
         }
         restore_env(host, port);
@@ -377,5 +386,27 @@ mod tests {
         let cli = Cli::parse_from(["ensemble"]);
         assert!(cli.command.is_none());
         restore_env(host, port);
+    }
+
+    #[test]
+    fn test_cli_no_subcommand_accepts_config_dir() {
+        let (_guard, host, port) = lock_and_clear_env();
+        let cli = Cli::try_parse_from(["ensemble", "--config-dir", "/tmp/ensemble"])
+            .expect("bare ensemble should accept --config-dir");
+        assert!(cli.command.is_none());
+        restore_env(host, port);
+    }
+
+    #[test]
+    fn test_cli_rejects_legacy_bare_config_path() {
+        let result = reject_legacy_config_overrides(
+            [
+                OsString::from("ensemble"),
+                OsString::from("custom/ensemble.yaml"),
+            ]
+            .into_iter(),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("--config-dir"));
     }
 }

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -1,7 +1,8 @@
 mod commands;
 mod embedded_ui;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -15,26 +16,34 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
 
-    /// Path to ensemble.yaml (used when no subcommand is given)
-    #[arg(default_value = "ensemble.yaml")]
-    config_path: PathBuf,
+    /// Config directory path (deprecated: use subcommand-specific --config-dir instead)
+    #[arg(default_value = None, hide = true)]
+    _legacy_config_path: Option<PathBuf>,
+}
+
+#[derive(Args, Debug, Clone)]
+struct ConfigDirArgs {
+    /// Path to the ensemble configuration directory (contains config.yaml)
+    #[arg(long, env = "ENSEMBLE_CONFIG_DIR")]
+    config_dir: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Interactively create an ensemble.yaml configuration file.
-    Init,
+    /// Interactively create an ensemble configuration directory.
+    Init {
+        #[command(flatten)]
+        config: ConfigDirArgs,
+    },
     /// Start the ensemble orchestrator in headless mode.
     Run {
-        /// Path to ensemble.yaml
-        #[arg(default_value = "ensemble.yaml")]
-        config_path: PathBuf,
+        #[command(flatten)]
+        config: ConfigDirArgs,
     },
     /// Start the ensemble orchestrator with web UI.
     Web {
-        /// Path to ensemble.yaml
-        #[arg(default_value = "ensemble.yaml")]
-        config_path: PathBuf,
+        #[command(flatten)]
+        config: ConfigDirArgs,
 
         /// HTTP server bind address.
         #[arg(long, env = "HOST", default_value = "127.0.0.1")]
@@ -44,36 +53,74 @@ enum Command {
         #[arg(long, env = "PORT")]
         port: Option<u16>,
     },
+    /// Open the ensemble configuration directory in the system file manager.
+    OpenConfigDir {
+        #[command(flatten)]
+        config: ConfigDirArgs,
+    },
+}
+
+/// Check for legacy config override arguments and print migration error.
+fn reject_legacy_config_overrides(args: impl Iterator<Item = OsString>) -> Result<(), String> {
+    let args_vec: Vec<_> = args.collect();
+    
+    // Check for deprecated --config flag
+    if args_vec.iter().any(|a| a == "--config" || a == "-c") {
+        return Err(
+            "error: --config is no longer supported. Use --config-dir or ENSEMBLE_CONFIG_DIR instead.\n\
+             example: ensemble run --config-dir /path/to/config\n\
+             example: ENSEMBLE_CONFIG_DIR=/path/to/config ensemble run".to_string()
+        );
+    }
+    
+    // Check for ENSEMBLE_CONFIG (old env var)
+    if std::env::var_os("ENSEMBLE_CONFIG").is_some() {
+        return Err(
+            "error: ENSEMBLE_CONFIG is no longer supported. Use ENSEMBLE_CONFIG_DIR instead.\n\
+             example: ENSEMBLE_CONFIG_DIR=/path/to/config ensemble run".to_string()
+        );
+    }
+    
+    Ok(())
 }
 
 #[tokio::main]
 async fn main() -> ExitCode {
+    // Check for legacy arguments before parsing
+    if let Err(msg) = reject_legacy_config_overrides(std::env::args_os()) {
+        eprintln!("{}", msg);
+        return ExitCode::FAILURE;
+    }
+    
     let cli = Cli::parse();
     init_logging();
 
     match cli.command {
-        Some(Command::Init) => commands::init::execute(commands::init::InitArgs).await,
-        Some(Command::Run { config_path }) => {
-            commands::run::execute(commands::run::RunArgs { config_path }).await
+        Some(Command::Init { config }) => commands::init::execute(commands::init::InitArgs { config_dir: config.config_dir }).await,
+        Some(Command::Run { config }) => {
+            commands::run::execute(commands::run::RunArgs { config_dir: config.config_dir }).await
         }
         Some(Command::Web {
-            config_path,
+            config,
             host,
             port,
         }) => {
             commands::web::execute(commands::web::WebArgs {
-                config_path,
+                config_dir: config.config_dir,
                 host,
                 port,
             })
             .await
         }
-        None => {
-            // No subcommand: default to headless run
-            commands::run::execute(commands::run::RunArgs {
-                config_path: cli.config_path,
+        Some(Command::OpenConfigDir { config }) => {
+            commands::open_config_dir::execute(commands::open_config_dir::OpenConfigDirArgs {
+                config_dir: config.config_dir,
             })
             .await
+        }
+        None => {
+            // No subcommand: default to headless run with default config dir
+            commands::run::execute(commands::run::RunArgs { config_dir: None }).await
         }
     }
 }
@@ -99,6 +146,7 @@ mod tests {
         let port = std::env::var("PORT").ok();
         std::env::remove_var("HOST");
         std::env::remove_var("PORT");
+        std::env::remove_var("ENSEMBLE_CONFIG");
         (guard, host, port)
     }
 
@@ -120,19 +168,19 @@ mod tests {
     fn test_cli_parse_init_subcommand() {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "init"]);
-        assert!(matches!(cli.command, Some(Command::Init)));
+        assert!(matches!(cli.command, Some(Command::Init { .. })));
         restore_env(host, port);
     }
 
     // ---- `ensemble run` subcommand ----
 
     #[test]
-    fn test_cli_parse_run_defaults() {
+    fn test_cli_parse_run_with_config_dir() {
         let (_guard, host, port) = lock_and_clear_env();
-        let cli = Cli::parse_from(["ensemble", "run"]);
+        let cli = Cli::parse_from(["ensemble", "run", "--config-dir", "/tmp/ensemble"]);
         match cli.command {
-            Some(Command::Run { config_path }) => {
-                assert_eq!(config_path, PathBuf::from("ensemble.yaml"));
+            Some(Command::Run { config }) => {
+                assert_eq!(config.config_dir, Some(PathBuf::from("/tmp/ensemble")));
             }
             other => panic!("expected Run subcommand, got {:?}", other),
         }
@@ -140,12 +188,12 @@ mod tests {
     }
 
     #[test]
-    fn test_cli_parse_run_custom_config() {
+    fn test_cli_parse_run_defaults() {
         let (_guard, host, port) = lock_and_clear_env();
-        let cli = Cli::parse_from(["ensemble", "run", "custom/ensemble.yaml"]);
+        let cli = Cli::parse_from(["ensemble", "run"]);
         match cli.command {
-            Some(Command::Run { config_path }) => {
-                assert_eq!(config_path, PathBuf::from("custom/ensemble.yaml"));
+            Some(Command::Run { config }) => {
+                assert_eq!(config.config_dir, None);
             }
             other => panic!("expected Run subcommand, got {:?}", other),
         }
@@ -160,11 +208,12 @@ mod tests {
         let cli = Cli::parse_from(["ensemble", "web"]);
         match cli.command {
             Some(Command::Web {
-                config_path,
+                config,
                 host: h,
                 port: p,
+                ..
             }) => {
-                assert_eq!(config_path, PathBuf::from("ensemble.yaml"));
+                assert_eq!(config.config_dir, None);
                 assert_eq!(h, "127.0.0.1");
                 assert_eq!(p, None);
             }
@@ -179,19 +228,21 @@ mod tests {
         let cli = Cli::parse_from([
             "ensemble",
             "web",
+            "--config-dir",
+            "/tmp/ensemble",
             "--host",
             "0.0.0.0",
             "--port",
             "8080",
-            "custom/ensemble.yaml",
         ]);
         match cli.command {
             Some(Command::Web {
-                config_path,
+                config,
                 host: h,
                 port: p,
+                ..
             }) => {
-                assert_eq!(config_path, PathBuf::from("custom/ensemble.yaml"));
+                assert_eq!(config.config_dir, Some(PathBuf::from("/tmp/ensemble")));
                 assert_eq!(h, "0.0.0.0");
                 assert_eq!(p, Some(8080));
             }
@@ -253,6 +304,55 @@ mod tests {
         restore_env(host, port);
     }
 
+    // ---- `ensemble open-config-dir` subcommand ----
+
+    #[test]
+    fn test_cli_parse_open_config_dir_subcommand() {
+        let (_guard, host, port) = lock_and_clear_env();
+        let cli = Cli::parse_from(["ensemble", "open-config-dir"]);
+        assert!(matches!(cli.command, Some(Command::OpenConfigDir { .. })));
+        restore_env(host, port);
+    }
+
+    #[test]
+    fn test_cli_parse_open_config_dir_with_config_dir() {
+        let (_guard, host, port) = lock_and_clear_env();
+        let cli = Cli::parse_from(["ensemble", "open-config-dir", "--config-dir", "/tmp/ensemble"]);
+        match cli.command {
+            Some(Command::OpenConfigDir { config }) => {
+                assert_eq!(config.config_dir, Some(PathBuf::from("/tmp/ensemble")));
+            }
+            other => panic!("expected OpenConfigDir subcommand, got {:?}", other),
+        }
+        restore_env(host, port);
+    }
+
+    // ---- legacy argument rejection ----
+
+    #[test]
+    fn test_cli_rejects_legacy_config_flag() {
+        let result = reject_legacy_config_overrides([
+            OsString::from("ensemble"),
+            OsString::from("run"),
+            OsString::from("--config"),
+            OsString::from("old.yaml"),
+        ].into_iter());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("--config-dir"));
+    }
+
+    #[test]
+    fn test_cli_rejects_legacy_short_config_flag() {
+        let result = reject_legacy_config_overrides([
+            OsString::from("ensemble"),
+            OsString::from("run"),
+            OsString::from("-c"),
+            OsString::from("old.yaml"),
+        ].into_iter());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("--config-dir"));
+    }
+
     // ---- no subcommand (default to headless run) ----
 
     #[test]
@@ -260,7 +360,6 @@ mod tests {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble"]);
         assert!(cli.command.is_none());
-        assert_eq!(cli.config_path, PathBuf::from("ensemble.yaml"));
         restore_env(host, port);
     }
 }

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -23,6 +23,9 @@ axum = { workspace = true }
 tower-http = { workspace = true }
 futures-util = { workspace = true }
 utoipa = { workspace = true }
+dirs = { workspace = true }
+dotenvy = { workspace = true }
+shellexpand = "3"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ensemble-core/src/api/config_handler.rs
+++ b/crates/ensemble-core/src/api/config_handler.rs
@@ -98,7 +98,7 @@ on_failure: Failed
             history_path: PathBuf::from("/tmp/history.jsonl"),
             event_bus: EventBus::new(),
             config: Arc::new(config),
-            config_path: "ensemble.yaml".to_string(),
+            config_path: "config.yaml".to_string(),
         }
     }
 
@@ -109,7 +109,7 @@ on_failure: Failed
         assert_eq!(status, StatusCode::OK);
         assert!(response.valid);
         assert!(response.errors.is_empty());
-        assert_eq!(response.config_path, "ensemble.yaml");
+        assert_eq!(response.config_path, "config.yaml");
         assert_eq!(response.config.tracker.kind, "todo_file");
     }
 

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -27,7 +27,7 @@ pub struct AppState {
     pub event_bus: EventBus,
     /// The loaded ensemble configuration.
     pub config: Arc<EnsembleConfig>,
-    /// Path to the ensemble.yaml config file.
+    /// Path to the config.yaml file.
     pub config_path: String,
 }
 

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -1,8 +1,9 @@
+use crate::config::location::default_todo_state_path;
 use crate::error::PipelineError;
 use crate::workspace::push_strategy::PushStrategy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Top-level configuration parsed from `ensemble.yaml`.
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
@@ -289,6 +290,17 @@ impl EnsembleConfig {
     /// - `agents.*.prompt_template`
     /// - `repos[*].path`
     pub fn resolve_env(&mut self) {
+        self.resolve_env_from(Path::new("."))
+            .expect("CWD should always be available");
+    }
+
+    /// Resolve environment variables and rebase relative paths from the config directory.
+    ///
+    /// This method:
+    /// 1. Resolves `$VAR` and `~` in all path fields
+    /// 2. Rebase relative paths to be relative to the config directory
+    /// 3. Sets default TODO path for todo_file tracker if not specified
+    pub fn resolve_env_from(&mut self, config_dir: &Path) -> Result<(), crate::error::ConfigError> {
         // tracker.api_key: $VAR resolution
         if let Some(ref raw) = self.tracker.api_key {
             self.tracker.api_key = resolve_env_var(raw);
@@ -297,44 +309,90 @@ impl EnsembleConfig {
             self.tracker.api_key = resolve_env_var("$GITHUB_TOKEN");
         }
 
-        // tracker.path: $VAR + ~ expansion
+        // tracker.path: $VAR + ~ expansion, with default for todo_file
+        if self.tracker.kind == "todo_file" && self.tracker.path.is_none() {
+            self.tracker.path = Some(default_todo_state_path()?);
+        }
+
         if let Some(ref path) = self.tracker.path {
             let path_str = path.to_string_lossy();
-            self.tracker.path = resolve_path(&path_str);
+            let resolved = resolve_path(&path_str);
+            self.tracker.path = resolved.map(|p| {
+                if p.is_absolute() {
+                    p
+                } else {
+                    config_dir.join(p)
+                }
+            });
         }
 
-        // workspace.root: $VAR + ~ expansion
+        // workspace.root: $VAR + ~ expansion + rebase
         if let Some(ref root) = self.workspace.root {
-            self.workspace.root = resolve_path(root).map(|p| p.to_string_lossy().into_owned());
+            let resolved = resolve_path(root);
+            self.workspace.root = resolved.map(|p| {
+                let final_path = if p.is_absolute() {
+                    p
+                } else {
+                    config_dir.join(p)
+                };
+                final_path.to_string_lossy().into_owned()
+            });
         }
 
-        // repos[*].path: $VAR + ~ expansion
+        // repos[*].path: $VAR + ~ expansion + rebase
         for repo in &mut self.repos {
             let path_str = &repo.path;
             if let Some(resolved) = resolve_path(path_str) {
-                repo.path = resolved.to_string_lossy().into_owned();
+                let final_path = if resolved.is_absolute() {
+                    resolved
+                } else {
+                    config_dir.join(resolved)
+                };
+                repo.path = final_path.to_string_lossy().into_owned();
             }
         }
 
-        // agents.*.prompt_template: $VAR + ~ expansion
+        // agents.*.prompt_template: $VAR + ~ expansion + rebase
         for agent in self.agents.values_mut() {
             if let Some(ref path) = agent.prompt_template {
                 let path_str = path.to_string_lossy();
-                agent.prompt_template = resolve_path(&path_str);
+                let resolved = resolve_path(&path_str);
+                agent.prompt_template = resolved.map(|p| {
+                    if p.is_absolute() {
+                        p
+                    } else {
+                        config_dir.join(p)
+                    }
+                });
             }
         }
+
+        Ok(())
     }
 }
 
-/// Load and parse an `ensemble.yaml` file from the given path.
+/// Load and parse a `config.yaml` file from the given path.
+///
+/// This function:
+/// 1. Loads `.env` from the config directory (if present) before expanding variables
+/// 2. Reads and parses the YAML file
+/// 3. Resolves environment variables and rebases relative paths from the config directory
 pub fn load_config(path: &std::path::Path) -> Result<EnsembleConfig, crate::error::ConfigError> {
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+
+    // Load .env from config directory (best-effort, don't fail if missing)
+    let env_path = config_dir.join(".env");
+    if env_path.exists() {
+        let _ = dotenvy::from_path(&env_path);
+    }
+
     let content = std::fs::read_to_string(path).map_err(|_| {
         crate::error::ConfigError::MissingConfigFile {
             path: path.display().to_string(),
         }
     })?;
     let mut config = parse_config(&content)?;
-    config.resolve_env();
+    config.resolve_env_from(config_dir)?;
     Ok(config)
 }
 
@@ -962,5 +1020,112 @@ on_failure: Failed
         config.resolve_env();
         let home = std::env::var("HOME").unwrap();
         assert_eq!(config.repos[0].path, format!("{}/projects/myrepo", home));
+    }
+
+    #[test]
+    fn test_load_config_rebases_relative_paths_from_config_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("templates")).unwrap();
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            r#"
+tracker:
+  kind: todo_file
+repos:
+  - path: repos/app
+    branch: main
+agents:
+  builder:
+    acpx_agent: claude
+    prompt_template: templates/implement.liquid
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+workspace:
+  root: workspaces
+"#,
+        )
+        .unwrap();
+
+        let config = load_config(&dir.path().join("config.yaml")).unwrap();
+        assert_eq!(
+            config.agents["builder"].prompt_template.as_deref(),
+            Some(dir.path().join("templates/implement.liquid").as_path())
+        );
+        assert_eq!(
+            config.repos[0].path,
+            dir.path().join("repos/app").display().to_string()
+        );
+        assert_eq!(
+            config.workspace.root.as_deref(),
+            Some(dir.path().join("workspaces").display().to_string().as_str())
+        );
+    }
+
+    #[test]
+    fn test_load_config_defaults_todo_tracker_path_to_home_state_path() {
+        let dir = tempfile::tempdir().unwrap();
+        // Write a minimal config without tracker.path
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        let config = load_config(&dir.path().join("config.yaml")).unwrap();
+        assert!(config
+            .tracker
+            .path
+            .as_ref()
+            .unwrap()
+            .to_string_lossy()
+            .contains("ensemble/TODO.md"));
+    }
+
+    #[test]
+    fn test_load_config_loads_sibling_dotenv_without_overriding_existing_env() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "GITHUB_TOKEN=from-dotenv\n").unwrap();
+        std::env::set_var("GITHUB_TOKEN", "from-process");
+
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            r#"
+tracker:
+  kind: github
+  repository: acme/repo
+  api_key: $GITHUB_TOKEN
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        let config = load_config(&dir.path().join("config.yaml")).unwrap();
+        // Process env var should take precedence over .env
+        assert_eq!(config.tracker.api_key.as_deref(), Some("from-process"));
+
+        std::env::remove_var("GITHUB_TOKEN");
     }
 }

--- a/crates/ensemble-core/src/config/location.rs
+++ b/crates/ensemble-core/src/config/location.rs
@@ -1,0 +1,211 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use crate::error::ConfigError;
+
+#[derive(Debug)]
+pub struct ResolvedConfigDir {
+    pub config_dir: PathBuf,
+    pub config_path: PathBuf,
+}
+
+pub fn config_path_for_dir(config_dir: &Path) -> PathBuf {
+    config_dir.join("config.yaml")
+}
+
+pub fn resolve_config_dir_for_cli(
+    cli_override: Option<&Path>,
+    env_override: Option<OsString>,
+    cwd: &Path,
+) -> Result<ResolvedConfigDir, ConfigError> {
+    let config_dir = if let Some(cli) = cli_override {
+        let expanded = expand_override_path(cli)?;
+        cwd.join(expanded)
+    } else if let Some(env) = env_override {
+        let env_path = PathBuf::from(env);
+        let expanded = expand_override_path(&env_path)?;
+        cwd.join(expanded)
+    } else {
+        default_config_dir()?
+    };
+
+    validate_config_dir_target(&config_dir)?;
+    let config_path = config_path_for_dir(&config_dir);
+
+    Ok(ResolvedConfigDir {
+        config_dir,
+        config_path,
+    })
+}
+
+pub fn resolve_config_dir_for_desktop(
+    env_override: Option<OsString>,
+) -> Result<ResolvedConfigDir, ConfigError> {
+    let config_dir = if let Some(env) = env_override {
+        let env_path = PathBuf::from(env);
+        // Desktop rejects relative paths
+        if !env_path.is_absolute() {
+            return Err(ConfigError::RelativeDesktopOverride {
+                path: env_path.display().to_string(),
+            });
+        }
+        let expanded = expand_override_path(&env_path)?;
+        expanded
+    } else {
+        default_config_dir()?
+    };
+
+    validate_config_dir_target(&config_dir)?;
+    let config_path = config_path_for_dir(&config_dir);
+
+    Ok(ResolvedConfigDir {
+        config_dir,
+        config_path,
+    })
+}
+
+pub fn default_config_dir() -> Result<PathBuf, ConfigError> {
+    dirs::config_dir()
+        .map(|d| d.join("ensemble"))
+        .ok_or(ConfigError::ConfigDirUnavailable)
+}
+
+pub fn default_config_dir_from(config_dir: Option<PathBuf>) -> Result<PathBuf, ConfigError> {
+    match config_dir {
+        Some(dir) => Ok(dir),
+        None => default_config_dir(),
+    }
+}
+
+pub fn default_todo_state_path() -> Result<PathBuf, ConfigError> {
+    let home = dirs::home_dir().ok_or(ConfigError::HomeDirUnavailable)?;
+    Ok(default_todo_state_path_from_home(&home))
+}
+
+pub fn default_todo_state_path_from_home(home: &Path) -> PathBuf {
+    home.join("ensemble").join("TODO.md")
+}
+
+pub fn default_todo_state_path_from_optional_home(
+    home: Option<&Path>,
+) -> Result<PathBuf, ConfigError> {
+    match home {
+        Some(h) => Ok(default_todo_state_path_from_home(h)),
+        None => Err(ConfigError::HomeDirUnavailable),
+    }
+}
+
+fn validate_config_dir_target(path: &Path) -> Result<(), ConfigError> {
+    if path.exists() && !path.is_dir() {
+        return Err(ConfigError::NotADirectory {
+            path: path.display().to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn expand_override_path(path: &Path) -> Result<PathBuf, ConfigError> {
+    let path_str = path.to_string_lossy();
+
+    // Expand environment variables first
+    let expanded = if path_str.contains('$') {
+        shellexpand::env(&path_str)
+            .map_err(|e| ConfigError::PathExpansionError {
+                path: path_str.to_string(),
+                reason: e.to_string(),
+            })?
+            .to_string()
+    } else {
+        path_str.to_string()
+    };
+
+    // Expand tilde
+    let expanded = shellexpand::tilde(&expanded).to_string();
+
+    Ok(PathBuf::from(expanded))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_path_for_dir_appends_config_yaml() {
+        let dir = PathBuf::from("/tmp/ensemble-config");
+        assert_eq!(config_path_for_dir(&dir), dir.join("config.yaml"));
+    }
+
+    #[test]
+    fn test_resolve_cli_config_dir_allows_relative_override() {
+        let cwd = Path::new("/tmp/project");
+        let resolved =
+            resolve_config_dir_for_cli(Some(Path::new("configs/dev")), None, cwd).unwrap();
+        assert_eq!(resolved.config_dir, cwd.join("configs/dev"));
+    }
+
+    #[test]
+    fn test_resolve_desktop_config_dir_rejects_relative_env_override() {
+        let err = resolve_config_dir_for_desktop(Some(OsString::from("configs/dev"))).unwrap_err();
+        assert!(err.to_string().contains("relative"));
+    }
+
+    #[test]
+    fn test_default_todo_state_path_uses_home_ensemble_directory() {
+        let home = Path::new("/tmp/home");
+        assert_eq!(
+            default_todo_state_path_from_home(home),
+            home.join("ensemble").join("TODO.md")
+        );
+    }
+
+    #[test]
+    fn test_resolve_cli_config_dir_prefers_flag_over_env() {
+        let cwd = Path::new("/tmp/project");
+        let resolved = resolve_config_dir_for_cli(
+            Some(Path::new("flag-dir")),
+            Some(OsString::from("env-dir")),
+            cwd,
+        )
+        .unwrap();
+        assert_eq!(resolved.config_dir, cwd.join("flag-dir"));
+    }
+
+    #[test]
+    fn test_resolve_cli_config_dir_uses_env_when_flag_missing() {
+        let cwd = Path::new("/tmp/project");
+        let resolved =
+            resolve_config_dir_for_cli(None, Some(OsString::from("env-dir")), cwd).unwrap();
+        assert_eq!(resolved.config_dir, cwd.join("env-dir"));
+    }
+
+    #[test]
+    fn test_resolve_config_dir_rejects_existing_file_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("not-a-dir");
+        std::fs::write(&file_path, "x").unwrap();
+        let err = validate_config_dir_target(&file_path).unwrap_err();
+        assert!(err.to_string().contains("directory"));
+    }
+
+    #[test]
+    fn test_expand_override_supports_tilde() {
+        let home = dirs::home_dir().unwrap();
+        let resolved = expand_override_path(Path::new("~/ensemble")).unwrap();
+        assert_eq!(resolved, home.join("ensemble"));
+    }
+
+    #[test]
+    fn test_default_resolution_errors_when_config_dir_is_unavailable() {
+        // This test verifies the error variant exists and is returned
+        // We can't easily mock dirs::config_dir() returning None in a test,
+        // but we can verify the error variant message
+        let err = ConfigError::ConfigDirUnavailable;
+        assert!(err.to_string().contains("config directory"));
+    }
+
+    #[test]
+    fn test_default_todo_state_path_errors_without_home_dir() {
+        let err = default_todo_state_path_from_optional_home(None).unwrap_err();
+        assert!(err.to_string().contains("home"));
+    }
+}

--- a/crates/ensemble-core/src/config/location.rs
+++ b/crates/ensemble-core/src/config/location.rs
@@ -43,13 +43,14 @@ pub fn resolve_config_dir_for_desktop(
 ) -> Result<ResolvedConfigDir, ConfigError> {
     let config_dir = if let Some(env) = env_override {
         let env_path = PathBuf::from(env);
+        let expanded = expand_override_path(&env_path)?;
         // Desktop rejects relative paths
-        if !env_path.is_absolute() {
+        if !expanded.is_absolute() {
             return Err(ConfigError::RelativeDesktopOverride {
-                path: env_path.display().to_string(),
+                path: expanded.display().to_string(),
             });
         }
-        expand_override_path(&env_path)?
+        expanded
     } else {
         default_config_dir()?
     };
@@ -146,6 +147,33 @@ mod tests {
     fn test_resolve_desktop_config_dir_rejects_relative_env_override() {
         let err = resolve_config_dir_for_desktop(Some(OsString::from("configs/dev"))).unwrap_err();
         assert!(err.to_string().contains("relative"));
+    }
+
+    #[test]
+    fn test_resolve_desktop_config_dir_expands_tilde_override() {
+        let home = dirs::home_dir().unwrap();
+        let resolved =
+            resolve_config_dir_for_desktop(Some(OsString::from("~/ensemble-config"))).unwrap();
+        assert_eq!(resolved.config_dir, home.join("ensemble-config"));
+        assert_eq!(
+            resolved.config_path,
+            home.join("ensemble-config").join("config.yaml")
+        );
+    }
+
+    #[test]
+    fn test_resolve_desktop_config_dir_expands_env_override() {
+        std::env::set_var("ENSEMBLE_TEST_DESKTOP_CONFIG_DIR", "/tmp/desktop-config");
+        let resolved = resolve_config_dir_for_desktop(Some(OsString::from(
+            "$ENSEMBLE_TEST_DESKTOP_CONFIG_DIR",
+        )))
+        .unwrap();
+        assert_eq!(resolved.config_dir, PathBuf::from("/tmp/desktop-config"));
+        assert_eq!(
+            resolved.config_path,
+            PathBuf::from("/tmp/desktop-config/config.yaml")
+        );
+        std::env::remove_var("ENSEMBLE_TEST_DESKTOP_CONFIG_DIR");
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/location.rs
+++ b/crates/ensemble-core/src/config/location.rs
@@ -49,8 +49,7 @@ pub fn resolve_config_dir_for_desktop(
                 path: env_path.display().to_string(),
             });
         }
-        let expanded = expand_override_path(&env_path)?;
-        expanded
+        expand_override_path(&env_path)?
     } else {
         default_config_dir()?
     };

--- a/crates/ensemble-core/src/config/mod.rs
+++ b/crates/ensemble-core/src/config/mod.rs
@@ -1,4 +1,5 @@
 pub mod ensemble;
+pub mod location;
 pub mod template;
 
 pub use crate::workspace::push_strategy::PushStrategy;

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -26,6 +26,16 @@ pub enum ConfigError {
     TemplateParseError { reason: String },
     #[error("template render error: {reason}")]
     TemplateRenderError { reason: String },
+    #[error("config directory unavailable")]
+    ConfigDirUnavailable,
+    #[error("home directory unavailable")]
+    HomeDirUnavailable,
+    #[error("relative path not allowed for desktop ENSEMBLE_CONFIG_DIR: {path}")]
+    RelativeDesktopOverride { path: String },
+    #[error("config directory path must be a directory, not a file: {path}")]
+    NotADirectory { path: String },
+    #[error("path expansion failed for '{path}': {reason}")]
+    PathExpansionError { path: String, reason: String },
 }
 
 #[derive(Debug, Error)]

--- a/crates/ensemble-core/src/tracker/mod.rs
+++ b/crates/ensemble-core/src/tracker/mod.rs
@@ -16,6 +16,10 @@ pub enum TrackerError {
     MissingApiKey,
     #[error("missing tracker repository")]
     MissingRepository,
+    #[error("missing tracker path for todo_file kind")]
+    MissingPath,
+    #[error("TODO file parent directory does not exist: {path}")]
+    MissingParentDirectory { path: String },
     #[error("I/O error: {reason}")]
     IoError { reason: String },
     #[error("GitHub API request failed: {reason}")]
@@ -77,11 +81,23 @@ pub trait IssueTracker: Send + Sync {
 pub fn create_tracker(config: &TrackerConfig) -> Result<Box<dyn IssueTracker>, TrackerError> {
     match config.kind.as_str() {
         "todo_file" => {
+            let path = config
+                .path
+                .as_ref()
+                .ok_or(TrackerError::MissingPath)?
+                .clone();
+            
+            // Validate parent directory exists for runtime safety
+            if let Some(parent) = path.parent() {
+                if !parent.exists() {
+                    return Err(TrackerError::MissingParentDirectory {
+                        path: parent.display().to_string(),
+                    });
+                }
+            }
+            
             let tracker = todo_file::TodoFileTracker::new(
-                config
-                    .path
-                    .clone()
-                    .unwrap_or_else(|| PathBuf::from("TODO.md")),
+                path,
                 config.active_states.clone(),
             );
             Ok(Box::new(tracker))
@@ -150,10 +166,37 @@ mod tests {
     #[test]
     fn test_create_todo_file_tracker() {
         let dir = TempDir::new().unwrap();
-        let config = todo_file_config(dir.path().join("TODO.md"));
+        let todo_path = dir.path().join("TODO.md");
+        // Ensure parent exists
+        let config = todo_file_config(todo_path.clone());
 
         let tracker = create_tracker(&config);
         assert!(tracker.is_ok());
+    }
+
+    #[test]
+    fn test_create_todo_file_tracker_missing_parent_directory() {
+        let missing_parent = PathBuf::from("/definitely/missing/dir/TODO.md");
+        let config = todo_file_config(missing_parent);
+        let result = create_tracker(&config);
+        assert!(matches!(result, Err(TrackerError::MissingParentDirectory { .. })));
+    }
+
+    #[test]
+    fn test_create_todo_file_tracker_missing_path() {
+        let config = TrackerConfig {
+            kind: "todo_file".to_string(),
+            active_states: vec!["Todo".to_string()],
+            terminal_states: vec!["Done".to_string()],
+            path: None,
+            endpoint: None,
+            api_key: None,
+            repository: None,
+            project_number: None,
+            labels_filter: vec![],
+        };
+        let result = create_tracker(&config);
+        assert!(matches!(result, Err(TrackerError::MissingPath)));
     }
 
     #[test]

--- a/crates/ensemble-core/src/tracker/mod.rs
+++ b/crates/ensemble-core/src/tracker/mod.rs
@@ -5,7 +5,6 @@ pub mod todo_file;
 use crate::config::ensemble::TrackerConfig;
 use async_trait::async_trait;
 use model::Issue;
-use std::path::PathBuf;
 
 /// Error type for tracker operations.
 #[derive(Debug, thiserror::Error)]
@@ -86,7 +85,7 @@ pub fn create_tracker(config: &TrackerConfig) -> Result<Box<dyn IssueTracker>, T
                 .as_ref()
                 .ok_or(TrackerError::MissingPath)?
                 .clone();
-            
+
             // Validate parent directory exists for runtime safety
             if let Some(parent) = path.parent() {
                 if !parent.exists() {
@@ -95,11 +94,8 @@ pub fn create_tracker(config: &TrackerConfig) -> Result<Box<dyn IssueTracker>, T
                     });
                 }
             }
-            
-            let tracker = todo_file::TodoFileTracker::new(
-                path,
-                config.active_states.clone(),
-            );
+
+            let tracker = todo_file::TodoFileTracker::new(path, config.active_states.clone());
             Ok(Box::new(tracker))
         }
         "github" => {
@@ -133,6 +129,7 @@ pub fn create_tracker(config: &TrackerConfig) -> Result<Box<dyn IssueTracker>, T
 mod tests {
     use super::*;
     use crate::config::ensemble::TrackerConfig;
+    use std::path::PathBuf;
     use tempfile::TempDir;
 
     fn todo_file_config(path: PathBuf) -> TrackerConfig {
@@ -179,7 +176,10 @@ mod tests {
         let missing_parent = PathBuf::from("/definitely/missing/dir/TODO.md");
         let config = todo_file_config(missing_parent);
         let result = create_tracker(&config);
-        assert!(matches!(result, Err(TrackerError::MissingParentDirectory { .. })));
+        assert!(matches!(
+            result,
+            Err(TrackerError::MissingParentDirectory { .. })
+        ));
     }
 
     #[test]

--- a/crates/ensemble-desktop/src/main.rs
+++ b/crates/ensemble-desktop/src/main.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use std::path::PathBuf;
 use tauri::Manager;
 use tracing::{error, info};
 
@@ -23,7 +22,9 @@ fn main() {
 
     // Reject legacy ENSEMBLE_CONFIG env var
     if std::env::var_os("ENSEMBLE_CONFIG").is_some() {
-        eprintln!("Error: ENSEMBLE_CONFIG is no longer supported. Use ENSEMBLE_CONFIG_DIR instead.");
+        eprintln!(
+            "Error: ENSEMBLE_CONFIG is no longer supported. Use ENSEMBLE_CONFIG_DIR instead."
+        );
         eprintln!("example: ENSEMBLE_CONFIG_DIR=/path/to/config ensemble-desktop");
         std::process::exit(1);
     }
@@ -127,11 +128,7 @@ fn show_config_missing_dialog(message: &str) {
                     .args(["--error", message, "--title=Ensemble"])
                     .output()
             })
-            .or_else(|_| {
-                Command::new("xmessage")
-                    .args(["-center", message])
-                    .output()
-            });
+            .or_else(|_| Command::new("xmessage").args(["-center", message]).output());
     }
 
     #[cfg(target_os = "windows")]

--- a/crates/ensemble-desktop/src/main.rs
+++ b/crates/ensemble-desktop/src/main.rs
@@ -9,6 +9,7 @@ mod embedded_ui;
 mod orchestrator;
 
 use embedded_ui::{resolve_path, spa_available};
+use ensemble_core::config::location::resolve_config_dir_for_desktop;
 use orchestrator::{get_state, trigger_refresh, DesktopOrchestrator};
 
 fn main() {
@@ -20,28 +21,38 @@ fn main() {
         eprintln!("Build with: cd ../ensemble-ui/src-ui && pnpm run build");
     }
 
-    let config_path = resolve_config_path();
-    if !config_path.exists() {
-        eprintln!("Error: Config file not found: {}", config_path.display());
-        eprintln!("Please create an ensemble.yaml file or run ensemble init to generate one.");
+    // Reject legacy ENSEMBLE_CONFIG env var
+    if std::env::var_os("ENSEMBLE_CONFIG").is_some() {
+        eprintln!("Error: ENSEMBLE_CONFIG is no longer supported. Use ENSEMBLE_CONFIG_DIR instead.");
+        eprintln!("example: ENSEMBLE_CONFIG_DIR=/path/to/config ensemble-desktop");
+        std::process::exit(1);
+    }
+
+    let resolved = match resolve_config_dir_for_desktop(std::env::var_os("ENSEMBLE_CONFIG_DIR")) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Error: Failed to resolve config directory: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    if !resolved.config_path.exists() {
+        let message = format_missing_config_message(&resolved.config_path);
+        eprintln!("Error: {}", message);
 
         if should_show_config_missing_dialog() {
             #[cfg(not(test))]
-            show_config_missing_dialog(&config_path);
+            show_config_missing_dialog(&message);
         }
 
         std::process::exit(1);
     }
 
-    let config_path = normalize_config_path(config_path);
-    if let Err(error) = change_to_config_directory(&config_path) {
-        eprintln!(
-            "Error: Failed to switch to config directory for {}: {}",
-            config_path.display(),
-            error
-        );
-        std::process::exit(1);
-    }
+    info!(
+        config_dir = %resolved.config_dir.display(),
+        config_path = %resolved.config_path.display(),
+        "Resolved configuration paths"
+    );
 
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
@@ -52,7 +63,7 @@ fn main() {
         .setup(|app| {
             let rt = tokio::runtime::Runtime::new().unwrap();
             let orchestrator =
-                rt.block_on(async { DesktopOrchestrator::new(config_path).await })?;
+                rt.block_on(async { DesktopOrchestrator::new(resolved.config_path).await })?;
 
             app.manage(orchestrator);
 
@@ -71,21 +82,11 @@ fn main() {
         .expect("error while running tauri application");
 }
 
-fn resolve_config_path() -> PathBuf {
-    std::env::var_os("ENSEMBLE_CONFIG")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("ensemble.yaml"))
-}
-
-fn normalize_config_path(config_path: PathBuf) -> PathBuf {
-    std::fs::canonicalize(&config_path).unwrap_or(config_path)
-}
-
-fn change_to_config_directory(config_path: &std::path::Path) -> std::io::Result<()> {
-    let config_dir = config_path
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("."));
-    std::env::set_current_dir(config_dir)
+fn format_missing_config_message(config_path: &std::path::Path) -> String {
+    format!(
+        "Configuration file not found: {}. Please run `ensemble init` to create a configuration directory, or set ENSEMBLE_CONFIG_DIR to an existing directory containing config.yaml.",
+        config_path.display()
+    )
 }
 
 fn should_show_config_missing_dialog() -> bool {
@@ -96,12 +97,7 @@ fn should_show_config_missing_dialog() -> bool {
 }
 
 #[cfg(not(test))]
-fn show_config_missing_dialog(config_path: &std::path::Path) {
-    let message = format!(
-        "Configuration file not found: {}. Please create an ensemble.yaml file or run ensemble init to generate one.",
-        config_path.display()
-    );
-
+fn show_config_missing_dialog(message: &str) {
     #[cfg(target_os = "macos")]
     {
         use std::process::Command;
@@ -128,12 +124,12 @@ fn show_config_missing_dialog(config_path: &std::path::Path) {
             .output()
             .or_else(|_| {
                 Command::new("kdialog")
-                    .args(["--error", &message, "--title=Ensemble"])
+                    .args(["--error", message, "--title=Ensemble"])
                     .output()
             })
             .or_else(|_| {
                 Command::new("xmessage")
-                    .args(["-center", &message])
+                    .args(["-center", message])
                     .output()
             });
     }
@@ -141,7 +137,7 @@ fn show_config_missing_dialog(config_path: &std::path::Path) {
     #[cfg(target_os = "windows")]
     {
         use std::process::Command;
-        let _ = Command::new("msg").args(["*", &message]).output();
+        let _ = Command::new("msg").args(["*", message]).output();
     }
 }
 
@@ -157,7 +153,7 @@ fn serve_ui_file(path: String) -> Result<serde_json::Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{resolve_config_path, should_show_config_missing_dialog};
+    use crate::{format_missing_config_message, should_show_config_missing_dialog};
     use std::path::{Path, PathBuf};
     use std::sync::{Mutex, OnceLock};
 
@@ -208,49 +204,12 @@ mod tests {
     }
 
     #[test]
-    fn resolve_config_path_defaults_to_workspace_file() {
-        let _guard = env_lock().lock().unwrap();
-        let env_value = std::env::var_os("ENSEMBLE_CONFIG");
-        std::env::remove_var("ENSEMBLE_CONFIG");
-
-        let resolved = resolve_config_path();
-
-        restore_env("ENSEMBLE_CONFIG", env_value);
-        assert_eq!(resolved, PathBuf::from("ensemble.yaml"));
-    }
-
-    #[test]
-    fn resolve_config_path_prefers_env_override() {
-        let _guard = env_lock().lock().unwrap();
-        let env_value = std::env::var_os("ENSEMBLE_CONFIG");
-        let override_path = PathBuf::from("custom/ensemble.yaml");
-        std::env::set_var("ENSEMBLE_CONFIG", &override_path);
-
-        let resolved = resolve_config_path();
-
-        restore_env("ENSEMBLE_CONFIG", env_value);
-        assert_eq!(resolved, override_path);
-    }
-
-    #[tokio::test]
-    async fn orchestrator_module_loads() {
-        use crate::orchestrator::DesktopOrchestrator;
-        let _ = DesktopOrchestrator::new;
-        fn check_clone<T: Clone>() {}
-        check_clone::<DesktopOrchestrator>();
-    }
-
-    #[test]
-    fn resolve_config_path_returns_relative_override_unchanged() {
-        let _guard = env_lock().lock().unwrap();
-        let env_value = std::env::var_os("ENSEMBLE_CONFIG");
-        let override_path = PathBuf::from("configs/dev/ensemble.yaml");
-        std::env::set_var("ENSEMBLE_CONFIG", &override_path);
-
-        let resolved = resolve_config_path();
-
-        restore_env("ENSEMBLE_CONFIG", env_value);
-        assert_eq!(resolved, override_path);
+    fn missing_config_message_mentions_resolved_config_yaml_path() {
+        let config_path = PathBuf::from("/tmp/ensemble/config.yaml");
+        let message = format_missing_config_message(&config_path);
+        assert!(message.contains("/tmp/ensemble/config.yaml"));
+        assert!(message.contains("ensemble init"));
+        assert!(message.contains("ENSEMBLE_CONFIG_DIR"));
     }
 
     #[test]

--- a/crates/ensemble-desktop/src/orchestrator.rs
+++ b/crates/ensemble-desktop/src/orchestrator.rs
@@ -20,7 +20,7 @@ pub struct DesktopOrchestrator {
 impl DesktopOrchestrator {
     /// Initialize the orchestrator from config
     pub async fn new(config_path: PathBuf) -> Result<Self, String> {
-        info!(config_path = %config_path.display(), "Initializing desktop orchestrator");
+        info!(config_path = %config_path.display(), "Initializing desktop orchestrator from config.yaml");
 
         // Load config
         let config =
@@ -32,7 +32,7 @@ impl DesktopOrchestrator {
 
         info!(
             tracker_kind = %config.tracker.kind,
-            "Orchestrator config loaded"
+            "Orchestrator config loaded from config.yaml"
         );
 
         let state = Arc::new(RwLock::new(OrchestratorState::new(

--- a/crates/ensemble-desktop/tests/e2e.rs
+++ b/crates/ensemble-desktop/tests/e2e.rs
@@ -96,9 +96,9 @@ fn app_launches_without_crash() {
 
     println!("Launching app binary: {}", binary_path.display());
 
-    // Create a minimal ensemble.yaml config file in a temp directory
+    // Create a minimal config directory with config.yaml
     let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-    let config_path = temp_dir.path().join("ensemble.yaml");
+    let config_path = temp_dir.path().join("config.yaml");
     let minimal_config = r#"
 tracker:
   kind: todo_file
@@ -121,7 +121,7 @@ on_failure: "Failed"
 
     let mut child = Command::new(&binary_path)
         .current_dir(workspace_root)
-        .env("ENSEMBLE_CONFIG", &config_path)
+        .env("ENSEMBLE_CONFIG_DIR", temp_dir.path())
         .env("TAURI_WEBVIEW_AUTOMATION", "1")
         .env("RUST_BACKTRACE", "1")
         .stdout(Stdio::piped())
@@ -178,11 +178,10 @@ fn app_shows_error_when_config_missing() {
     let possible_paths = candidate_binary_paths(manifest_dir, workspace_root);
     let binary_path = resolve_binary_path(&possible_paths).expect("App binary not found");
     let missing_config_dir = tempfile::tempdir().expect("Failed to create temp dir");
-    let missing_config = missing_config_dir.path().join("missing-ensemble.yaml");
 
     let mut child = Command::new(&binary_path)
         .current_dir(workspace_root)
-        .env("ENSEMBLE_CONFIG", &missing_config)
+        .env("ENSEMBLE_CONFIG_DIR", missing_config_dir.path())
         .env("ENSEMBLE_SUPPRESS_CONFIG_DIALOG", "1")
         .env("RUST_BACKTRACE", "1")
         .stdout(Stdio::piped())
@@ -211,8 +210,8 @@ fn app_shows_error_when_config_missing() {
 
     let combined_output = format!("{} {}", stdout, stderr);
     assert!(
-        combined_output.contains("Config file not found")
-            || combined_output.contains("ensemble.yaml"),
+        combined_output.contains("Configuration file not found")
+            || combined_output.contains("config.yaml"),
         "App should show helpful error message about missing config. Got:\n{}",
         combined_output
     );

--- a/crates/ensemble-desktop/tests/e2e.rs
+++ b/crates/ensemble-desktop/tests/e2e.rs
@@ -102,7 +102,7 @@ fn app_launches_without_crash() {
     let minimal_config = r#"
 tracker:
   kind: todo_file
-  file: issues.json
+  path: TODO.md
 agents:
   coder:
     model: claude-sonnet-4-20250514
@@ -111,7 +111,6 @@ agents:
 steps:
   - name: build
     agent: coder
-    prompt: "Build the code"
 on_success: "Done"
 on_failure: "Failed"
 "#;

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -344,31 +344,39 @@ Fields:
 - `Session ID`
   - Use the `sessionId` returned by the ACP `session/new` response.
 
-## 5. Configuration Specification (Repository Contract)
+## 5. Configuration Specification (Config-Directory Contract)
 
-### 5.1 File Discovery and Path Resolution
+### 5.1 Config Directory Discovery and Resolution
 
-Config file path precedence:
+Config directory path precedence:
 
-1. Explicit application/runtime setting (set by CLI startup path).
-2. Default: `ensemble.yaml` in the current process working directory.
+1. `--config-dir` CLI flag (highest priority).
+2. `ENSEMBLE_CONFIG_DIR` environment variable.
+3. Default: platform-specific config directory:
+   - Linux: `~/.config/ensemble/`
+   - macOS: `~/Library/Application Support/ensemble/`
+   - Windows: `%APPDATA%\ensemble\`
 
 Loader behavior:
 
-- If the file cannot be read, return `missing_config_file` error.
-- The config file is expected to be repository-owned and version-controlled.
+- The configuration file is always named `config.yaml` and lives in the resolved config directory.
+- If the directory or `config.yaml` cannot be read, return `missing_config_file` error.
+- Relative paths in `config.yaml` are resolved relative to the config directory.
+- A `.env` file in the config directory is auto-loaded before `$VAR` expansion.
+
+**Legacy note:** The old `ENSEMBLE_CONFIG` environment variable is no longer supported. Use `ENSEMBLE_CONFIG_DIR` instead.
 
 ### 5.2 File Format
 
-`ensemble.yaml` is a YAML file containing all pipeline configuration: tracker settings, agent
+`config.yaml` is a YAML file containing all pipeline configuration: tracker settings, agent
 definitions, step DAG, concurrency limits, and prompt references.
 
 Design note:
 
-- `ensemble.yaml` should be self-contained enough to describe and run different workflows (agent
+- `config.yaml` should be self-contained enough to describe and run different workflows (agent
   definitions, step pipeline, runtime settings, hooks, and tracker selection/config) without
   requiring out-of-band service-specific configuration.
-- Prompt templates are referenced by file path or defined inline within agent definitions.
+- Prompt templates are referenced by file path relative to the config directory or defined inline within agent definitions.
 
 Parsing rules:
 
@@ -427,7 +435,7 @@ Fields:
 
 - `path` (string, optional)
   - Path to the todo file.
-  - Default: `TODO.md` in the current process working directory.
+  - Default: `~/ensemble/TODO.md` (in the `ensemble` directory in the user's home folder).
   - Supports `~` and `$VAR` expansion.
 - `active_states` / `terminal_states`
   - Headings in the todo file are matched against these state lists (case-insensitive).
@@ -503,6 +511,7 @@ Fields:
 - `path` (string)
   - Required. Local filesystem path for the repository.
   - Supports `~` and `$VAR` expansion.
+  - Relative paths are resolved from the configuration directory.
 - `branch` (string)
   - Required. Target branch for pull requests and upstream merges.
 
@@ -510,9 +519,9 @@ Example:
 
 ```yaml
 repos:
-  - path: /home/dev/frontend
+  - path: repos/frontend     # Relative to config directory
     branch: main
-  - path: /home/dev/api
+  - path: /home/dev/api       # Absolute path
     branch: develop
 ```
 
@@ -533,11 +542,12 @@ Named agent definitions. Each key is the agent role name, each value is an objec
 - `reasoning_level` (string, optional)
   - Reasoning/thinking level for agents that support it (for example `high`, `low`).
   - When omitted, the agent uses its default reasoning level.
-  - Currently set manually in `ensemble.yaml`; reserved for future tooling that may auto-detect supported reasoning levels.
+  - Currently set manually in `config.yaml`; reserved for future tooling that may auto-detect supported reasoning levels.
 - `prompt` (string, optional)
   - Inline prompt text. Mutually exclusive with `prompt_template`.
 - `prompt_template` (path string, optional)
-  - Path to a Markdown prompt template file. Supports `~` and `$VAR` expansion.
+  - Path to a Markdown prompt template file, relative to the configuration directory.
+  - Supports `~` and `$VAR` expansion.
   - Mutually exclusive with `prompt`.
 - Exactly one of `prompt` or `prompt_template` must be set.
 
@@ -711,30 +721,43 @@ Dispatch gating behavior:
 - DAG validation errors block dispatch at startup.
 - Template errors fail only the affected run attempt.
 
-## 6. Configuration Specification
+## 6. Configuration Loading and Resolution Semantics
 
 ### 6.1 Source Precedence and Resolution Semantics
 
-Configuration precedence:
+Config directory precedence:
 
-1. Config file path selection (runtime setting -> cwd default `ensemble.yaml`).
-2. YAML config values.
-3. Environment indirection via `$VAR_NAME` inside selected YAML values.
-4. Built-in defaults.
+1. `--config-dir <path>` CLI flag (highest priority).
+2. `ENSEMBLE_CONFIG_DIR` environment variable.
+3. Platform-specific default config directory (lowest priority).
+
+The configuration file is always `<config_dir>/config.yaml`.
 
 Value coercion semantics:
 
 - Path/command fields support:
   - `~` home expansion
   - `$VAR` expansion for env-backed path values
+  - Relative paths are resolved from the config directory
   - Apply expansion only to values intended to be local filesystem paths; do not rewrite URIs or
     arbitrary shell command strings.
 
-### 6.2 Dynamic Reload Semantics
+**Legacy migration:** The old `ENSEMBLE_CONFIG` environment variable and `--config` flag are no longer supported. Use `ENSEMBLE_CONFIG_DIR` and `--config-dir` instead.
+
+### 6.2 Environment Variable Loading
+
+Before expanding `$VAR` references in the configuration, Ensemble loads environment variables from:
+
+1. The process environment (highest priority)
+2. A `.env` file in the config directory (if present)
+
+This means variables in the process environment take precedence over those in `.env`. The `.env` file is loaded automatically—no manual `source .env` is required.
+
+### 6.3 Dynamic Reload Semantics
 
 Dynamic reload is required:
 
-- The software should watch `ensemble.yaml` for changes.
+- The software should watch `config.yaml` for changes.
 - On change, it should re-read and re-apply config and prompt templates without restart.
 - The software should attempt to adjust live behavior to the new config (for example polling
   cadence, concurrency limits, active/terminal states, agent settings, workspace paths/hooks, and
@@ -750,7 +773,7 @@ Dynamic reload is required:
 - Invalid reloads should not crash the service; keep operating with the last known good effective
   configuration and emit an operator-visible error.
 
-### 6.3 Dispatch Preflight Validation
+### 6.4 Dispatch Preflight Validation
 
 This validation is a scheduler preflight run before attempting to dispatch new work. It validates
 the config needed to poll and launch workers, not a full audit of all possible runtime behavior.
@@ -768,7 +791,8 @@ Per-tick dispatch validation:
 
 Validation checks:
 
-- Config file can be loaded and parsed.
+- Config directory and `config.yaml` can be resolved and read.
+- YAML can be parsed.
 - `tracker.kind` is present and supported.
 - `tracker.api_key` is present after `$` resolution (when required by the selected tracker kind).
 - `tracker.repository` is present when required by the selected tracker kind.
@@ -778,12 +802,14 @@ Validation checks:
   writes (`supports_writes()` returns true).
 - `on_success` and `on_failure` are present.
 
-### 6.4 Config Fields Summary (Cheat Sheet)
+### 6.5 Config Fields Summary (Cheat Sheet)
 
 This section is intentionally redundant so a coding agent can implement the config layer quickly.
 
+- Config directory resolution: `--config-dir` > `ENSEMBLE_CONFIG_DIR` > platform default
+- Config file: `<config_dir>/config.yaml`
 - `tracker.kind`: string, required; supported values: `todo_file`, `github`
-- `tracker.path`: string, default `TODO.md`; path to todo file when `tracker.kind=todo_file`
+- `tracker.path`: string, default `~/ensemble/TODO.md`; path to todo file when `tracker.kind=todo_file`
 - `tracker.endpoint`: string, default `https://api.github.com/graphql` when `tracker.kind=github`
 - `tracker.api_key`: string or `$VAR`, canonical env `GITHUB_TOKEN` when `tracker.kind=github`
 - `tracker.repository`: string (`owner/repo`), required when `tracker.kind=github`
@@ -794,7 +820,7 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `agents.<name>.executor`: string, required; ACP-compatible agent executable identifier
 - `agents.<name>.model`: string, required; model identifier
 - `agents.<name>.prompt`: string, optional; inline prompt (mutually exclusive with prompt_template)
-- `agents.<name>.prompt_template`: path, optional; file reference to prompt template
+- `agents.<name>.prompt_template`: path, optional; file reference to prompt template (config-relative)
 - `steps[].name`: string, required; unique step identifier
 - `steps[].agent`: string, required; references a key in `agents`
 - `steps[].depends`: list of strings, optional; step dependencies for DAG
@@ -805,7 +831,7 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `concurrency.max_step_parallelism`: integer, default `2`; per-issue cap
 - `max_cycles`: integer, default `3`; max pipeline re-entries per issue
 - `polling.interval_ms`: integer, default `30000`
-- `workspace.root`: path, default `<system-temp>/ensemble_workspaces`
+- `workspace.root`: path, default `<system-temp>/ensemble_workspaces` (config-relative if not absolute)
 - `worker.ssh_hosts` (extension): list of SSH host strings, optional; when omitted, work runs
   locally
 - `worker.max_concurrent_agents_per_host` (extension): positive integer, optional; shared per-host

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,17 +1,56 @@
 # Configuration Reference
 
-Ensemble is configured through a single `ensemble.yaml` file, typically at the root of your repository.
+Ensemble is configured through a `config.yaml` file located in a configuration directory. The default config directory is determined by your platform:
 
-## Environment variables
+- **Linux:** `~/.config/ensemble/`
+- **macOS:** `~/Library/Application Support/ensemble/`
+- **Windows:** `%APPDATA%\ensemble\`
 
-Any string value can reference an environment variable with `$VAR_NAME` syntax. Ensemble resolves these at load time. Path values (`~`, `$HOME`) are also expanded.
+## Config directory resolution
 
-```yaml
-tracker:
-  api_key: $GITHUB_TOKEN
-workspace:
-  root: ~/ensemble-workspaces
+Ensemble resolves the configuration directory using this precedence:
+
+1. `--config-dir <path>` CLI flag (highest priority)
+2. `ENSEMBLE_CONFIG_DIR` environment variable
+3. Platform-specific default config directory (lowest priority)
+
+Both the CLI flag and environment variable support shell expansion (`~` for home directory, `$ENV_VAR` for environment variables).
+
+**Example:**
+```sh
+# Using the --config-dir flag
+ensemble run --config-dir ~/my-ensemble-config
+
+# Using environment variable
+ENSEMBLE_CONFIG_DIR=~/my-ensemble-config ensemble run
+
+# With environment variable expansion
+ENSEMBLE_CONFIG_DIR=$HOME/projects/ensemble ensemble run
 ```
+
+**Open the config directory:**
+
+```sh
+ensemble open-config-dir
+```
+
+This opens the resolved configuration directory in your system's file manager. If the directory doesn't exist, it will prompt you to run `ensemble init` to create it.
+
+**Legacy note:** The old `ENSEMBLE_CONFIG` environment variable and `--config` flag are no longer supported. Use `ENSEMBLE_CONFIG_DIR` and `--config-dir` instead.
+
+## Auto-loading .env
+
+If a `.env` file exists in the configuration directory, Ensemble automatically loads it before expanding `$VAR` references in the configuration. This means you don't need to manually source `.env` files—environment variables defined there are automatically available for config expansion.
+
+## Config-relative paths
+
+All relative paths in `config.yaml` are resolved relative to the configuration directory:
+
+- `workspace.root` — resolved from config directory
+- `repos[*].path` — resolved from config directory  
+- `agents.*.prompt_template` — resolved from config directory
+
+This makes configurations portable and self-contained.
 
 ## Minimal example
 
@@ -20,7 +59,7 @@ The smallest working config uses a local TODO file and a single agent:
 ```yaml
 tracker:
   kind: todo_file
-  path: TODO.md
+  # path defaults to ~/ensemble/TODO.md if not specified
 
 agents:
   build:
@@ -56,13 +95,13 @@ tracker:
     - ensemble
 
 repos:
-  - path: /home/dev/my-repo
+  - path: repos/my-repo    # Relative to config directory
     branch: main
 
 agents:
   builder:
     acpx_agent: claude
-    prompt_template: templates/implement.liquid
+    prompt_template: templates/implement.liquid  # Relative to config directory
   reviewer:
     executor: claude-code
     model: claude-opus-4-6
@@ -88,7 +127,7 @@ concurrency:
 max_cycles: 3
 
 workspace:
-  root: ~/ensemble-workspaces
+  root: workspaces  # Relative to config directory
 
 hooks:
   after_create: "git checkout -b ensemble/$ISSUE_ID"
@@ -129,15 +168,17 @@ Defines where Ensemble reads and writes issues.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `path` | string | — | Path to the TODO markdown file |
+| `path` | string | `~/ensemble/TODO.md` | Path to the TODO markdown file |
+
+For todo_file trackers, if `path` is not specified, it defaults to `~/ensemble/TODO.md` (the `ensemble` directory in your home folder).
 
 ### repos
 
-List of repositories for workspace setup.
+List of repositories for workspace setup. Paths can be absolute or relative to the config directory.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `path` | string | *required* | Path to repository (supports `$VAR` and `~`) |
+| `path` | string | *required* | Path to repository (supports `$VAR`, `~`, and config-relative paths) |
 | `branch` | string | *required* | Branch name to work on |
 
 ### agents
@@ -150,7 +191,7 @@ Named agent definitions. Each key is the agent name referenced by steps.
 | `model` | string | — | Model identifier (e.g., `"claude-opus-4-6"`) |
 | `acpx_agent` | string | — | ACPX agent name (alternative to executor+model) |
 | `prompt` | string | — | Inline prompt text |
-| `prompt_template` | string | — | Path to a Liquid template file |
+| `prompt_template` | string | — | Path to a Liquid template file (config-relative) |
 
 **Validation rules:**
 - Provide either `acpx_agent` alone, or both `executor` and `model`.
@@ -193,7 +234,7 @@ See [Pipeline Guide](pipelines.md) for details on DAG construction and execution
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `root` | string | system temp dir | Root directory for per-issue workspace directories (supports `$VAR` and `~`) |
+| `root` | string | system temp dir | Root directory for per-issue workspace directories (supports `$VAR`, `~`, and config-relative paths) |
 
 ### hooks
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,7 +29,7 @@ ensemble/
 
 | Module | Purpose |
 |--------|---------|
-| `config/` | `ensemble.yaml` parsing, prompt template rendering |
+| `config/` | `config.yaml` parsing, prompt template rendering, config directory resolution |
 | `tracker/` | `IssueTracker` trait + GitHub and todo_file backends |
 | `pipeline/` | DAG construction, step execution, verdict parsing |
 | `orchestrator/` | Poll loop, dispatch, retry, reconciliation |

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -4,7 +4,7 @@ A pipeline is a directed acyclic graph (DAG) of steps that Ensemble runs for eac
 
 ## Steps and agents
 
-Each step references an agent defined in `ensemble.yaml`:
+Each step references an agent defined in `config.yaml`:
 
 ```yaml
 agents:
@@ -16,6 +16,8 @@ steps:
   - name: build
     agent: builder
 ```
+
+The `templates/` directory is relative to your configuration directory. See [Configuration Reference](configuration.md) for details on config directory resolution.
 
 When a step runs, Ensemble:
 1. Renders the agent's prompt template with the issue context

--- a/docs/superpowers/plans/2026-04-01-config-dir-and-todo-state.md
+++ b/docs/superpowers/plans/2026-04-01-config-dir-and-todo-state.md
@@ -1,0 +1,838 @@
+# Config Dir and Todo State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch Ensemble from cwd-relative `ensemble.yaml` to config-dir-based `config.yaml`, move the default TODO tracker state to `~/ensemble/TODO.md`, add `ensemble open-config-dir`, and update the living docs to match.
+
+**Architecture:** Put config-directory resolution in a shared `ensemble-core::config::location` module so CLI and desktop both derive `<config_dir>/config.yaml` the same way. Make `load_config()` source-aware so config-relative paths rebase from the resolved config directory and a sibling `.env` is loaded before `$VAR` expansion. Then rework CLI, init, desktop startup, API strings, tests, and user-facing docs around the new config-dir-only model.
+
+**Tech Stack:** Rust 2021, clap, dirs, dotenvy, serde_yaml, inquire, tauri, axum
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `Cargo.toml` | Modify | Add shared `dotenvy` dependency for config-dir `.env` loading |
+| `crates/ensemble-core/Cargo.toml` | Modify | Add `dirs` and `dotenvy` to core |
+| `crates/ensemble-core/src/error.rs` | Modify | Add config-dir/home-dir specific error variants |
+| `crates/ensemble-core/src/config/mod.rs` | Modify | Export new config-location module |
+| `crates/ensemble-core/src/config/location.rs` | Create | Shared config-dir resolution, `config.yaml` derivation, default TODO state path |
+| `crates/ensemble-core/src/config/ensemble.rs` | Modify | Rebase relative paths from config dir, auto-load `.env`, default TODO path, rename docs/comments/tests to `config.yaml` |
+| `crates/ensemble-core/src/tracker/mod.rs` | Modify | Stop hardcoding `TODO.md`; use resolved/default TODO path behavior |
+| `crates/ensemble-core/src/api/router.rs` | Modify | Update `config_path` docs/tests to `config.yaml` semantics |
+| `crates/ensemble-core/src/api/config_handler.rs` | Modify | Update config path expectations in API tests |
+| `crates/ensemble-core/src/api/history_handler.rs` | Modify | Update hardcoded config path fixtures |
+| `crates/ensemble-core/src/api/controls.rs` | Modify | Update hardcoded config path fixtures |
+| `crates/ensemble-core/src/api/handlers.rs` | Modify | Update hardcoded config path fixtures |
+| `crates/ensemble-core/tests/api_endpoints.rs` | Modify | Update API fixture expectations for `config.yaml` |
+| `crates/ensemble-core/tests/workflow_to_workspace.rs` | Modify | Update config filename comments/fixtures if needed |
+| `crates/ensemble-cli/src/main.rs` | Modify | Replace positional/`--config` flow with `--config-dir` and add `open-config-dir` subcommand |
+| `crates/ensemble-cli/src/commands/mod.rs` | Modify | Export new `open_config_dir` command |
+| `crates/ensemble-cli/src/commands/run.rs` | Modify | Resolve config dir into `<config_dir>/config.yaml` before loading |
+| `crates/ensemble-cli/src/commands/web.rs` | Modify | Resolve config dir into `<config_dir>/config.yaml` before loading |
+| `crates/ensemble-cli/src/commands/open_config_dir.rs` | Create | Open existing config dir in Finder/Explorer/etc or fail with init guidance |
+| `crates/ensemble-cli/src/commands/init.rs` | Modify | Resolve config dir, load existing `config.yaml`, pass target dir into generation |
+| `crates/ensemble-cli/src/commands/init/tracker.rs` | Modify | Default TODO prompt to `~/ensemble/TODO.md` and preserve existing `tracker.path` |
+| `crates/ensemble-cli/src/commands/init/generate.rs` | Modify | Write `config.yaml` into config dir, write TODO state at resolved tracker path, write `.env` beside config |
+| `crates/ensemble-desktop/src/main.rs` | Modify | Resolve config dir via shared resolver, reject legacy env usage, remove cwd mutation |
+| `crates/ensemble-desktop/src/orchestrator.rs` | Modify | Keep logging/messages aligned with resolved `config.yaml` path |
+| `crates/ensemble-desktop/tests/e2e.rs` | Modify | Use `ENSEMBLE_CONFIG_DIR` and `config.yaml` in smoke tests |
+| `README.md` | Modify | Update quick start, config location, TODO default, and `open-config-dir` docs |
+| `docs/configuration.md` | Modify | Document `config.yaml`, `--config-dir`, `ENSEMBLE_CONFIG_DIR`, default TODO state path, and config-relative asset behavior |
+| `docs/pipelines.md` | Modify | Update examples to reference `config.yaml`-backed config dir layout |
+| `docs/contributing.md` | Modify | Update module descriptions and config terminology |
+| `docs/SPEC.md` | Modify | Replace living spec references to `ensemble.yaml` / repo-root config with `config.yaml` / config-dir model |
+| `AGENTS.md` | Modify | Update contributor instructions to the new config-dir model |
+| `CLAUDE.md` | Modify | Update contributor instructions to the new config-dir model |
+
+---
+
+### Task 1: Add Shared Config-Directory Resolution in `ensemble-core`
+
+**Files:**
+- Modify: `crates/ensemble-core/Cargo.toml`
+- Modify: `crates/ensemble-core/src/error.rs`
+- Modify: `crates/ensemble-core/src/config/mod.rs`
+- Create: `crates/ensemble-core/src/config/location.rs`
+- Test: `crates/ensemble-core/src/config/location.rs`
+
+- [ ] **Step 1: Write failing config-location tests**
+
+Add inline tests in `crates/ensemble-core/src/config/location.rs` for:
+
+```rust
+#[test]
+fn test_config_path_for_dir_appends_config_yaml() {
+    let dir = PathBuf::from("/tmp/ensemble-config");
+    assert_eq!(config_path_for_dir(&dir), dir.join("config.yaml"));
+}
+
+#[test]
+fn test_resolve_cli_config_dir_allows_relative_override() {
+    let cwd = Path::new("/tmp/project");
+    let resolved = resolve_config_dir_for_cli(Some(Path::new("configs/dev")), None, cwd).unwrap();
+    assert_eq!(resolved.config_dir, cwd.join("configs/dev"));
+}
+
+#[test]
+fn test_resolve_desktop_config_dir_rejects_relative_env_override() {
+    let err = resolve_config_dir_for_desktop(Some(OsString::from("configs/dev"))).unwrap_err();
+    assert!(err.to_string().contains("relative"));
+}
+
+#[test]
+fn test_default_todo_state_path_uses_home_ensemble_directory() {
+    let home = Path::new("/tmp/home");
+    assert_eq!(default_todo_state_path_from_home(home), home.join("ensemble").join("TODO.md"));
+}
+
+#[test]
+fn test_resolve_cli_config_dir_prefers_flag_over_env() {
+    let cwd = Path::new("/tmp/project");
+    let resolved = resolve_config_dir_for_cli(
+        Some(Path::new("flag-dir")),
+        Some(OsString::from("env-dir")),
+        cwd,
+    )
+    .unwrap();
+    assert_eq!(resolved.config_dir, cwd.join("flag-dir"));
+}
+
+#[test]
+fn test_resolve_cli_config_dir_uses_env_when_flag_missing() {
+    let cwd = Path::new("/tmp/project");
+    let resolved = resolve_config_dir_for_cli(None, Some(OsString::from("env-dir")), cwd).unwrap();
+    assert_eq!(resolved.config_dir, cwd.join("env-dir"));
+}
+
+#[test]
+fn test_resolve_config_dir_rejects_existing_file_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("not-a-dir");
+    std::fs::write(&file_path, "x").unwrap();
+    let err = validate_config_dir_target(&file_path).unwrap_err();
+    assert!(err.to_string().contains("directory"));
+}
+
+#[test]
+fn test_expand_override_supports_env_and_tilde() {
+    std::env::set_var("ENSEMBLE_TEST_CONFIG_DIR", "/tmp/from-env");
+    let resolved = expand_override_path("$ENSEMBLE_TEST_CONFIG_DIR").unwrap();
+    assert_eq!(resolved, PathBuf::from("/tmp/from-env"));
+}
+
+#[test]
+fn test_default_resolution_errors_when_config_dir_is_unavailable() {
+    let err = default_config_dir_from(None).unwrap_err();
+    assert!(err.to_string().contains("config directory"));
+}
+
+#[test]
+fn test_default_todo_state_path_errors_without_home_dir() {
+    let err = default_todo_state_path_from_optional_home(None).unwrap_err();
+    assert!(err.to_string().contains("home"));
+}
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run: `cargo test -p ensemble-core test_config_path_for_dir_appends_config_yaml -- --exact`
+Expected: FAIL because `crates/ensemble-core/src/config/location.rs` and the helpers do not exist yet.
+
+- [ ] **Step 3: Add the new module and error variants**
+
+Create `crates/ensemble-core/src/config/location.rs` with a focused API like:
+
+```rust
+pub struct ResolvedConfigDir {
+    pub config_dir: PathBuf,
+    pub config_path: PathBuf,
+}
+
+pub fn config_path_for_dir(config_dir: &Path) -> PathBuf {
+    config_dir.join("config.yaml")
+}
+
+pub fn resolve_config_dir_for_cli(
+    cli_override: Option<&Path>,
+    env_override: Option<OsString>,
+    cwd: &Path,
+) -> Result<ResolvedConfigDir, ConfigError> { /* ... */ }
+
+pub fn resolve_config_dir_for_desktop(
+    env_override: Option<OsString>,
+) -> Result<ResolvedConfigDir, ConfigError> { /* ... */ }
+
+pub fn default_todo_state_path() -> Result<PathBuf, ConfigError> { /* ... */ }
+```
+
+Add matching `ConfigError` variants in `crates/ensemble-core/src/error.rs` for missing config-dir discovery, missing home directory, relative desktop overrides, and config-dir paths that point to files.
+
+- [ ] **Step 4: Implement the full spec semantics in the resolver**
+
+Make the resolver explicitly handle all spec rules:
+
+```rust
+// precedence: CLI flag > ENSEMBLE_CONFIG_DIR > dirs::config_dir()/ensemble
+// expansion: first $ENV_VAR, then ~
+// validation: target must not be an existing file
+// desktop: relative ENSEMBLE_CONFIG_DIR is an error
+// defaults: missing dirs::config_dir() / home directory are explicit errors
+```
+
+- [ ] **Step 5: Export the module and wire dependencies**
+
+Update `crates/ensemble-core/src/config/mod.rs`:
+
+```rust
+pub mod ensemble;
+pub mod location;
+pub mod template;
+```
+
+Update `crates/ensemble-core/Cargo.toml` to include:
+
+```toml
+dirs = { workspace = true }
+```
+
+- [ ] **Step 6: Run the focused config-location test set**
+
+Run: `cargo test -p ensemble-core config::location`
+Expected: PASS — new config-location tests all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-core/Cargo.toml crates/ensemble-core/src/error.rs crates/ensemble-core/src/config/mod.rs crates/ensemble-core/src/config/location.rs
+git commit -m "Add shared config directory resolution helpers"
+```
+
+---
+
+### Task 2: Make `load_config()` Config-Dir Aware and Auto-Load `.env`
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/ensemble-core/Cargo.toml`
+- Modify: `crates/ensemble-core/src/config/ensemble.rs`
+- Modify: `crates/ensemble-core/src/tracker/mod.rs`
+- Test: `crates/ensemble-core/src/config/ensemble.rs`
+- Test: `crates/ensemble-core/src/tracker/mod.rs`
+
+- [ ] **Step 1: Write failing loader tests for rebasing, `.env`, and TODO defaults**
+
+Add tests in `crates/ensemble-core/src/config/ensemble.rs` like:
+
+```rust
+#[test]
+fn test_load_config_rebases_relative_paths_from_config_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("templates")).unwrap();
+    std::fs::write(
+        dir.path().join("config.yaml"),
+        r#"
+tracker:
+  kind: todo_file
+repos:
+  - path: repos/app
+    branch: main
+agents:
+  builder:
+    acpx_agent: claude
+    prompt_template: templates/implement.liquid
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+workspace:
+  root: workspaces
+"#,
+    ).unwrap();
+
+    let config = load_config(&dir.path().join("config.yaml")).unwrap();
+    assert_eq!(config.agents["builder"].prompt_template.as_deref(), Some(dir.path().join("templates/implement.liquid").as_path()));
+    assert_eq!(config.repos[0].path, dir.path().join("repos/app").display().to_string());
+    assert_eq!(config.workspace.root.as_deref(), Some(dir.path().join("workspaces").display().to_string().as_str()));
+}
+
+#[test]
+fn test_load_config_defaults_todo_tracker_path_to_home_state_path() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("config.yaml"), minimal_yaml_without_tracker_path()).unwrap();
+    let config = load_config(&dir.path().join("config.yaml")).unwrap();
+    assert!(config.tracker.path.unwrap().ends_with("ensemble/TODO.md"));
+}
+
+#[test]
+fn test_load_config_loads_sibling_dotenv_without_overriding_existing_env() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join(".env"), "GITHUB_TOKEN=from-dotenv\n").unwrap();
+    std::env::set_var("GITHUB_TOKEN", "from-process");
+    std::fs::write(dir.path().join("config.yaml"), github_yaml_using_env()).unwrap();
+    let config = load_config(&dir.path().join("config.yaml")).unwrap();
+    assert_eq!(config.tracker.api_key.as_deref(), Some("from-process"));
+}
+```
+
+Add a runtime validation test in `crates/ensemble-core/src/tracker/mod.rs` for the missing TODO parent directory case:
+
+```rust
+#[test]
+fn test_create_todo_file_tracker_fails_when_parent_directory_is_missing() {
+    let missing_parent = PathBuf::from("/definitely/missing/dir/TODO.md");
+    let result = create_tracker(&todo_file_config(missing_parent));
+    assert!(result.is_err());
+}
+```
+
+- [ ] **Step 2: Run the first new loader test and verify it fails**
+
+Run: `cargo test -p ensemble-core test_load_config_rebases_relative_paths_from_config_dir -- --exact`
+Expected: FAIL because relative paths are still interpreted from process cwd, not the config directory.
+
+- [ ] **Step 3: Add `dotenvy` and rework config loading**
+
+Update dependencies:
+
+```toml
+# Cargo.toml
+dotenvy = "0.15"
+
+# crates/ensemble-core/Cargo.toml
+dotenvy = { workspace = true }
+```
+
+Then update `crates/ensemble-core/src/config/ensemble.rs` so `load_config()`:
+
+```rust
+pub fn load_config(path: &Path) -> Result<EnsembleConfig, ConfigError> {
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    load_sibling_dotenv(config_dir)?;
+    let content = std::fs::read_to_string(path).map_err(|_| ConfigError::MissingConfigFile {
+        path: path.display().to_string(),
+    })?;
+    let mut config = parse_config(&content)?;
+    config.resolve_env_from(config_dir)?;
+    Ok(config)
+}
+```
+
+And replace the old cwd-sensitive resolver with a base-dir-aware method:
+
+```rust
+pub fn resolve_env_from(&mut self, config_dir: &Path) -> Result<(), ConfigError> {
+    // resolve tracker.api_key
+    // resolve tracker.path; if missing for todo_file, inject default_todo_state_path()
+    // resolve workspace.root, repos[*].path, agents.*.prompt_template relative to config_dir
+}
+```
+
+- [ ] **Step 4: Make tracker fallback match the new default**
+
+Update `crates/ensemble-core/src/tracker/mod.rs` so the fallback is no longer `PathBuf::from("TODO.md")`; use the shared default TODO state helper instead:
+
+```rust
+let tracker = todo_file::TodoFileTracker::new(
+    config.path.clone().unwrap_or_else(|| default_todo_state_path().expect("todo path")),
+    config.active_states.clone(),
+);
+```
+
+Do not use `unwrap()` in final code; propagate a `TrackerError` or make the config loader populate `tracker.path` before tracker creation so the fallback is unreachable in normal runtime.
+
+- [ ] **Step 5: Add explicit runtime validation for missing TODO parent directories**
+
+Before constructing `TodoFileTracker`, validate that the resolved TODO parent directory exists for runtime commands. Return a clear error naming the missing parent path instead of silently creating directories during runtime.
+
+- [ ] **Step 6: Run the focused core tests**
+
+Run: `cargo test -p ensemble-core load_config`
+Expected: PASS — the new load-config tests and existing load-config tests pass with `config.yaml` semantics.
+
+- [ ] **Step 7: Run the full `ensemble-core` test suite**
+
+Run: `cargo test -p ensemble-core`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Cargo.toml crates/ensemble-core/Cargo.toml crates/ensemble-core/src/config/ensemble.rs crates/ensemble-core/src/tracker/mod.rs
+git commit -m "Make config loading relative to config directories"
+```
+
+---
+
+### Task 3: Switch CLI Runtime Parsing to `--config-dir` and Add `open-config-dir`
+
+**Files:**
+- Modify: `crates/ensemble-cli/src/main.rs`
+- Modify: `crates/ensemble-cli/src/commands/mod.rs`
+- Modify: `crates/ensemble-cli/src/commands/run.rs`
+- Modify: `crates/ensemble-cli/src/commands/web.rs`
+- Create: `crates/ensemble-cli/src/commands/open_config_dir.rs`
+- Test: `crates/ensemble-cli/src/main.rs`
+- Test: `crates/ensemble-cli/src/commands/open_config_dir.rs`
+
+- [ ] **Step 1: Write failing CLI parsing tests**
+
+Add/update tests in `crates/ensemble-cli/src/main.rs` like:
+
+```rust
+#[test]
+fn test_cli_parse_run_with_config_dir() {
+    let cli = Cli::parse_from(["ensemble", "run", "--config-dir", "/tmp/ensemble"]);
+    match cli.command {
+        Some(Command::Run { config_dir }) => assert_eq!(config_dir, Some(PathBuf::from("/tmp/ensemble"))),
+        other => panic!("expected Run, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_cli_parse_open_config_dir_subcommand() {
+    let cli = Cli::parse_from(["ensemble", "open-config-dir"]);
+    assert!(matches!(cli.command, Some(Command::OpenConfigDir { .. })));
+}
+
+#[test]
+fn test_cli_rejects_legacy_config_flag() {
+    let err = reject_legacy_config_overrides(["ensemble", "run", "--config", "old.yaml"]).unwrap_err();
+    assert!(err.contains("--config-dir"));
+}
+```
+
+- [ ] **Step 2: Run the new CLI test and verify it fails**
+
+Run: `cargo test -p ensemble-cli test_cli_parse_run_with_config_dir -- --exact`
+Expected: FAIL because `Run` still accepts a positional config file path instead of `--config-dir`.
+
+- [ ] **Step 3: Rework CLI argument structs around config directories**
+
+Update `crates/ensemble-cli/src/main.rs` to remove the old positional config path and introduce a shared arg struct:
+
+```rust
+#[derive(clap::Args, Debug, Clone)]
+struct ConfigDirArgs {
+    #[arg(long, env = "ENSEMBLE_CONFIG_DIR")]
+    config_dir: Option<PathBuf>,
+}
+
+enum Command {
+    Init { #[command(flatten)] config: ConfigDirArgs },
+    Run { #[command(flatten)] config: ConfigDirArgs },
+    Web { #[command(flatten)] config: ConfigDirArgs, /* host/port */ },
+    OpenConfigDir { #[command(flatten)] config: ConfigDirArgs },
+}
+```
+
+Add a small `reject_legacy_config_overrides(std::env::args_os())` preflight before `Cli::parse()` so `--config`, `-c`, positional config paths, and `ENSEMBLE_CONFIG` fail with a migration hint to use `--config-dir` / `ENSEMBLE_CONFIG_DIR`.
+
+- [ ] **Step 4: Resolve config dirs in runtime commands**
+
+Update `run.rs` and `web.rs` so they accept `config_dir: Option<PathBuf>` and derive `config_path` via the new core helper before calling `load_config()`:
+
+```rust
+let cwd = std::env::current_dir().map_err(|e| /* print + exit */)?;
+let resolved = resolve_config_dir_for_cli(args.config_dir.as_deref(), std::env::var_os("ENSEMBLE_CONFIG_DIR"), &cwd)?;
+let config = load_config(&resolved.config_path)?;
+```
+
+- [ ] **Step 5: Add the `open-config-dir` command**
+
+Create `crates/ensemble-cli/src/commands/open_config_dir.rs` with:
+
+```rust
+pub async fn execute(args: OpenConfigDirArgs) -> ExitCode {
+    let cwd = std::env::current_dir().unwrap();
+    let resolved = resolve_config_dir_for_cli(args.config_dir.as_deref(), std::env::var_os("ENSEMBLE_CONFIG_DIR"), &cwd)?;
+    if !resolved.config_dir.exists() {
+        eprintln!("error: config directory does not exist: {}", resolved.config_dir.display());
+        eprintln!("run `ensemble init` to create it");
+        return ExitCode::FAILURE;
+    }
+    open_in_system_file_manager(&resolved.config_dir)
+}
+```
+
+Also add unit tests for missing-directory failure and the platform-specific command builder instead of spawning Finder/Explorer in tests.
+
+- [ ] **Step 6: Run the full CLI test suite**
+
+Run: `cargo test -p ensemble-cli`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-cli/src/main.rs crates/ensemble-cli/src/commands/mod.rs crates/ensemble-cli/src/commands/run.rs crates/ensemble-cli/src/commands/web.rs crates/ensemble-cli/src/commands/open_config_dir.rs
+git commit -m "Switch CLI to config-dir based configuration"
+```
+
+---
+
+### Task 4: Rework `ensemble init` to Write `config.yaml` and External TODO State
+
+**Files:**
+- Modify: `crates/ensemble-cli/src/commands/init.rs`
+- Modify: `crates/ensemble-cli/src/commands/init/tracker.rs`
+- Modify: `crates/ensemble-cli/src/commands/init/generate.rs`
+- Test: `crates/ensemble-cli/src/commands/init/tracker.rs`
+- Test: `crates/ensemble-cli/src/commands/init/generate.rs`
+
+- [ ] **Step 1: Write failing tests for init output paths**
+
+Add tests in `crates/ensemble-cli/src/commands/init/generate.rs` like:
+
+```rust
+#[test]
+fn test_write_files_writes_config_yaml_inside_target_config_dir() {
+    let config_dir = tempfile::tempdir().unwrap();
+    let todo_dir = tempfile::tempdir().unwrap();
+    write_files(
+        config_dir.path(),
+        &todo_tracker_choice(todo_dir.path().join("TODO.md")),
+        &sample_repos(),
+        &sample_agents(),
+        &sample_steps(),
+        "Done",
+        "Failed",
+    ).unwrap();
+    assert!(config_dir.path().join("config.yaml").exists());
+    assert!(config_dir.path().join("templates/implement.liquid").exists());
+}
+
+#[test]
+fn test_write_files_writes_todo_state_at_tracker_path() {
+    let config_dir = tempfile::tempdir().unwrap();
+    let todo_dir = tempfile::tempdir().unwrap();
+    let todo_path = todo_dir.path().join("state/TODO.md");
+    write_files(/* ... */).unwrap();
+    assert!(todo_path.exists());
+}
+
+#[test]
+fn test_write_files_declining_existing_config_yaml_aborts_before_writing_templates() {
+    let config_dir = tempfile::tempdir().unwrap();
+    std::fs::write(config_dir.path().join("config.yaml"), "existing").unwrap();
+    // stub confirm -> false
+    // assert config file unchanged and templates dir absent
+}
+```
+
+Add init-level tests in `crates/ensemble-cli/src/commands/init.rs` for:
+
+```rust
+#[test]
+fn test_init_warns_and_uses_fresh_defaults_when_existing_config_is_invalid() { /* ... */ }
+
+#[test]
+fn test_init_shows_legacy_ensemble_yaml_upgrade_hint() { /* ... */ }
+```
+
+Add a small default-path helper test in `tracker.rs`:
+
+```rust
+#[test]
+fn test_default_todo_prompt_path_uses_home_ensemble_dir() {
+    assert_eq!(default_todo_prompt_path(None), "~/ensemble/TODO.md");
+}
+```
+
+- [ ] **Step 2: Run the first init generation test and verify it fails**
+
+Run: `cargo test -p ensemble-cli test_write_files_writes_config_yaml_inside_target_config_dir -- --exact`
+Expected: FAIL because `write_files()` still writes `ensemble.yaml` and `TODO.md` into the process cwd.
+
+- [ ] **Step 3: Resolve the init target config directory**
+
+Update `crates/ensemble-cli/src/commands/init.rs` so `InitArgs` carries `config_dir: Option<PathBuf>`, resolve it with the shared core helper, and load existing defaults from `<config_dir>/config.yaml` instead of `./ensemble.yaml`.
+
+Use a flow like:
+
+```rust
+let cwd = std::env::current_dir()?;
+let resolved = resolve_config_dir_for_cli(args.config_dir.as_deref(), std::env::var_os("ENSEMBLE_CONFIG_DIR"), &cwd)?;
+let existing_config_path = resolved.config_path.clone();
+```
+
+Before prompting for overwrite, add the legacy migration check from the spec:
+
+```rust
+let legacy_path = resolved.config_dir.join("ensemble.yaml");
+if legacy_path.exists() && !resolved.config_path.exists() {
+    eprintln!("found legacy ensemble.yaml at {}; rename it to config.yaml", legacy_path.display());
+}
+```
+
+If `config.yaml` exists but fails to parse, keep the warning-and-fresh-defaults flow explicit and test-covered.
+
+- [ ] **Step 4: Change the TODO prompt default and file writer**
+
+Update `crates/ensemble-cli/src/commands/init/tracker.rs` so the todo prompt default is:
+
+```rust
+let default_path = existing
+    .and_then(|c| c.tracker.path.as_ref())
+    .map(|p| p.to_string_lossy().into_owned())
+    .unwrap_or_else(|| "~/ensemble/TODO.md".to_string());
+```
+
+Then update `write_files()` in `generate.rs` to accept a `config_dir: &Path` parameter and write:
+
+```rust
+std::fs::create_dir_all(config_dir)?;
+std::fs::write(config_dir.join("config.yaml"), &yaml)?;
+std::fs::create_dir_all(config_dir.join("templates"))?;
+std::fs::write(config_dir.join(".env"), ...)?;
+
+if let TrackerChoice::TodoFile { path } = tracker {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, generate_todo_md())?;
+}
+```
+
+Keep the overwrite prompts, but point them at the resolved `config.yaml`, `.env`, template paths, and TODO target path.
+
+- [ ] **Step 5: Update success messaging**
+
+Change the init completion message to mention `config.yaml`, the resolved config directory, and `.env` auto-loading from that directory. Remove the old instruction that users should `source .env` manually.
+
+- [ ] **Step 6: Guarantee overwrite prompts happen before any writes**
+
+Structure `execute()` / `write_files()` so the overwrite decision for existing `config.yaml` happens before creating `templates/`, `.env`, or TODO parent directories. Keep this covered by a test that proves no side effects occur when the user declines overwrite.
+
+- [ ] **Step 7: Run the full init-related test suite**
+
+Run: `cargo test -p ensemble-cli init`
+Expected: PASS — init and generation tests now pass with config-dir output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/ensemble-cli/src/commands/init.rs crates/ensemble-cli/src/commands/init/tracker.rs crates/ensemble-cli/src/commands/init/generate.rs
+git commit -m "Write init output to config directories"
+```
+
+---
+
+### Task 5: Update Desktop Startup, API Fixtures, and Remaining Path Strings
+
+**Files:**
+- Modify: `crates/ensemble-desktop/src/main.rs`
+- Modify: `crates/ensemble-desktop/src/orchestrator.rs`
+- Modify: `crates/ensemble-desktop/tests/e2e.rs`
+- Modify: `crates/ensemble-core/src/api/router.rs`
+- Modify: `crates/ensemble-core/src/api/config_handler.rs`
+- Modify: `crates/ensemble-core/src/api/history_handler.rs`
+- Modify: `crates/ensemble-core/src/api/controls.rs`
+- Modify: `crates/ensemble-core/src/api/handlers.rs`
+- Modify: `crates/ensemble-core/tests/api_endpoints.rs`
+- Modify: `crates/ensemble-core/tests/workflow_to_workspace.rs`
+
+- [ ] **Step 1: Write failing desktop/API tests around `config.yaml` and `ENSEMBLE_CONFIG_DIR`**
+
+Update tests first so they assert the new behavior:
+
+```rust
+#[test]
+fn resolve_config_dir_prefers_env_override() {
+    std::env::set_var("ENSEMBLE_CONFIG_DIR", "/tmp/ensemble");
+    let resolved = resolve_config_dir();
+    assert_eq!(resolved.config_dir, PathBuf::from("/tmp/ensemble"));
+    assert_eq!(resolved.config_path, PathBuf::from("/tmp/ensemble/config.yaml"));
+}
+
+#[tokio::test]
+async fn test_get_config_valid() {
+    let state = build_app_state(test_config());
+    let (_status, Json(response)) = get_config(State(state)).await;
+    assert_eq!(response.config_path, "config.yaml");
+}
+
+#[test]
+fn missing_config_message_mentions_resolved_config_yaml_path() {
+    let resolved = ResolvedConfigDir {
+        config_dir: PathBuf::from("/tmp/ensemble"),
+        config_path: PathBuf::from("/tmp/ensemble/config.yaml"),
+    };
+    let message = format_missing_config_message(&resolved.config_path);
+    assert!(message.contains("/tmp/ensemble/config.yaml"));
+}
+```
+
+Update the desktop smoke test to write `config.yaml` and export `ENSEMBLE_CONFIG_DIR` instead of `ENSEMBLE_CONFIG`.
+
+- [ ] **Step 2: Run one desktop unit test and verify it fails**
+
+Run: `cargo test -p ensemble-desktop resolve_config_dir_prefers_env_override -- --exact`
+Expected: FAIL because desktop still reads `ENSEMBLE_CONFIG` and defaults to `ensemble.yaml`.
+
+- [ ] **Step 3: Remove cwd mutation from desktop startup**
+
+Refactor `crates/ensemble-desktop/src/main.rs` so it:
+
+```rust
+let resolved = resolve_config_dir_for_desktop(std::env::var_os("ENSEMBLE_CONFIG_DIR"))?;
+let config_path = resolved.config_path;
+
+if std::env::var_os("ENSEMBLE_CONFIG").is_some() {
+    eprintln!("Error: ENSEMBLE_CONFIG is no longer supported. Use ENSEMBLE_CONFIG_DIR.");
+    std::process::exit(1);
+}
+```
+
+Delete `change_to_config_directory()` and stop calling `set_current_dir()` entirely.
+
+- [ ] **Step 4: Make missing-config UX explicit and tested**
+
+Extract the desktop missing-config string construction into a small helper (for example `format_missing_config_message`) so unit tests can assert that both stderr output and dialog text include the fully resolved `<config_dir>/config.yaml` path.
+
+- [ ] **Step 5: Update API/config path fixtures and smoke tests**
+
+Replace remaining hardcoded `ensemble.yaml` fixture strings in the API modules/tests and desktop e2e test setup with `config.yaml` or resolved `<config_dir>/config.yaml` values.
+
+For the desktop e2e smoke test, switch the setup to:
+
+```rust
+let config_dir = tempfile::tempdir().unwrap();
+let config_path = config_dir.path().join("config.yaml");
+Command::new(&binary_path)
+    .env("ENSEMBLE_CONFIG_DIR", config_dir.path())
+```
+
+- [ ] **Step 6: Run focused desktop and API tests**
+
+Run: `cargo test -p ensemble-desktop`
+Expected: PASS (ignored e2e tests remain ignored, unit tests pass)
+
+Run: `cargo test -p ensemble-core api`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-desktop/src/main.rs crates/ensemble-desktop/src/orchestrator.rs crates/ensemble-desktop/tests/e2e.rs crates/ensemble-core/src/api/router.rs crates/ensemble-core/src/api/config_handler.rs crates/ensemble-core/src/api/history_handler.rs crates/ensemble-core/src/api/controls.rs crates/ensemble-core/src/api/handlers.rs crates/ensemble-core/tests/api_endpoints.rs crates/ensemble-core/tests/workflow_to_workspace.rs
+git commit -m "Align desktop and API paths with config directories"
+```
+
+---
+
+### Task 6: Update Living Docs and Contributor Guidance
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/pipelines.md`
+- Modify: `docs/contributing.md`
+- Modify: `docs/SPEC.md`
+- Modify: `AGENTS.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update README quick start and command docs**
+
+Change `README.md` so it explains:
+
+```md
+- configuration lives in `<config_dir>/config.yaml`
+- `ensemble init` creates that config directory
+- `ensemble run --config-dir <dir>` overrides the config directory
+- `ensemble open-config-dir` opens the existing config directory
+- `ensemble open-config-dir` fails with a pointer to `ensemble init` when the directory does not exist
+- legacy positional config paths, `--config`, and `ENSEMBLE_CONFIG` are no longer supported; use `--config-dir` / `ENSEMBLE_CONFIG_DIR`
+- the default todo tracker state file is `~/ensemble/TODO.md`
+```
+
+- [ ] **Step 2: Update `docs/configuration.md` with the new model**
+
+Replace the current repo-root `ensemble.yaml` narrative with:
+
+```md
+Ensemble is configured through `<config_dir>/config.yaml`, where the default config directory is `dirs::config_dir()/ensemble`.
+
+Runtime commands accept `--config-dir`, and both CLI and desktop honor `ENSEMBLE_CONFIG_DIR`.
+
+For `tracker.kind: todo_file`, omitting `tracker.path` defaults to `~/ensemble/TODO.md`.
+
+Legacy positional config arguments, `--config`, and `ENSEMBLE_CONFIG` are unsupported and should be migrated to config-directory-based resolution.
+
+`ensemble open-config-dir` opens the resolved config directory when it exists and otherwise fails with guidance to run `ensemble init`.
+```
+
+Update all YAML examples and field descriptions accordingly.
+
+- [ ] **Step 3: Update the remaining living docs and guidance files**
+
+Touch `docs/pipelines.md`, `docs/contributing.md`, `docs/SPEC.md`, `AGENTS.md`, and `CLAUDE.md` so they consistently say `config.yaml` / config-dir instead of `ensemble.yaml` / repo-root config.
+
+Do **not** rewrite historical design docs under `docs/superpowers/specs/` or `docs/superpowers/plans/`; those are historical records.
+
+- [ ] **Step 4: Run a docs consistency sweep**
+
+Run:
+
+```bash
+rg -n 'ensemble\.yaml|ENSEMBLE_CONFIG([^_A-Z]|$)|TODO\.md' README.md docs AGENTS.md CLAUDE.md -g '!docs/superpowers/specs/**' -g '!docs/superpowers/plans/**'
+```
+
+Expected: only intentional migration notes remain; living docs reference `config.yaml`, `--config-dir`, `ENSEMBLE_CONFIG_DIR`, `~/ensemble/TODO.md`, the unsupported legacy override forms, and `open-config-dir` missing-directory guidance correctly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/configuration.md docs/pipelines.md docs/contributing.md docs/SPEC.md AGENTS.md CLAUDE.md
+git commit -m "Update docs for config-dir based configuration"
+```
+
+---
+
+### Task 7: Run Full Verification and Final Cleanup
+
+**Files:**
+- Verify: all touched code and docs from Tasks 1-6
+
+- [ ] **Step 1: Run workspace build**
+
+Run: `cargo build --workspace`
+Expected: PASS
+
+- [ ] **Step 2: Run workspace tests**
+
+Run: `cargo test --workspace`
+Expected: PASS
+
+- [ ] **Step 3: Run clippy with warnings denied**
+
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: PASS
+
+- [ ] **Step 4: Run formatting check**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS
+
+- [ ] **Step 5: Run one final string-sweep for live code/docs**
+
+Run:
+
+```bash
+rg -n 'ensemble\.yaml|ENSEMBLE_CONFIG([^_A-Z]|$)' crates README.md docs AGENTS.md CLAUDE.md -g '!docs/superpowers/specs/**' -g '!docs/superpowers/plans/**'
+```
+
+Expected: no stale living-code references remain except intentional migration-error strings.
+
+- [ ] **Step 6: Commit any verification fixes**
+
+If verification required code or docs edits:
+
+```bash
+git add -A
+git commit -m "Fix verification issues for config-dir migration"
+```
+
+If verification passes without further edits, skip this commit.

--- a/docs/superpowers/specs/2026-04-01-config-home-and-path-resolution-design.md
+++ b/docs/superpowers/specs/2026-04-01-config-home-and-path-resolution-design.md
@@ -1,0 +1,240 @@
+# Config Home and Path Resolution
+
+## Overview
+
+Ensemble currently assumes a cwd-relative `ensemble.yaml` in several entrypoints. That breaks down for the Tauri desktop app, where there is no stable working directory, and it also makes config-relative assets such as prompt templates and local TODO files depend on how the process was launched.
+
+This design moves Ensemble to a per-user config home, renames the main file to `config.yaml`, and makes path resolution deterministic by resolving path-like config fields relative to the loaded config file instead of the process cwd.
+
+## Goals
+
+- Make desktop startup independent of cwd.
+- Keep CLI usage friendly while allowing explicit overrides.
+- Give Ensemble one canonical per-user config location.
+- Rename `ensemble.yaml` to `config.yaml`.
+- Make config-relative paths deterministic for templates, TODO files, repos, and workspace paths.
+
+## Non-Goals
+
+- Backward-compatibility search for repo-local `./ensemble.yaml`.
+- Multi-profile or named-config support.
+- Automatic migration tooling from old config filenames.
+
+## Canonical Config Home
+
+The default config directory is:
+
+```text
+dirs::config_dir()/ensemble
+```
+
+The canonical main config file is:
+
+```text
+<config_dir>/config.yaml
+```
+
+Examples:
+
+- Linux: `~/.config/ensemble/config.yaml`
+- macOS: `~/Library/Application Support/ensemble/config.yaml`
+- Windows: `%AppData%\ensemble\config.yaml`
+
+Supporting files live next to it by default:
+
+- `templates/`
+- `TODO.md` when using the `todo_file` tracker
+- `.env` if the init flow writes one
+
+## Resolution Precedence
+
+Both CLI and desktop use the same shared resolution rules:
+
+1. Explicit `--config <path>` resolves an exact config file path.
+2. Explicit `--config-dir <dir>` resolves to `<dir>/config.yaml`.
+3. `ENSEMBLE_CONFIG` resolves an exact config file path.
+4. `ENSEMBLE_CONFIG_DIR` resolves to `<dir>/config.yaml`.
+5. Default to `dirs::config_dir()/ensemble/config.yaml`.
+
+Runtime CLI commands expose both `--config` and `--config-dir`.
+
+Desktop has no CLI flag surface, but it honors both environment variables and otherwise falls back to the default config home.
+
+### Conflict Handling
+
+- `--config` and `--config-dir` are mutually exclusive in clap.
+- If both `ENSEMBLE_CONFIG` and `ENSEMBLE_CONFIG_DIR` are set, treat it as a configuration error with a clear message instead of silently picking one.
+- CLI flags always win over environment variables.
+
+### Override Path Semantics
+
+Override values may include `$ENV_VAR` and `~`.
+
+After expansion:
+
+- CLI resolves relative `--config`, `--config-dir`, `ENSEMBLE_CONFIG`, and `ENSEMBLE_CONFIG_DIR` values against the invocation cwd.
+- Desktop rejects relative `ENSEMBLE_CONFIG` and `ENSEMBLE_CONFIG_DIR` values with a clear error and requires them to resolve to absolute paths.
+
+This keeps the CLI shell-friendly while preserving the desktop guarantee that default startup and override handling do not depend on an implicit cwd.
+
+## Relative Path Semantics
+
+Once `config.yaml` is resolved, Ensemble treats the config file's parent directory as the base directory for path-like fields.
+
+This applies to:
+
+- `tracker.path`
+- `agents.*.prompt_template`
+- `repos[*].path`
+- `workspace.root`
+
+Resolution order for each path-like field:
+
+1. Resolve `$ENV_VAR` if present.
+2. Expand `~` if present.
+3. If the resulting path is relative, join it against the directory containing `config.yaml`.
+4. Preserve absolute paths unchanged.
+
+This removes cwd sensitivity and lets users move the whole config directory without breaking adjacent files.
+
+## Todo File Location
+
+The config already has `tracker.path`; this remains the way users set the location of the local TODO tracker file.
+
+For `tracker.kind: todo_file`:
+
+- If `tracker.path` is set, use it after normal path resolution.
+- If `tracker.path` is omitted, default it to `TODO.md` relative to the config directory.
+
+That means the default todo tracker file becomes:
+
+```text
+<config_dir>/TODO.md
+```
+
+`ensemble init` should make this visible by prompting for the TODO file path and defaulting it to `TODO.md`.
+
+## Entrypoint Behavior
+
+### CLI
+
+- Replace positional default config arguments with explicit shared config options.
+- `ensemble run` and `ensemble web` resolve config through the shared resolver.
+- Bare `ensemble` continues to default to `run`, using the same resolver.
+- `ensemble init` supports `--config-dir` but not `--config`, and always writes the canonical `config.yaml` filename inside the resolved directory.
+- If `<config_dir>/config.yaml` already exists, `init` prompts before overwrite. If the user accepts, it loads the existing config and uses it as the source of prompt defaults where possible.
+- If the existing `config.yaml` cannot be parsed, `init` warns and continues with fresh defaults after the overwrite confirmation.
+- `ensemble init` writes into the resolved config directory by default.
+- If the config directory does not exist, create it before writing files.
+
+### Desktop
+
+- Resolve config before startup using the shared resolver.
+- Do not call `set_current_dir()` as part of config discovery.
+- Missing-config errors and dialogs should point to the resolved `config.yaml` path.
+- Honor `ENSEMBLE_CONFIG` and `ENSEMBLE_CONFIG_DIR` for automation and debugging.
+
+## Init Output
+
+The init wizard should stop writing files into the process cwd. Instead it writes into the resolved config directory:
+
+```text
+<config_dir>/config.yaml
+<config_dir>/templates/*.liquid
+<config_dir>/TODO.md
+<config_dir>/.env
+```
+
+Generated config examples and prompts should use `config.yaml`, not `ensemble.yaml`.
+
+If the target config directory already contains a legacy `ensemble.yaml` but not `config.yaml`, `init` should show a targeted upgrade hint before writing a new config.
+
+When `init` writes sibling files in an existing config directory:
+
+- overwrite of `config.yaml` is controlled by the initial config overwrite confirmation
+- existing `templates/*.liquid` files prompt individually before overwrite
+- existing `TODO.md` prompts before overwrite when `todo_file` is selected
+- existing `.env` prompts before overwrite
+
+This keeps `init` non-destructive for adjacent user-managed files while still allowing the canonical config file to be refreshed intentionally.
+
+## `.env` Loading
+
+After resolving the final config file path, but before config parsing and `$VAR` substitution, Ensemble should attempt to load a sibling `.env` file from the config directory.
+
+Rules:
+
+- `.env` loading is optional; missing files are ignored.
+- Values from `.env` do not override environment variables that are already set in the parent process.
+- The `.env` file is always looked up relative to the resolved config file directory, not cwd.
+
+This allows desktop and CLI launches to resolve values like `tracker.api_key: $GITHUB_TOKEN` consistently from `<config_dir>/.env`.
+
+## Config Loader Changes
+
+The current loader in `crates/ensemble-core/src/config/ensemble.rs` resolves `$VAR` and `~`, but it does not know the source config directory. That is the root cause of cwd-sensitive behavior.
+
+The loader should be updated so that loading a config file includes source-aware path rebasing. A small shared module should own:
+
+- default config home calculation
+- precedence resolution for file vs directory overrides
+- deriving `<dir>/config.yaml`
+- rebasing relative config fields against the config file directory
+
+`load_config()` should accept the resolved config file path, load a sibling `.env` file if present, and use the config file parent directory during path resolution.
+
+## Error Handling
+
+- When the resolved config file is missing, error messages must include the exact expected `config.yaml` path.
+- Desktop missing-config dialogs must reference that resolved path, not a cwd-relative filename.
+- `init` should print the full paths it created.
+- If `dirs::config_dir()` returns `None`, fail with a clear error explaining that the config directory could not be determined and that `--config` or `--config-dir` can be used instead.
+- If a resolved directory contains a legacy `ensemble.yaml` sibling but no `config.yaml`, include an upgrade hint such as "found legacy ensemble.yaml; rename it to config.yaml or pass --config <path>".
+- If desktop receives a relative env-var override path, fail with a clear error instead of attempting cwd-based resolution.
+- If both override env vars are set, fail with a clear configuration error.
+- If `init` targets an existing `config.yaml`, the overwrite prompt must happen before any files are changed.
+
+## Migration and Documentation
+
+- Switch docs, tests, examples, and API status payloads from `ensemble.yaml` to `config.yaml`.
+- Remove references to repo-root config discovery as the default model.
+- Do not search for `./ensemble.yaml` automatically.
+- Keep `ENSEMBLE_CONFIG` as the file override env var name and add `ENSEMBLE_CONFIG_DIR` as the directory override env var.
+- Document that runtime commands accept both `--config` and `--config-dir`, while `init` accepts only `--config-dir`.
+- Update init messaging so `.env` is described as auto-loaded from the config directory instead of telling users to `source` it manually.
+
+## Testing
+
+Add or update tests for:
+
+- config resolution precedence across flags, env vars, and defaults
+- deriving `config.yaml` from `--config-dir` and `ENSEMBLE_CONFIG_DIR`
+- conflict errors for `--config` plus `--config-dir`, and for `ENSEMBLE_CONFIG` plus `ENSEMBLE_CONFIG_DIR`
+- CLI relative override resolution against cwd
+- desktop rejection of relative env-var overrides
+- missing `dirs::config_dir()` handling
+- sibling `.env` loading without overriding existing process env
+- relative path rebasing for `tracker.path`, `prompt_template`, `repos[*].path`, and `workspace.root`
+- default `TODO.md` placement under the config directory when `tracker.path` is omitted
+- `init` writing files into the resolved config directory
+- `init` loading an existing `config.yaml` for defaults after overwrite confirmation
+- `init` refusing to overwrite an existing `config.yaml` when the user declines
+- `init` behavior when a legacy `ensemble.yaml` exists in the target directory
+- desktop missing-config behavior using resolved paths
+
+## Files Likely Affected
+
+- `crates/ensemble-core/src/config/ensemble.rs`
+- `crates/ensemble-core/src/config/` (new shared config-location module)
+- `crates/ensemble-core/src/tracker/mod.rs`
+- `crates/ensemble-cli/src/main.rs`
+- `crates/ensemble-cli/src/commands/init.rs`
+- `crates/ensemble-cli/src/commands/init/generate.rs`
+- `crates/ensemble-cli/src/commands/run.rs`
+- `crates/ensemble-cli/src/commands/web.rs`
+- `crates/ensemble-desktop/src/main.rs`
+- docs and tests that currently reference `ensemble.yaml`
+
+## Recommendation
+
+Adopt a single per-user config home based on `dirs::config_dir()/ensemble`, keep CLI-friendly overrides via `--config` and `--config-dir`, and make all relative config paths resolve from the loaded `config.yaml` location. This fixes the Tauri cwd issue and makes configuration behavior consistent and portable across entrypoints.

--- a/docs/superpowers/specs/2026-04-01-config-home-and-path-resolution-design.md
+++ b/docs/superpowers/specs/2026-04-01-config-home-and-path-resolution-design.md
@@ -2,23 +2,26 @@
 
 ## Overview
 
-Ensemble currently assumes a cwd-relative `ensemble.yaml` in several entrypoints. That breaks down for the Tauri desktop app, where there is no stable working directory, and it also makes config-relative assets such as prompt templates and local TODO files depend on how the process was launched.
+Ensemble currently assumes a cwd-relative `ensemble.yaml` in several entrypoints. That breaks down for the Tauri desktop app, where there is no stable working directory, and it also makes config-relative assets such as prompt templates depend on how the process was launched.
 
-This design moves Ensemble to a per-user config home, renames the main file to `config.yaml`, and makes path resolution deterministic by resolving path-like config fields relative to the loaded config file instead of the process cwd.
+This design moves Ensemble to a per-user config home, renames the main file to `config.yaml`, makes config-relative paths deterministic by resolving them relative to the loaded config directory, keeps TODO tracker state outside the config directory by default, and adds a CLI command to open the config directory in the system file manager.
 
 ## Goals
 
 - Make desktop startup independent of cwd.
-- Keep CLI usage friendly while allowing explicit overrides.
-- Give Ensemble one canonical per-user config location.
+- Give Ensemble one canonical per-user config directory.
 - Rename `ensemble.yaml` to `config.yaml`.
-- Make config-relative paths deterministic for templates, TODO files, repos, and workspace paths.
+- Expose a single config-directory override model instead of separate file and directory concepts.
+- Keep config assets relative to the config directory.
+- Treat local TODO tracker data as state, not config.
+- Add an ergonomic way to open the config directory from the CLI.
 
 ## Non-Goals
 
 - Backward-compatibility search for repo-local `./ensemble.yaml`.
 - Multi-profile or named-config support.
 - Automatic migration tooling from old config filenames.
+- A CLI mode for pointing at an arbitrary config filename.
 
 ## Canonical Config Home
 
@@ -28,7 +31,7 @@ The default config directory is:
 dirs::config_dir()/ensemble
 ```
 
-The canonical main config file is:
+The canonical config file is always:
 
 ```text
 <config_dir>/config.yaml
@@ -40,88 +43,96 @@ Examples:
 - macOS: `~/Library/Application Support/ensemble/config.yaml`
 - Windows: `%AppData%\ensemble\config.yaml`
 
-Supporting files live next to it by default:
+Supporting config-adjacent files live there by default:
 
 - `templates/`
-- `TODO.md` when using the `todo_file` tracker
 - `.env` if the init flow writes one
 
-## Resolution Precedence
+Local TODO tracker state does not live in the config directory by default.
 
-Both CLI and desktop use the same shared resolution rules:
+## Config Directory Resolution
 
-1. Explicit `--config <path>` resolves an exact config file path.
-2. Explicit `--config-dir <dir>` resolves to `<dir>/config.yaml`.
-3. `ENSEMBLE_CONFIG` resolves an exact config file path.
-4. `ENSEMBLE_CONFIG_DIR` resolves to `<dir>/config.yaml`.
-5. Default to `dirs::config_dir()/ensemble/config.yaml`.
+Both CLI and desktop use the same shared config-directory resolution rules:
 
-Runtime CLI commands expose both `--config` and `--config-dir`.
+1. Explicit `--config-dir <dir>` for CLI runtime commands.
+2. `ENSEMBLE_CONFIG_DIR` for CLI and desktop.
+3. Default to `dirs::config_dir()/ensemble`.
 
-Desktop has no CLI flag surface, but it honors both environment variables and otherwise falls back to the default config home.
+After the config directory is resolved, the config file path is always derived as:
 
-### Conflict Handling
+```text
+<config_dir>/config.yaml
+```
 
-- `--config` and `--config-dir` are mutually exclusive in clap.
-- If both `ENSEMBLE_CONFIG` and `ENSEMBLE_CONFIG_DIR` are set, treat it as a configuration error with a clear message instead of silently picking one.
-- CLI flags always win over environment variables.
+There is no separate `--config` or `ENSEMBLE_CONFIG` behavior.
 
-### Override Path Semantics
+### Conflict and Path Semantics
 
-Override values may include `$ENV_VAR` and `~`.
+- There is only one override mechanism: config directory.
+- Override values may include `$ENV_VAR` and `~`.
+- CLI resolves relative `--config-dir` and `ENSEMBLE_CONFIG_DIR` values against the invocation cwd.
+- Desktop rejects relative `ENSEMBLE_CONFIG_DIR` values with a clear error and requires an absolute path after expansion.
+- The resolved config-dir target must either not exist yet or exist as a directory. If it exists as a file, fail with a clear error.
+- If `dirs::config_dir()` returns `None`, fail with a clear error explaining that the config directory could not be determined and that `--config-dir` or `ENSEMBLE_CONFIG_DIR` can be used instead.
+- If `~` expansion is required but the home directory cannot be determined, fail with a clear error instead of guessing.
 
-After expansion:
-
-- CLI resolves relative `--config`, `--config-dir`, `ENSEMBLE_CONFIG`, and `ENSEMBLE_CONFIG_DIR` values against the invocation cwd.
-- Desktop rejects relative `ENSEMBLE_CONFIG` and `ENSEMBLE_CONFIG_DIR` values with a clear error and requires them to resolve to absolute paths.
-
-This keeps the CLI shell-friendly while preserving the desktop guarantee that default startup and override handling do not depend on an implicit cwd.
+This keeps the CLI shell-friendly while preserving the desktop guarantee that startup does not depend on an implicit cwd.
 
 ## Relative Path Semantics
 
-Once `config.yaml` is resolved, Ensemble treats the config file's parent directory as the base directory for path-like fields.
+Once `config.yaml` is resolved, Ensemble treats the config file's parent directory as the base directory for config-relative fields.
 
 This applies to:
 
-- `tracker.path`
 - `agents.*.prompt_template`
 - `repos[*].path`
 - `workspace.root`
+- `tracker.path` when the user explicitly sets it to a relative path
 
-Resolution order for each path-like field:
+Resolution order for each path-like config field:
 
 1. Resolve `$ENV_VAR` if present.
 2. Expand `~` if present.
 3. If the resulting path is relative, join it against the directory containing `config.yaml`.
 4. Preserve absolute paths unchanged.
 
-This removes cwd sensitivity and lets users move the whole config directory without breaking adjacent files.
+This removes cwd sensitivity and lets users move the whole config directory without breaking config-adjacent assets.
 
 ## Todo File Location
 
-The config already has `tracker.path`; this remains the way users set the location of the local TODO tracker file.
+The config still uses `tracker.path` to specify the TODO tracker file location.
 
 For `tracker.kind: todo_file`:
 
 - If `tracker.path` is set, use it after normal path resolution.
-- If `tracker.path` is omitted, default it to `TODO.md` relative to the config directory.
+- If `tracker.path` is omitted, default it to `~/ensemble/TODO.md`.
 
-That means the default todo tracker file becomes:
+Parent-directory behavior:
 
-```text
-<config_dir>/TODO.md
-```
+- `ensemble init` creates the parent directory for the resolved TODO file path before writing the file.
+- Runtime commands do not create missing parent directories for the TODO file; they fail with a clear error naming the missing path.
 
-`ensemble init` should make this visible by prompting for the TODO file path and defaulting it to `TODO.md`.
+That default is intentionally outside the config directory because the TODO file is treated as mutable state rather than configuration.
+
+This means:
+
+- config lives under `dirs::config_dir()/ensemble/`
+- default TODO state lives under `~/ensemble/TODO.md`
+
+`ensemble init` should make this visible by prompting for the TODO file path and defaulting it to `~/ensemble/TODO.md`.
 
 ## Entrypoint Behavior
 
-### CLI
+### CLI Runtime Commands
 
-- Replace positional default config arguments with explicit shared config options.
-- `ensemble run` and `ensemble web` resolve config through the shared resolver.
+- `ensemble run` and `ensemble web` resolve the config directory through the shared resolver.
 - Bare `ensemble` continues to default to `run`, using the same resolver.
-- `ensemble init` supports `--config-dir` but not `--config`, and always writes the canonical `config.yaml` filename inside the resolved directory.
+- Runtime commands accept `--config-dir` and do not accept `--config`.
+- Old positional config-path invocation and `--config` should fail with clear help directing the user to `--config-dir`.
+
+### CLI Init
+
+- `ensemble init` supports `--config-dir` and always writes the canonical `config.yaml` filename inside the resolved directory.
 - If `<config_dir>/config.yaml` already exists, `init` prompts before overwrite. If the user accepts, it loads the existing config and uses it as the source of prompt defaults where possible.
 - If the existing `config.yaml` cannot be parsed, `init` warns and continues with fresh defaults after the overwrite confirmation.
 - `ensemble init` writes into the resolved config directory by default.
@@ -129,21 +140,29 @@ That means the default todo tracker file becomes:
 
 ### Desktop
 
-- Resolve config before startup using the shared resolver.
+- Resolve config before startup using the shared config-directory resolver.
 - Do not call `set_current_dir()` as part of config discovery.
-- Missing-config errors and dialogs should point to the resolved `config.yaml` path.
-- Honor `ENSEMBLE_CONFIG` and `ENSEMBLE_CONFIG_DIR` for automation and debugging.
+- Missing-config errors and dialogs should point to the resolved `<config_dir>/config.yaml` path.
+- Honor `ENSEMBLE_CONFIG_DIR` for automation and debugging.
+- Ignore legacy `ENSEMBLE_CONFIG`; if set, report that only `ENSEMBLE_CONFIG_DIR` is supported.
 
 ## Init Output
 
-The init wizard should stop writing files into the process cwd. Instead it writes into the resolved config directory:
+The init wizard should stop writing files into the process cwd. Instead it writes config assets into the resolved config directory:
 
 ```text
 <config_dir>/config.yaml
 <config_dir>/templates/*.liquid
-<config_dir>/TODO.md
 <config_dir>/.env
 ```
+
+If `todo_file` is selected and the user accepts the default TODO path, `init` should also write:
+
+```text
+~/ensemble/TODO.md
+```
+
+If the user overrides `tracker.path`, `init` writes the TODO file at that resolved location instead.
 
 Generated config examples and prompts should use `config.yaml`, not `ensemble.yaml`.
 
@@ -153,73 +172,106 @@ When `init` writes sibling files in an existing config directory:
 
 - overwrite of `config.yaml` is controlled by the initial config overwrite confirmation
 - existing `templates/*.liquid` files prompt individually before overwrite
-- existing `TODO.md` prompts before overwrite when `todo_file` is selected
 - existing `.env` prompts before overwrite
+- existing TODO files prompt before overwrite at their resolved target path
 
 This keeps `init` non-destructive for adjacent user-managed files while still allowing the canonical config file to be refreshed intentionally.
 
 ## `.env` Loading
 
-After resolving the final config file path, but before config parsing and `$VAR` substitution, Ensemble should attempt to load a sibling `.env` file from the config directory.
+After resolving the final config directory, but before config parsing and `$VAR` substitution, Ensemble should attempt to load a sibling `.env` file from the config directory.
 
 Rules:
 
 - `.env` loading is optional; missing files are ignored.
 - Values from `.env` do not override environment variables that are already set in the parent process.
-- The `.env` file is always looked up relative to the resolved config file directory, not cwd.
+- The `.env` file is always looked up relative to the resolved config directory, not cwd.
 
 This allows desktop and CLI launches to resolve values like `tracker.api_key: $GITHUB_TOKEN` consistently from `<config_dir>/.env`.
+
+## Open Config Directory Command
+
+Add a CLI command:
+
+```text
+ensemble open-config-dir
+```
+
+Behavior:
+
+- Resolve the config directory using the same `--config-dir` / `ENSEMBLE_CONFIG_DIR` / default rules.
+- If the directory exists, open it in the platform file manager.
+  - macOS: Finder via `open`
+  - Linux: desktop opener such as `xdg-open`
+  - Windows: Explorer via `explorer`
+- If the directory does not exist, fail with a clear message showing the resolved path and direct the user to run `ensemble init`.
+- The command does not create directories.
+
+This command is for directory discovery and debugging, not initialization.
 
 ## Config Loader Changes
 
 The current loader in `crates/ensemble-core/src/config/ensemble.rs` resolves `$VAR` and `~`, but it does not know the source config directory. That is the root cause of cwd-sensitive behavior.
 
-The loader should be updated so that loading a config file includes source-aware path rebasing. A small shared module should own:
+The loader should be updated so that loading a config directory includes source-aware path rebasing. A small shared module should own:
 
 - default config home calculation
-- precedence resolution for file vs directory overrides
-- deriving `<dir>/config.yaml`
-- rebasing relative config fields against the config file directory
+- config-directory override resolution
+- deriving `<config_dir>/config.yaml`
+- rebasing relative config fields against the config directory
+- default TODO state path derivation (`~/ensemble/TODO.md`)
 
 `load_config()` should accept the resolved config file path, load a sibling `.env` file if present, and use the config file parent directory during path resolution.
 
 ## Error Handling
 
-- When the resolved config file is missing, error messages must include the exact expected `config.yaml` path.
+- When the resolved config file is missing, error messages must include the exact expected `<config_dir>/config.yaml` path.
 - Desktop missing-config dialogs must reference that resolved path, not a cwd-relative filename.
 - `init` should print the full paths it created.
-- If `dirs::config_dir()` returns `None`, fail with a clear error explaining that the config directory could not be determined and that `--config` or `--config-dir` can be used instead.
-- If a resolved directory contains a legacy `ensemble.yaml` sibling but no `config.yaml`, include an upgrade hint such as "found legacy ensemble.yaml; rename it to config.yaml or pass --config <path>".
-- If desktop receives a relative env-var override path, fail with a clear error instead of attempting cwd-based resolution.
-- If both override env vars are set, fail with a clear configuration error.
+- If a resolved directory contains a legacy `ensemble.yaml` sibling but no `config.yaml`, include an upgrade hint such as "found legacy ensemble.yaml; rename it to config.yaml".
+- If desktop receives a relative `ENSEMBLE_CONFIG_DIR`, fail with a clear error instead of attempting cwd-based resolution.
 - If `init` targets an existing `config.yaml`, the overwrite prompt must happen before any files are changed.
+- If `open-config-dir` targets a missing directory, fail and direct the user to `ensemble init`.
+- If legacy CLI or env override forms are used (`ensemble [PATH]`, `--config`, `ENSEMBLE_CONFIG`), fail with a migration hint to use config-directory-based resolution.
+- If the default TODO path or a configured TODO path requires `~` expansion but the home directory cannot be determined, fail with a clear error.
+- If the resolved config-dir target exists as a file rather than a directory, fail with a clear error.
 
 ## Migration and Documentation
 
 - Switch docs, tests, examples, and API status payloads from `ensemble.yaml` to `config.yaml`.
 - Remove references to repo-root config discovery as the default model.
 - Do not search for `./ensemble.yaml` automatically.
-- Keep `ENSEMBLE_CONFIG` as the file override env var name and add `ENSEMBLE_CONFIG_DIR` as the directory override env var.
-- Document that runtime commands accept both `--config` and `--config-dir`, while `init` accepts only `--config-dir`.
+- Keep only `ENSEMBLE_CONFIG_DIR` as the override env var.
+- Document that runtime commands and `init` accept `--config-dir` only.
+- Document migration away from legacy positional config arguments, `--config`, and `ENSEMBLE_CONFIG`.
+- Document the new default separation between config (`dirs::config_dir()/ensemble`) and TODO state (`~/ensemble/TODO.md`).
 - Update init messaging so `.env` is described as auto-loaded from the config directory instead of telling users to `source` it manually.
+- Document `ensemble open-config-dir` and its failure behavior for missing directories.
 
 ## Testing
 
 Add or update tests for:
 
-- config resolution precedence across flags, env vars, and defaults
-- deriving `config.yaml` from `--config-dir` and `ENSEMBLE_CONFIG_DIR`
-- conflict errors for `--config` plus `--config-dir`, and for `ENSEMBLE_CONFIG` plus `ENSEMBLE_CONFIG_DIR`
-- CLI relative override resolution against cwd
-- desktop rejection of relative env-var overrides
+- config-directory resolution precedence across flags, env vars, and defaults
+- derivation of `<config_dir>/config.yaml`
+- CLI relative `--config-dir` and `ENSEMBLE_CONFIG_DIR` resolution against cwd
+- desktop rejection of relative `ENSEMBLE_CONFIG_DIR`
+- failure behavior for legacy positional config path usage, `--config`, and `ENSEMBLE_CONFIG`
+- failure when the resolved config-dir path is an existing file
 - missing `dirs::config_dir()` handling
+- missing home-directory expansion for `~` and the default TODO path
 - sibling `.env` loading without overriding existing process env
 - relative path rebasing for `tracker.path`, `prompt_template`, `repos[*].path`, and `workspace.root`
-- default `TODO.md` placement under the config directory when `tracker.path` is omitted
-- `init` writing files into the resolved config directory
+- default `~/ensemble/TODO.md` placement when `tracker.path` is omitted
+- `init` writing config files into the resolved config directory
+- `init` writing TODO state to the resolved tracker path
+- `init` creating missing parent directories for TODO state output
+- runtime failure when the resolved TODO parent directory is missing
 - `init` loading an existing `config.yaml` for defaults after overwrite confirmation
 - `init` refusing to overwrite an existing `config.yaml` when the user declines
 - `init` behavior when a legacy `ensemble.yaml` exists in the target directory
+- `open-config-dir` opening an existing directory
+- `open-config-dir` failing with a helpful message when the directory is missing
 - desktop missing-config behavior using resolved paths
 
 ## Files Likely Affected
@@ -232,9 +284,10 @@ Add or update tests for:
 - `crates/ensemble-cli/src/commands/init/generate.rs`
 - `crates/ensemble-cli/src/commands/run.rs`
 - `crates/ensemble-cli/src/commands/web.rs`
+- `crates/ensemble-cli/src/commands/` (new `open_config_dir.rs` or equivalent)
 - `crates/ensemble-desktop/src/main.rs`
 - docs and tests that currently reference `ensemble.yaml`
 
 ## Recommendation
 
-Adopt a single per-user config home based on `dirs::config_dir()/ensemble`, keep CLI-friendly overrides via `--config` and `--config-dir`, and make all relative config paths resolve from the loaded `config.yaml` location. This fixes the Tauri cwd issue and makes configuration behavior consistent and portable across entrypoints.
+Adopt a single per-user config directory based on `dirs::config_dir()/ensemble`, derive the config file as `<config_dir>/config.yaml`, expose only `config-dir` overrides, keep config-relative paths rooted in the config directory, default TODO tracker state to `~/ensemble/TODO.md`, and add `ensemble open-config-dir` for discoverability. This fixes the Tauri cwd issue while drawing a clean boundary between config and mutable local state.


### PR DESCRIPTION
## Summary
- move runtime config discovery to a shared config-directory model built around `<config_dir>/config.yaml`
- update CLI, desktop startup, and TODO tracker defaults to work without cwd assumptions, including `ensemble open-config-dir`
- refresh docs, specs, tests, and smoke coverage for the config-dir migration and follow-up review fixes

## Test Plan
- [x] `SKIP_UI_BUILD=1 cargo test -p ensemble-cli`
- [x] `cargo test -p ensemble-core`
- [x] `SKIP_UI_BUILD=1 cargo test -p ensemble-desktop`