### PR TITLE
Document GSD-style workflow examples for Ensemble

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,6 @@ This opens the resolved configuration directory in your system's file manager. I
 
 - [Configuration Reference](docs/configuration.md) — every `config.yaml` field
 - [Pipeline Guide](docs/pipelines.md) — steps, DAGs, verdicts, retries
+- [GSD-Style Workflow](docs/gsd-workflow.md) — parent planning issues, wave execution issues, and board rules
 - [Contributing](docs/contributing.md) — building, testing, project structure
 - [Roadmap](docs/roadmap.md) — what's built, what's coming

--- a/docs/examples/github-projects/gsd-board-rules.md
+++ b/docs/examples/github-projects/gsd-board-rules.md
@@ -1,0 +1,38 @@
+# GSD Board Rules
+
+Use one shared GitHub status field for both parent planning issues and child wave execution issues.
+
+## Parent Issue States
+
+- `Draft`
+- `Planning`
+- `Plan Review`
+- `Planned`
+- `Done`
+
+## Child Wave States
+
+- `Planned`
+- `Ready`
+- `In Progress`
+- `Needs Input`
+- `In Review`
+- `Done`
+
+## Execution Rules
+
+- Only `Ready` is executable by Ensemble.
+- Only waves with satisfied dependencies may move to `Ready`.
+- Multiple waves may be `Ready` in parallel when their dependency sets are fully satisfied.
+- Review rejection returns the same wave issue to `Ready`.
+- Retries and technical failures stay attached to the same wave issue.
+- The parent issue reaches `Done` only when all child wave issues are `Done`.
+
+## Ownership Notes
+
+- The planning agent sets parent issues to `Planning` and `Plan Review`, creates child wave issues, and initializes child issue state.
+- Ensemble may move a wave from `Ready` to `In Progress` when its tracker integration supports that state transition.
+- The execution agent usually moves wave issues to `Needs Input`, `In Review`, or `Done` when the tracker tooling supports it.
+- A release or promotion workflow advances later waves from `Planned` to `Ready` and completes the parent issue.
+
+If the runtime cannot write a board state directly, the agent must record the intended state transition in the issue comment or verification artifact.

--- a/docs/examples/issues/ensemble-parent-planning.md
+++ b/docs/examples/issues/ensemble-parent-planning.md
@@ -1,0 +1,38 @@
+# Ensemble Parent Planning Example
+
+## Goal
+
+Describe the feature or outcome this parent issue should deliver.
+
+## Context
+
+Summarize the relevant product, codebase, or workflow context.
+
+## Constraints
+
+List boundaries, non-goals, rollout concerns, or repo conventions.
+
+## Acceptance Criteria
+
+List the feature-level outcomes that must be true when all waves are complete.
+
+## Related Docs
+
+- Spec:
+- Plan:
+- Additional context:
+
+## Planning Output Expectations
+
+- `docs/phases/<parent-or-feature-slug>/SPEC.md`
+- `docs/phases/<parent-or-feature-slug>/PLAN.md`
+- child wave issues after approval
+
+## Agent Instructions
+
+- Treat this issue as the planning container.
+- Avoid clarifying-question loops unless blocked.
+- Do not create child issues until the plan is approved or finalized.
+- Do not move any child wave issue to `Ready` until the approved `SPEC.md` and `PLAN.md` artifacts are committed or merged.
+- Create exactly one child issue per wave after approval.
+- Update this parent issue with a wave summary table and links to all generated child wave issues.

--- a/docs/examples/issues/ensemble-wave-execution.md
+++ b/docs/examples/issues/ensemble-wave-execution.md
@@ -1,0 +1,55 @@
+# Ensemble Wave Execution Example
+
+## Parent
+
+Parent issue reference.
+
+## Wave Number
+
+Wave number within the approved plan.
+
+## Goal
+
+What this wave should accomplish.
+
+## Depends On
+
+List prerequisite wave issues or write `None`.
+
+## Included Tasks
+
+List the tasks from the approved plan that belong in this wave.
+
+## Success Criteria
+
+State the wave-specific outcomes that must be true before marking this issue done.
+
+## Artifacts
+
+- Spec:
+- Plan:
+- Expected Verification Path:
+- Verification Link:
+
+## Execution Metadata
+
+- Branch:
+- Workspace:
+- Last Run Timestamp:
+- Attempt Count:
+- Latest Verdict:
+- PR Link:
+- Blocker Summary:
+
+Required fields: parent, wave number, goal, dependencies, included tasks, success criteria, spec/plan links, expected verification path.
+
+Best-effort during execution: verification link, branch, workspace, last run timestamp, attempt count, latest verdict, PR link, blocker summary.
+
+Best-effort execution metadata should be left blank or omitted when the runtime cannot maintain it reliably.
+
+## Agent Notes
+
+- Follow the approved plan artifact.
+- Do not replan from scratch.
+- Move back to `Ready` if review rejects the wave.
+- Use `Needs Input` when confidence is too low.

--- a/docs/examples/prompts/gsd-parent-planning-prompt.md
+++ b/docs/examples/prompts/gsd-parent-planning-prompt.md
@@ -1,0 +1,28 @@
+# GSD Parent Planning Prompt
+
+Use this prompt when an agent is planning from a parent GitHub issue.
+
+```text
+You are working on a parent planning issue for Ensemble's GSD-style workflow.
+
+Your job is to act as the planning agent for the whole feature, not the execution agent for a single wave.
+
+Required behavior:
+- Read the parent issue, repository context, and any linked design docs.
+- Produce or update `docs/phases/<parent-or-feature-slug>/SPEC.md` and `docs/phases/<parent-or-feature-slug>/PLAN.md`.
+- Decompose the approved plan into execution waves.
+- Avoid clarifying-question loops unless blocked.
+- Wait for finalized approval before creating child issues.
+- Ensure the approved `SPEC.md` and `PLAN.md` artifacts are committed or merged before any child wave issue is moved to `Ready`.
+- Create exactly one child issue per wave using the approved wave issue template.
+- Ensure each child wave issue includes parent reference, wave number, dependencies, success criteria, spec link, plan link, and expected verification artifact path.
+- Set initial child issue states by wave order: wave 1 starts `Ready`, later waves start `Planned`.
+- Update the parent issue with a wave summary table and links to all generated child issues.
+
+Tooling expectations:
+- You have git access.
+- You can edit repo docs.
+- You can write to the tracker via `gh`, MCP, or an equivalent tool.
+
+If direct tracker state writes are unavailable, record the intended state transition in an issue comment or in the relevant verification artifact instead of dropping it.
+```

