### PR TITLE
Fix code review findings: shell injection, performance, and simplifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shellexpand",
+ "shlex",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/ensemble-cli/build.rs
+++ b/crates/ensemble-cli/build.rs
@@ -45,11 +45,13 @@ fn main() {
     // which would deadlock (cargo already holds the build lock).
     let openapi_json = ui_dir.join("openapi.json");
     if !openapi_json.exists() {
-        panic!(
-            "openapi.json not found at {}. Run `pnpm run codegen:spec` in crates/ensemble-ui/src-ui/ first, \
-             or set SKIP_UI_BUILD=1 to skip the UI embed.",
+        println!(
+            "cargo:warning=openapi.json not found at {}. UI will not be embedded.",
             openapi_json.display()
         );
+        println!("cargo:warning=Run `pnpm run codegen:spec` in crates/ensemble-ui/src-ui/ to generate it.");
+        std::fs::create_dir_all(assets_dir).ok();
+        return;
     }
 
     // Build the SPA (using build:embed which skips codegen:spec to avoid circular cargo dep)

--- a/crates/ensemble-cli/build.rs
+++ b/crates/ensemble-cli/build.rs
@@ -51,7 +51,7 @@ fn main() {
         );
         println!("cargo:warning=Run `pnpm run codegen:spec` in crates/ensemble-ui/src-ui/ to generate it.");
         // Remove any stale assets so we don't embed an old UI
-        std::fs::remove_dir_all(&assets_dir).ok();
+        std::fs::remove_dir_all(assets_dir).ok();
         std::fs::create_dir_all(assets_dir).ok();
         return;
     }

--- a/crates/ensemble-cli/build.rs
+++ b/crates/ensemble-cli/build.rs
@@ -50,6 +50,8 @@ fn main() {
             openapi_json.display()
         );
         println!("cargo:warning=Run `pnpm run codegen:spec` in crates/ensemble-ui/src-ui/ to generate it.");
+        // Remove any stale assets so we don't embed an old UI
+        std::fs::remove_dir_all(&assets_dir).ok();
         std::fs::create_dir_all(assets_dir).ok();
         return;
     }

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -26,6 +26,7 @@ utoipa = { workspace = true }
 dirs = { workspace = true }
 dotenvy = { workspace = true }
 shellexpand = "3"
+shlex = "1"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -547,17 +547,16 @@ impl AcpSession {
             reason: format!("json serialize error: {e}"),
         })?;
         debug!(msg = %line, "sending JSON-RPC");
+
+        let mut buf = Vec::with_capacity(line.len() + 1);
+        buf.extend_from_slice(line.as_bytes());
+        buf.push(b'\n');
+
         self.stdin
-            .write_all(line.as_bytes())
+            .write_all(&buf)
             .await
             .map_err(|e| AgentError::IoError {
                 reason: format!("stdin write error: {e}"),
-            })?;
-        self.stdin
-            .write_all(b"\n")
-            .await
-            .map_err(|e| AgentError::IoError {
-                reason: format!("stdin write newline error: {e}"),
             })?;
         self.stdin.flush().await.map_err(|e| AgentError::IoError {
             reason: format!("stdin flush error: {e}"),

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -84,6 +84,37 @@ pub enum AgentEvent {
     },
 }
 
+impl AgentEvent {
+    /// Returns the event name for logging/state tracking.
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            AgentEvent::SessionStarted { .. } => "session_started",
+            AgentEvent::TurnStarted => "turn_started",
+            AgentEvent::TurnUpdate { .. } => "turn_update",
+            AgentEvent::TurnCompleted { .. } => "turn_completed",
+            AgentEvent::TurnFailed { .. } => "turn_failed",
+            AgentEvent::PermissionRequested { .. } => "permission_requested",
+            AgentEvent::PermissionResolved { .. } => "permission_resolved",
+            AgentEvent::Notification { .. } => "notification",
+            AgentEvent::OtherMessage { .. } => "other_message",
+            AgentEvent::Malformed { .. } => "malformed",
+        }
+    }
+
+    /// Returns the message content for state tracking, truncated.
+    pub fn message_for_state(&self) -> Option<String> {
+        match self {
+            AgentEvent::TurnUpdate { content } => Some(content.clone()),
+            AgentEvent::TurnFailed { reason, .. } => Some(reason.clone()),
+            AgentEvent::PermissionRequested { description, .. } => Some(description.clone()),
+            AgentEvent::Notification { message } => Some(message.clone()),
+            AgentEvent::OtherMessage { raw } => Some(raw.chars().take(100).collect()),
+            AgentEvent::Malformed { line } => Some(line.chars().take(100).collect()),
+            _ => None,
+        }
+    }
+}
+
 /// Events sent from worker tasks to the orchestrator.
 #[derive(Debug)]
 pub enum WorkerEvent {

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -101,17 +103,29 @@ impl AgentEvent {
         }
     }
 
-    /// Returns the message content for state tracking, truncated.
-    pub fn message_for_state(&self) -> Option<String> {
+    /// Returns the message content for state tracking, truncated to 200 chars.
+    pub fn message_for_state(&self) -> Option<Cow<'_, str>> {
         match self {
-            AgentEvent::TurnUpdate { content } => Some(content.clone()),
-            AgentEvent::TurnFailed { reason, .. } => Some(reason.clone()),
-            AgentEvent::PermissionRequested { description, .. } => Some(description.clone()),
-            AgentEvent::Notification { message } => Some(message.clone()),
-            AgentEvent::OtherMessage { raw } => Some(raw.chars().take(100).collect()),
-            AgentEvent::Malformed { line } => Some(line.chars().take(100).collect()),
+            AgentEvent::TurnUpdate { content } => Some(truncate_for_state(content)),
+            AgentEvent::TurnFailed { reason, .. } => Some(truncate_for_state(reason)),
+            AgentEvent::PermissionRequested { description, .. } => {
+                Some(truncate_for_state(description))
+            }
+            AgentEvent::Notification { message } => Some(truncate_for_state(message)),
+            AgentEvent::OtherMessage { raw } => Some(truncate_for_state(raw)),
+            AgentEvent::Malformed { line } => Some(truncate_for_state(line)),
             _ => None,
         }
+    }
+}
+
+fn truncate_for_state(value: &str) -> Cow<'_, str> {
+    const STATE_MESSAGE_LIMIT: usize = 200;
+
+    if value.chars().count() > STATE_MESSAGE_LIMIT {
+        Cow::Owned(value.chars().take(STATE_MESSAGE_LIMIT).collect())
+    } else {
+        Cow::Borrowed(value)
     }
 }
 
@@ -318,5 +332,16 @@ mod tests {
         assert_eq!(parsed.input_tokens, 1000);
         assert_eq!(parsed.output_tokens, 500);
         assert_eq!(parsed.total_tokens, 1500);
+    }
+
+    #[test]
+    fn test_message_for_state_truncates_long_turn_updates() {
+        let event = AgentEvent::TurnUpdate {
+            content: "x".repeat(250),
+        };
+
+        let message = event.message_for_state().unwrap();
+
+        assert_eq!(message.len(), 200);
     }
 }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -135,10 +135,25 @@ fn resolve_agent_command(
             return cmd;
         }
         if let Some(ref executor) = ac.executor {
-            return executor.clone();
+            return shell_escape_command(executor);
         }
     }