--- a/docs/examples/prompts/gsd-wave-execution-prompt.md
+++ b/docs/examples/prompts/gsd-wave-execution-prompt.md
@@ -1,0 +1,27 @@
+# GSD Wave Execution Prompt
+
+Use this prompt when an agent is executing one approved wave issue.
+
+```text
+You are working on a child wave issue for Ensemble's GSD-style workflow.
+
+Your job is to execute only the current wave using the approved planning artifacts.
+
+Required behavior:
+- Read the wave issue and all linked artifacts before making changes.
+- Execute only the current wave.
+- Use a branch-per-wave strategy from `main`.
+- Write verification output to `docs/phases/<parent-or-feature-slug>/verification/WAVE-<n>.md`.
+- Keep the issue summary compact and operational.
+- Include the latest verdict, PR link when present, and blocker summary when relevant.
+- Move the issue to `Needs Input` instead of guessing when confidence is too low.
+- Return the same wave issue to `Ready` after review rejection.
+- Keep retries and technical failures on the same wave issue and update retry metadata instead of creating replacement issues.
+
+Tooling expectations:
+- You have git access.
+- You can edit repo docs.
+- You can write to the tracker via `gh`, MCP, or an equivalent tool.
+
+If direct tracker state writes are unavailable, record the intended next state in the issue comment or verification artifact instead of silently dropping it.
+```

--- a/docs/gsd-workflow.md
+++ b/docs/gsd-workflow.md
@@ -1,0 +1,153 @@
+# GSD-Style Workflow With Ensemble
+
+## Who This Is For
+
+This workflow is for teams using GitHub issues as the human-facing planning surface and Ensemble as the issue executor. It is useful when you want GSD-style planning and wave-based execution without forking GSD and without teaching Ensemble any GSD-specific concepts.
+
+## What Ensemble Does And Does Not Know
+
+Ensemble remains a generic orchestrator. It knows how to poll eligible issues, create isolated workspaces, run agents, and write tracker updates that its runtime supports.
+
+Ensemble does not natively understand:
+
+- planning issues versus execution issues
+- wave graphs or dependency promotion rules
+- issue creation on your behalf
+- GSD-specific commands or artifacts
+
+Those behaviors come from your board rules, issue templates, and agent prompts.
+
+## Parent Issue Workflow
+
+The parent issue is the planning container for the whole feature.
+
+Recommended lifecycle:
+
+- `Draft` - initial human request
+- `Planning` - agent is writing or revising artifacts
+- `Plan Review` - artifacts are ready for approval
+- `Planned` - approved and ready to release waves
+- `Done` - all child waves are complete
+
+The planning agent should produce durable artifacts at:
+
+- `docs/phases/<parent-or-feature-slug>/SPEC.md`
+- `docs/phases/<parent-or-feature-slug>/PLAN.md`
+
+Those approved artifacts must be committed or merged before any child wave issue is moved to `Ready`.
+
+After approval, the planning agent creates one child issue per wave and updates the parent issue with a wave summary table plus links to every generated child issue.
+
+Example wave summary table:
+
+| Wave | Goal | Status | Issue |
+|---|---|---|---|
+| 1 | Write docs and templates | Ready | `#123` |
+| 2 | Validate workflow on a real feature | Planned | `#124` |
+
+## Wave Issue Workflow
+
+Each child issue is an execution container for one approved wave.
+
+Required fields:
+
+- parent reference
+- wave number and goal
+- dependencies
+- included tasks
+- success criteria
+- spec link
+- plan link
+- expected verification artifact path
+
+Best-effort execution metadata:
+
+- verification link
+- branch
+- workspace
+- last run timestamp
+- attempt count
+- latest verdict
+- PR link
+- blocker summary
+
+Best-effort metadata should be left blank or omitted when the runtime cannot maintain it reliably.
+
+The execution agent should read the linked artifacts, execute only the current wave, and keep the issue summary compact. Detailed progress belongs in repo artifacts, especially the per-wave verification file.
+
+## Branch Strategy
+
+The recommended default is one branch per wave created from `main`.
+
+This keeps each wave independently reviewable and matches the rule that dependency waves must already be complete and available on `main` before later waves become executable.
+
+## Board States
+
+Use one shared GitHub status field.
+
+Parent issue states:
+
+- `Draft`
+- `Planning`
+- `Plan Review`
+- `Planned`
+- `Done`
+
+Child wave states:
+
+- `Planned`
+- `Ready`
+- `In Progress`
+- `Needs Input`
+- `In Review`
+- `Done`
+
+`Ready` is the only state Ensemble should treat as executable.
+
+Multiple wave issues may be `Ready` at the same time when their dependency sets are fully satisfied.
+
+## Required Agent Capabilities
+
+The agent runtime should provide:
+
+- git access
+- tracker write access through `gh`, MCP, or an equivalent tool
+- permission to edit repo docs and issue bodies/comments
+
+## Recommended Artifacts
+
+Use durable docs under one feature-specific directory:
+
+- `docs/phases/<parent-or-feature-slug>/SPEC.md`
+- `docs/phases/<parent-or-feature-slug>/PLAN.md`
+- `docs/phases/<parent-or-feature-slug>/verification/WAVE-<n>.md`
+- optional `docs/phases/<parent-or-feature-slug>/HANDOFF.md`
+
+This keeps detailed decomposition and verification in git while leaving tracker issues as operational summaries.
+
+## Failure And Review Handling
+
+Use the same wave issue for retries, review cycles, and ambiguity handling.
+
+- low-confidence execution moves to `Needs Input`
+- review-required work moves to `In Review`
+- review rejection returns the same wave issue to `Ready`
+- transient failures stay on the same wave issue and update retry metadata
+
+If tracker state writes are unavailable, record the intended next state in the issue comment or verification artifact instead of silently dropping it.
+
+## Worked Example
+
+Parent issue: `Add issue templates and planning workflow`
+
+- Wave 1: write `docs/gsd-workflow.md`, issue templates, prompt examples, and board rules
+- Wave 2: run the workflow on a real parent issue and polish anything confusing
+
+See also:
+
+- `docs/superpowers/specs/2026-04-02-gsd-workflow-integration-design.md`
+- `docs/examples/issues/ensemble-parent-planning.md`
+- `docs/examples/issues/ensemble-wave-execution.md`
+- `docs/examples/prompts/gsd-parent-planning-prompt.md`
+- `docs/examples/prompts/gsd-wave-execution-prompt.md`
+- `docs/examples/github-projects/gsd-board-rules.md`

--- a/docs/superpowers/plans/2026-04-02-gsd-prompts-issue-templates-and-board-rules.md
+++ b/docs/superpowers/plans/2026-04-02-gsd-prompts-issue-templates-and-board-rules.md
@@ -1,0 +1,538 @@
+# GSD Prompts, Issue Templates, and Board Rules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add concrete repository artifacts for the GSD-inspired operating model by documenting reusable agent prompts, GitHub issue templates, and board rules that work with Ensemble without changing Ensemble itself.
+
+**Architecture:** Treat the workflow as a documentation-and-templates package rather than a product feature. Capture the operating contract in one implementation-facing doc, then add copy-pasteable parent issue templates, wave issue templates, and prompt templates that encode the approved behavior: parent-first planning, child issue per wave, branch-per-wave from `main`, non-interactive execution, and `Ready` as the only executable board state.
+
+**Tech Stack:** Markdown docs, GitHub issue templates, GitHub Projects conventions, existing Ensemble docs structure
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `docs/gsd-workflow.md` | Create | End-user operational guide for using GSD-style workflows with Ensemble |
+| `.github/ISSUE_TEMPLATE/ensemble-parent-planning.md` | Create | Parent issue template for feature planning containers |
+| `.github/ISSUE_TEMPLATE/ensemble-wave-execution.md` | Create | Child wave issue template created after plan approval |
+| `docs/examples/prompts/gsd-parent-planning-prompt.md` | Create | Reusable prompt for agents planning on parent issues |
+| `docs/examples/prompts/gsd-wave-execution-prompt.md` | Create | Reusable prompt for agents executing wave issues |
+| `docs/examples/github-projects/gsd-board-rules.md` | Create | Concrete board/state rules for parent and child issues |
+| `README.md` | Modify | Link to the new workflow guide if it fits existing docs navigation |
+
+---
+
+### Task 1: Write the End-User Workflow Guide
+
+**Files:**
+- Create: `docs/gsd-workflow.md`
+
+- [ ] **Step 1: Write the failing outline as headings only**
+
+Create `docs/gsd-workflow.md` with this initial structure:
+
+```md
+# GSD-Style Workflow With Ensemble
+
+## Who This Is For
+## What Ensemble Does And Does Not Know
+## Parent Issue Workflow
+## Wave Issue Workflow
+## Branch Strategy
+## Board States
+## Required Agent Capabilities
+## Recommended Artifacts
+## Failure And Review Handling
+## Worked Example
+```
+
+- [ ] **Step 2: Fill in the guide with operational details from the approved design**
+
+Document:
+
+```text
+- parent issue is the planning container
+- child issue per wave, created after plan approval
+- Ready is the only Ensemble-executable state
+- branch per wave from main
+- durable artifacts live under docs/phases/<parent-or-feature-slug>/
+- verification docs live at docs/phases/<parent-or-feature-slug>/verification/WAVE-<n>.md
+- issue creation uses gh or MCP, not Ensemble features
+```
+
+The finished guide must include these exact sections and contents:
+
+```text
+Who This Is For: explain this is a procedural workflow for teams using GitHub + Ensemble
+What Ensemble Does And Does Not Know: explain Ensemble does not understand waves or create issues
+Parent Issue Workflow: planning lifecycle, required outputs, wave summary table, and links to child wave issues
+Wave Issue Workflow: execution lifecycle, required fields, and compact operational updates
+Branch Strategy: branch per wave from main
+Board States: one shared status field with parent and child subsets
+Required Agent Capabilities: git, tracker write, repo doc editing
+Recommended Artifacts: SPEC.md, PLAN.md, verification/WAVE-n.md
+Failure And Review Handling: Needs Input, In Review, and review rejection back to Ready
+Worked Example: one short parent-plus-waves example
+```
+
+The parent workflow section must explicitly state that approved `docs/phases/<parent-or-feature-slug>/SPEC.md` and `docs/phases/<parent-or-feature-slug>/PLAN.md` artifacts are committed or merged before any child wave issue is moved to `Ready`.
+
+- [ ] **Step 3: Add one concrete example section**
+
+Include a short worked example showing:
+
+```text
+Parent issue: "Add issue templates and planning workflow"
+Wave 1: write docs and templates
+Wave 2: validate flow with a real parent issue
+```
+
+- [ ] **Step 4: Review for duplication and keep it user-facing**
+
+Verify all of the following acceptance checks:
+
+```text
+- the guide explains how to use the workflow rather than restating the full design doc
+- the parent issue section includes a short wave summary table example
+- the guide links to the parent issue template, wave issue template, prompt examples, and board rules doc
+- the guide states that Ensemble does not create issues or understand waves natively
+- the guide states that approved SPEC.md and PLAN.md artifacts land before any wave is released to Ready
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/gsd-workflow.md
+git commit -m "Document GSD-style Ensemble workflow"
+```
+
+---
+
+### Task 2: Add the Parent Issue Template
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/ensemble-parent-planning.md`
+
+- [ ] **Step 0: Verify the parent template directory exists before writing files**
+
+Run:
+
+```bash
+ls .github
+```
+
+If `.github/ISSUE_TEMPLATE/` does not exist, create it before writing the template.
+
+Run:
+
+```bash
+mkdir -p .github/ISSUE_TEMPLATE
+```
+
+- [ ] **Step 1: Create the template scaffold**
+
+Use a GitHub issue template frontmatter and body like:
+
+```md
+---
+name: Ensemble Parent Planning
+about: Planning container for a GSD-style feature workflow
+title: "[Parent] "
+---
+
+## Goal
+
+## Context
+
+## Constraints
+
+## Acceptance Criteria
+
+## Related Docs
+
+## Planning Output Expectations
+- SPEC.md
+- PLAN.md
+- child wave issues after approval
+```
+
+- [ ] **Step 2: Add instructions for the planning agent**
+
+Include a short note in the template body telling the agent to:
+
+```text
+- treat this issue as the planning container
+- do not create child issues until the plan is approved/finalized
+- do not move any child wave issue to Ready until the approved SPEC.md and PLAN.md artifacts are committed or merged
+- create one child issue per wave after approval
+- update this parent issue with a wave summary table and links to all generated child wave issues
+```
+
+- [ ] **Step 3: Review the template for GitHub readability**
+
+Verify all of the following acceptance checks:
+
+```text
+- a human can fill out Goal, Context, Constraints, and Acceptance Criteria without reading other docs
+- the template tells the agent to wait for plan approval before creating child issues
+- the template tells the agent to update the parent issue with a wave summary table and child links
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/ensemble-parent-planning.md
+git commit -m "Add parent planning issue template"
+```
+
+---
+
+### Task 3: Add the Wave Issue Template
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/ensemble-wave-execution.md`
+
+- [ ] **Step 0: Verify the wave template directory exists before writing files**
+
+Run:
+
+```bash
+ls .github
+```
+
+If `.github/ISSUE_TEMPLATE/` does not exist, create it before writing the template.
+
+Run:
+
+```bash
+mkdir -p .github/ISSUE_TEMPLATE
+```
+
+- [ ] **Step 1: Create the template scaffold**
+
+Start with a wave-focused body:
+
+```md
+---
+name: Ensemble Wave Execution
+about: Execution container for one approved wave
+title: "[Wave] "
+---
+
+## Parent
+
+## Wave Number
+
+## Goal
+
+## Depends On
+
+## Included Tasks
+
+## Success Criteria
+
+## Artifacts
+- Spec:
+- Plan:
+- Expected Verification Path:
+- Verification Link:
+
+## Execution Metadata
+- Branch:
+- Workspace:
+- Last Run Timestamp:
+- Attempt Count:
+- Latest Verdict:
+- PR Link:
+- Blocker Summary:
+```
+
+- [ ] **Step 2: Mark required versus best-effort fields in template text**
+
+Make the body clearly distinguish:
+
+```text
+Required: parent, wave number, goal, dependencies, included tasks, success criteria, spec/plan links, expected verification path
+Best-effort during execution: verification link, branch, workspace, attempt count, latest verdict, PR link, blocker summary
+```
+
+Add one sentence to the template notes stating that best-effort execution metadata should be left blank or omitted when the runtime cannot maintain it reliably.
+
+- [ ] **Step 3: Add execution notes for the agent**
+
+Add a small section that says:
+
+```text
+- follow the approved plan artifact
+- do not replan from scratch
+- move back to Ready if review rejects the wave
+- use Needs Input when confidence is too low
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/ensemble-wave-execution.md
+git commit -m "Add wave execution issue template"
+```
+
+---
+
+### Task 4: Write Reusable Parent And Wave Prompts
+
+**Files:**
+- Create: `docs/examples/prompts/gsd-parent-planning-prompt.md`
+- Create: `docs/examples/prompts/gsd-wave-execution-prompt.md`
+
+- [ ] **Step 0: Verify the prompt examples directory exists before writing files**
+
+Run:
+
+```bash
+ls docs
+```
+
+If `docs/examples/prompts/` does not exist, create it before writing the prompt examples.
+
+Run:
+
+```bash
+mkdir -p docs/examples/prompts
+```
+
+- [ ] **Step 1: Draft the parent planning prompt**
+
+Write a reusable prompt that instructs an agent to:
+
+```text
+- read the parent issue and repo context
+- produce docs at docs/phases/<parent-or-feature-slug>/SPEC.md and docs/phases/<parent-or-feature-slug>/PLAN.md
+- decompose the plan into waves
+- avoid clarifying-question loops unless blocked
+- ensure the approved SPEC.md and PLAN.md artifacts are committed or merged before any child wave issue is moved to Ready
+- wait for finalized approval before creating child issues
+- create one child issue per wave using the wave template
+- ensure each child wave issue includes parent reference, wave number, dependencies, success criteria, spec/plan links, and expected verification artifact path
+- update the parent issue with a wave summary table and links to generated child issues
+- set initial child issue states by wave order: wave 1 to Ready, later waves to Planned
+```
+
+- [ ] **Step 2: Draft the wave execution prompt**
+
+Write a reusable prompt that instructs an agent to:
+
+```text
+- read the wave issue and linked artifacts
+- execute only the current wave
+- use branch-per-wave from main
+- write verification to docs/phases/<parent-or-feature-slug>/verification/WAVE-<n>.md
+- update issue state and metadata compactly
+- include latest verdict, PR link when present, and blocker summary when relevant
+- return to Ready after review rejection
+- keep retries and technical failures on the same wave issue and update retry metadata instead of creating replacement issues
+- move the issue to Needs Input instead of guessing when confidence is too low
+- if tracker state writes are unavailable, record the intended next state in the issue comment or verification artifact
+```
+
+- [ ] **Step 3: Add explicit tool requirements to both prompts**
+
+Document the expected runtime capabilities:
+
+```text
+- git access
+- tracker write access via gh or MCP
+- ability to edit repo docs
+```
+
+- [ ] **Step 4: Review both prompts for contradiction with the design doc**
+
+Verify all of the following acceptance checks:
+
+```text
+- parent prompt says avoid clarifying-question loops unless blocked
+- parent prompt says create one child issue per wave only after plan finalization
+- parent prompt says each child issue must include the required wave fields from the spec
+- parent prompt says wave 1 starts Ready and later waves start Planned
+- wave prompt says branch per wave from main
+- wave prompt says review rejection returns to Ready
+- wave prompt says low-confidence execution moves to Needs Input
+- wave prompt says retries stay on the same wave issue
+- both prompts say tracker writes may fall back to issue comments or verification artifacts when direct state writes are unavailable
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/examples/prompts/gsd-parent-planning-prompt.md docs/examples/prompts/gsd-wave-execution-prompt.md
+git commit -m "Add GSD workflow prompt examples"
+```
+
+---
+
+### Task 5: Document GitHub Board Rules
+
+**Files:**
+- Create: `docs/examples/github-projects/gsd-board-rules.md`
+
+- [ ] **Step 0: Verify the board-rules directory exists before writing files**
+
+Run:
+
+```bash
+ls docs
+```
+
+If `docs/examples/github-projects/` does not exist, create it before writing the board rules doc.
+
+Run:
+
+```bash
+mkdir -p docs/examples/github-projects
+```
+
+- [ ] **Step 1: Write the board-state contract**
+
+Document one shared GitHub status field with these states:
+
+```text
+Parent issues: Draft, Planning, Plan Review, Planned, Done
+Child issues: Planned, Ready, In Progress, Needs Input, In Review, Done
+```
+
+- [ ] **Step 2: Add promotion and rejection rules**
+
+Capture the key invariants:
+
+```text
+- only Ready is executable by Ensemble
+- only waves with satisfied dependencies may move to Ready
+- multiple waves may be Ready at the same time when their dependency sets are satisfied
+- review rejection returns the same wave issue to Ready
+- retries and technical failures stay attached to the same wave issue
+- parent reaches Done only when all child waves are Done
+```
+
+- [ ] **Step 3: Add ownership notes**
+
+Specify who usually performs each transition:
+
+```text
+- planning agent sets parent Planning/Plan Review and creates wave issues
+- Ensemble dispatch moves Ready to In Progress when supported
+- execution agent sets Needs Input, In Review, or Done when supported
+- release/promotion workflow advances later waves and completes parent issue
+```
+
+Also include one explicit note that there is a single shared GitHub status field rather than separate parent and child boards.
+
+Also include one explicit fallback note: if the runtime cannot write a board state directly, the agent must record the intended state transition in the issue comment or verification artifact.
+
+- [ ] **Step 4: Verify the board rules against the key invariants**
+
+Confirm the doc explicitly states:
+
+```text
+- only Ready is executable
+- dependency-satisfied waves may become Ready in parallel
+- review rejection returns to Ready
+- retries stay on the same wave issue
+- parent reaches Done only when all child waves are Done
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/examples/github-projects/gsd-board-rules.md
+git commit -m "Document GSD workflow board rules"
+```
+
+---
+
+### Task 6: Link the New Workflow Docs From Existing Entry Points
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add one small docs link in the most relevant section**
+
+Add a concise pointer to `docs/gsd-workflow.md` in the existing documentation list or the nearest equivalent docs navigation section. Do not add a new top-level README section just for this workflow.
+
+If the README does not currently have a natural docs navigation location, skip the edit and record that decision in the final verification notes instead of forcing an awkward link.
+
+- [ ] **Step 2: Verify the new link text matches existing README tone**
+
+Keep the wording short and consistent with current documentation style.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git status --short README.md
+```
+
+Expected: either `M README.md` if a natural docs link was added, or no output if the README was intentionally left unchanged.
+
+- [ ] **Step 4: Only if README.md changed, commit it**
+
+```bash
+git add README.md
+git commit -m "Link GSD workflow guide from README"
+```
+
+---
+
+### Task 7: Verify the Documentation Package End-to-End
+
+**Files:**
+- Modify as needed: any files created above
+
+- [ ] **Step 1: Check all new file paths and references**
+
+Verify every referenced path exists:
+
+```bash
+ls docs/gsd-workflow.md .github/ISSUE_TEMPLATE/ensemble-parent-planning.md .github/ISSUE_TEMPLATE/ensemble-wave-execution.md docs/examples/prompts/gsd-parent-planning-prompt.md docs/examples/prompts/gsd-wave-execution-prompt.md docs/examples/github-projects/gsd-board-rules.md
+```
+
+Expected: all files exist.
+
+- [ ] **Step 2: Search for outdated contradictory wording**
+
+Run:
+
+```bash
+rg -n "In Progress.*review rejection|shared feature branch|child issue per plan" docs .github/ISSUE_TEMPLATE README.md
+```
+
+Expected: no contradictory wording remains, or every hit is intentionally updated.
+
+- [ ] **Step 3: Read the final doc set for consistency**
+
+Confirm the same defaults appear everywhere:
+
+```text
+- parent issue plans first
+- child issue per wave
+- branch per wave from main
+- Ready is the executable state
+- review rejection returns to Ready
+- direct tracker-write failures fall back to recording intended state in issue comments or verification docs
+- approved SPEC.md and PLAN.md land before waves are released to Ready
+- unsupported best-effort metadata is omitted rather than partially maintained
+```
+
+- [ ] **Step 4: Commit the final documentation package**
+
+```bash
+git status --short
+```
+
+Expected: either a clean working tree because the per-task commits already captured everything, or a small final consistency fix that still needs committing.
+
+- [ ] **Step 5: Only if verification caused additional edits, create a final cleanup commit**
+
+```bash
+git add docs/gsd-workflow.md .github/ISSUE_TEMPLATE/ensemble-parent-planning.md .github/ISSUE_TEMPLATE/ensemble-wave-execution.md docs/examples/prompts/gsd-parent-planning-prompt.md docs/examples/prompts/gsd-wave-execution-prompt.md docs/examples/github-projects/gsd-board-rules.md README.md
+git commit -m "Polish GSD workflow documentation package"
+```

--- a/docs/superpowers/plans/2026-04-02-gsd-prompts-issue-templates-and-board-rules.md
+++ b/docs/superpowers/plans/2026-04-02-gsd-prompts-issue-templates-and-board-rules.md
@@ -15,8 +15,8 @@
 | File | Action | Responsibility |
 |------|--------|----------------|
 | `docs/gsd-workflow.md` | Create | End-user operational guide for using GSD-style workflows with Ensemble |
-| `.github/ISSUE_TEMPLATE/ensemble-parent-planning.md` | Create | Parent issue template for feature planning containers |
-| `.github/ISSUE_TEMPLATE/ensemble-wave-execution.md` | Create | Child wave issue template created after plan approval |
+| `docs/examples/issues/ensemble-parent-planning.md` | Create | Parent issue example for feature planning containers |
+| `docs/examples/issues/ensemble-wave-execution.md` | Create | Child wave issue example created after plan approval |
 | `docs/examples/prompts/gsd-parent-planning-prompt.md` | Create | Reusable prompt for agents planning on parent issues |
 | `docs/examples/prompts/gsd-wave-execution-prompt.md` | Create | Reusable prompt for agents executing wave issues |
 | `docs/examples/github-projects/gsd-board-rules.md` | Create | Concrete board/state rules for parent and child issues |
@@ -110,38 +110,32 @@ git commit -m "Document GSD-style Ensemble workflow"
 
 ---
 
-### Task 2: Add the Parent Issue Template
+### Task 2: Add the Parent Issue Example
 
 **Files:**
-- Create: `.github/ISSUE_TEMPLATE/ensemble-parent-planning.md`
+- Create: `docs/examples/issues/ensemble-parent-planning.md`
 
-- [ ] **Step 0: Verify the parent template directory exists before writing files**
+- [ ] **Step 0: Verify the example issue directory exists before writing files**
 
 Run:
 
 ```bash