-    default_command.to_string()
+    shell_escape_command(default_command)
+}
+
+fn shell_escape_command(command: &str) -> String {
+    let parts = shlex::split(command)
+        .unwrap_or_else(|| command.split_whitespace().map(str::to_string).collect());
+
+    if parts.is_empty() {
+        return shell_escape(command);
+    }
+
+    parts
+        .iter()
+        .map(|part| shell_escape(part))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[async_trait]
@@ -474,20 +489,20 @@ mod tests {
     #[test]
     fn test_resolve_agent_command_falls_back_to_default() {
         let cmd = resolve_agent_command(None, "default-cmd");
-        assert_eq!(cmd, "default-cmd");
+        assert_eq!(cmd, "'default-cmd'");
     }
 
     #[test]
-    fn test_resolve_agent_command_uses_executor_raw() {
+    fn test_resolve_agent_command_escapes_executor_tokens() {
         let config = crate::config::ensemble::AgentConfig {
             acpx_agent: None,
             model: None,
-            executor: Some("codex --profile prod".to_string()),
+            executor: Some("codex --profile prod; touch /tmp/pwned".to_string()),
             prompt: None,
             prompt_template: None,
             reasoning_level: None,
         };
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
-        assert_eq!(cmd, "codex --profile prod");
+        assert_eq!(cmd, "'codex' '--profile' 'prod;' 'touch' '/tmp/pwned'");
     }
 }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -17,30 +17,30 @@ use events::{AgentEvent, WorkerEvent};
 
 use acp_client::{AcpSession, TurnResult};
 
+pub struct AgentRunRequest<'a> {
+    pub config: Arc<EnsembleConfig>,
+    pub issue: &'a Issue,
+    pub agent_name: &'a str,
+    pub step_name: &'a str,
+    pub attempt: Option<u32>,
+    pub workspace_path: &'a Path,
+    pub event_tx: mpsc::Sender<WorkerEvent>,
+}
+
 /// Trait for running an agent session against an issue.
 /// The orchestrator dispatches work through this trait.
 /// Implementations must send WorkerEvents via the channel during execution.
 #[async_trait]
 pub trait AgentRunner: Send + Sync {
-    async fn run(
-        &self,
-        issue: &Issue,
-        agent_name: &str,
-        step_name: &str,
-        attempt: Option<u32>,
-        workspace_path: &Path,
-        event_tx: mpsc::Sender<WorkerEvent>,
-    ) -> Result<(), AgentError>;
+    async fn run(&self, request: AgentRunRequest<'_>) -> Result<(), AgentError>;
 }
 
 /// Real ACP agent runner that implements the full worker loop from SPEC.md Section 16.5.
-pub struct AcpAgentRunner {
-    pub config: Arc<RwLock<EnsembleConfig>>,
-}
+pub struct AcpAgentRunner;
 
 impl AcpAgentRunner {
-    pub fn new(config: Arc<RwLock<EnsembleConfig>>) -> Self {
-        Self { config }
+    pub fn new(_config: Arc<RwLock<EnsembleConfig>>) -> Self {
+        Self
     }
 
     /// Build the prompt for a given turn.
@@ -48,13 +48,13 @@ impl AcpAgentRunner {
     /// continuation turns use guidance text.
     async fn build_prompt(
         &self,
+        config: &EnsembleConfig,
         issue: &Issue,
         agent_name: &str,
         attempt: Option<u32>,
         turn_number: u32,
     ) -> Result<String, AgentError> {
         if turn_number == 1 {
-            let config = self.config.read().await;
             let agent_config =
                 config
                     .agents
@@ -158,16 +158,16 @@ fn shell_escape_command(command: &str) -> String {
 
 #[async_trait]
 impl AgentRunner for AcpAgentRunner {
-    async fn run(
-        &self,
-        issue: &Issue,
-        agent_name: &str,
-        step_name: &str,
-        attempt: Option<u32>,
-        workspace_path: &Path,
-        event_tx: mpsc::Sender<WorkerEvent>,
-    ) -> Result<(), AgentError> {
-        let config = self.config.read().await.clone();
+    async fn run(&self, request: AgentRunRequest<'_>) -> Result<(), AgentError> {
+        let AgentRunRequest {
+            config,
+            issue,
+            agent_name,
+            step_name,
+            attempt,
+            workspace_path,
+            event_tx,
+        } = request;
 
         // 1. Run before_run hook
         if let Some(ref script) = config.hooks.before_run {
@@ -235,7 +235,7 @@ impl AgentRunner for AcpAgentRunner {
         let result = loop {
             // Build prompt for this turn
             let prompt = match self
-                .build_prompt(issue, agent_name, attempt, turn_number)
+                .build_prompt(config.as_ref(), issue, agent_name, attempt, turn_number)
                 .await
             {
                 Ok(p) => p,
@@ -321,6 +321,7 @@ impl AgentRunner for AcpAgentRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ensemble::parse_config;
 
     /// Mock agent runner for testing the orchestrator.
     pub struct MockAgentRunner {
@@ -330,15 +331,13 @@ mod tests {
 
     #[async_trait]
     impl AgentRunner for MockAgentRunner {
-        async fn run(
-            &self,
-            issue: &Issue,
-            _agent_name: &str,
-            step_name: &str,
-            _attempt: Option<u32>,
-            _workspace_path: &Path,
-            event_tx: mpsc::Sender<WorkerEvent>,
-        ) -> Result<(), AgentError> {
+        async fn run(&self, request: AgentRunRequest<'_>) -> Result<(), AgentError> {
+            let AgentRunRequest {
+                issue,
+                step_name,
+                event_tx,
+                ..
+            } = request;
             // Simulate some work
             if self.delay_ms > 0 {
                 tokio::time::sleep(std::time::Duration::from_millis(self.delay_ms)).await;
@@ -383,6 +382,32 @@ mod tests {
         }
     }
 
+    fn test_config() -> Arc<EnsembleConfig> {
+        Arc::new(
+            parse_config(
+                r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo"]
+  terminal_states: ["Done"]
+agents:
+  builder:
+    prompt: hi
+steps:
+  - name: build
+    agent: builder
+workspace:
+  root: /tmp/test
+agent:
+  command: echo test
+on_success: Done
+on_failure: Todo
+"#,
+            )
+            .unwrap(),
+        )
+    }
+
     #[tokio::test]
     async fn test_mock_agent_runner_success() {
         let runner = MockAgentRunner {
@@ -393,14 +418,15 @@ mod tests {
         let workspace = tempfile::TempDir::new().unwrap();
 
         let result = runner
-            .run(
-                &test_issue(),
-                "builder",
-                "build",
-                None,
-                workspace.path(),
-                tx,
-            )
+            .run(AgentRunRequest {
+                config: test_config(),
+                issue: &test_issue(),
+                agent_name: "builder",
+                step_name: "build",
+                attempt: None,
+                workspace_path: workspace.path(),
+                event_tx: tx,
+            })
             .await;
 
         assert!(result.is_ok());
@@ -429,14 +455,15 @@ mod tests {
         let workspace = tempfile::TempDir::new().unwrap();
 
         let result = runner
-            .run(
-                &test_issue(),
-                "builder",
-                "build",
-                None,
-                workspace.path(),
-                tx,
-            )
+            .run(AgentRunRequest {
+                config: test_config(),
+                issue: &test_issue(),
+                agent_name: "builder",
+                step_name: "build",
+                attempt: None,
+                workspace_path: workspace.path(),
+                event_tx: tx,
+            })
             .await;
 
         assert!(result.is_err());

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -1,7 +1,6 @@
 pub mod acp_client;
 pub mod events;
 
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -37,67 +36,11 @@ pub trait AgentRunner: Send + Sync {
 /// Real ACP agent runner that implements the full worker loop from SPEC.md Section 16.5.
 pub struct AcpAgentRunner {
     pub config: Arc<RwLock<EnsembleConfig>>,
-    cached_prompts: RwLock<HashMap<String, String>>,
 }
 
 impl AcpAgentRunner {
     pub fn new(config: Arc<RwLock<EnsembleConfig>>) -> Self {
-        Self {
-            config,
-            cached_prompts: RwLock::new(HashMap::new()),
-        }
-    }
-
-    /// Clear the prompt cache. Call this when config is reloaded.
-    pub fn clear_cache(&self) {
-        let cache = self.cached_prompts.try_write();
-        if let Ok(mut cache) = cache {
-            cache.clear();
-        }
-    }
-
-    async fn get_or_cache_prompt_template(&self, agent_name: &str) -> Result<String, AgentError> {
-        {
-            let cache = self.cached_prompts.read().await;
-            if let Some(template) = cache.get(agent_name) {
-                return Ok(template.clone());
-            }
-        }
-
-        let config = self.config.read().await;
-        let agent_config =
-            config
-                .agents
-                .get(agent_name)
-                .ok_or_else(|| AgentError::PromptError {
-                    reason: format!("agent '{}' not found in config", agent_name),
-                })?;
-
-        let template = if let Some(ref prompt) = agent_config.prompt {
-            prompt.clone()
-        } else if let Some(ref template_path) = agent_config.prompt_template {
-            std::fs::read_to_string(template_path).map_err(|e| AgentError::PromptError {
-                reason: format!(
-                    "failed to read prompt template '{}': {}",
-                    template_path.display(),
-                    e
-                ),
-            })?
-        } else {
-            return Err(AgentError::PromptError {
-                reason: format!(
-                    "agent '{}' has neither prompt nor prompt_template",
-                    agent_name
-                ),
-            });
-        };
-
-        {
-            let mut cache = self.cached_prompts.write().await;
-            cache.insert(agent_name.to_string(), template.clone());
-        }
-
-        Ok(template)
+        Self { config }
     }
 
     /// Build the prompt for a given turn.
@@ -111,11 +54,40 @@ impl AcpAgentRunner {
         turn_number: u32,
     ) -> Result<String, AgentError> {
         if turn_number == 1 {
-            let template = self.get_or_cache_prompt_template(agent_name).await?;
-            render_prompt(&template, issue, attempt).map_err(|e| AgentError::PromptError {
+            let config = self.config.read().await;
+            let agent_config =
+                config
+                    .agents
+                    .get(agent_name)
+                    .ok_or_else(|| AgentError::PromptError {
+                        reason: format!("agent '{}' not found in config", agent_name),
+                    })?;
+
+            // Resolve the prompt template: inline prompt or file-based prompt_template
+            let template_str = if let Some(ref prompt) = agent_config.prompt {
+                prompt.clone()
+            } else if let Some(ref template_path) = agent_config.prompt_template {
+                std::fs::read_to_string(template_path).map_err(|e| AgentError::PromptError {
+                    reason: format!(
+                        "failed to read prompt template '{}': {}",
+                        template_path.display(),
+                        e
+                    ),
+                })?
+            } else {
+                return Err(AgentError::PromptError {
+                    reason: format!(
+                        "agent '{}' has neither prompt nor prompt_template",
+                        agent_name
+                    ),
+                });
+            };
+
+            render_prompt(&template_str, issue, attempt).map_err(|e| AgentError::PromptError {
                 reason: e.to_string(),
             })
         } else {
+            // Continuation turns: send guidance, not the full original prompt
             Ok(format!(
                 "Continue working on {}. This is turn {} of this session. \
                  The issue is still in an active state. \
@@ -163,7 +135,7 @@ fn resolve_agent_command(
             return cmd;
         }
         if let Some(ref executor) = ac.executor {
-            return shell_escape(executor);
+            return executor.clone();
         }
     }
     default_command.to_string()
@@ -506,16 +478,16 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_agent_command_escapes_executor() {
+    fn test_resolve_agent_command_uses_executor_raw() {
         let config = crate::config::ensemble::AgentConfig {
             acpx_agent: None,
             model: None,
-            executor: Some("my-agent; rm -rf /".to_string()),
+            executor: Some("codex --profile prod".to_string()),
             prompt: None,
             prompt_template: None,
             reasoning_level: None,
         };
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
-        assert_eq!(cmd, "'my-agent; rm -rf /'");
+        assert_eq!(cmd, "codex --profile prod");
     }
 }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -65,11 +65,13 @@ impl AcpAgentRunner {
         }
 
         let config = self.config.read().await;
-        let agent_config = config.agents.get(agent_name).ok_or_else(|| {
-            AgentError::PromptError {
-                reason: format!("agent '{}' not found in config", agent_name),
-            }
-        })?;
+        let agent_config =
+            config
+                .agents
+                .get(agent_name)
+                .ok_or_else(|| AgentError::PromptError {
+                    reason: format!("agent '{}' not found in config", agent_name),
+                })?;
 
         let template = if let Some(ref prompt) = agent_config.prompt {
             prompt.clone()

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -135,7 +135,7 @@ fn resolve_agent_command(
             return cmd;
         }
         if let Some(ref executor) = ac.executor {
-            return executor.clone();
+            return shell_escape(executor);
         }
     }
     default_command.to_string()
@@ -475,5 +475,19 @@ mod tests {
     fn test_resolve_agent_command_falls_back_to_default() {
         let cmd = resolve_agent_command(None, "default-cmd");
         assert_eq!(cmd, "default-cmd");
+    }
+
+    #[test]
+    fn test_resolve_agent_command_escapes_executor() {
+        let config = crate::config::ensemble::AgentConfig {
+            acpx_agent: None,
+            model: None,
+            executor: Some("my-agent; rm -rf /".to_string()),
+            prompt: None,
+            prompt_template: None,
+            reasoning_level: None,
+        };
+        let cmd = resolve_agent_command(Some(&config), "default-cmd");
+        assert_eq!(cmd, "'my-agent; rm -rf /'");
     }
 }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -1,6 +1,7 @@
 pub mod acp_client;
 pub mod events;
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -36,11 +37,65 @@ pub trait AgentRunner: Send + Sync {
 /// Real ACP agent runner that implements the full worker loop from SPEC.md Section 16.5.
 pub struct AcpAgentRunner {
     pub config: Arc<RwLock<EnsembleConfig>>,
+    cached_prompts: RwLock<HashMap<String, String>>,
 }
 
 impl AcpAgentRunner {
     pub fn new(config: Arc<RwLock<EnsembleConfig>>) -> Self {
-        Self { config }
+        Self {
+            config,
+            cached_prompts: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Clear the prompt cache. Call this when config is reloaded.
+    pub fn clear_cache(&self) {
+        let cache = self.cached_prompts.try_write();
+        if let Ok(mut cache) = cache {
+            cache.clear();
+        }
+    }
+
+    async fn get_or_cache_prompt_template(&self, agent_name: &str) -> Result<String, AgentError> {
+        {
+            let cache = self.cached_prompts.read().await;
+            if let Some(template) = cache.get(agent_name) {
+                return Ok(template.clone());
+            }
+        }
+
+        let config = self.config.read().await;
+        let agent_config = config.agents.get(agent_name).ok_or_else(|| {
+            AgentError::PromptError {
+                reason: format!("agent '{}' not found in config", agent_name),
+            }
+        })?;
+
+        let template = if let Some(ref prompt) = agent_config.prompt {
+            prompt.clone()
+        } else if let Some(ref template_path) = agent_config.prompt_template {
+            std::fs::read_to_string(template_path).map_err(|e| AgentError::PromptError {
+                reason: format!(
+                    "failed to read prompt template '{}': {}",
+                    template_path.display(),
+                    e
+                ),
+            })?
+        } else {
+            return Err(AgentError::PromptError {
+                reason: format!(
+                    "agent '{}' has neither prompt nor prompt_template",
+                    agent_name
+                ),
+            });
+        };
+
+        {
+            let mut cache = self.cached_prompts.write().await;
+            cache.insert(agent_name.to_string(), template.clone());
+        }
+
+        Ok(template)
     }
 
     /// Build the prompt for a given turn.
@@ -54,40 +109,11 @@ impl AcpAgentRunner {
         turn_number: u32,
     ) -> Result<String, AgentError> {
         if turn_number == 1 {
-            let config = self.config.read().await;
-            let agent_config =
-                config
-                    .agents
-                    .get(agent_name)
-                    .ok_or_else(|| AgentError::PromptError {
-                        reason: format!("agent '{}' not found in config", agent_name),
-                    })?;
-
-            // Resolve the prompt template: inline prompt or file-based prompt_template
-            let template_str = if let Some(ref prompt) = agent_config.prompt {
-                prompt.clone()
-            } else if let Some(ref template_path) = agent_config.prompt_template {
-                std::fs::read_to_string(template_path).map_err(|e| AgentError::PromptError {
-                    reason: format!(
-                        "failed to read prompt template '{}': {}",
-                        template_path.display(),
-                        e
-                    ),
-                })?
-            } else {
-                return Err(AgentError::PromptError {
-                    reason: format!(
-                        "agent '{}' has neither prompt nor prompt_template",
-                        agent_name
-                    ),
-                });
-            };
-
-            render_prompt(&template_str, issue, attempt).map_err(|e| AgentError::PromptError {
+            let template = self.get_or_cache_prompt_template(agent_name).await?;
+            render_prompt(&template, issue, attempt).map_err(|e| AgentError::PromptError {
                 reason: e.to_string(),
             })
         } else {
-            // Continuation turns: send guidance, not the full original prompt
             Ok(format!(
                 "Continue working on {}. This is turn {} of this session. \
                  The issue is still in an active state. \

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -468,13 +468,14 @@ pub struct ValidateGuidedFormResponse {
     tag = "config"
 )]
 pub async fn validate_guided_form(
+    State(state): State<AppState>,
     Json(request): Json<ValidateGuidedFormRequest>,
 ) -> (StatusCode, Json<ValidateGuidedFormResponse>) {
     match crate::config::form::apply_guided_form(&request.base_raw_yaml, &request.form) {
         Ok(merged_yaml) => {
             // Parse and validate the merged YAML
             let draft = crate::config::draft::parse_raw_yaml(
-                std::path::PathBuf::from("config.yaml"),
+                state.config_runtime.config_path.clone(),
                 merged_yaml.clone(),
             );
 

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -69,14 +69,21 @@ pub fn load_config_state(path: &Path) -> Result<ConfigDocumentState, ConfigError
 
 pub fn parse_raw_yaml(path: PathBuf, raw_yaml: String) -> ConfigDocumentState {
     let parsed: Result<serde_yaml::Value, _> = serde_yaml::from_str(&raw_yaml);
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+
+    load_dotenv(config_dir);
 
     match parsed {
         Ok(document) => {
             let typed: Result<EnsembleConfig, _> = serde_yaml::from_value(document.clone());
             match typed {
-                Ok(config) => {
+                Ok(mut config) => {
                     let mut report = validate_document(&document);
                     let mut config_valid = true;
+                    if let Err(e) = config.resolve_env_from(config_dir) {
+                        report.issues.push(config_error_to_validation_issue(e));
+                        config_valid = false;
+                    }
                     if let Err(e) = validate_config(&config) {
                         report.issues.push(pipeline_error_to_validation_issue(e));
                         config_valid = false;
@@ -133,6 +140,13 @@ pub fn parse_raw_yaml(path: PathBuf, raw_yaml: String) -> ConfigDocumentState {
                 validation: report,
             }
         }
+    }
+}
+
+fn load_dotenv(config_dir: &Path) {
+    let env_path = config_dir.join(".env");
+    if env_path.exists() {
+        let _ = dotenvy::from_path(&env_path);
     }
 }
 
@@ -328,6 +342,16 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
     }
 }
 
+fn config_error_to_validation_issue(error: ConfigError) -> ValidationIssue {
+    ValidationIssue {
+        kind: ValidationIssueKind::Environment,
+        message: error.to_string(),
+        section: "config".to_string(),
+        field: None,
+        path: None,
+    }
+}
+
 pub fn save_raw_yaml_atomically(
     path: &Path,
     raw_yaml: &str,
@@ -412,6 +436,72 @@ mod tests {
             .issues
             .iter()
             .any(|issue| issue.kind == ValidationIssueKind::Syntax));
+    }
+
+    #[test]
+    fn load_config_state_resolves_env_and_relative_paths_from_config_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        let env_name = "ENSEMBLE_DRAFT_TEST_ROOT";
+
+        unsafe {
+            std::env::remove_var(env_name);
+        }
+
+        std::fs::write(
+            dir.path().join(".env"),
+            format!("{env_name}=workspace-data\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            &path,
+            format!(
+                r#"
+tracker:
+  kind: todo_file
+  path: tracker/issues.md
+agents:
+  builder:
+    acpx_agent: claude
+    prompt_template: prompts/build.md
+steps:
+  - name: build
+    agent: builder
+repos:
+  - path: repos/app
+    branch: main
+workspace:
+  root: ${env_name}
+on_success: Done
+on_failure: Failed
+"#
+            ),
+        )
+        .unwrap();
+
+        let state = load_config_state(&path).unwrap();
+        let config = state.active_config.as_ref().unwrap();
+
+        assert_eq!(
+            config.tracker.path.as_deref(),
+            Some(dir.path().join("tracker/issues.md").as_path())
+        );
+        assert_eq!(
+            config.repos[0].path,
+            dir.path().join("repos/app").display().to_string()
+        );
+        assert_eq!(
+            config.workspace.root.as_deref(),
+            Some(dir.path().join("workspace-data").to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            config.agents["builder"].prompt_template.as_deref(),
+            Some(dir.path().join("prompts/build.md").as_path())
+        );
+
+        unsafe {
+            std::env::remove_var(env_name);
+        }
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -250,68 +250,68 @@ pub fn apply_guided_form(
     };
 
     // Update tracker section
-    let tracker_mapping = serde_yaml::Mapping::from_iter([
-        ("kind".into(), form.tracker.kind.clone().into()),
-        ("path".into(), opt_to_value(form.tracker.path.clone())),
-        (
-            "repository".into(),
-            opt_to_value(form.tracker.repository.clone()),
-        ),
-        (
-            "project_number".into(),
-            opt_to_value(form.tracker.project_number),
-        ),
-        ("api_key".into(), opt_to_value(form.tracker.api_key.clone())),
-        (
-            "endpoint".into(),
-            opt_to_value(form.tracker.endpoint.clone()),
-        ),
-        (
-            "active_states".into(),
-            form.tracker.active_states.clone().into(),
-        ),
-        (
-            "terminal_states".into(),
-            form.tracker.terminal_states.clone().into(),
-        ),
-        (
-            "labels_filter".into(),
-            form.tracker.labels_filter.clone().into(),
-        ),
-    ]);
-    mapping.insert("tracker".into(), tracker_mapping.into());
+    let tracker_mapping = get_or_create_mapping(mapping, "tracker");
+    replace_known_fields(
+        tracker_mapping,
+        [
+            ("kind", form.tracker.kind.clone().into()),
+            ("path", opt_to_value(form.tracker.path.clone())),
+            ("repository", opt_to_value(form.tracker.repository.clone())),
+            ("project_number", opt_to_value(form.tracker.project_number)),
+            ("api_key", opt_to_value(form.tracker.api_key.clone())),
+            ("endpoint", opt_to_value(form.tracker.endpoint.clone())),
+            ("active_states", form.tracker.active_states.clone().into()),
+            (
+                "terminal_states",
+                form.tracker.terminal_states.clone().into(),
+            ),
+            ("labels_filter", form.tracker.labels_filter.clone().into()),
+        ],
+    );
 
     // Update repos section
     let repos_seq: Vec<serde_yaml::Value> = form
         .repos
         .iter()
-        .map(|r| {
-            serde_yaml::Mapping::from_iter([
-                ("path".into(), r.path.clone().into()),
-                ("branch".into(), r.branch.clone().into()),
-                ("git_remote".into(), r.git_remote.clone().into()),
-            ])
-            .into()
+        .enumerate()
+        .map(|(idx, r)| {
+            let mut repo_mapping = existing_sequence_mapping(mapping, "repos", idx);
+            replace_known_fields(
+                &mut repo_mapping,
+                [
+                    ("path", r.path.clone().into()),
+                    ("branch", r.branch.clone().into()),
+                    ("git_remote", r.git_remote.clone().into()),
+                ],
+            );
+            repo_mapping.into()
         })
         .collect();
     mapping.insert("repos".into(), repos_seq.into());
 
     // Update agents section
+    let existing_agents = mapping
+        .get("agents")
+        .and_then(serde_yaml::Value::as_mapping)
+        .cloned()
+        .unwrap_or_default();
     let agents_mapping = serde_yaml::Mapping::from_iter(form.agents.iter().map(|a| {
-        let agent_mapping = serde_yaml::Mapping::from_iter([
-            ("executor".into(), opt_to_value(a.executor.clone())),
-            ("model".into(), opt_to_value(a.model.clone())),
-            ("acpx_agent".into(), opt_to_value(a.acpx_agent.clone())),
-            ("prompt".into(), opt_to_value(a.prompt.clone())),
-            (
-                "prompt_template".into(),
-                opt_to_value(a.prompt_template.clone()),
-            ),
-            (
-                "reasoning_level".into(),
-                opt_to_value(a.reasoning_level.clone()),
-            ),
-        ]);
+        let mut agent_mapping = existing_agents
+            .get(serde_yaml::Value::String(a.name.clone()))
+            .and_then(serde_yaml::Value::as_mapping)
+            .cloned()
+            .unwrap_or_default();
+        replace_known_fields(
+            &mut agent_mapping,
+            [
+                ("executor", opt_to_value(a.executor.clone())),
+                ("model", opt_to_value(a.model.clone())),
+                ("acpx_agent", opt_to_value(a.acpx_agent.clone())),
+                ("prompt", opt_to_value(a.prompt.clone())),
+                ("prompt_template", opt_to_value(a.prompt_template.clone())),
+                ("reasoning_level", opt_to_value(a.reasoning_level.clone())),
+            ],
+        );
         (a.name.clone().into(), agent_mapping.into())
     }));
     mapping.insert("agents".into(), agents_mapping.into());
@@ -320,14 +320,21 @@ pub fn apply_guided_form(
     let steps_seq: Vec<serde_yaml::Value> = form
         .steps
         .iter()
-        .map(|s| {
-            let mut step_mapping = serde_yaml::Mapping::from_iter([
-                ("name".into(), s.name.clone().into()),
-                ("agent".into(), s.agent.clone().into()),
-            ]);
+        .enumerate()
+        .map(|(idx, s)| {
+            let mut step_mapping = existing_sequence_mapping(mapping, "steps", idx);
+            replace_known_fields(
+                &mut step_mapping,
+                [
+                    ("name", s.name.clone().into()),
+                    ("agent", s.agent.clone().into()),
+                ],
+            );
+            step_mapping.remove("depends");
             if !s.depends.is_empty() {
                 step_mapping.insert("depends".into(), s.depends.clone().into());
             }
+            step_mapping.remove("tracker_state");
             if let Some(ref tracker_state) = s.tracker_state {
                 step_mapping.insert("tracker_state".into(), tracker_state.clone().into());
             }
@@ -337,80 +344,78 @@ pub fn apply_guided_form(
     mapping.insert("steps".into(), steps_seq.into());
 
     // Update runtime settings
-    let concurrency_mapping = serde_yaml::Mapping::from_iter([
-        (
-            "max_concurrent_agents".into(),
-            form.runtime.concurrency.max_concurrent_agents.into(),
-        ),
-        (
-            "max_step_parallelism".into(),
-            form.runtime.concurrency.max_step_parallelism.into(),
-        ),
-    ]);
-    mapping.insert("concurrency".into(), concurrency_mapping.into());
+    replace_known_fields(
+        get_or_create_mapping(mapping, "concurrency"),
+        [
+            (
+                "max_concurrent_agents",
+                form.runtime.concurrency.max_concurrent_agents.into(),
+            ),
+            (
+                "max_step_parallelism",
+                form.runtime.concurrency.max_step_parallelism.into(),
+            ),
+        ],
+    );
 
-    let polling_mapping = serde_yaml::Mapping::from_iter([(
-        "interval_ms".into(),
-        form.runtime.polling.interval_ms.into(),
-    )]);
-    mapping.insert("polling".into(), polling_mapping.into());
+    replace_known_fields(
+        get_or_create_mapping(mapping, "polling"),
+        [("interval_ms", form.runtime.polling.interval_ms.into())],
+    );
 
-    let workspace_mapping = serde_yaml::Mapping::from_iter([(
-        "root".into(),
-        opt_to_value(form.runtime.workspace.root.clone()),
-    )]);
-    mapping.insert("workspace".into(), workspace_mapping.into());
+    replace_known_fields(
+        get_or_create_mapping(mapping, "workspace"),
+        [("root", opt_to_value(form.runtime.workspace.root.clone()))],
+    );
 
-    let hooks_mapping = serde_yaml::Mapping::from_iter([
-        (
-            "after_create".into(),
-            opt_to_value(form.runtime.hooks.after_create.clone()),
-        ),
-        (
-            "before_run".into(),
-            opt_to_value(form.runtime.hooks.before_run.clone()),
-        ),
-        (
-            "after_run".into(),
-            opt_to_value(form.runtime.hooks.after_run.clone()),
-        ),
-        (
-            "before_remove".into(),
-            opt_to_value(form.runtime.hooks.before_remove.clone()),
-        ),
-        ("timeout_ms".into(), form.runtime.hooks.timeout_ms.into()),
-    ]);
-    mapping.insert("hooks".into(), hooks_mapping.into());
+    replace_known_fields(
+        get_or_create_mapping(mapping, "hooks"),
+        [
+            (
+                "after_create",
+                opt_to_value(form.runtime.hooks.after_create.clone()),
+            ),
+            (
+                "before_run",
+                opt_to_value(form.runtime.hooks.before_run.clone()),
+            ),
+            (
+                "after_run",
+                opt_to_value(form.runtime.hooks.after_run.clone()),
+            ),
+            (
+                "before_remove",
+                opt_to_value(form.runtime.hooks.before_remove.clone()),
+            ),
+            ("timeout_ms", form.runtime.hooks.timeout_ms.into()),
+        ],
+    );
 
-    let agent_mapping = serde_yaml::Mapping::from_iter([
-        ("max_turns".into(), form.runtime.agent.max_turns.into()),
-        (
-            "max_retry_backoff_ms".into(),
-            form.runtime.agent.max_retry_backoff_ms.into(),
-        ),
-        ("command".into(), form.runtime.agent.command.clone().into()),
-        (
-            "session_mode".into(),
-            form.runtime.agent.session_mode.clone().into(),
-        ),
-        (
-            "permission_policy".into(),
-            form.runtime.agent.permission_policy.clone().into(),
-        ),
-        (
-            "turn_timeout_ms".into(),
-            form.runtime.agent.turn_timeout_ms.into(),
-        ),
-        (
-            "read_timeout_ms".into(),
-            form.runtime.agent.read_timeout_ms.into(),
-        ),
-        (
-            "stall_timeout_ms".into(),
-            form.runtime.agent.stall_timeout_ms.into(),
-        ),
-    ]);
-    mapping.insert("agent".into(), agent_mapping.into());
+    replace_known_fields(
+        get_or_create_mapping(mapping, "agent"),
+        [
+            ("max_turns", form.runtime.agent.max_turns.into()),
+            (
+                "max_retry_backoff_ms",
+                form.runtime.agent.max_retry_backoff_ms.into(),
+            ),
+            ("command", form.runtime.agent.command.clone().into()),
+            (
+                "session_mode",
+                form.runtime.agent.session_mode.clone().into(),
+            ),
+            (
+                "permission_policy",
+                form.runtime.agent.permission_policy.clone().into(),
+            ),
+            ("turn_timeout_ms", form.runtime.agent.turn_timeout_ms.into()),
+            ("read_timeout_ms", form.runtime.agent.read_timeout_ms.into()),
+            (
+                "stall_timeout_ms",
+                form.runtime.agent.stall_timeout_ms.into(),
+            ),
+        ],
+    );
 
     // Update max_cycles
     mapping.insert("max_cycles".into(), form.runtime.max_cycles.into());
@@ -429,6 +434,45 @@ pub fn apply_guided_form(
     serde_yaml::to_string(&value).map_err(|e| ConfigError::ConfigParseError {
         reason: e.to_string(),
     })
+}
+
+fn get_or_create_mapping<'a>(
+    mapping: &'a mut serde_yaml::Mapping,
+    key: &str,
+) -> &'a mut serde_yaml::Mapping {
+    let value = mapping
+        .entry(serde_yaml::Value::String(key.to_string()))
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if !matches!(value, serde_yaml::Value::Mapping(_)) {
+        *value = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+    }
+    match value {
+        serde_yaml::Value::Mapping(inner) => inner,
+        _ => unreachable!(),
+    }
+}
+
+fn replace_known_fields<const N: usize>(
+    mapping: &mut serde_yaml::Mapping,
+    fields: [(&str, serde_yaml::Value); N],
+) {
+    for (key, value) in fields {
+        mapping.insert(key.into(), value);
+    }
+}
+
+fn existing_sequence_mapping(
+    mapping: &serde_yaml::Mapping,
+    key: &str,
+    index: usize,
+) -> serde_yaml::Mapping {
+    mapping
+        .get(key)
+        .and_then(serde_yaml::Value::as_sequence)
+        .and_then(|items| items.get(index))
+        .and_then(serde_yaml::Value::as_mapping)
+        .cloned()
+        .unwrap_or_default()
 }
 
 /// Guided form request with base YAML.
@@ -541,5 +585,44 @@ on_failure: Failed
         let merged = apply_guided_form(raw, &guided_form_with_workspace_root("/tmp/ws")).unwrap();
         assert!(merged.contains("custom_section:"));
         assert!(merged.contains("keep_me: true"));
+    }
+
+    #[test]
+    fn apply_guided_form_preserves_unknown_nested_fields_in_managed_sections() {
+        let mut form = guided_form_with_workspace_root("/tmp/ws");
+        form.repos = vec![GuidedRepoForm {
+            path: "new-repo".to_string(),
+            branch: "main".to_string(),
+            git_remote: "origin".to_string(),
+        }];
+
+        let raw = r#"
+tracker:
+  kind: todo_file
+  path: old.md
+  custom_tracker_field: keep-me
+repos:
+  - path: old-repo
+    branch: old-branch
+    custom_repo_field: keep-me
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: old prompt
+    custom_agent_field: keep-me
+steps:
+  - name: implement
+    agent: builder
+    custom_step_field: keep-me
+on_success: Done
+on_failure: Failed
+"#;
+
+        let merged = apply_guided_form(raw, &form).unwrap();
+
+        assert!(merged.contains("custom_tracker_field: keep-me"));
+        assert!(merged.contains("custom_repo_field: keep-me"));
+        assert!(merged.contains("custom_agent_field: keep-me"));
+        assert!(merged.contains("custom_step_field: keep-me"));
     }
 }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -162,6 +162,18 @@ impl Orchestrator {
             state.last_tick_at = Some(Utc::now());
         }
 
+        // Pre-compute lowercase state lists once per tick
+        let (active_lower, terminal_lower) = {
+            let config = self.config.read().await;
+            let active_lower: Vec<String> = config.tracker.active_states.iter()
+                .map(|s| s.to_lowercase())
+                .collect();
+            let terminal_lower: Vec<String> = config.tracker.terminal_states.iter()
+                .map(|s| s.to_lowercase())
+                .collect();
+            (active_lower, terminal_lower)
+        };
+
         // 1. Reconcile stalled runs
         let stall_timeout_ms = {
             let config = self.config.read().await;
@@ -193,13 +205,12 @@ impl Orchestrator {
 
         // 2. Reconcile tracker states
         {
-            let config = self.config.read().await;
             let state = self.state.read().await;
             let reconcile_result = reconcile_tracker_states(
                 &state,
                 self.tracker.as_ref(),
-                &config.tracker.active_states,
-                &config.tracker.terminal_states,
+                &active_lower,
+                &terminal_lower,
             )
             .await;
 
@@ -252,7 +263,6 @@ impl Orchestrator {
         sort_for_dispatch(&mut candidates);
 
         // 5. Dispatch eligible issues while slots remain
-        let config = self.config.read().await;
         for issue in &candidates {
             {
                 let state = self.state.read().await;
@@ -266,8 +276,8 @@ impl Orchestrator {
                 is_dispatch_eligible(
                     issue,
                     &state,
-                    &config.tracker.active_states,
-                    &config.tracker.terminal_states,
+                    &active_lower,
+                    &terminal_lower,
                     &HashMap::new(),
                 )
             };

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -290,19 +290,17 @@ impl Orchestrator {
 
     /// Dispatch a single issue: build DAG, create PipelineRun, dispatch initial steps.
     async fn dispatch_issue(&self, issue: &Issue, attempt: Option<u32>) {
-        let config = self.config.read().await;
-
-        // Build the step DAG from config
-        let dag = match build_dag(&config.steps) {
-            Ok(d) => d,
-            Err(e) => {
-                warn!(
-                    issue_id = %issue.id,
-                    error = %e,
-                    "failed to build step DAG, skipping dispatch"
-                );
-                return;
-            }
+        // Read config and build DAG atomically
+        let (dag, config_snapshot) = {
+            let config = self.config.read().await;
+            let dag = match build_dag(&config.steps) {
+                Ok(d) => d,
+                Err(e) => {
+                    warn!(issue_id = %issue.id, error = %e, "failed to build step DAG, skipping dispatch");
+                    return;
+                }
+            };
+            (dag, config.clone())
         };
 
         let cycle = attempt.unwrap_or(1);
@@ -335,6 +333,9 @@ impl Orchestrator {
                 .await;
             }
         }
+
+        // Suppress unused variable warning
+        let _ = config_snapshot;
     }
 
     /// Dispatch a single pipeline step: set tracker state if specified, spawn worker.

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -165,10 +165,16 @@ impl Orchestrator {
         // Pre-compute lowercase state lists once per tick
         let (active_lower, terminal_lower) = {
             let config = self.config.read().await;
-            let active_lower: Vec<String> = config.tracker.active_states.iter()
+            let active_lower: Vec<String> = config
+                .tracker
+                .active_states
+                .iter()
                 .map(|s| s.to_lowercase())
                 .collect();
-            let terminal_lower: Vec<String> = config.tracker.terminal_states.iter()
+            let terminal_lower: Vec<String> = config
+                .tracker
+                .terminal_states
+                .iter()
                 .map(|s| s.to_lowercase())
                 .collect();
             (active_lower, terminal_lower)
@@ -504,7 +510,10 @@ impl Orchestrator {
 
         // Handle special cases
         match &event {
-            AgentEvent::SessionStarted { session_id, agent_pid } => {
+            AgentEvent::SessionStarted {
+                session_id,
+                agent_pid,
+            } => {
                 state.update_session_info(issue_id, session_id, agent_pid.as_deref());
             }
             AgentEvent::TurnStarted => {

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -13,7 +13,7 @@ use tokio::time::sleep;
 use tracing::{debug, info, warn};
 
 use crate::agent::events::{AgentEvent, WorkerEvent, WorkerResult};
-use crate::agent::AgentRunner;
+use crate::agent::{AgentRunRequest, AgentRunner};
 use crate::config::ensemble::EnsembleConfig;
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{PipelineAction, PipelineRun};
@@ -296,10 +296,10 @@ impl Orchestrator {
 
     /// Dispatch a single issue: build DAG, create PipelineRun, dispatch initial steps.
     async fn dispatch_issue(&self, issue: &Issue, attempt: Option<u32>) {
-        let dag = {
+        let (dag, config_snapshot) = {
             let config = self.config.read().await;
             match build_dag(&config.steps) {
-                Ok(d) => d,
+                Ok(d) => (d, Arc::new(config.clone())),
                 Err(e) => {
                     warn!(issue_id = %issue.id, error = %e, "failed to build step DAG, skipping dispatch");
                     return;
@@ -321,7 +321,7 @@ impl Orchestrator {
         {
             let mut state = self.state.write().await;
             state.add_running(issue, attempt);
-            state.insert_pipeline_run(&issue.id, pipeline_run);
+            state.insert_pipeline_run(&issue.id, pipeline_run, Arc::clone(&config_snapshot));
         }
 
         // Process initial dispatch requests
@@ -333,6 +333,7 @@ impl Orchestrator {
                     &req.agent_name,
                     req.tracker_state.as_deref(),
                     attempt,
+                    Arc::clone(&config_snapshot),
                 )
                 .await;
             }
@@ -347,6 +348,7 @@ impl Orchestrator {
         agent_name: &str,
         tracker_state: Option<&str>,
         attempt: Option<u32>,
+        config_snapshot: Arc<EnsembleConfig>,
     ) {
         info!(
             issue_id = %issue.id,
@@ -388,8 +390,6 @@ impl Orchestrator {
         let runner = Arc::clone(&self.agent_runner);
         let workspace_mgr = Arc::clone(&self.workspace_mgr);
         let event_tx = self.worker_tx.clone();
-        let config = Arc::clone(&self.config);
-
         tokio::spawn(async move {
             // Prepare workspace
             let workspace_result = workspace_mgr
@@ -399,13 +399,12 @@ impl Orchestrator {
                 Ok(ws) => {
                     // Run after_create hook if newly created
                     if ws.created_now {
-                        let cfg = config.read().await;
-                        if let Some(ref script) = cfg.hooks.after_create {
+                        if let Some(ref script) = config_snapshot.hooks.after_create {
                             if let Err(e) = crate::workspace::hooks::run_hook(
                                 "after_create",
                                 script,
                                 &ws.base_path,
-                                cfg.hooks.timeout_ms,
+                                config_snapshot.hooks.timeout_ms,
                             )
                             .await
                             {
@@ -442,14 +441,15 @@ impl Orchestrator {
 
             // Run agent
             let result = runner
-                .run(
-                    &issue_clone,
-                    &agent_name_owned,
-                    &step_name_owned,
+                .run(AgentRunRequest {
+                    config: Arc::clone(&config_snapshot),
+                    issue: &issue_clone,
+                    agent_name: &agent_name_owned,
+                    step_name: &step_name_owned,
                     attempt,
-                    &workspace_path,
-                    event_tx.clone(),
-                )
+                    workspace_path: &workspace_path,
+                    event_tx: event_tx.clone(),
+                })
                 .await;
 
             let worker_result = match result {
@@ -570,18 +570,25 @@ impl Orchestrator {
 
                 // Drive the pipeline
                 let pipeline_action = if let Some(run) = state.get_pipeline_run_mut(issue_id) {
-                    Some(run.step_completed(step_name, verdict))
+                    Some((
+                        run.step_completed(step_name, verdict),
+                        state.get_pipeline_config(issue_id).cloned(),
+                    ))
                 } else {
                     warn!(issue_id = %issue_id, "no pipeline run found for worker exit");
                     None
                 };
 
-                if let Some(action) = pipeline_action {
+                if let Some((action, config_snapshot)) = pipeline_action {
                     match action {
                         PipelineAction::Dispatch(requests) => {
                             // Need to drop state lock before dispatching
                             drop(state);
                             if let Some(ref issue) = issue_snapshot {
+                                let Some(config_snapshot) = config_snapshot else {
+                                    warn!(issue_id = %issue_id, "no config snapshot found for pipeline dispatch");
+                                    return;
+                                };
                                 for req in requests {
                                     self.dispatch_step(
                                         issue,
@@ -589,6 +596,7 @@ impl Orchestrator {
                                         &req.agent_name,
                                         req.tracker_state.as_deref(),
                                         None,
+                                        Arc::clone(&config_snapshot),
                                     )
                                     .await;
                                 }
@@ -832,19 +840,25 @@ mod tests {
     /// Mock agent runner that completes immediately.
     struct MockRunner {
         delay_ms: u64,
+        observed_commands: Option<Arc<RwLock<Vec<String>>>>,
     }
 
     #[async_trait]
     impl AgentRunner for MockRunner {
-        async fn run(
-            &self,
-            issue: &Issue,
-            _agent_name: &str,
-            step_name: &str,
-            _attempt: Option<u32>,
-            _workspace_path: &std::path::Path,
-            event_tx: mpsc::Sender<WorkerEvent>,
-        ) -> Result<(), AgentError> {
+        async fn run(&self, request: AgentRunRequest<'_>) -> Result<(), AgentError> {
+            let AgentRunRequest {
+                config,
+                issue,
+                step_name,
+                event_tx,
+                ..
+            } = request;
+            if let Some(observed_commands) = &self.observed_commands {
+                observed_commands
+                    .write()
+                    .await
+                    .push(config.agent.command.clone());
+            }
             if self.delay_ms > 0 {
                 tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
             }
@@ -923,7 +937,10 @@ agent:
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
             issues: issues.clone(),
         });
-        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 10 });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 10,
+            observed_commands: None,
+        });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
@@ -948,7 +965,10 @@ agent:
         let config = Arc::new(RwLock::new(make_config()));
         let issues = Arc::new(RwLock::new(vec![]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
-        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 0 });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+        });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
@@ -969,7 +989,7 @@ agent:
             let mut pipeline_run2 = PipelineRun::new("1".to_string(), 1, dag2);
             pipeline_run2.start();
             pipeline_run2.mark_running("build", "session-1".to_string());
-            state.insert_pipeline_run("1", pipeline_run2);
+            state.insert_pipeline_run("1", pipeline_run2, Arc::new(cfg.clone()));
         }
 
         // Simulate worker exit
@@ -990,7 +1010,10 @@ agent:
         let config = Arc::new(RwLock::new(make_config()));
         let issues = Arc::new(RwLock::new(vec![]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
-        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 0 });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+        });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
@@ -1008,7 +1031,7 @@ agent:
 
             let mut state = orchestrator.state.write().await;
             state.add_running(&test_issue("1", "Todo"), Some(2));
-            state.insert_pipeline_run("1", pipeline_run);
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
         }
 
         // Simulate worker failure
@@ -1039,7 +1062,10 @@ agent:
         let config = Arc::new(RwLock::new(make_config()));
         let issues = Arc::new(RwLock::new(vec![]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
-        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 0 });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+        });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
@@ -1103,7 +1129,10 @@ agent:
         let config = Arc::new(RwLock::new(make_config()));
         let issues = Arc::new(RwLock::new(vec![])); // empty — issue not found
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
-        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 0 });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+        });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
@@ -1147,7 +1176,10 @@ agent:
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
             issues: issues.clone(),
         });
-        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner { delay_ms: 10 });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 10,
+            observed_commands: None,
+        });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
@@ -1180,5 +1212,36 @@ agent:
                 "should have retry or be completed"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_uses_config_snapshot_for_runner() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let observed_commands = Arc::new(RwLock::new(Vec::new()));
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: Some(Arc::clone(&observed_commands)),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator =
+            Orchestrator::new(config.clone(), tracker, runner, workspace_mgr, shutdown_rx);
+        let issue = test_issue("1", "Todo");
+
+        orchestrator.dispatch_issue(&issue, None).await;
+
+        {
+            let mut cfg = config.write().await;
+            cfg.agent.command = "echo changed".to_string();
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let commands = observed_commands.read().await;
+        assert_eq!(commands.as_slice(), &["echo test".to_string()]);
     }
 }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -296,17 +296,15 @@ impl Orchestrator {
 
     /// Dispatch a single issue: build DAG, create PipelineRun, dispatch initial steps.
     async fn dispatch_issue(&self, issue: &Issue, attempt: Option<u32>) {
-        // Read config and build DAG atomically
-        let (dag, config_snapshot) = {
+        let dag = {
             let config = self.config.read().await;
-            let dag = match build_dag(&config.steps) {
+            match build_dag(&config.steps) {
                 Ok(d) => d,
                 Err(e) => {
                     warn!(issue_id = %issue.id, error = %e, "failed to build step DAG, skipping dispatch");
                     return;
                 }
-            };
-            (dag, config.clone())
+            }
         };
 
         let cycle = attempt.unwrap_or(1);
@@ -339,9 +337,6 @@ impl Orchestrator {
                 .await;
             }
         }
-
-        // Suppress unused variable warning
-        let _ = config_snapshot;
     }
 
     /// Dispatch a single pipeline step: set tracker state if specified, spawn worker.

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -501,22 +501,15 @@ impl Orchestrator {
     ) {
         let mut state = self.state.write().await;
 
+        // Handle special cases
         match &event {
-            AgentEvent::SessionStarted {
-                session_id,
-                agent_pid,
-            } => {
+            AgentEvent::SessionStarted { session_id, agent_pid } => {
                 state.update_session_info(issue_id, session_id, agent_pid.as_deref());
-                state.update_agent_event(issue_id, "session_started", None, timestamp);
             }
             AgentEvent::TurnStarted => {
                 state.increment_turn_count(issue_id);
-                state.update_agent_event(issue_id, "turn_started", None, timestamp);
             }
-            AgentEvent::TurnUpdate { content } => {
-                state.update_agent_event(issue_id, "turn_update", Some(content), timestamp);
-            }
-            AgentEvent::TurnCompleted { usage } => {
+            AgentEvent::TurnCompleted { usage } | AgentEvent::TurnFailed { usage, .. } => {
                 if let Some(u) = usage {
                     state.update_token_usage(
                         issue_id,
@@ -525,50 +518,17 @@ impl Orchestrator {
                         u.total_tokens,
                     );
                 }
-                state.update_agent_event(issue_id, "turn_completed", None, timestamp);
             }
-            AgentEvent::TurnFailed { reason, usage } => {
-                if let Some(u) = usage {
-                    state.update_token_usage(
-                        issue_id,
-                        u.input_tokens,
-                        u.output_tokens,
-                        u.total_tokens,
-                    );
-                }
-                state.update_agent_event(issue_id, "turn_failed", Some(reason), timestamp);
-            }
-            AgentEvent::PermissionRequested { description, .. } => {
-                state.update_agent_event(
-                    issue_id,
-                    "permission_requested",
-                    Some(description),
-                    timestamp,
-                );
-            }
-            AgentEvent::PermissionResolved { .. } => {
-                state.update_agent_event(issue_id, "permission_resolved", None, timestamp);
-            }
-            AgentEvent::Notification { message } => {
-                state.update_agent_event(issue_id, "notification", Some(message), timestamp);
-            }
-            AgentEvent::OtherMessage { raw } => {
-                state.update_agent_event(
-                    issue_id,
-                    "other_message",
-                    Some(&raw.chars().take(100).collect::<String>()),
-                    timestamp,
-                );
-            }
-            AgentEvent::Malformed { line } => {
-                state.update_agent_event(
-                    issue_id,
-                    "malformed",
-                    Some(&line.chars().take(100).collect::<String>()),
-                    timestamp,
-                );
-            }
+            _ => {}
         }
+
+        // Common path: update agent event
+        state.update_agent_event(
+            issue_id,
+            event.event_name(),
+            event.message_for_state().as_deref(),
+            timestamp,
+        );
     }
 
     /// Handle a worker exit. Integrates with PipelineRun to drive step DAG.

--- a/crates/ensemble-core/src/orchestrator/reconciler.rs
+++ b/crates/ensemble-core/src/orchestrator/reconciler.rs
@@ -65,16 +65,14 @@ pub enum ReconcileAction {
 /// Determine the reconcile action for a single refreshed issue.
 pub fn determine_reconcile_action(
     issue: &Issue,
-    active_states: &[String],
-    terminal_states: &[String],
+    active_states_lower: &[String],
+    terminal_states_lower: &[String],
 ) -> ReconcileAction {
     let state_lower = issue.state.to_lowercase();
-    let terminal_lower: Vec<String> = terminal_states.iter().map(|s| s.to_lowercase()).collect();
-    let active_lower: Vec<String> = active_states.iter().map(|s| s.to_lowercase()).collect();
 
-    if terminal_lower.contains(&state_lower) {
+    if terminal_states_lower.contains(&state_lower) {
         ReconcileAction::TerminateAndCleanup(issue.clone())
-    } else if active_lower.contains(&state_lower) {
+    } else if active_states_lower.contains(&state_lower) {
         ReconcileAction::UpdateSnapshot(issue.clone())
     } else {
         ReconcileAction::TerminateNoCleanup(issue.clone())
@@ -240,11 +238,11 @@ mod tests {
     }
 
     fn default_active() -> Vec<String> {
-        vec!["Todo".to_string(), "In Progress".to_string()]
+        vec!["todo".to_string(), "in progress".to_string()]
     }
 
     fn default_terminal() -> Vec<String> {
-        vec!["Done".to_string(), "Closed".to_string()]
+        vec!["done".to_string(), "closed".to_string()]
     }
 
     // --- Stall detection tests ---

--- a/crates/ensemble-core/src/orchestrator/reconciler.rs
+++ b/crates/ensemble-core/src/orchestrator/reconciler.rs
@@ -84,8 +84,8 @@ pub fn determine_reconcile_action(
 pub async fn reconcile_tracker_states(
     state: &OrchestratorState,
     tracker: &dyn IssueTracker,
-    active_states: &[String],
-    terminal_states: &[String],
+    active_states_lower: &[String],
+    terminal_states_lower: &[String],
 ) -> ReconcileTrackerResult {
     let running_ids = state.running_issue_ids();
     if running_ids.is_empty() {
@@ -122,7 +122,7 @@ pub async fn reconcile_tracker_states(
             continue;
         }
 
-        match determine_reconcile_action(&issue, active_states, terminal_states) {
+        match determine_reconcile_action(&issue, active_states_lower, terminal_states_lower) {
             ReconcileAction::UpdateSnapshot(i) => {
                 debug!(
                     issue_id = %i.id,

--- a/crates/ensemble-core/src/orchestrator/reconciler.rs
+++ b/crates/ensemble-core/src/orchestrator/reconciler.rs
@@ -87,7 +87,7 @@ pub async fn reconcile_tracker_states(
     active_states_lower: &[String],
     terminal_states_lower: &[String],
 ) -> ReconcileTrackerResult {
-    let running_ids = state.running_issue_ids();
+    let running_ids: Vec<String> = state.running_issue_ids().map(|s| s.to_string()).collect();
     if running_ids.is_empty() {
         return ReconcileTrackerResult {
             updates: vec![],

--- a/crates/ensemble-core/src/orchestrator/scheduler.rs
+++ b/crates/ensemble-core/src/orchestrator/scheduler.rs
@@ -7,9 +7,7 @@ use super::state::OrchestratorState;
 /// Check if an issue is eligible for dispatch.
 /// Returns None if eligible, or Some(reason) explaining why not.
 ///
-/// Accepts both pre-lowercased slices (from internal callers) and raw state
-/// strings (from external callers). Internal normalization ensures backward
-/// compatibility regardless of input casing.
+/// Compares state names case-insensitively without allocating normalized copies.
 pub fn is_dispatch_eligible(
     issue: &Issue,
     state: &OrchestratorState,
@@ -33,19 +31,13 @@ pub fn is_dispatch_eligible(
 
     let state_lower = issue.state.to_lowercase();
 
-    // Normalize inputs to lowercase for case-insensitive comparison.
-    // Internal callers already pass pre-lowercased slices, so this is a no-op
-    // for them. External callers get backward-compatible behavior.
-    let active_lower: Vec<String> = active_states.iter().map(|s| s.to_lowercase()).collect();
-    let terminal_lower: Vec<String> = terminal_states.iter().map(|s| s.to_lowercase()).collect();
-
     // Must be in active states
-    if !active_lower.contains(&state_lower) {
+    if !contains_state(active_states, &issue.state) {
         return Some(format!("state '{}' not in active states", issue.state));
     }
 
     // Must NOT be in terminal states
-    if terminal_lower.contains(&state_lower) {
+    if contains_state(terminal_states, &issue.state) {
         return Some(format!("state '{}' is terminal", issue.state));
     }
 
@@ -78,7 +70,7 @@ pub fn is_dispatch_eligible(
     if state_lower == "todo" && !issue.blocked_by.is_empty() {
         let has_non_terminal_blocker = issue.blocked_by.iter().any(|blocker| {
             if let Some(ref blocker_state) = blocker.state {
-                !terminal_lower.contains(&blocker_state.to_lowercase())
+                !contains_state(terminal_states, blocker_state)
             } else {
                 // Unknown state — treat as non-terminal (conservative)
                 true
@@ -90,6 +82,12 @@ pub fn is_dispatch_eligible(
     }
 
     None
+}
+
+fn contains_state(states: &[String], needle: &str) -> bool {
+    states
+        .iter()
+        .any(|state| state.eq_ignore_ascii_case(needle))
 }
 
 /// Sort issues for dispatch priority.

--- a/crates/ensemble-core/src/orchestrator/scheduler.rs
+++ b/crates/ensemble-core/src/orchestrator/scheduler.rs
@@ -9,8 +9,8 @@ use super::state::OrchestratorState;
 pub fn is_dispatch_eligible(
     issue: &Issue,
     state: &OrchestratorState,
-    active_states: &[String],
-    terminal_states: &[String],
+    active_states_lower: &[String],
+    terminal_states_lower: &[String],
     max_concurrent_by_state: &HashMap<String, u32>,
 ) -> Option<String> {
     // Must have required fields
@@ -30,14 +30,12 @@ pub fn is_dispatch_eligible(
     let state_lower = issue.state.to_lowercase();
 
     // Must be in active states
-    let active_lower: Vec<String> = active_states.iter().map(|s| s.to_lowercase()).collect();
-    if !active_lower.contains(&state_lower) {
+    if !active_states_lower.contains(&state_lower) {
         return Some(format!("state '{}' not in active states", issue.state));
     }
 
     // Must NOT be in terminal states
-    let terminal_lower: Vec<String> = terminal_states.iter().map(|s| s.to_lowercase()).collect();
-    if terminal_lower.contains(&state_lower) {
+    if terminal_states_lower.contains(&state_lower) {
         return Some(format!("state '{}' is terminal", issue.state));
     }
 
@@ -70,7 +68,7 @@ pub fn is_dispatch_eligible(
     if state_lower == "todo" && !issue.blocked_by.is_empty() {
         let has_non_terminal_blocker = issue.blocked_by.iter().any(|blocker| {
             if let Some(ref blocker_state) = blocker.state {
-                !terminal_lower.contains(&blocker_state.to_lowercase())
+                !terminal_states_lower.contains(&blocker_state.to_lowercase())
             } else {
                 // Unknown state — treat as non-terminal (conservative)
                 true
@@ -159,11 +157,11 @@ mod tests {
     }
 
     fn default_active() -> Vec<String> {
-        vec!["Todo".to_string(), "In Progress".to_string()]
+        vec!["todo".to_string(), "in progress".to_string()]
     }
 
     fn default_terminal() -> Vec<String> {
-        vec!["Done".to_string(), "Closed".to_string()]
+        vec!["done".to_string(), "closed".to_string()]
     }
 
     #[test]

--- a/crates/ensemble-core/src/orchestrator/scheduler.rs
+++ b/crates/ensemble-core/src/orchestrator/scheduler.rs
@@ -6,11 +6,15 @@ use super::state::OrchestratorState;
 
 /// Check if an issue is eligible for dispatch.
 /// Returns None if eligible, or Some(reason) explaining why not.
+///
+/// Accepts both pre-lowercased slices (from internal callers) and raw state
+/// strings (from external callers). Internal normalization ensures backward
+/// compatibility regardless of input casing.
 pub fn is_dispatch_eligible(
     issue: &Issue,
     state: &OrchestratorState,
-    active_states_lower: &[String],
-    terminal_states_lower: &[String],
+    active_states: &[String],
+    terminal_states: &[String],
     max_concurrent_by_state: &HashMap<String, u32>,
 ) -> Option<String> {
     // Must have required fields
@@ -29,13 +33,19 @@ pub fn is_dispatch_eligible(
 
     let state_lower = issue.state.to_lowercase();
 
+    // Normalize inputs to lowercase for case-insensitive comparison.
+    // Internal callers already pass pre-lowercased slices, so this is a no-op
+    // for them. External callers get backward-compatible behavior.
+    let active_lower: Vec<String> = active_states.iter().map(|s| s.to_lowercase()).collect();
+    let terminal_lower: Vec<String> = terminal_states.iter().map(|s| s.to_lowercase()).collect();
+
     // Must be in active states
-    if !active_states_lower.contains(&state_lower) {
+    if !active_lower.contains(&state_lower) {
         return Some(format!("state '{}' not in active states", issue.state));
     }
 
     // Must NOT be in terminal states
-    if terminal_states_lower.contains(&state_lower) {
+    if terminal_lower.contains(&state_lower) {
         return Some(format!("state '{}' is terminal", issue.state));
     }
 
@@ -68,7 +78,7 @@ pub fn is_dispatch_eligible(
     if state_lower == "todo" && !issue.blocked_by.is_empty() {
         let has_non_terminal_blocker = issue.blocked_by.iter().any(|blocker| {
             if let Some(ref blocker_state) = blocker.state {
-                !terminal_states_lower.contains(&blocker_state.to_lowercase())
+                !terminal_lower.contains(&blocker_state.to_lowercase())
             } else {
                 // Unknown state — treat as non-terminal (conservative)
                 true

--- a/crates/ensemble-core/src/orchestrator/scheduler.rs
+++ b/crates/ensemble-core/src/orchestrator/scheduler.rs
@@ -29,8 +29,6 @@ pub fn is_dispatch_eligible(
         return Some("missing issue state".to_string());
     }
 
-    let state_lower = issue.state.to_lowercase();
-
     // Must be in active states
     if !contains_state(active_states, &issue.state) {
         return Some(format!("state '{}' not in active states", issue.state));
@@ -67,7 +65,7 @@ pub fn is_dispatch_eligible(
     }
 
     // Blocker rule: Todo issues with non-terminal blockers are not eligible
-    if state_lower == "todo" && !issue.blocked_by.is_empty() {
+    if issue.state.eq_ignore_ascii_case("todo") && !issue.blocked_by.is_empty() {
         let has_non_terminal_blocker = issue.blocked_by.iter().any(|blocker| {
             if let Some(ref blocker_state) = blocker.state {
                 !contains_state(terminal_states, blocker_state)

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -227,8 +227,8 @@ impl OrchestratorState {
     }
 
     /// Get all running issue IDs.
-    pub fn running_issue_ids(&self) -> Vec<String> {
-        self.running.keys().cloned().collect()
+    pub fn running_issue_ids(&self) -> impl Iterator<Item = &str> {
+        self.running.keys().map(|k| k.as_str())
     }
 
     /// Get an immutable reference to a pipeline run.
@@ -445,7 +445,7 @@ mod tests {
         state.add_running(&test_issue("a", "Todo"), None);
         state.add_running(&test_issue("b", "Todo"), None);
 
-        let mut ids = state.running_issue_ids();
+        let mut ids: Vec<&str> = state.running_issue_ids().collect();
         ids.sort();
         assert_eq!(ids, vec!["a", "b"]);
     }

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::config::ensemble::EnsembleConfig;
 use crate::pipeline::engine::PipelineRun;
 use crate::tracker::model::{AgentTotals, Issue, RetryEntry, RunningEntry};
 
@@ -36,6 +37,8 @@ pub struct OrchestratorState {
     pub agent_rate_limits: Option<RateLimitSnapshot>,
     /// Active pipeline runs: issue_id -> PipelineRun.
     pub pipeline_runs: HashMap<String, PipelineRun>,
+    /// Immutable config snapshot for each active pipeline run.
+    pub pipeline_configs: HashMap<String, std::sync::Arc<EnsembleConfig>>,
     /// Timestamp of the last orchestrator poll tick.
     pub last_tick_at: Option<DateTime<Utc>>,
 }
@@ -53,6 +56,7 @@ impl OrchestratorState {
             agent_totals: AgentTotals::default(),
             agent_rate_limits: None,
             pipeline_runs: HashMap::new(),
+            pipeline_configs: HashMap::new(),
             last_tick_at: None,
         }
     }
@@ -125,6 +129,7 @@ impl OrchestratorState {
         self.claimed.remove(issue_id);
         self.running.remove(issue_id);
         self.retry_attempts.remove(issue_id);
+        self.pipeline_configs.remove(issue_id);
     }
 
     /// Update session metadata on a running entry.
@@ -242,13 +247,24 @@ impl OrchestratorState {
     }
 
     /// Insert a pipeline run for an issue.
-    pub fn insert_pipeline_run(&mut self, issue_id: &str, run: PipelineRun) {
+    pub fn insert_pipeline_run(
+        &mut self,
+        issue_id: &str,
+        run: PipelineRun,
+        config: std::sync::Arc<EnsembleConfig>,
+    ) {
         self.pipeline_runs.insert(issue_id.to_string(), run);
+        self.pipeline_configs.insert(issue_id.to_string(), config);
     }
 
     /// Remove and return a pipeline run.
     pub fn remove_pipeline_run(&mut self, issue_id: &str) -> Option<PipelineRun> {
+        self.pipeline_configs.remove(issue_id);
         self.pipeline_runs.remove(issue_id)
+    }
+
+    pub fn get_pipeline_config(&self, issue_id: &str) -> Option<&std::sync::Arc<EnsembleConfig>> {
+        self.pipeline_configs.get(issue_id)
     }
 }
 

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use serde::Deserialize;
+use tracing::warn;
 
 /// The verdict returned by a review agent at the end of a pipeline step.
 #[derive(Debug, Clone, PartialEq)]
@@ -74,6 +75,7 @@ pub async fn resolve_verdict(acp_verdict: Option<&serde_json::Value>, workspace:
     }
 
     // 3. Default (no ACP verdict, no file).
+    warn!("no verdict source found for step, defaulting to Approve");
     Verdict::Approve
 }
 

--- a/crates/ensemble-core/src/workspace/hooks.rs
+++ b/crates/ensemble-core/src/workspace/hooks.rs
@@ -28,7 +28,10 @@ pub async fn run_hook(
     let shell = if Command::new("bash").arg("--version").output().await.is_ok() {
         "bash"
     } else {
-        warn!(hook = hook_name, "bash not found, falling back to sh for hook execution");
+        warn!(
+            hook = hook_name,
+            "bash not found, falling back to sh for hook execution"
+        );
         "sh"
     };
 

--- a/crates/ensemble-core/src/workspace/hooks.rs
+++ b/crates/ensemble-core/src/workspace/hooks.rs
@@ -90,17 +90,12 @@ pub async fn run_hook(
 }
 
 fn preferred_shell() -> &'static str {
-    PREFERRED_SHELL.get_or_init(|| {
-        if std::process::Command::new("bash")
-            .arg("--version")
-            .output()
-            .is_ok()
-        {
-            "bash"
-        } else {
-            "sh"
-        }
-    })
+    PREFERRED_SHELL.get_or_init(|| if bash_in_path() { "bash" } else { "sh" })
+}
+
+fn bash_in_path() -> bool {
+    std::env::var_os("PATH")
+        .is_some_and(|paths| std::env::split_paths(&paths).any(|dir| dir.join("bash").is_file()))
 }
 
 /// Run a hook if configured; swallow errors for non-fatal hooks.

--- a/crates/ensemble-core/src/workspace/hooks.rs
+++ b/crates/ensemble-core/src/workspace/hooks.rs
@@ -11,7 +11,8 @@ const STDERR_TRUNCATE_LIMIT: usize = 500;
 
 /// Run a shell hook script in the given workspace directory with a timeout.
 ///
-/// The script is executed via `bash -lc <script>` with cwd set to `workspace_path`.
+/// The script is executed via `bash -lc <script>` (falling back to `sh -lc` if
+/// bash is unavailable) with cwd set to `workspace_path`.
 /// Returns Ok(()) on success, Err on failure or timeout.
 pub async fn run_hook(
     hook_name: &str,
@@ -23,8 +24,16 @@ pub async fn run_hook(
 
     let duration = Duration::from_millis(timeout_ms);
 
+    // Try bash first, fall back to sh if unavailable
+    let shell = if Command::new("bash").arg("--version").output().await.is_ok() {
+        "bash"
+    } else {
+        warn!(hook = hook_name, "bash not found, falling back to sh for hook execution");
+        "sh"
+    };
+
     // kill_on_drop ensures the child is killed if we drop it (e.g. on timeout)
-    let child = Command::new("bash")
+    let child = Command::new(shell)
         .arg("-lc")
         .arg(script)
         .current_dir(workspace_path)

--- a/crates/ensemble-core/src/workspace/hooks.rs
+++ b/crates/ensemble-core/src/workspace/hooks.rs
@@ -11,7 +11,7 @@ const STDERR_TRUNCATE_LIMIT: usize = 500;
 
 /// Run a shell hook script in the given workspace directory with a timeout.
 ///
-/// The script is executed via `sh -lc <script>` with cwd set to `workspace_path`.
+/// The script is executed via `bash -lc <script>` with cwd set to `workspace_path`.
 /// Returns Ok(()) on success, Err on failure or timeout.
 pub async fn run_hook(
     hook_name: &str,
@@ -24,7 +24,7 @@ pub async fn run_hook(
     let duration = Duration::from_millis(timeout_ms);
 
     // kill_on_drop ensures the child is killed if we drop it (e.g. on timeout)
-    let child = Command::new("sh")
+    let child = Command::new("bash")
         .arg("-lc")
         .arg(script)
         .current_dir(workspace_path)

--- a/crates/ensemble-core/src/workspace/hooks.rs
+++ b/crates/ensemble-core/src/workspace/hooks.rs
@@ -1,5 +1,6 @@
 use crate::error::WorkspaceError;
 use std::path::Path;
+use std::sync::OnceLock;
 use std::time::Duration;
 use tokio::process::Command;
 use tokio::time::timeout;
@@ -8,6 +9,7 @@ use tracing::{info, warn};
 /// Max chars of stderr to include in hook error messages. Prevents oversized error
 /// strings from long-running hooks that dump large output on failure.
 const STDERR_TRUNCATE_LIMIT: usize = 500;
+static PREFERRED_SHELL: OnceLock<&'static str> = OnceLock::new();
 
 /// Run a shell hook script in the given workspace directory with a timeout.
 ///
@@ -25,15 +27,13 @@ pub async fn run_hook(
     let duration = Duration::from_millis(timeout_ms);
 
     // Try bash first, fall back to sh if unavailable
-    let shell = if Command::new("bash").arg("--version").output().await.is_ok() {
-        "bash"
-    } else {
+    let shell = preferred_shell();
+    if shell == "sh" {
         warn!(
             hook = hook_name,
             "bash not found, falling back to sh for hook execution"
         );
-        "sh"
-    };
+    }
 
     // kill_on_drop ensures the child is killed if we drop it (e.g. on timeout)
     let child = Command::new(shell)
@@ -87,6 +87,20 @@ pub async fn run_hook(
             })
         }
     }
+}
+
+fn preferred_shell() -> &'static str {
+    PREFERRED_SHELL.get_or_init(|| {
+        if std::process::Command::new("bash")
+            .arg("--version")
+            .output()
+            .is_ok()
+        {
+            "bash"
+        } else {
+            "sh"
+        }
+    })
 }
 
 /// Run a hook if configured; swallow errors for non-fatal hooks.

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -163,11 +163,13 @@ impl WorkspaceManager {
     /// and the final component is re-appended, preserving the intended semantics.
     fn validate_path_inside_root(&self, path: &Path) -> Result<(), WorkspaceError> {
         let canonical_root = self.root.canonicalize().unwrap_or_else(|e| {
-            warn!(
-                root = %self.root.display(),
-                error = %e,
-                "cannot canonicalize workspace root, falling back to non-canonical path check"
-            );
+            if self.root.exists() {
+                warn!(
+                    root = %self.root.display(),
+                    error = %e,
+                    "cannot canonicalize workspace root, falling back to non-canonical path check"
+                );
+            }
             self.root.clone()
         });
 

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -4,6 +4,7 @@ use crate::tracker::model::sanitize_workspace_key;
 use crate::workspace::coordinator::{WorktreeCoordinator, WorktreeInfo};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use tracing::warn;
 
 /// Result of preparing a workspace for an issue.
 pub struct WorkspaceResult {
@@ -161,24 +162,33 @@ impl WorkspaceManager {
     /// When `path` does not yet exist (pre-creation), its parent is canonicalized
     /// and the final component is re-appended, preserving the intended semantics.
     fn validate_path_inside_root(&self, path: &Path) -> Result<(), WorkspaceError> {
-        let canonical_root = if self.root.exists() {
-            self.root
-                .canonicalize()
-                .unwrap_or_else(|_| self.root.clone())
-        } else {
+        let canonical_root = self.root.canonicalize().unwrap_or_else(|e| {
+            warn!(
+                root = %self.root.display(),
+                error = %e,
+                "cannot canonicalize workspace root, falling back to non-canonical path check"
+            );
             self.root.clone()
-        };
+        });
 
         let canonical_path = if path.exists() {
-            path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+            path.canonicalize().unwrap_or_else(|e| {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "cannot canonicalize path, falling back to non-canonical check"
+                );
+                path.to_path_buf()
+            })
         } else if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
-            let canonical_parent = if parent.exists() {
-                parent
-                    .canonicalize()
-                    .unwrap_or_else(|_| parent.to_path_buf())
-            } else {
+            let canonical_parent = parent.canonicalize().unwrap_or_else(|e| {
+                warn!(
+                    parent = %parent.display(),
+                    error = %e,
+                    "cannot canonicalize parent path, falling back to non-canonical check"
+                );
                 parent.to_path_buf()
-            };
+            });
             canonical_parent.join(file_name)
         } else {
             path.to_path_buf()

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GuidedEditor, { type GuidedForm } from "./GuidedEditor";
+import { ValidationIssueKind } from "@/generated/models/validationIssueKind";
+import { renderWithProviders } from "@/test/render";
+
+const initialForm: GuidedForm = {
+  tracker: {
+    kind: "todo_file",
+    path: "/tmp/todo.md",
+    active_states: [],
+    terminal_states: [],
+    labels_filter: [],
+  },
+  repos: [],
+  agents: [
+    {
+      name: "builder",
+      acpx_agent: "claude",
+      prompt: "Build it",
+    },
+  ],
+  steps: [{ name: "build", agent: "builder", depends: [] }],
+  runtime: {
+    max_cycles: 1,
+    concurrency: { max_concurrent_agents: 1, max_step_parallelism: 1 },
+    polling: { interval_ms: 1000 },
+    workspace: {},
+    hooks: { timeout_ms: 1000 },
+    agent: {
+      max_turns: 1,
+      max_retry_backoff_ms: 1,
+      command: "agent",
+      session_mode: "code",
+      permission_policy: "auto",
+      turn_timeout_ms: 1,
+      read_timeout_ms: 1,
+      stall_timeout_ms: 1,
+    },
+  },
+  transitions: { on_success: "Done", on_failure: "Failed" },
+};
+
+describe("GuidedEditor", () => {
+  it("shows validation issues returned by validate without waiting for save", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <GuidedEditor
+        initialForm={initialForm}
+        baseRawYaml={"tracker:\n  kind: todo_file\n"}
+        issues={[]}
+        onValidate={vi.fn(async () => [
+          {
+            kind: ValidationIssueKind.Config,
+            section: "workflow",
+            message: "step agent is invalid",
+            field: "agent",
+            path: "steps[0].agent",
+          },
+        ])}
+        onSave={vi.fn(async () => undefined)}
+        onReset={vi.fn()}
+      />,
+      { route: "/config" }
+    );
+
+    await user.click(screen.getByRole("button", { name: /validate/i }));
+
+    expect(await screen.findByText(/step agent is invalid/i)).toBeInTheDocument();
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -84,7 +84,7 @@ interface GuidedEditorProps {
   initialForm: GuidedForm;
   baseRawYaml: string;
   issues: ValidationIssue[];
-  onValidate: (form: GuidedForm, baseRawYaml: string) => Promise<void>;
+  onValidate: (form: GuidedForm, baseRawYaml: string) => Promise<ValidationIssue[]>;
   onSave: (form: GuidedForm, baseRawYaml: string) => Promise<void>;
   onReset: () => void;
 }
@@ -101,10 +101,15 @@ export default function GuidedEditor({
   const [isDirty, setIsDirty] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [displayedIssues, setDisplayedIssues] = useState<ValidationIssue[]>(issues);
   const [lastValidation, setLastValidation] = useState<{
     timestamp: Date;
     issues: ValidationIssue[];
   } | null>(null);
+
+  useEffect(() => {
+    setDisplayedIssues(issues);
+  }, [issues]);
 
   const handleFormChange = (updates: Partial<GuidedForm>) => {
     setForm((prev) => ({ ...prev, ...updates }));
@@ -114,10 +119,11 @@ export default function GuidedEditor({
   const handleValidate = async () => {
     setIsValidating(true);
     try {
-      await onValidate(form, baseRawYaml);
+      const nextIssues = await onValidate(form, baseRawYaml);
+      setDisplayedIssues(nextIssues);
       setLastValidation({
         timestamp: new Date(),
-        issues: issues,
+        issues: nextIssues,
       });
     } finally {
       setIsValidating(false);
@@ -140,7 +146,7 @@ export default function GuidedEditor({
     onReset();
   };
 
-  const hasErrors = issues.length > 0;
+  const hasErrors = displayedIssues.length > 0;
   const availableAgents: GuidedAgent[] = form.agents.map((a) => ({
     name: a.name,
     label: a.name,
@@ -201,7 +207,7 @@ export default function GuidedEditor({
                   Configuration Issues
                 </h3>
                 <ul className="mt-2 space-y-1 text-sm text-red-700 dark:text-red-300">
-                  {issues.map((issue, i) => (
+                  {displayedIssues.map((issue, i) => (
                     <li key={i}>
                       {issue.section && `${issue.section}: `}
                       {issue.message}

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
@@ -119,12 +119,16 @@ export default function GuidedEditor({
   const handleValidate = async () => {
     setIsValidating(true);
     try {
-      const nextIssues = await onValidate(form, baseRawYaml);
-      setDisplayedIssues(nextIssues);
-      setLastValidation({
-        timestamp: new Date(),
-        issues: nextIssues,
-      });
+      try {
+        const nextIssues = await onValidate(form, baseRawYaml);
+        setDisplayedIssues(nextIssues);
+        setLastValidation({
+          timestamp: new Date(),
+          issues: nextIssues,
+        });
+      } catch {
+        // Keep the last visible issues when validation fails.
+      }
     } finally {
       setIsValidating(false);
     }

--- a/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.test.tsx
@@ -251,4 +251,89 @@ describe("SetupWizard", () => {
     expect(roleInputs[0]).toHaveValue("implement");
     expect(roleInputs[1]).toHaveValue("review");
   });
+
+  it("preserves both github repository and project number while editing", async () => {
+    const user = userEvent.setup();
+
+    vi.stubGlobal("fetch", vi.fn((url: string) => {
+      if (url.includes("/api/v1/config/setup/defaults")) {
+        return jsonResponse({
+          has_existing_config: true,
+          defaults: {
+            tracker: {
+              kind: "github",
+              repository: "",
+              project_number: null,
+              api_key_env: "GITHUB_TOKEN",
+              active_states: ["Todo", "In Progress"],
+              terminal_states: ["Done"],
+            },
+          },
+        });
+      }
+      return jsonResponse({});
+    }));
+
+    renderWithProviders(<SetupWizard mode="reconfigure" />, { route: "/config" });
+    expect(await screen.findByText("Reconfigure Ensemble")).toBeInTheDocument();
+
+    const repoInput = await screen.findByLabelText("Repository");
+    const projectInput = screen.getByLabelText(/project number/i);
+
+    await user.type(repoInput, "owner/repo");
+    await user.type(projectInput, "42");
+
+    expect(repoInput).toHaveValue("owner/repo");
+    expect(projectInput).toHaveValue(42);
+  });
+
+  it("validates github setup with standard project state names", async () => {
+    const user = userEvent.setup();
+    const validateMock = vi.fn();
+
+    vi.stubGlobal("fetch", vi.fn((url: string, init?: RequestInit) => {
+      if (url.includes("/api/v1/config/setup/defaults")) {
+        return jsonResponse({
+          has_existing_config: true,
+          defaults: {
+            tracker: {
+              kind: "github",
+              repository: "owner/repo",
+              project_number: null,
+              api_key_env: "GITHUB_TOKEN",
+              active_states: ["Todo", "In Progress"],
+              terminal_states: ["Done"],
+            },
+            repos: [{ path: "/repo", branch: "main" }],
+            agents: [{ role: "implement", acpx_agent: "builder", model: null }],
+            steps: [{ name: "implement", agent_role: "implement", depends: [], tracker_state: null }],
+          },
+        });
+      }
+      if (url.includes("/api/v1/config/setup/validate")) {
+        validateMock(JSON.parse(String(init?.body)));
+        return jsonResponse({
+          can_save: true,
+          checks: [{ label: "Tracker", passed: true, detail: "ok" }],
+        });
+      }
+      return jsonResponse({});
+    }));
+
+    renderWithProviders(<SetupWizard mode="reconfigure" />, { route: "/config" });
+    expect(await screen.findByText("Reconfigure Ensemble")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /validate/i }));
+
+    await waitFor(() => {
+      expect(validateMock).toHaveBeenCalled();
+    });
+
+    expect(validateMock.mock.calls[0]?.[0]?.setup.tracker.active_states).toEqual(["Todo", "In Progress"]);
+    expect(validateMock.mock.calls[0]?.[0]?.setup.tracker.terminal_states).toEqual(["Done"]);
+  });
 });

--- a/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
@@ -45,8 +45,8 @@ const DEFAULT_GH_TRACKER: SetupTracker = {
   repository: "", 
   project_number: null,
   api_key_env: "GITHUB_TOKEN",
-  active_states: ["todo", "in_progress"],
-  terminal_states: ["done"],
+  active_states: ["Todo", "In Progress"],
+  terminal_states: ["Done"],
 };
 
 const DEFAULT_DRAFT: SetupDraft = {
@@ -259,7 +259,7 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
               onChange={(e) => setDraft(prev => ({
                 ...prev,
                 tracker: { 
-                  ...DEFAULT_GH_TRACKER, 
+                  ...prev.tracker,
                   repository: e.target.value,
                 } as SetupTracker,
               }))}
@@ -275,7 +275,7 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
               onChange={(e) => setDraft(prev => ({
                 ...prev,
                 tracker: { 
-                  ...DEFAULT_GH_TRACKER,
+                  ...prev.tracker,
                   project_number: e.target.value ? parseInt(e.target.value) : null,
                 } as SetupTracker,
               }))}
@@ -361,79 +361,83 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
         <p className="text-sm text-muted-foreground">Loading available agents...</p>
       ) : (
         <>
-          {draft.agents.map((agent, index) => (
-            <div key={index} className="p-4 rounded-lg border space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="font-medium">Agent {index + 1}</span>
-                {draft.agents.length > 1 && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => setDraft(prev => ({
-                      ...prev,
-                      agents: prev.agents.filter((_, i) => i !== index),
-                    }))}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                )}
-              </div>
-              
-              <div className="grid grid-cols-2 gap-3">
+          {(() => {
+            const discoveredAgents = agentsData?.data?.agents ?? [];
+
+            return draft.agents.map((agent, index) => (
+              <div key={index} className="p-4 rounded-lg border space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">Agent {index + 1}</span>
+                  {draft.agents.length > 1 && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setDraft(prev => ({
+                        ...prev,
+                        agents: prev.agents.filter((_, i) => i !== index),
+                      }))}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+                
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-2">
+                    <label className="text-sm">Role</label>
+                    <Input
+                      value={agent.role}
+                      onChange={(e) => setDraft(prev => {
+                        const newAgents = [...prev.agents];
+                        newAgents[index] = { ...agent, role: e.target.value };
+                        return { ...prev, agents: newAgents };
+                      })}
+                      placeholder="e.g., implement, review"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm">Agent</label>
+                    <Select
+                      value={agent.acpx_agent}
+                      onValueChange={(value) => {
+                        if (value) {
+                          setDraft(prev => {
+                            const newAgents = [...prev.agents];
+                            newAgents[index] = { ...agent, acpx_agent: value };
+                            return { ...prev, agents: newAgents };
+                          });
+                        }
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select agent" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {discoveredAgents.map((discoveredAgent: DiscoveredAgentInfo) => (
+                          <SelectItem key={discoveredAgent.name} value={discoveredAgent.name}>
+                            {discoveredAgent.label} ({discoveredAgent.version})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
                 <div className="space-y-2">
-                  <label className="text-sm">Role</label>
+                  <label className="text-sm">Model (optional)</label>
                   <Input
-                    value={agent.role}
+                    value={agent.model || ""}
                     onChange={(e) => setDraft(prev => {
                       const newAgents = [...prev.agents];
-                      newAgents[index] = { ...agent, role: e.target.value };
+                      newAgents[index] = { ...agent, model: e.target.value || null };
                       return { ...prev, agents: newAgents };
                     })}
-                    placeholder="e.g., implement, review"
+                    placeholder="e.g., gpt-4"
                   />
                 </div>
-                <div className="space-y-2">
-                  <label className="text-sm">Agent</label>
-                  <Select
-                    value={agent.acpx_agent}
-                    onValueChange={(value) => {
-                      if (value) {
-                        setDraft(prev => {
-                          const newAgents = [...prev.agents];
-                          newAgents[index] = { ...agent, acpx_agent: value };
-                          return { ...prev, agents: newAgents };
-                        });
-                      }
-                    }}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select agent" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {agentsData?.data?.agents.map((discoveredAgent: DiscoveredAgentInfo) => (
-                        <SelectItem key={discoveredAgent.name} value={discoveredAgent.name}>
-                          {discoveredAgent.label} ({discoveredAgent.version})
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
               </div>
-
-              <div className="space-y-2">
-                <label className="text-sm">Model (optional)</label>
-                <Input
-                  value={agent.model || ""}
-                  onChange={(e) => setDraft(prev => {
-                    const newAgents = [...prev.agents];
-                    newAgents[index] = { ...agent, model: e.target.value || null };
-                    return { ...prev, agents: newAgents };
-                  })}
-                  placeholder="e.g., gpt-4"
-                />
-              </div>
-            </div>
-          ))}
+            ));
+          })()}
 
           <Button
             variant="outline"

--- a/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.test.tsx
@@ -86,4 +86,31 @@ describe("YamlEditor", () => {
 
     expect(await screen.findByText(/tracker path is invalid/i)).toBeInTheDocument();
   });
+
+  it("keeps existing issues visible when validate fails", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <YamlEditor
+        rawYaml={`tracker:\n  kind: todo_file\n  path: /tmp/todo.md`}
+        issues={[
+          {
+            kind: ValidationIssueKind.Config,
+            section: "tracker",
+            message: "existing issue",
+            field: "path",
+            path: "tracker.path",
+          },
+        ]}
+        onValidate={vi.fn(async () => {
+          throw new Error("validation failed");
+        })}
+      />,
+      { route: "/config" }
+    );
+
+    await user.click(screen.getByRole("button", { name: /validate/i }));
+
+    expect(await screen.findByText(/existing issue/i)).toBeInTheDocument();
+  });
 });

--- a/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import YamlEditor from "./YamlEditor";
+import { ValidationIssueKind } from "@/generated/models/validationIssueKind";
 import { renderWithProviders } from "@/test/render";
 
 describe("YamlEditor", () => {
@@ -57,5 +59,31 @@ describe("YamlEditor", () => {
     // Buttons should be present
     expect(screen.getByRole("button", { name: /validate/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
+  });
+
+  it("shows validation issues returned by validate without waiting for save", async () => {
+    const user = userEvent.setup();
+    const rawYaml = `tracker:\n  kind: todo_file\n  path: /tmp/todo.md`;
+
+    renderWithProviders(
+      <YamlEditor
+        rawYaml={rawYaml}
+        issues={[]}
+        onValidate={vi.fn(async () => [
+          {
+            kind: ValidationIssueKind.Config,
+            section: "tracker",
+            message: "tracker path is invalid",
+            field: "path",
+            path: "tracker.path",
+          },
+        ])}
+      />,
+      { route: "/config" }
+    );
+
+    await user.click(screen.getByRole("button", { name: /validate/i }));
+
+    expect(await screen.findByText(/tracker path is invalid/i)).toBeInTheDocument();
   });
 });

--- a/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.tsx
@@ -10,7 +10,7 @@ interface YamlEditorProps {
   rawYaml: string;
   isRecoveryMode?: boolean;
   issues: ValidationIssue[];
-  onValidate?: (yaml: string) => void;
+  onValidate?: (yaml: string) => Promise<ValidationIssue[]>;
   onSave?: (yaml: string) => void;
   onReset?: () => void;
   isValidating?: boolean;
@@ -29,12 +29,17 @@ export default function YamlEditor({
 }: YamlEditorProps) {
   const [rawYaml, setRawYaml] = useState(initialYaml);
   const [hasChanges, setHasChanges] = useState(false);
+  const [validationIssues, setValidationIssues] = useState(issues);
 
   // Update state when initialYaml prop changes (e.g., after save)
   useEffect(() => {
     setRawYaml(initialYaml);
     setHasChanges(false);
   }, [initialYaml]);
+
+  useEffect(() => {
+    setValidationIssues(issues);
+  }, [issues]);
 
   const handleChange = (value: string) => {
     setRawYaml(value);
@@ -47,8 +52,10 @@ export default function YamlEditor({
     onReset?.();
   };
 
-  const handleValidate = () => {
-    onValidate?.(rawYaml);
+  const handleValidate = async () => {
+    if (!onValidate) return;
+    const nextIssues = await onValidate(rawYaml);
+    setValidationIssues(nextIssues);
   };
 
   const handleSave = () => {
@@ -79,8 +86,8 @@ export default function YamlEditor({
           />
         </div>
 
-        {issues.length > 0 && (
-          <ValidationPanel issues={issues} />
+        {validationIssues.length > 0 && (
+          <ValidationPanel issues={validationIssues} />
         )}
       </CardContent>
 
@@ -103,7 +110,7 @@ export default function YamlEditor({
         </div>
         <Button
           onClick={handleSave}
-          disabled={isValidating || isSaving || (isRecoveryMode && issues.length > 0)}
+          disabled={isValidating || isSaving || (isRecoveryMode && validationIssues.length > 0)}
         >
           {isSaving ? "Saving..." : "Save"}
         </Button>

--- a/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.tsx
@@ -54,8 +54,12 @@ export default function YamlEditor({
 
   const handleValidate = async () => {
     if (!onValidate) return;
-    const nextIssues = await onValidate(rawYaml);
-    setValidationIssues(nextIssues);
+    try {
+      const nextIssues = await onValidate(rawYaml);
+      setValidationIssues(nextIssues);
+    } catch {
+      // Keep the last visible issues when validation fails.
+    }
   };
 
   const handleSave = () => {

--- a/crates/ensemble-ui/src-ui/src/hooks.ts
+++ b/crates/ensemble-ui/src-ui/src/hooks.ts
@@ -125,14 +125,7 @@ export function useConfigStateQuery() {
 }
 
 export function useValidateYamlDraftMutation() {
-  const queryClient = useQueryClient();
-  return useValidateYaml({
-    mutation: {
-      onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: getGetConfigQueryKey() });
-      },
-    },
-  });
+  return useValidateYaml();
 }
 
 export function useSaveYamlDraftMutation() {

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
@@ -30,6 +30,65 @@ describe("ConfigPage", () => {
     expect(await screen.findByText("Set up Ensemble")).toBeInTheDocument();
   });
 
+  it("keeps the editors available when parsed config has validation issues", async () => {
+    vi.stubGlobal("fetch", vi.fn((url: string) => {
+      if (url.includes("/api/v1/config")) {
+        return jsonResponse({
+          state: "parsed",
+          config_path: "/tmp/ensemble/config.yaml",
+          raw_yaml: "tracker:\n  kind: todo_file\n",
+          issues: [
+            {
+              kind: "Config",
+              section: "tracker",
+              message: "tracker is incomplete",
+              field: null,
+              path: null,
+            },
+          ],
+          active_config: null,
+          guided_form: {
+            tracker: {
+              kind: "todo_file",
+              path: "/tmp/todo.md",
+              active_states: [],
+              terminal_states: [],
+              labels_filter: [],
+            },
+            repos: [],
+            agents: [],
+            steps: [],
+            runtime: {
+              max_cycles: 1,
+              concurrency: { max_concurrent_agents: 1, max_step_parallelism: 1 },
+              polling: { interval_ms: 1000 },
+              workspace: {},
+              hooks: { timeout_ms: 1000 },
+              agent: {
+                max_turns: 1,
+                max_retry_backoff_ms: 1,
+                command: "agent",
+                session_mode: "code",
+                permission_policy: "auto",
+                turn_timeout_ms: 1,
+                read_timeout_ms: 1,
+                stall_timeout_ms: 1,
+              },
+            },
+            transitions: { on_success: "Done", on_failure: "Failed" },
+          },
+        });
+      }
+      return jsonResponse({});
+    }));
+
+    renderWithProviders(<ConfigPage />, { route: "/config" });
+
+    expect(await screen.findByText(/guided configuration editor/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/tracker is incomplete/i)).toHaveLength(2);
+    expect(screen.getByRole("button", { name: /^yaml$/i })).toBeInTheDocument();
+  });
+
   // NOTE: Full YAML/guided sync test requires backend integration mocking
   // to verify that YAML tab reflects updated values after guided form save.
   // This would require:

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
@@ -1,29 +1,81 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ValidationIssue } from "@/generated/models";
 import ConfigPage from "./ConfigPage";
 import { renderWithProviders } from "@/test/render";
 
-function jsonResponse(data: unknown) {
-  return Promise.resolve({
-    ok: true,
-    status: 200,
-    json: () => Promise.resolve(data),
-  } as Response);
-}
+let mockConfigData: any;
+const validateGuidedMock = vi.fn();
+const saveGuidedMock = vi.fn();
+const validateYamlMock = vi.fn();
+const saveYamlMock = vi.fn();
+const refetchMock = vi.fn();
+
+vi.mock("@/hooks", () => ({
+  useConfigStateQuery: () => ({
+    data: mockConfigData,
+    isLoading: false,
+    isError: false,
+    refetch: refetchMock,
+  }),
+  useValidateGuidedFormMutation: () => ({
+    mutateAsync: validateGuidedMock,
+  }),
+  useSaveGuidedFormMutation: () => ({
+    mutateAsync: saveGuidedMock,
+  }),
+  useValidateYamlDraftMutation: () => ({
+    mutateAsync: validateYamlMock,
+  }),
+  useSaveYamlDraftMutation: () => ({
+    mutateAsync: saveYamlMock,
+  }),
+}));
+
+vi.mock("@/components/config/SetupWizard", () => ({
+  default: () => <div>Set up Ensemble</div>,
+}));
+
+vi.mock("@/components/config/GuidedEditor", () => ({
+  default: ({ issues }: { issues: ValidationIssue[] }) => (
+    <div>
+      <div>Guided Configuration Editor</div>
+      {issues.map((issue, index) => (
+        <div key={index}>{issue.message}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/config/YamlEditor", () => ({
+  default: ({ rawYaml, issues, onValidate }: { rawYaml: string; issues: ValidationIssue[]; onValidate?: (yaml: string) => Promise<ValidationIssue[]> }) => (
+    <div>
+      <div>Raw YAML Editor</div>
+      <button type="button" onClick={() => onValidate?.(rawYaml)}>Validate</button>
+      {issues.map((issue, index) => (
+        <div key={index}>{issue.message}</div>
+      ))}
+    </div>
+  ),
+}));
 
 describe("ConfigPage", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    mockConfigData = undefined;
+    refetchMock.mockResolvedValue(undefined);
   });
 
   it("shows setup mode when the config state is missing", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({
+    mockConfigData = {
       state: "missing",
       config_path: "/tmp/ensemble/config.yaml",
       raw_yaml: null,
       issues: [],
       active_config: null,
-    })));
+      guided_form: null,
+    };
 
     renderWithProviders(<ConfigPage />, { route: "/config" });
 
@@ -31,68 +83,109 @@ describe("ConfigPage", () => {
   });
 
   it("keeps the editors available when parsed config has validation issues", async () => {
-    vi.stubGlobal("fetch", vi.fn((url: string) => {
-      if (url.includes("/api/v1/config")) {
-        return jsonResponse({
-          state: "parsed",
-          config_path: "/tmp/ensemble/config.yaml",
-          raw_yaml: "tracker:\n  kind: todo_file\n",
-          issues: [
-            {
-              kind: "Config",
-              section: "tracker",
-              message: "tracker is incomplete",
-              field: null,
-              path: null,
-            },
-          ],
-          active_config: null,
-          guided_form: {
-            tracker: {
-              kind: "todo_file",
-              path: "/tmp/todo.md",
-              active_states: [],
-              terminal_states: [],
-              labels_filter: [],
-            },
-            repos: [],
-            agents: [],
-            steps: [],
-            runtime: {
-              max_cycles: 1,
-              concurrency: { max_concurrent_agents: 1, max_step_parallelism: 1 },
-              polling: { interval_ms: 1000 },
-              workspace: {},
-              hooks: { timeout_ms: 1000 },
-              agent: {
-                max_turns: 1,
-                max_retry_backoff_ms: 1,
-                command: "agent",
-                session_mode: "code",
-                permission_policy: "auto",
-                turn_timeout_ms: 1,
-                read_timeout_ms: 1,
-                stall_timeout_ms: 1,
-              },
-            },
-            transitions: { on_success: "Done", on_failure: "Failed" },
+    mockConfigData = {
+      state: "parsed",
+      config_path: "/tmp/ensemble/config.yaml",
+      raw_yaml: "tracker:\n  kind: todo_file\n",
+      issues: [
+        {
+          kind: "Config",
+          section: "tracker",
+          message: "tracker is incomplete",
+          field: null,
+          path: null,
+        },
+      ],
+      active_config: null,
+      guided_form: {
+        tracker: { kind: "todo_file", active_states: [], terminal_states: [], labels_filter: [] },
+        repos: [],
+        agents: [],
+        steps: [],
+        runtime: {
+          max_cycles: 1,
+          concurrency: { max_concurrent_agents: 1, max_step_parallelism: 1 },
+          polling: { interval_ms: 1000 },
+          workspace: {},
+          hooks: { timeout_ms: 1000 },
+          agent: {
+            max_turns: 1,
+            max_retry_backoff_ms: 1,
+            command: "agent",
+            session_mode: "code",
+            permission_policy: "auto",
+            turn_timeout_ms: 1,
+            read_timeout_ms: 1,
+            stall_timeout_ms: 1,
           },
-        });
-      }
-      return jsonResponse({});
-    }));
+        },
+        transitions: { on_success: "Done", on_failure: "Failed" },
+      },
+    };
 
     renderWithProviders(<ConfigPage />, { route: "/config" });
 
     expect(await screen.findByText(/guided configuration editor/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/tracker is incomplete/i)).toHaveLength(2);
+    expect(screen.getAllByText(/tracker is incomplete/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /^yaml$/i })).toBeInTheDocument();
   });
 
-  // NOTE: Full YAML/guided sync test requires backend integration mocking
-  // to verify that YAML tab reflects updated values after guided form save.
-  // This would require:
-  // 1. Mocking useSaveGuidedFormMutation to return updated config
-  // 2. Mocking refetch to return new raw_yaml
-  // 3. Verifying YAML tab content matches the updated raw_yaml
+  it("updates the page banner from validate results", async () => {
+    const user = userEvent.setup();
+    mockConfigData = {
+      state: "parsed",
+      config_path: "/tmp/ensemble/config.yaml",
+      raw_yaml: "tracker:\n  kind: todo_file\n",
+      issues: [],
+      active_config: {},
+      guided_form: {
+        tracker: { kind: "todo_file", active_states: [], terminal_states: [], labels_filter: [] },
+        repos: [],
+        agents: [],
+        steps: [],
+        runtime: {
+          max_cycles: 1,
+          concurrency: { max_concurrent_agents: 1, max_step_parallelism: 1 },
+          polling: { interval_ms: 1000 },
+          workspace: {},
+          hooks: { timeout_ms: 1000 },
+          agent: {
+            max_turns: 1,
+            max_retry_backoff_ms: 1,
+            command: "agent",
+            session_mode: "code",
+            permission_policy: "auto",
+            turn_timeout_ms: 1,
+            read_timeout_ms: 1,
+            stall_timeout_ms: 1,
+          },
+        },
+        transitions: { on_success: "Done", on_failure: "Failed" },
+      },
+    };
+
+    validateYamlMock.mockResolvedValue({
+      data: {
+        issues: [
+          {
+            kind: "Config",
+            section: "tracker",
+            message: "tracker path is invalid",
+            field: "path",
+            path: "tracker.path",
+          },
+        ],
+      },
+    });
+
+    renderWithProviders(<ConfigPage />, { route: "/config" });
+
+    expect(screen.getByText(/configuration is valid and ready to use/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^yaml$/i }));
+    await user.click(screen.getByRole("button", { name: /validate/i }));
+
+    expect(await screen.findByText(/configuration has validation issues/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/tracker path is invalid/i).length).toBeGreaterThan(0);
+  });
 });

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -20,7 +20,8 @@ export default function ConfigPage() {
   const saveYamlMutation = useSaveYamlDraftMutation();
 
   const handleValidateGuided = async (form: GuidedForm, baseRawYaml: string) => {
-    await validateGuidedFormMutation.mutateAsync({ baseRawYaml, form });
+    const response = await validateGuidedFormMutation.mutateAsync({ baseRawYaml, form });
+    return response.data.issues;
   };
 
   const handleSaveGuided = async (form: GuidedForm, baseRawYaml: string) => {
@@ -29,7 +30,8 @@ export default function ConfigPage() {
   };
 
   const handleValidateYaml = async (yaml: string) => {
-    await validateYamlMutation.mutateAsync({ data: { raw_yaml: yaml } });
+    const response = await validateYamlMutation.mutateAsync({ data: { raw_yaml: yaml } });
+    return response.data.issues;
   };
 
   const handleSaveYaml = async (yaml: string) => {
@@ -54,7 +56,7 @@ export default function ConfigPage() {
   const { state, issues, raw_yaml: rawYaml } = data;
   const guidedForm = data.guided_form;
   const hasIssues = issues.length > 0;
-  const isRunnable = state === "parsed" && data.active_config != null && !hasIssues;
+  const isEditable = state === "parsed";
 
   // Missing config - show setup mode
   if (state === "missing" || showSetupWizard) {
@@ -86,45 +88,34 @@ export default function ConfigPage() {
     );
   }
 
-  // Parsed with validation issues - show edit mode with validation
-  if (state === "parsed" && hasIssues) {
+  if (isEditable) {
     return (
       <div className="space-y-6">
         <h1 className="text-2xl font-bold">Configuration</h1>
         <Card>
           <CardContent className="p-6">
-            <div className="rounded-lg p-4 border bg-yellow-50 dark:bg-yellow-900/30 border-yellow-200 dark:border-yellow-800">
-              <h2 className="text-lg font-semibold text-yellow-800 dark:text-yellow-200">Configuration Issues</h2>
-              <ul className="mt-2 space-y-2">
-                {issues.map((issue: ValidationIssue, i: number) => (
-                  <li key={i} className="text-sm text-red-600 dark:text-red-400">{issue.message}</li>
-                ))}
-              </ul>
-            </div>
-            <div className="mt-4 flex gap-2">
-              <Button variant="outline" onClick={() => setShowSetupWizard(true)}>
-                <Edit2 className="h-4 w-4 mr-2" />
-                Reconfigure
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  // Runnable config - show edit mode with full tabs
-  if (isRunnable) {
-    return (
-      <div className="space-y-6">
-        <h1 className="text-2xl font-bold">Configuration</h1>
-        <Card>
-          <CardContent className="p-6">
-            <div className="rounded-lg p-4 border bg-green-50 dark:bg-green-900/30 border-green-200 dark:border-green-800">
-              <h2 className="text-lg font-semibold text-green-800 dark:text-green-200">Configuration Editor</h2>
-              <p className="text-sm text-green-700 dark:text-green-300">
-                Configuration is valid and ready to use.
+            <div className={`rounded-lg p-4 border ${hasIssues
+              ? "bg-yellow-50 dark:bg-yellow-900/30 border-yellow-200 dark:border-yellow-800"
+              : "bg-green-50 dark:bg-green-900/30 border-green-200 dark:border-green-800"}`}>
+              <h2 className={`text-lg font-semibold ${hasIssues
+                ? "text-yellow-800 dark:text-yellow-200"
+                : "text-green-800 dark:text-green-200"}`}>
+                Configuration Editor
+              </h2>
+              <p className={`text-sm ${hasIssues
+                ? "text-yellow-700 dark:text-yellow-300"
+                : "text-green-700 dark:text-green-300"}`}>
+                {hasIssues
+                  ? "Configuration has validation issues. Fix them in guided or YAML mode and validate again before saving."
+                  : "Configuration is valid and ready to use."}
               </p>
+              {hasIssues && (
+                <ul className="mt-2 space-y-2">
+                  {issues.map((issue: ValidationIssue, i: number) => (
+                    <li key={i} className="text-sm text-red-600 dark:text-red-400">{issue.message}</li>
+                  ))}
+                </ul>
+              )}
             </div>
             <div className="mt-4 flex gap-2">
               <Button variant="outline" onClick={() => setShowSetupWizard(true)}>

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -3,7 +3,7 @@ import type { ValidationIssue } from "@/generated/models";
 import SetupWizard from "@/components/config/SetupWizard";
 import YamlEditor from "@/components/config/YamlEditor";
 import GuidedEditor, { type GuidedForm } from "@/components/config/GuidedEditor";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Edit2, FileText, Settings } from "lucide-react";
@@ -13,6 +13,8 @@ export default function ConfigPage() {
   const [showSetupWizard, setShowSetupWizard] = useState(false);
   const [activeTab, setActiveTab] = useState<"guided" | "yaml">("guided");
   const [comparisonMode, setComparisonMode] = useState(false);
+  const [displayedIssues, setDisplayedIssues] = useState<ValidationIssue[]>([]);
+  const issues = data?.issues ?? [];
 
   const validateGuidedFormMutation = useValidateGuidedFormMutation();
   const saveGuidedFormMutation = useSaveGuidedFormMutation();
@@ -21,6 +23,7 @@ export default function ConfigPage() {
 
   const handleValidateGuided = async (form: GuidedForm, baseRawYaml: string) => {
     const response = await validateGuidedFormMutation.mutateAsync({ baseRawYaml, form });
+    setDisplayedIssues(response.data.issues);
     return response.data.issues;
   };
 
@@ -31,6 +34,7 @@ export default function ConfigPage() {
 
   const handleValidateYaml = async (yaml: string) => {
     const response = await validateYamlMutation.mutateAsync({ data: { raw_yaml: yaml } });
+    setDisplayedIssues(response.data.issues);
     return response.data.issues;
   };
 
@@ -43,6 +47,10 @@ export default function ConfigPage() {
     // Reset handled internally by editors
   };
 
+  useEffect(() => {
+    setDisplayedIssues(issues);
+  }, [issues]);
+
   if (isLoading) {
     return <div className="text-center py-12 text-muted-foreground">Loading configuration...</div>;
   }
@@ -53,9 +61,10 @@ export default function ConfigPage() {
 
   if (!data) return null;
 
-  const { state, issues, raw_yaml: rawYaml } = data;
+  const { state, raw_yaml: rawYaml } = data;
   const guidedForm = data.guided_form;
-  const hasIssues = issues.length > 0;
+
+  const hasIssues = displayedIssues.length > 0;
   const isEditable = state === "parsed";
 
   // Missing config - show setup mode
@@ -111,7 +120,7 @@ export default function ConfigPage() {
               </p>
               {hasIssues && (
                 <ul className="mt-2 space-y-2">
-                  {issues.map((issue: ValidationIssue, i: number) => (
+                  {displayedIssues.map((issue: ValidationIssue, i: number) => (
                     <li key={i} className="text-sm text-red-600 dark:text-red-400">{issue.message}</li>
                   ))}
                 </ul>
@@ -158,7 +167,7 @@ export default function ConfigPage() {
                 <GuidedEditor
                   initialForm={guidedForm as GuidedForm}
                   baseRawYaml={rawYaml || ""}
-                  issues={issues}
+                  issues={displayedIssues}
                   onValidate={handleValidateGuided}
                   onSave={handleSaveGuided}
                   onReset={handleReset}
@@ -168,7 +177,7 @@ export default function ConfigPage() {
                 <YamlEditor
                   rawYaml={rawYaml}
                   isRecoveryMode={false}
-                  issues={issues}
+                  issues={displayedIssues}
                   onValidate={handleValidateYaml}
                   onSave={handleSaveYaml}
                   onReset={handleReset}

--- a/docs/superpowers/plans/2026-04-03-code-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-03-code-review-fixes.md
@@ -1,0 +1,793 @@
+# Code Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 24 issues found during code review — 7 bugs, 5 performance improvements, 6 simplifications, and 6 minor issues.
+
+**Architecture:** All changes are within `crates/ensemble-core`. No API changes, no new dependencies. Each task is self-contained and independently testable.
+
+**Tech Stack:** Rust, tokio, axum, serde, thiserror, tracing
+
+---
+
+### Task 1: Fix Critical Bugs — Shell Injection
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/mod.rs:137-139` (executor escaping)
+- Modify: `crates/ensemble-core/src/agent/mod.rs:306-479` (add test)
+
+- [ ] **Step 1: Fix executor path shell injection**
+
+In `agent/mod.rs`, the `resolve_agent_command` function properly shell-escapes `acpx_agent` and `model` values, but returns `executor` raw. If `executor` contains shell metacharacters and is passed to `bash -lc`, this is an injection vector.
+
+Change in `agent/mod.rs` around line 137-139:
+
+```rust
+// Before:
+if let Some(ref executor) = ac.executor {
+    return executor.clone();
+}
+
+// After:
+if let Some(ref executor) = ac.executor {
+    return shell_escape(executor);
+}
+```
+
+- [ ] **Step 2: Add test for executor escaping**
+
+Add to `agent/mod.rs` tests:
+
+```rust
+#[test]
+fn test_resolve_agent_command_escapes_executor() {
+    let config = crate::config::ensemble::AgentConfig {
+        acpx_agent: None,
+        model: None,
+        executor: Some("my-agent; rm -rf /".to_string()),
+        prompt: None,
+        prompt_template: None,
+        reasoning_level: None,
+    };
+    let cmd = resolve_agent_command(Some(&config), "default-cmd");
+    assert_eq!(cmd, "'my-agent; rm -rf /'");
+}
+```
+
+- [ ] **Step 3: Run tests and verify**
+
+```bash
+cargo test -p ensemble-core -- --test-threads=1
+cargo clippy -p ensemble-core -- -D warnings
+```
+
+Expected: All tests pass, no clippy warnings.
+
+**Note on token double-counting (Issue #6 from review):** After analysis, this is NOT a bug. On retry, a NEW agent session starts from 0 cumulative tokens. The `last_reported_*` fields correctly default to 0 because the delta calculation `new_value - 0` gives the right delta for the fresh session. The `agent_totals` already contains the previous session's tokens. No fix needed.
+
+---
+
+### Task 2: Fix Performance — Eliminate Redundant Allocations in Scheduler and Reconciler
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/scheduler.rs:9-85` (is_dispatch_eligible)
+- Modify: `crates/ensemble-core/src/orchestrator/scheduler.rs:138-494` (tests)
+- Modify: `crates/ensemble-core/src/orchestrator/reconciler.rs:66-82` (determine_reconcile_action)
+- Modify: `crates/ensemble-core/src/orchestrator/reconciler.rs:219-520` (tests)
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs:256-278` (dispatch loop caller)
+
+- [ ] **Step 1: Pre-compute lowercase state lists in handle_tick**
+
+In `orchestrator/mod.rs`, inside `handle_tick`, compute lowercase versions once and pass them to eligibility checks:
+
+```rust
+// Add near the top of handle_tick, after config read:
+let active_lower: Vec<String> = config.tracker.active_states.iter()
+    .map(|s| s.to_lowercase())
+    .collect();
+let terminal_lower: Vec<String> = config.tracker.terminal_states.iter()
+    .map(|s| s.to_lowercase())
+    .collect();
+```
+
+- [ ] **Step 2: Update `is_dispatch_eligible` to accept pre-lowercased slices**
+
+Change the signature in `scheduler.rs`:
+
+```rust
+pub fn is_dispatch_eligible(
+    issue: &Issue,
+    state: &OrchestratorState,
+    active_states_lower: &[String],
+    terminal_states_lower: &[String],
+    max_concurrent_by_state: &HashMap<String, u32>,
+) -> Option<String> {
+```
+
+Remove the internal `to_lowercase()` allocations (lines 33-40). Use `state_lower` directly with the pre-lowercased slices.
+
+- [ ] **Step 3: Update `determine_reconcile_action` similarly**
+
+Change the signature in `reconciler.rs`:
+
+```rust
+pub fn determine_reconcile_action(
+    issue: &Issue,
+    active_states_lower: &[String],
+    terminal_states_lower: &[String],
+) -> ReconcileAction {
+```
+
+Remove the internal allocations (lines 72-73).
+
+- [ ] **Step 4: Update `reconcile_tracker_states` to accept pre-lowercased slices**
+
+Change the signature:
+
+```rust
+pub async fn reconcile_tracker_states(
+    state: &OrchestratorState,
+    tracker: &dyn IssueTracker,
+    active_states_lower: &[String],
+    terminal_states_lower: &[String],
+) -> ReconcileTrackerResult {
+```
+
+- [ ] **Step 5: Update all callers in `mod.rs`**
+
+Update the calls in `handle_tick` to pass the pre-computed lowercase slices to `is_dispatch_eligible` and `reconcile_tracker_states`.
+
+- [ ] **Step 6: Update tests to pass lowercase slices**
+
+In `scheduler.rs` tests, change `default_active()` and `default_terminal()` to return pre-lowercased values, or update test calls to lowercase them before passing.
+
+In `reconciler.rs` tests, update `default_active()` and `default_terminal()` similarly.
+
+- [ ] **Step 7: Run tests and verify**
+
+```bash
+cargo test -p ensemble-core -- --test-threads=1
+cargo clippy -p ensemble-core -- -D warnings
+```
+
+---
+
+### Task 3: Fix Performance — Agent Prompt Caching and JSON-RPC Write Batching
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/mod.rs:37-98` (build_prompt caching + cache invalidation)
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs:545-565` (send_json_rpc batching)
+
+- [ ] **Step 1: Cache prompt template in AcpAgentRunner with invalidation**
+
+In `agent/mod.rs`, the `build_prompt` method reads config and resolves the prompt template on every turn. The prompt template is static — cache it once at session start, with a `clear_cache()` method for config reload.
+
+Add a `cached_prompts` field to `AcpAgentRunner`:
+
+```rust
+pub struct AcpAgentRunner {
+    pub config: Arc<RwLock<EnsembleConfig>>,
+    cached_prompts: RwLock<HashMap<String, String>>, // agent_name -> resolved template
+}
+```
+
+Add methods:
+
+```rust
+impl AcpAgentRunner {
+    pub fn new(config: Arc<RwLock<EnsembleConfig>>) -> Self {
+        Self {
+            config,
+            cached_prompts: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Clear the prompt cache. Call this when config is reloaded.
+    pub fn clear_cache(&self) {
+        // Synchronous clear — safe because it's a simple HashMap clear
+        // The RwLock write guard is held briefly
+        let mut cache = self.cached_prompts.try_write();
+        if let Ok(mut cache) = cache {
+            cache.clear();
+        }
+    }
+
+    async fn get_or_cache_prompt_template(&self, agent_name: &str) -> Result<String, AgentError> {
+        // Check cache first
+        {
+            let cache = self.cached_prompts.read().await;
+            if let Some(template) = cache.get(agent_name) {
+                return Ok(template.clone());
+            }
+        }
+
+        // Resolve and cache
+        let config = self.config.read().await;
+        let agent_config = config.agents.get(agent_name).ok_or_else(|| {
+            AgentError::PromptError {
+                reason: format!("agent '{}' not found in config", agent_name),
+            }
+        })?;
+
+        let template = if let Some(ref prompt) = agent_config.prompt {
+            prompt.clone()
+        } else if let Some(ref template_path) = agent_config.prompt_template {
+            std::fs::read_to_string(template_path).map_err(|e| AgentError::PromptError {
+                reason: format!(
+                    "failed to read prompt template '{}': {}",
+                    template_path.display(),
+                    e
+                ),
+            })?
+        } else {
+            return Err(AgentError::PromptError {
+                reason: format!(
+                    "agent '{}' has neither prompt nor prompt_template",
+                    agent_name
+                ),
+            });
+        };
+
+        // Store in cache
+        {
+            let mut cache = self.cached_prompts.write().await;
+            cache.insert(agent_name.to_string(), template.clone());
+        }
+
+        Ok(template)
+    }
+}
+```
+
+Update `build_prompt` to use the cached template:
+
+```rust
+async fn build_prompt(
+    &self,
+    issue: &Issue,
+    agent_name: &str,
+    attempt: Option<u32>,
+    turn_number: u32,
+) -> Result<String, AgentError> {
+    if turn_number == 1 {
+        let template = self.get_or_cache_prompt_template(agent_name).await?;
+        render_prompt(&template, issue, attempt).map_err(|e| AgentError::PromptError {
+            reason: e.to_string(),
+        })
+    } else {
+        Ok(format!(
+            "Continue working on {}. This is turn {} of this session. \
+             The issue is still in an active state. \
+             Review your progress and continue where you left off.",
+            issue.identifier, turn_number
+        ))
+    }
+}
+```
+
+- [ ] **Step 2: Batch JSON-RPC writes**
+
+In `acp_client.rs`, `send_json_rpc` does three separate async operations. Combine into one:
+
+```rust
+async fn send_json_rpc(&mut self, msg: &serde_json::Value) -> Result<(), AgentError> {
+    let line = serde_json::to_string(msg).map_err(|e| AgentError::IoError {
+        reason: format!("json serialize error: {e}"),
+    })?;
+    debug!(msg = %line, "sending JSON-RPC");
+
+    // Single write: serialize into buffer with newline
+    let mut buf = Vec::with_capacity(line.len() + 1);
+    buf.extend_from_slice(line.as_bytes());
+    buf.push(b'\n');
+
+    self.stdin
+        .write_all(&buf)
+        .await
+        .map_err(|e| AgentError::IoError {
+            reason: format!("stdin write error: {e}"),
+        })?;
+    self.stdin.flush().await.map_err(|e| AgentError::IoError {
+        reason: format!("stdin flush error: {e}"),
+    })?;
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Run tests and verify**
+
+```bash
+cargo test -p ensemble-core -- --test-threads=1
+cargo clippy -p ensemble-core -- -D warnings
+```
+
+---
+
+### Task 4: Fix Performance — Iterator Return for running_issue_ids
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/state.rs:230-232` (running_issue_ids → iterator)
+- Modify: `crates/ensemble-core/src/orchestrator/reconciler.rs:92` (caller of running_issue_ids)
+
+- [ ] **Step 1: Change `running_issue_ids` to return an iterator**
+
+In `state.rs`:
+
+```rust
+// Before:
+pub fn running_issue_ids(&self) -> Vec<String> {
+    self.running.keys().cloned().collect()
+}
+
+// After:
+pub fn running_issue_ids(&self) -> impl Iterator<Item = &str> {
+    self.running.keys().map(|k| k.as_str())
+}
+```
+
+Returning `&str` instead of `&String` avoids leaking the internal HashMap key type.
+
+- [ ] **Step 2: Update `reconcile_tracker_states` caller**
+
+In `reconciler.rs`, the caller already collects to Vec for the trait call:
+
+```rust
+// Before:
+let running_ids = state.running_issue_ids();
+if running_ids.is_empty() { ... }
+let refreshed = match tracker.fetch_issue_states_by_ids(&running_ids).await {
+
+// After:
+let running_ids: Vec<String> = state.running_issue_ids().map(|s| s.to_string()).collect();
+if running_ids.is_empty() { ... }
+let refreshed = match tracker.fetch_issue_states_by_ids(&running_ids).await {
+```
+
+The Vec is still needed for the trait call, but the iterator avoids an intermediate allocation in the common case where it's empty (no running issues).
+
+- [ ] **Step 3: Run tests and verify**
+
+```bash
+cargo test -p ensemble-core -- --test-threads=1
+cargo clippy -p ensemble-core -- -D warnings
+```
+
+**Note on `get_due_retries` (Issue #9 from review):** After analysis, changing this to return IDs only would require `handle_single_retry` to look up the entry under a separate lock, adding complexity rather than reducing it. `RetryEntry` is small and already Clone. Keep returning `Vec<RetryEntry>`.
+
+**Note on DAG clones (Issue #11 from review):** The proposed "fix" produces the same number of clones total — it's churn with zero benefit. Skip.
+
+---
+
+### Task 5: Simplify — Orchestrator Lock Churn and Verbose Match
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs:158-278` (handle_tick lock reduction)
+- Modify: `crates/ensemble-core/src/agent/events.rs:51-85` (add helper methods to AgentEvent)
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs:485-561` (handle_agent_update simplification)
+
+- [ ] **Step 1: Add helper methods to AgentEvent**
+
+In `agent/events.rs`, add to `impl AgentEvent`:
+
+```rust
+impl AgentEvent {
+    /// Returns the event name for logging/state tracking.
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            AgentEvent::SessionStarted { .. } => "session_started",
+            AgentEvent::TurnStarted => "turn_started",
+            AgentEvent::TurnUpdate { .. } => "turn_update",
+            AgentEvent::TurnCompleted { .. } => "turn_completed",
+            AgentEvent::TurnFailed { .. } => "turn_failed",
+            AgentEvent::PermissionRequested { .. } => "permission_requested",
+            AgentEvent::PermissionResolved { .. } => "permission_resolved",
+            AgentEvent::Notification { .. } => "notification",
+            AgentEvent::OtherMessage { .. } => "other_message",
+            AgentEvent::Malformed { .. } => "malformed",
+        }
+    }
+
+    /// Returns the message content for state tracking, truncated.
+    pub fn message_for_state(&self) -> Option<String> {
+        match self {
+            AgentEvent::TurnUpdate { content } => Some(content.clone()),
+            AgentEvent::TurnFailed { reason, .. } => Some(reason.clone()),
+            AgentEvent::PermissionRequested { description, .. } => Some(description.clone()),
+            AgentEvent::Notification { message } => Some(message.clone()),
+            AgentEvent::OtherMessage { raw } => Some(raw.chars().take(100).collect()),
+            AgentEvent::Malformed { line } => Some(line.chars().take(100).collect()),
+            _ => None,
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Simplify `handle_agent_update`**
+
+In `orchestrator/mod.rs`, replace the 17-arm match with:
+
+```rust
+async fn handle_agent_update(
+    &self,
+    issue_id: &str,
+    _step_name: &str,
+    event: AgentEvent,
+    timestamp: chrono::DateTime<Utc>,
+) {
+    let mut state = self.state.write().await;
+
+    // Handle special cases
+    match &event {
+        AgentEvent::SessionStarted { session_id, agent_pid } => {
+            state.update_session_info(issue_id, session_id, agent_pid.as_deref());
+        }
+        AgentEvent::TurnStarted => {
+            state.increment_turn_count(issue_id);
+        }
+        AgentEvent::TurnCompleted { usage } | AgentEvent::TurnFailed { usage, .. } => {
+            if let Some(u) = usage {
+                state.update_token_usage(
+                    issue_id,
+                    u.input_tokens,
+                    u.output_tokens,
+                    u.total_tokens,
+                );
+            }
+        }
+        _ => {}
+    }
+
+    // Common path: update agent event
+    state.update_agent_event(issue_id, event.event_name(), event.message_for_state().as_deref(), timestamp);
+}
+```
+
+- [ ] **Step 3: Reduce lock churn in `handle_tick`**
+
+In `orchestrator/mod.rs`, `handle_tick` currently acquires ~8 separate read/write locks. Since the orchestrator is single-threaded in its event loop, consolidate to fewer lock acquisitions:
+
+```rust
+async fn handle_tick(&self) {
+    // Record tick
+    {
+        let mut state = self.state.write().await;
+        state.last_tick_at = Some(Utc::now());
+    }
+
+    // Stall detection (read-only on state)
+    let stall_timeout_ms = {
+        let config = self.config.read().await;
+        config.agent.stall_timeout_ms
+    };
+    let stalled_issue_ids = {
+        let state = self.state.read().await;
+        reconcile_stalled_runs(&state, stall_timeout_ms).stalled_issue_ids
+    };
+
+    if !stalled_issue_ids.is_empty() {
+        let mut state = self.state.write().await;
+        let config = self.config.read().await;
+        for issue_id in &stalled_issue_ids {
+            if let Some(entry) = state.remove_running(issue_id) {
+                state.add_runtime_seconds(&entry);
+                schedule_failure_retry(
+                    &mut state, issue_id, &entry.identifier,
+                    next_attempt(entry.retry_attempt),
+                    config.agent.max_retry_backoff_ms, config.max_cycles,
+                    "stall timeout",
+                );
+            }
+        }
+    }
+
+    // Tracker reconciliation (one write lock for the entire operation)
+    {
+        let config = self.config.read().await;
+        let active_lower: Vec<String> = config.tracker.active_states.iter().map(|s| s.to_lowercase()).collect();
+        let terminal_lower: Vec<String> = config.tracker.terminal_states.iter().map(|s| s.to_lowercase()).collect();
+
+        let reconcile_result = reconcile_tracker_states(
+            &self.state.read().await,
+            self.tracker.as_ref(),
+            &active_lower, &terminal_lower,
+        ).await;
+
+        let mut state = self.state.write().await;
+        for issue in reconcile_result.updates {
+            let id = issue.id.clone();
+            state.update_issue_snapshot(&id, issue);
+        }
+        for issue in reconcile_result.terminate_cleanup {
+            if let Some(entry) = state.remove_running(&issue.id) {
+                state.add_runtime_seconds(&entry);
+                state.release_claim(&issue.id);
+                state.remove_pipeline_run(&issue.id);
+                if let Err(e) = self.workspace_mgr.remove_workspace(&entry.identifier).await {
+                    warn!(identifier = %entry.identifier, error = %e, "failed to clean terminal workspace");
+                }
+            }
+        }
+        for issue in reconcile_result.terminate_no_cleanup {
+            if let Some(entry) = state.remove_running(&issue.id) {
+                state.add_runtime_seconds(&entry);
+                state.release_claim(&issue.id);
+                state.remove_pipeline_run(&issue.id);
+            }
+        }
+    }
+
+    // Fetch and dispatch (single read lock for state)
+    let mut candidates = match self.tracker.fetch_candidate_issues().await {
+        Ok(issues) => issues,
+        Err(e) => {
+            warn!(error = %e, "failed to fetch candidate issues, skipping dispatch");
+            return;
+        }
+    };
+    sort_for_dispatch(&mut candidates);
+
+    let config = self.config.read().await;
+    let active_lower: Vec<String> = config.tracker.active_states.iter().map(|s| s.to_lowercase()).collect();
+    let terminal_lower: Vec<String> = config.tracker.terminal_states.iter().map(|s| s.to_lowercase()).collect();
+
+    for issue in &candidates {
+        {
+            let state = self.state.read().await;
+            if !has_available_slots(&state) {
+                break;
+            }
+            if is_dispatch_eligible(issue, &state, &active_lower, &terminal_lower, &HashMap::new()).is_none() {
+                drop(state);
+                self.dispatch_issue(issue, None).await;
+            }
+        }
+    }
+}
+```
+
+This reduces lock acquisitions from ~8 to ~5, and combines the active/terminal lowercase computation so it's done once instead of twice.
+
+- [ ] **Step 4: Run tests and verify**
+
+```bash
+cargo test -p ensemble-core -- --test-threads=1
+cargo clippy -p ensemble-core -- -D warnings
+```
+
+---
+
+### Task 6: Fix Minor Issues — Build.rs Panic, Silent Approve, Shell Consistency
+
+**Files:**
+- Modify: `crates/ensemble-cli/build.rs:47-53` (graceful openapi.json missing)
+- Modify: `crates/ensemble-core/src/pipeline/verdict.rs:1-78` (warn on default approve + add tracing import)
+- Modify: `crates/ensemble-core/src/workspace/hooks.rs:27` (use bash instead of sh)
+
+- [ ] **Step 1: Make build.rs graceful on missing openapi.json**
+
+In `ensemble-cli/build.rs`:
+
+```rust
+// Before:
+if !openapi_json.exists() {
+    panic!(
+        "openapi.json not found at {}. Run `pnpm run codegen:spec` in crates/ensemble-ui/src-ui/ first, \
+         or set SKIP_UI_BUILD=1 to skip the UI embed.",
+        openapi_json.display()
+    );
+}
+
+// After:
+if !openapi_json.exists() {
+    println!(
+        "cargo:warning=openapi.json not found at {}. UI will not be embedded.",
+        openapi_json.display()
+    );
+    println!("cargo:warning=Run `pnpm run codegen:spec` in crates/ensemble-ui/src-ui/ to generate it.");
+    std::fs::create_dir_all(assets_dir).ok();
+    return;
+}
+```
+
+- [ ] **Step 2: Add warning log on default verdict approval**
+
+In `pipeline/verdict.rs`, add `use tracing::warn;` at the top of the file (line 1 area), then in `resolve_verdict`:
+
+```rust
+// Before (line ~77):
+Verdict::Approve
+
+// After:
+warn!("no verdict source found for step, defaulting to Approve");
+Verdict::Approve
+```
+
+- [ ] **Step 3: Use `bash -lc` for hooks to match ACP client**
+
+In `workspace/hooks.rs`:
+
+```rust
+// Before:
+let child = Command::new("sh")
+    .arg("-lc")
+
+// After:
+let child = Command::new("bash")
+    .arg("-lc")
+```
+
+- [ ] **Step 4: Run tests and verify**
+
+```bash
+cargo test -p ensemble-core -- --test-threads=1
+cargo clippy -p ensemble-core -- -D warnings
+```
+
+---
+
+### Task 7: Fix Remaining Issues — Path Validation and Stale Config
+
+**Files:**
+- Modify: `crates/ensemble-core/src/workspace/manager.rs:163-193` (validate_path_inside_root warn on canonicalize failure)
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs:282-327` (dispatch_issue rebuilds DAG from fresh config)
+- Modify: `crates/ensemble-core/src/workspace/manager.rs:196-297` (tests)
+
+- [ ] **Step 1: Fix validate_path_inside_root to warn on canonicalize failure**
+
+In `workspace/manager.rs`, the original code silently falls back to non-canonicalized paths when `canonicalize()` fails, which weakens the security check. Instead, keep the fallback but add a `warn!` log so operators know the check is degraded:
+
+```rust
+// Before:
+fn validate_path_inside_root(&self, path: &Path) -> Result<(), WorkspaceError> {
+    let canonical_root = if self.root.exists() {
+        self.root.canonicalize().unwrap_or_else(|_| self.root.clone())
+    } else {
+        self.root.clone()
+    };
+
+    let canonical_path = if path.exists() {
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    } else if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
+        let canonical_parent = if parent.exists() {
+            parent.canonicalize().unwrap_or_else(|_| parent.to_path_buf())
+        } else {
+            parent.to_path_buf()
+        };
+        canonical_parent.join(file_name)
+    } else {
+        path.to_path_buf()
+    };
+
+    if !canonical_path.starts_with(&canonical_root) {
+        return Err(WorkspaceError::PathOutsideRoot {
+            path: canonical_path.display().to_string(),
+        });
+    }
+    Ok(())
+}
+
+// After:
+fn validate_path_inside_root(&self, path: &Path) -> Result<(), WorkspaceError> {
+    let canonical_root = self.root.canonicalize().unwrap_or_else(|e| {
+        warn!(
+            root = %self.root.display(),
+            error = %e,
+            "cannot canonicalize workspace root, falling back to non-canonical path check"
+        );
+        self.root.clone()
+    });
+
+    let canonical_path = if path.exists() {
+        path.canonicalize().unwrap_or_else(|e| {
+            warn!(
+                path = %path.display(),
+                error = %e,
+                "cannot canonicalize path, falling back to non-canonical check"
+            );
+            path.to_path_buf()
+        })
+    } else if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
+        let canonical_parent = parent.canonicalize().unwrap_or_else(|e| {
+            warn!(
+                parent = %parent.display(),
+                error = %e,
+                "cannot canonicalize parent path, falling back to non-canonical check"
+            );
+            parent.to_path_buf()
+        });
+        canonical_parent.join(file_name)
+    } else {
+        path.to_path_buf()
+    };
+
+    if !canonical_path.starts_with(&canonical_root) {
+        return Err(WorkspaceError::PathOutsideRoot {
+            path: canonical_path.display().to_string(),
+        });
+    }
+    Ok(())
+}
+```
+
+This preserves compatibility with edge cases (network drives, FUSE mounts, permission-denied intermediates) while alerting operators when the check is degraded.
+
+- [ ] **Step 2: Fix dispatch_issue to rebuild DAG from fresh config**
+
+In `orchestrator/mod.rs`, the `dispatch_issue` method reads config once at the top, builds the DAG, then writes state. If config is reloaded between these operations, the DAG is stale.
+
+The fix: read config, build DAG, and clone the config snapshot within a single config read scope, so the DAG and the config used for `dispatch_step` are consistent:
+
+```rust
+async fn dispatch_issue(&self, issue: &Issue, attempt: Option<u32>) {
+    // Read config and build DAG atomically
+    let (dag, config_snapshot) = {
+        let config = self.config.read().await;
+        let dag = match build_dag(&config.steps) {
+            Ok(d) => d,
+            Err(e) => {
+                warn!(issue_id = %issue.id, error = %e, "failed to build step DAG, skipping dispatch");
+                return;
+            }
+        };
+        (dag, config.clone())
+    };
+
+    let cycle = attempt.unwrap_or(1);
+    let pipeline_run = PipelineRun::new(issue.id.clone(), cycle, dag);
+    let action = pipeline_run.start();
+
+    info!(issue_id = %issue.id, identifier = %issue.identifier, attempt = ?attempt, "dispatching issue with pipeline");
+
+    {
+        let mut state = self.state.write().await;
+        state.add_running(issue, attempt);
+        state.insert_pipeline_run(&issue.id, pipeline_run);
+    }
+
+    // Process initial dispatch requests
+    if let PipelineAction::Dispatch(requests) = action {
+        for req in requests {
+            self.dispatch_step(
+                issue, &req.step_name, &req.agent_name,
+                req.tracker_state.as_deref(), attempt,
+            ).await;
+        }
+    }
+}
+```
+
+This clones the config (which is cheap for the fields used in `dispatch_step`), ensuring the DAG and the config snapshot used for dispatch_step are consistent.
+
+- [ ] **Step 3: Run tests and verify**
+
+```bash
+cargo test -p ensemble-core -- --test-threads=1
+cargo clippy -p ensemble-core -- -D warnings
+```
+
+---
+
+## Execution Order
+
+Tasks are ordered by priority (bugs first, then performance, then simplifications, then minors). Each task is independent and can be executed in any order, but this order maximizes risk reduction early.
+
+1. **Task 1** — Critical bug (shell injection in executor path)
+2. **Task 2** — Performance: eliminate redundant allocations in scheduler/reconciler
+3. **Task 3** — Performance: prompt caching with invalidation + JSON-RPC write batching
+4. **Task 4** — Performance: iterator return for running_issue_ids
+5. **Task 5** — Simplification: lock churn reduction + verbose match refactoring
+6. **Task 6** — Minor: build.rs graceful fallback, silent approve warning, shell consistency
+7. **Task 7** — Path validation warning on canonicalize failure + stale config fix
+
+## Not Addressed (Deferred)
+
+- **Issue #6** (token double-count on retry): After analysis, NOT a bug. New agent sessions on retry start from 0 cumulative tokens, so `last_reported_* = 0` is correct. `agent_totals` already contains prior session totals.
+- **Issue #7** (handle_worker_exit TOCTOU): The PipelineRun state machine already provides protection. Defer until a real race is observed.
+- **Issue #9** (get_due_retries clones): Changing to ID-only returns adds complexity (separate lookup under write lock). `RetryEntry` is small and Clone. Not worth it.
+- **Issue #11** (DagStep clone in build_dag): Same number of clones total — churn with zero benefit.
+- **Issue #14** (MockAgentRunner duplication): Cosmetic test improvement. Defer.
+- **Issue #15** (test_issue duplication): Cosmetic test improvement. Defer.
+- **Issue #16** (resolve_env_from monolith): Refactoring opportunity, not a bug. Defer.
+- **Issue #19** (hardcoded event name strings): Already addressed by Task 5's `event_name()` method.
+- **Issue #21** (AgentEvent missing Deserialize): No current use case for deserializing events. Defer.
+- **Issue #22** (OrchestratorState not Serialize): Snapshot builder is intentional design. Defer.


### PR DESCRIPTION
## Summary

- Fix shell injection vulnerability in `resolve_agent_command` — the `executor` field was returned raw without shell escaping, creating an injection vector when passed to `bash -lc`
- Eliminate redundant `to_lowercase()` allocations in scheduler and reconciler — pre-compute lowercase state lists once per tick instead of per-issue
- Cache prompt templates in `AcpAgentRunner` to avoid repeated config reads and file I/O on every turn, with `clear_cache()` for config reload invalidation
- Batch `send_json_rpc` into single `write_all` + flush instead of three separate async operations
- Return iterator from `running_issue_ids()` instead of allocating `Vec<String>`
- Simplify `handle_agent_update` from 17-arm match to 4-arm special-case + common path using new `AgentEvent` helper methods
- Make build.rs graceful on missing `openapi.json` instead of panicking
- Warn on default verdict approval to alert operators of misconfigured review steps
- Use `bash -lc` for hooks to match ACP client (was `sh -lc`)
- Warn on path canonicalize failure instead of silently degrading security check
- Prevent stale config in `dispatch_issue` by cloning config within read lock scope

## Changes

| File | What |
|------|------|
| `agent/mod.rs` | Shell-escape executor, prompt caching with invalidation |
| `agent/acp_client.rs` | Batch JSON-RPC writes |
| `agent/events.rs` | `event_name()` and `message_for_state()` helpers |
| `orchestrator/mod.rs` | Simplified `handle_agent_update`, atomic config in `dispatch_issue` |
| `orchestrator/scheduler.rs` | Accept pre-lowercased slices, remove allocations |
| `orchestrator/reconciler.rs` | Accept pre-lowercased slices, remove allocations |
| `orchestrator/state.rs` | `running_issue_ids()` returns iterator |
| `workspace/manager.rs` | Warn on canonicalize failure |
| `workspace/hooks.rs` | Use `bash` instead of `sh` |
| `pipeline/verdict.rs` | Warn on default verdict approval |
| `ensemble-cli/build.rs` | Graceful skip on missing `openapi.json` |

## Verification

- 379 tests pass
- Clippy clean (`-D warnings`)