-ls .github
+ls docs
 ```
 
-If `.github/ISSUE_TEMPLATE/` does not exist, create it before writing the template.
+If `docs/examples/issues/` does not exist, create it before writing the example.
 
 Run:
 
 ```bash
-mkdir -p .github/ISSUE_TEMPLATE
+mkdir -p docs/examples/issues
 ```
 
 - [ ] **Step 1: Create the template scaffold**
 
-Use a GitHub issue template frontmatter and body like:
+Use a markdown example issue body like:
 
 ```md
----
-name: Ensemble Parent Planning
-about: Planning container for a GSD-style feature workflow
-title: "[Parent] "
----
-
 ## Goal
 
 ## Context
@@ -183,44 +177,38 @@ Verify all of the following acceptance checks:
 - [ ] **Step 4: Commit**
 
 ```bash
-git add .github/ISSUE_TEMPLATE/ensemble-parent-planning.md
-git commit -m "Add parent planning issue template"
+git add docs/examples/issues/ensemble-parent-planning.md
+git commit -m "Add parent planning issue example"
 ```
 
 ---
 
-### Task 3: Add the Wave Issue Template
+### Task 3: Add the Wave Issue Example
 
 **Files:**
-- Create: `.github/ISSUE_TEMPLATE/ensemble-wave-execution.md`
+- Create: `docs/examples/issues/ensemble-wave-execution.md`
 
-- [ ] **Step 0: Verify the wave template directory exists before writing files**
+- [ ] **Step 0: Verify the example issue directory exists before writing files**
 
 Run:
 
 ```bash
-ls .github
+ls docs
 ```
 
-If `.github/ISSUE_TEMPLATE/` does not exist, create it before writing the template.
+If `docs/examples/issues/` does not exist, create it before writing the example.
 
 Run:
 
 ```bash
-mkdir -p .github/ISSUE_TEMPLATE
+mkdir -p docs/examples/issues
 ```
 
 - [ ] **Step 1: Create the template scaffold**
 
-Start with a wave-focused body:
+Start with a wave-focused example body:
 
 ```md
----
-name: Ensemble Wave Execution
-about: Execution container for one approved wave
-title: "[Wave] "
----
-
 ## Parent
 
 ## Wave Number
@@ -274,8 +262,8 @@ Add a small section that says:
 - [ ] **Step 4: Commit**
 
 ```bash
-git add .github/ISSUE_TEMPLATE/ensemble-wave-execution.md
-git commit -m "Add wave execution issue template"
+git add docs/examples/issues/ensemble-wave-execution.md
+git commit -m "Add wave execution issue example"
 ```
 
 ---
@@ -492,7 +480,7 @@ git commit -m "Link GSD workflow guide from README"
 Verify every referenced path exists:
 
 ```bash
-ls docs/gsd-workflow.md .github/ISSUE_TEMPLATE/ensemble-parent-planning.md .github/ISSUE_TEMPLATE/ensemble-wave-execution.md docs/examples/prompts/gsd-parent-planning-prompt.md docs/examples/prompts/gsd-wave-execution-prompt.md docs/examples/github-projects/gsd-board-rules.md
+ls docs/gsd-workflow.md docs/examples/issues/ensemble-parent-planning.md docs/examples/issues/ensemble-wave-execution.md docs/examples/prompts/gsd-parent-planning-prompt.md docs/examples/prompts/gsd-wave-execution-prompt.md docs/examples/github-projects/gsd-board-rules.md
 ```
 
 Expected: all files exist.
@@ -502,7 +490,7 @@ Expected: all files exist.
 Run:
 
 ```bash
-rg -n "In Progress.*review rejection|shared feature branch|child issue per plan" docs .github/ISSUE_TEMPLATE README.md
+rg -n "In Progress.*review rejection|shared feature branch|child issue per plan" docs README.md
 ```
 
 Expected: no contradictory wording remains, or every hit is intentionally updated.
@@ -533,6 +521,6 @@ Expected: either a clean working tree because the per-task commits already captu
 - [ ] **Step 5: Only if verification caused additional edits, create a final cleanup commit**
 
 ```bash
-git add docs/gsd-workflow.md .github/ISSUE_TEMPLATE/ensemble-parent-planning.md .github/ISSUE_TEMPLATE/ensemble-wave-execution.md docs/examples/prompts/gsd-parent-planning-prompt.md docs/examples/prompts/gsd-wave-execution-prompt.md docs/examples/github-projects/gsd-board-rules.md README.md
+git add docs/gsd-workflow.md docs/examples/issues/ensemble-parent-planning.md docs/examples/issues/ensemble-wave-execution.md docs/examples/prompts/gsd-parent-planning-prompt.md docs/examples/prompts/gsd-wave-execution-prompt.md docs/examples/github-projects/gsd-board-rules.md README.md
 git commit -m "Polish GSD workflow documentation package"
 ```

--- a/docs/superpowers/specs/2026-04-02-gsd-workflow-integration-design.md
+++ b/docs/superpowers/specs/2026-04-02-gsd-workflow-integration-design.md
@@ -111,7 +111,8 @@ Required fields:
 - included plans or tasks from the approved plan
 - dependencies on prior waves
 - success criteria for the wave
-- links to spec, plan, and verification artifacts
+- links to spec and plan artifacts
+- expected verification artifact path
 
 Optional best-effort fields:
 
@@ -136,7 +137,17 @@ If a field cannot be updated consistently by the available tooling, it should be
 
 ## Board Model
 
-The board should use a small number of coarse states:
+The board should use one shared GitHub status field with a union of parent and child states.
+
+Parent issues use:
+
+- `Draft`
+- `Planning`
+- `Plan Review`
+- `Planned`
+- `Done`
+
+Child wave issues use:
 
 - `Planned`
 - `Ready`
@@ -146,6 +157,8 @@ The board should use a small number of coarse states:
 - `Done`
 
 Only `Ready` issues are eligible for Ensemble pickup.
+
+Using one shared status field keeps board automation and filtering simple while still allowing parent and child issues to use different subsets of the available states.
 
 Wave promotion is handled through board policy rather than Ensemble logic:
 
@@ -191,6 +204,19 @@ Recommended transient workspace state:
 The repo is the long-lived record. The issue links to that record. The workspace is disposable.
 
 Using per-wave verification files avoids one large shared verification document becoming a conflict hotspot across multiple execution cycles.
+
+## Branch Model
+
+The recommended default is one branch per wave, created from `main`.
+
+This model assumes:
+
+- parent planning artifacts are committed or merged before any child wave is released
+- a later wave is not promoted to `Ready` until all of its dependency waves are `Done` and their required code is available on `main`
+
+This keeps each wave branch independently reviewable and avoids a long-lived shared feature branch becoming the hidden source of truth.
+
+If a team prefers a shared integration branch for wave execution, that is a valid local variation, but the default recommendation is branch-per-wave from `main`.
 
 ## Agent Prompt Contract
 
@@ -287,6 +313,8 @@ Suggested parent states:
 
 The parent issue is updated by the planning or release workflow, not by Ensemble's child execution loop. That workflow is responsible for moving the parent into `Plan Review`, `Planned`, and `Done`.
 
+Parent completion is detected by the same planning or release workflow that manages wave promotion. When all child wave issues are `Done`, that workflow moves the parent issue to `Done`.
+
 ### Child Wave Issue
 
 Suggested child states:
@@ -303,7 +331,8 @@ State ownership for child issues:
 - planning agent sets initial `Planned` or `Ready` when creating wave issues
 - Ensemble moves `Ready` to `In Progress` when it dispatches a run, if the tracker integration supports that transition
 - execution agent moves the issue to `Needs Input` or `In Review` when the result requires it and the available tracker tooling allows it
-- execution completion or follow-up automation moves successfully completed issues to `Done`
+- execution agent is the default authority for moving successfully completed issues to `Done` and review-required issues to `In Review` when tracker write tools are available
+- follow-up automation may mirror or repair those transitions, but it should not be the primary source of truth
 
 If a particular tracker write is not supported by the runtime environment, the agent must still record the intended state in the issue comment or verification artifact so the missing transition is visible.
 
@@ -313,11 +342,13 @@ If a particular tracker write is not supported by the runtime environment, the a
 - persistent ambiguity or product uncertainty should move the issue to `Needs Input`
 - review-required outcomes should move the issue to `In Review`
 - unrecoverable technical failure should remain attached to the same wave issue with an explicit failure summary and either retry or human intervention path
-- review rejection should return the same child wave issue to `Ready` or `In Progress` depending on whether execution can resume automatically or needs a fresh dispatch
+- review rejection should return the same child wave issue to `Ready`
 
 The key rule is that retries and blockers stay attached to the same wave issue so the tracker preserves one operational thread per wave.
 
 Review rejection should never create a replacement wave issue. The same issue remains the unit of record until the wave is complete or deliberately cancelled.
+
+Returning rejected work to `Ready` preserves a single re-dispatch state: Ensemble only picks up issues that are ready to run again.
 
 ## Issue Creation Capability
 
@@ -340,7 +371,7 @@ The planning prompt for parent issues should explicitly require the agent to:
 - avoid clarifying-question loops unless blocked
 - produce a finalized wave plan before creating child issues
 - create exactly one child issue per wave
-- include parent reference, wave number, dependencies, success criteria, and artifact links in each child issue
+- include parent reference, wave number, dependencies, success criteria, spec/plan links, and expected verification artifact path in each child issue
 - set initial board state based on wave order
 
 The execution prompt for wave issues should explicitly require the agent to:

--- a/docs/superpowers/specs/2026-04-02-gsd-workflow-integration-design.md
+++ b/docs/superpowers/specs/2026-04-02-gsd-workflow-integration-design.md
@@ -1,0 +1,379 @@
+# GSD Workflow Integration Design
+
+## Overview
+
+This design describes how to run a GSD-inspired planning and execution workflow through Ensemble without forking GSD and without making GSD-specific changes to Ensemble.
+
+The integration lives in three places:
+
+- GitHub issue structure
+- board states and promotion rules
+- agent prompt and available GitHub write tooling
+
+Ensemble stays a generic orchestrator. It reads eligible issues, creates workspaces, runs agents, and syncs tracker state. GSD remains an external workflow influence for how agents plan, decompose, execute, and verify work.
+
+## Goals
+
+- Use a GSD-style spec -> plan -> execute -> verify workflow with Ensemble.
+- Keep the parent issue as the planning container for a larger feature.
+- Create child issues only after the parent plan is finalized.
+- Represent execution as wave issues, not one issue per internal plan.
+- Preserve wave sequencing without teaching Ensemble about GSD waves.
+- Keep durable planning artifacts in the repo and operational summaries in issues.
+- Avoid a GSD fork and avoid GSD-specific product work inside Ensemble.
+
+## Non-Goals
+
+- Adding GSD-specific logic, concepts, or commands to Ensemble.
+- Making Ensemble understand plan graphs or wave dependencies natively.
+- Creating tracker issues for every internal plan or task.
+- Requiring interactive clarifying-question loops during execution intake.
+- Replacing GSD itself or tightly coupling Ensemble to GSD internals.
+
+## Operating Model
+
+The operating model separates planning from execution.
+
+- The parent issue is the planning container for the whole feature or milestone slice.
+- The planning agent works on the parent issue first and produces the durable spec and execution plan.
+- After the plan is finalized, the planning agent creates child issues representing execution waves.
+- Ensemble runs on the child wave issues, not the parent issue.
+- Internal plans and tasks remain in repo artifacts rather than becoming first-class tracker tickets.
+
+This gives GitHub a readable structure:
+
+- parent issue = strategic context and approved plan
+- wave issues = executable envelopes
+- repo docs = detailed decomposition and verification record
+
+### Planning Entrypoint
+
+Planning on the parent issue is a separate agent workflow from Ensemble's normal child-issue execution loop.
+
+Recommended entrypoints:
+
+- manual invocation by the human against the parent issue
+- a dedicated planning agent workflow triggered from the parent issue state or label
+
+The important invariant is:
+
+- parent issue planning produces approved artifacts and child wave issues
+- Ensemble execution only runs on child wave issues in `Ready`
+
+This keeps planning and execution clearly separated even when both use the same underlying agent runtime.
+
+## Why Child Issues Represent Waves
+
+Using child issues for waves instead of individual plans is the best fit for Ensemble's current model.
+
+- It keeps the tracker compact and understandable.
+- It preserves GSD's dependency-aware execution shape.
+- It avoids needing Ensemble to reason about many tiny issue dependencies.
+- It allows the agent to execute several internal tasks inside one wave issue using the approved plan artifact.
+
+The trade-off is that fine-grained task visibility lives in docs rather than the tracker. That is acceptable because the tracker remains the operational surface while the repo remains the detailed source of truth.
+
+## Issue Model
+
+### Parent Issue
+
+The parent issue is created by the human and acts as the planning hub.
+
+It should contain:
+
+- feature or milestone objective
+- constraints and context
+- high-level acceptance criteria
+- links to approved spec and plan documents
+- a wave summary table after planning is complete
+- links to all generated child wave issues
+
+The parent issue is where planning discussion happens. It is not the issue Ensemble should execute.
+
+The parent issue should have a lightweight planning lifecycle outside the execution loop, for example:
+
+- `Draft`
+- `Planning`
+- `Plan Review`
+- `Planned`
+- `Done`
+
+Only the parent issue uses this planning lifecycle. Child wave issues use the execution lifecycle.
+
+### Child Wave Issue
+
+Each child issue represents one approved execution wave created from the parent plan.
+
+Required fields:
+
+- parent issue reference
+- wave number and wave goal
+- included plans or tasks from the approved plan
+- dependencies on prior waves
+- success criteria for the wave
+- links to spec, plan, and verification artifacts
+
+Optional best-effort fields:
+
+- branch reference
+- workspace reference
+- last run timestamp
+- attempt count
+- latest verdict or blocking reason
+
+The child issue should stay compact. It is an operational summary, not a duplicate of the spec and plan docs.
+
+### Issue Metadata Ownership
+
+Metadata ownership should be explicit:
+
+- planning agent writes parent links, wave number, dependencies, artifact links, and initial success criteria when creating child issues
+- Ensemble writes or derives execution metadata that belongs to runtime orchestration, such as workspace reference and attempt count, when available through its existing tracker updates
+- execution agent writes compact operational summaries such as latest verdict, blockers, and verification links
+- if branch names or PR links are produced by the execution workflow, the execution agent writes them back to the wave issue
+
+If a field cannot be updated consistently by the available tooling, it should be omitted rather than partially maintained.
+
+## Board Model
+
+The board should use a small number of coarse states:
+
+- `Planned`
+- `Ready`
+- `In Progress`
+- `Needs Input`
+- `In Review`
+- `Done`
+
+Only `Ready` issues are eligible for Ensemble pickup.
+
+Wave promotion is handled through board policy rather than Ensemble logic:
+
+- Wave 1 child issue starts as `Ready`.
+- Later waves start as `Planned`.
+- When a wave completes, the next wave is promoted to `Ready`.
+
+This keeps wave sequencing visible while allowing Ensemble to remain unaware of wave semantics.
+
+### Wave Sequencing Invariant
+
+The workflow must enforce this rule:
+
+- only waves whose dependencies are fully satisfied may be moved to `Ready`
+
+Recommended enforcement options:
+
+- a human follows a strict board policy
+- a separate automation checks that all prior-wave issues are `Done` before promoting the next wave
+- a planning or release agent performs promotion and validates dependencies before changing state
+
+The recommended default is a small external automation or agent step that refuses to promote any wave whose dependency set is not fully complete. This allows multiple parallel waves to become `Ready` at the same time when the approved plan allows it.
+
+## Artifact Model
+
+Durable artifacts live in the repo. Transient execution state lives in the workspace.
+
+Recommended durable artifacts:
+
+- `docs/phases/<parent-or-feature-slug>/SPEC.md`
+- `docs/phases/<parent-or-feature-slug>/PLAN.md`
+- `docs/phases/<parent-or-feature-slug>/verification/WAVE-<n>.md`
+- optional `docs/phases/<parent-or-feature-slug>/HANDOFF.md`
+
+Recommended transient workspace state:
+
+- run logs
+- scratch notes
+- partial research notes
+- retry state
+- temporary execution context files
+
+The repo is the long-lived record. The issue links to that record. The workspace is disposable.
+
+Using per-wave verification files avoids one large shared verification document becoming a conflict hotspot across multiple execution cycles.
+
+## Agent Prompt Contract
+
+The integration depends on a disciplined agent prompt rather than product changes inside Ensemble.
+
+### Parent-Issue Prompt Responsibilities
+
+When the agent is running against a parent issue, it should:
+
+- read the parent issue, repository context, and any existing design docs
+- create or update the durable spec and plan artifacts
+- decompose the approved plan into execution waves
+- create one child issue per wave after the plan is finalized
+- update the parent issue with links to artifacts and created wave issues
+
+### Wave-Issue Prompt Responsibilities
+
+When the agent is running against a wave issue, it should:
+
+- read the wave issue and linked artifacts
+- execute the internal tasks assigned to that wave
+- verify the results against the wave success criteria
+- update artifacts and issue metadata with the latest result
+- stop and surface blockers when confidence is too low
+
+### Ambiguity Handling
+
+The workflow should avoid interactive clarification during execution.
+
+Agents should:
+
+- infer from repository conventions, parent issue context, and existing docs
+- proceed when confidence is high enough
+- move the issue to `Needs Input` when ambiguity is too high
+- document assumptions, missing information, and recommended defaults in the issue and artifacts
+
+## Workflow
+
+### 1. Plan On The Parent Issue
+
+The human creates the parent issue with the feature brief. A planning agent produces the approved spec and execution plan in repo docs.
+
+The parent issue enters `Planning` while this work is underway.
+
+The planning workflow must publish the approved artifacts into the repository branch that child execution agents will later consume. In practice, that means the planning run either commits the artifacts directly to the working branch or lands them through a reviewable PR before any wave issue is released for execution.
+
+### 2. Create Child Wave Issues
+
+After the plan is finalized, the planning agent creates child issues for each wave described in the plan.
+
+The plan is considered finalized when:
+
+- the parent spec and plan artifacts exist and are linked from the parent issue
+- the parent issue reaches `Planned` or an equivalent approval state
+- the human has explicitly approved the plan, unless the team intentionally adopts an auto-approval policy
+
+- Wave 1 is created in `Ready`.
+- Later waves are created in `Planned`.
+
+### 3. Execute The Current Wave
+
+Ensemble picks up the `Ready` wave issue, creates the workspace, and runs the execution agent. The agent uses the linked artifacts to execute the wave's internal tasks.
+
+### 4. Verify And Update
+
+The execution agent records verification results in the repo artifacts and posts a compact operational update to the wave issue.
+
+At minimum, that update should include:
+
+- latest verdict
+- links to any branch or PR created by the workflow
+- verification artifact link
+- blocker summary if the wave did not complete
+
+### 5. Promote The Next Wave
+
+When the current wave is complete, the next wave is promoted from `Planned` to `Ready` by a human or a separate automation outside Ensemble.
+
+### 6. Finish The Parent Issue
+
+When all wave issues are done, the parent issue represents a fully executed feature. GitHub's built-in rollup and sub-issue relationships provide the high-level progress view.
+
+## State Transitions And Non-Happy Paths
+
+### Parent Issue
+
+Suggested parent states:
+
+- `Draft` -> initial human-authored request
+- `Planning` -> agent is producing or revising artifacts
+- `Plan Review` -> plan is ready for human approval
+- `Planned` -> approved and wave issues may be created or already exist
+- `Done` -> all child wave issues are complete
+
+The parent issue is updated by the planning or release workflow, not by Ensemble's child execution loop. That workflow is responsible for moving the parent into `Plan Review`, `Planned`, and `Done`.
+
+### Child Wave Issue
+
+Suggested child states:
+
+- `Planned` -> wave exists but is not yet eligible
+- `Ready` -> eligible for Ensemble pickup
+- `In Progress` -> currently executing
+- `Needs Input` -> blocked on ambiguity or missing product direction
+- `In Review` -> code or deliverable is waiting for review
+- `Done` -> wave completed successfully
+
+State ownership for child issues:
+
+- planning agent sets initial `Planned` or `Ready` when creating wave issues
+- Ensemble moves `Ready` to `In Progress` when it dispatches a run, if the tracker integration supports that transition
+- execution agent moves the issue to `Needs Input` or `In Review` when the result requires it and the available tracker tooling allows it
+- execution completion or follow-up automation moves successfully completed issues to `Done`
+
+If a particular tracker write is not supported by the runtime environment, the agent must still record the intended state in the issue comment or verification artifact so the missing transition is visible.
+
+### Failure And Retry Behavior
+
+- transient execution failure should remain within the same child wave issue and increment retry metadata rather than creating a new issue
+- persistent ambiguity or product uncertainty should move the issue to `Needs Input`
+- review-required outcomes should move the issue to `In Review`
+- unrecoverable technical failure should remain attached to the same wave issue with an explicit failure summary and either retry or human intervention path
+- review rejection should return the same child wave issue to `Ready` or `In Progress` depending on whether execution can resume automatically or needs a fresh dispatch
+
+The key rule is that retries and blockers stay attached to the same wave issue so the tracker preserves one operational thread per wave.
+
+Review rejection should never create a replacement wave issue. The same issue remains the unit of record until the wave is complete or deliberately cancelled.
+
+## Issue Creation Capability
+
+Agents do need a way to create child issues after planning is finalized, but this does not need to be a GSD-specific Ensemble feature.
+
+The preferred model is to treat issue creation as part of the agent runtime environment:
+
+- GitHub CLI such as `gh issue create`
+- a GitHub MCP server
+- another tracker-write tool already available to the agent
+
+This capability belongs in prompt contract, runtime permissions, and agent tooling rather than in Ensemble's core orchestration model.
+
+If Ensemble later grows a tracker write abstraction that can create issues generically, that could improve portability across trackers, but it is not required for this workflow design.
+
+## Recommended Prompt Requirements
+
+The planning prompt for parent issues should explicitly require the agent to:
+
+- avoid clarifying-question loops unless blocked
+- produce a finalized wave plan before creating child issues
+- create exactly one child issue per wave
+- include parent reference, wave number, dependencies, success criteria, and artifact links in each child issue
+- set initial board state based on wave order
+
+The execution prompt for wave issues should explicitly require the agent to:
+
+- follow the approved plan artifact rather than replanning from scratch
+- keep the issue summary compact and operational
+- write detailed progress and verification into repo artifacts
+- move to `Needs Input` instead of guessing when confidence falls below the allowed threshold
+
+## Trade-Offs
+
+### Advantages
+
+- No GSD fork.
+- No GSD-specific changes to Ensemble.
+- Tracker stays readable and human-friendly.
+- GSD-style decomposition survives in durable docs.
+- Waves can be coordinated through board policy.
+
+### Costs
+
+- Wave promotion is external to Ensemble.
+- Detailed task-level tracking lives in docs, not as tracker tickets.
+- Success depends on prompt discipline and agent access to issue-creation tooling.
+
+## Recommendation
+
+Use the following model:
+
+- parent issue = planning container
+- child issue = wave container
+- repo docs = spec, plan, and verification source of truth
+- board states = coarse eligibility and review states
+- issue creation = agent capability via GitHub tooling, not an Ensemble-specific feature
+
+This keeps Ensemble generic, preserves the useful parts of GSD's operating model, and minimizes integration cost.


### PR DESCRIPTION
## Summary
- add a GSD-style workflow guide covering parent planning issues, wave execution issues, and board-state rules
- add reusable example issue bodies, agent prompts, and GitHub Projects board rules under `docs/examples/`
- keep the design and implementation plan docs aligned with the examples-only approach and link the workflow guide from the README

## Test Plan
- [x] `SKIP_UI_BUILD=1 cargo test --workspace`
- [x] verified the new docs/example files exist and cross-reference each other
- [x] confirmed the workflow package no longer uses live `.github/ISSUE_TEMPLATE/` files