### PR TITLE
Harden config editing and desktop/web setup flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,7 @@ dependencies = [
  "futures-util",
  "libc",
  "liquid",
+ "mime_guess",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,5 @@ utoipa = { version = "5.3", features = ["axum_extras", "chrono"] }
 rust-embed = { version = "8", features = ["axum"] }
 dirs = "6"
 dotenvy = "0.15"
+shellexpand = "3"
+mime_guess = "2"

--- a/crates/ensemble-cli/Cargo.toml
+++ b/crates/ensemble-cli/Cargo.toml
@@ -21,7 +21,7 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
 rust-embed = { workspace = true }
-mime_guess = "2"
+mime_guess = { workspace = true }
 reqwest = { workspace = true }
 dirs = { workspace = true }
 

--- a/crates/ensemble-cli/src/commands/init.rs
+++ b/crates/ensemble-cli/src/commands/init.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 pub mod agents;
+pub mod convert;
 pub mod generate;
 pub mod pipeline;
 pub mod repos;
@@ -40,13 +41,45 @@ pub async fn execute(args: InitArgs) -> ExitCode {
         }
     };
 
-    // Check for legacy ensemble.yaml and warn
+    // Offer to migrate legacy ensemble.yaml before loading defaults.
     let legacy_path = resolved.config_dir.join("ensemble.yaml");
     if legacy_path.exists() && !resolved.config_path.exists() {
-        eprintln!(
-            "found legacy ensemble.yaml at {} - rename it to config.yaml",
-            legacy_path.display()
-        );
+        let rename_legacy = match inquire::Confirm::new(&format!(
+            "Found legacy {}. Rename it to {}?",
+            legacy_path.display(),
+            resolved.config_path.display()
+        ))
+        .with_default(true)
+        .prompt()
+        {
+            Ok(value) => value,
+            Err(e) => {
+                eprintln!("error: failed to confirm legacy config migration: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+
+        if rename_legacy {
+            if let Err(e) = std::fs::rename(&legacy_path, &resolved.config_path) {
+                eprintln!(
+                    "error: failed to rename {} to {}: {e}",
+                    legacy_path.display(),
+                    resolved.config_path.display()
+                );
+                return ExitCode::FAILURE;
+            }
+            println!(
+                "Renamed {} to {}.",
+                legacy_path.display(),
+                resolved.config_path.display()
+            );
+        } else {
+            eprintln!(
+                "warning: legacy config at {} will be ignored until renamed to {}",
+                legacy_path.display(),
+                resolved.config_path.display()
+            );
+        }
     }
 
     // Try to load existing config for defaults

--- a/crates/ensemble-cli/src/commands/init/agents.rs
+++ b/crates/ensemble-cli/src/commands/init/agents.rs
@@ -101,7 +101,9 @@ pub async fn discover_agents(existing: Option<&EnsembleConfig>) -> Result<Vec<Ag
     }
 
     // Use shared discovery function
-    let discovered = discover_available_agents().map_err(|e| e.to_string())?;
+    let discovered = discover_available_agents()
+        .await
+        .map_err(|e| e.to_string())?;
 
     let available: Vec<String> = discovered.iter().map(|d| d.name.clone()).collect();
 

--- a/crates/ensemble-cli/src/commands/init/convert.rs
+++ b/crates/ensemble-cli/src/commands/init/convert.rs
@@ -1,0 +1,66 @@
+//! Shared conversions from CLI init types to `ensemble_core` setup types.
+//!
+//! These `From` impls eliminate the copy-pasted match arms in `generate.rs`
+//! and `validate.rs`.
+
+use crate::commands::init::agents::AgentEntry;
+use crate::commands::init::pipeline::PipelineStep;
+use crate::commands::init::repos::RepoEntry;
+use crate::commands::init::tracker::TrackerChoice;
+use ensemble_core::config::setup::{SetupAgent, SetupRepo, SetupStep, SetupTracker};
+
+impl From<&TrackerChoice> for SetupTracker {
+    fn from(choice: &TrackerChoice) -> Self {
+        match choice {
+            TrackerChoice::TodoFile { path } => SetupTracker::TodoFile { path: path.clone() },
+            TrackerChoice::GitHub {
+                repository,
+                project_number,
+                api_key_env,
+                api_token,
+                active_states,
+                terminal_states,
+                ..
+            } => SetupTracker::GitHub {
+                repository: repository.clone(),
+                project_number: *project_number,
+                api_key_env: api_key_env.clone(),
+                api_token: api_token.clone(),
+                active_states: active_states.clone(),
+                terminal_states: terminal_states.clone(),
+            },
+        }
+    }
+}
+
+impl From<&RepoEntry> for SetupRepo {
+    fn from(entry: &RepoEntry) -> Self {
+        SetupRepo {
+            path: entry.path.clone(),
+            branch: entry.branch.clone(),
+        }
+    }
+}
+
+impl From<&AgentEntry> for SetupAgent {
+    fn from(entry: &AgentEntry) -> Self {
+        SetupAgent {
+            role: entry.role.clone(),
+            acpx_agent: entry.acpx_agent.clone(),
+            model: entry.model.clone(),
+            prompt: None,
+            prompt_file: None,
+        }
+    }
+}
+
+impl From<&PipelineStep> for SetupStep {
+    fn from(step: &PipelineStep) -> Self {
+        SetupStep {
+            name: step.name.clone(),
+            agent_role: step.agent_role.clone(),
+            depends: step.depends.clone(),
+            tracker_state: step.tracker_state.clone(),
+        }
+    }
+}

--- a/crates/ensemble-cli/src/commands/init/generate.rs
+++ b/crates/ensemble-cli/src/commands/init/generate.rs
@@ -57,6 +57,8 @@ fn to_setup_request(
             role: a.role.clone(),
             acpx_agent: a.acpx_agent.clone(),
             model: a.model.clone(),
+            prompt: None,
+            prompt_file: None,
         })
         .collect();
 
@@ -502,6 +504,8 @@ mod tests {
                 role: "builder".to_string(),
                 acpx_agent: "claude".to_string(),
                 model: None,
+                prompt: None,
+                prompt_file: None,
             }],
             steps: vec![SetupStep {
                 name: "build".to_string(),
@@ -538,6 +542,8 @@ mod tests {
                 role: "builder".to_string(),
                 acpx_agent: "claude".to_string(),
                 model: None,
+                prompt: None,
+                prompt_file: None,
             }],
             steps: vec![SetupStep {
                 name: "build".to_string(),
@@ -567,6 +573,8 @@ mod tests {
                 role: "builder".to_string(),
                 acpx_agent: "claude".to_string(),
                 model: None,
+                prompt: None,
+                prompt_file: None,
             }],
             steps: vec![SetupStep {
                 name: "build".to_string(),

--- a/crates/ensemble-cli/src/commands/init/generate.rs
+++ b/crates/ensemble-cli/src/commands/init/generate.rs
@@ -4,7 +4,7 @@ use crate::commands::init::repos::RepoEntry;
 use crate::commands::init::tracker::TrackerChoice;
 use ensemble_core::config::setup::{
     build_setup_artifacts, merge_setup_request, resolve_tracker_output_path, write_setup_artifacts,
-    SetupAgent, SetupRepo, SetupRequest, SetupStep, SetupTracker,
+    SetupRequest, SetupTracker,
 };
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -23,60 +23,11 @@ fn to_setup_request(
     on_success: &str,
     on_failure: &str,
 ) -> SetupRequest {
-    let tracker = match tracker {
-        TrackerChoice::TodoFile { path } => SetupTracker::TodoFile { path: path.clone() },
-        TrackerChoice::GitHub {
-            repository,
-            project_number,
-            api_key_env,
-            api_token,
-            active_states,
-            terminal_states,
-            ..
-        } => SetupTracker::GitHub {
-            repository: repository.clone(),
-            project_number: *project_number,
-            api_key_env: api_key_env.clone(),
-            api_token: api_token.clone(),
-            active_states: active_states.clone(),
-            terminal_states: terminal_states.clone(),
-        },
-    };
-
-    let repos = repos
-        .iter()
-        .map(|r| SetupRepo {
-            path: r.path.clone(),
-            branch: r.branch.clone(),
-        })
-        .collect();
-
-    let agents = agents
-        .iter()
-        .map(|a| SetupAgent {
-            role: a.role.clone(),
-            acpx_agent: a.acpx_agent.clone(),
-            model: a.model.clone(),
-            prompt: None,
-            prompt_file: None,
-        })
-        .collect();
-
-    let steps = steps
-        .iter()
-        .map(|s| SetupStep {
-            name: s.name.clone(),
-            agent_role: s.agent_role.clone(),
-            depends: s.depends.clone(),
-            tracker_state: s.tracker_state.clone(),
-        })
-        .collect();
-
     SetupRequest {
-        tracker,
-        repos,
-        agents,
-        steps,
+        tracker: tracker.into(),
+        repos: repos.iter().map(Into::into).collect(),
+        agents: agents.iter().map(Into::into).collect(),
+        steps: steps.iter().map(Into::into).collect(),
         on_success: on_success.to_string(),
         on_failure: on_failure.to_string(),
     }
@@ -150,7 +101,7 @@ pub fn write_files(
                 println!("  Skipping {}", template_path.display());
                 declined.template_prompts.push(template_path.clone());
             }
-            Err(_) => return Ok(()),
+            Err(e) => return Err(std::io::Error::other(format!("prompt cancelled: {e}"))),
         }
     }
 
@@ -167,7 +118,7 @@ pub fn write_files(
                 println!("  Skipping {} (token not saved)", env_path.display());
                 declined.env_prompt = Some(env_path.clone());
             }
-            Err(_) => return Ok(()),
+            Err(e) => return Err(std::io::Error::other(format!("prompt cancelled: {e}"))),
         }
     }
 
@@ -184,7 +135,7 @@ pub fn write_files(
                 println!("  Skipping {}", todo_path.display());
                 declined.todo_prompt = Some(todo_path.clone());
             }
-            Err(_) => return Ok(()),
+            Err(e) => return Err(std::io::Error::other(format!("prompt cancelled: {e}"))),
         }
     }
 
@@ -295,6 +246,7 @@ fn apply_declined_overwrites(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ensemble_core::config::setup::{SetupAgent, SetupStep};
     use std::path::PathBuf;
 
     #[test]

--- a/crates/ensemble-cli/src/commands/init/validate.rs
+++ b/crates/ensemble-cli/src/commands/init/validate.rs
@@ -2,9 +2,28 @@ use crate::commands::init::agents::AgentEntry;
 use crate::commands::init::pipeline::PipelineStep;
 use crate::commands::init::repos::RepoEntry;
 use crate::commands::init::tracker::TrackerChoice;
-use ensemble_core::config::setup::{
-    run_setup_checks, SetupAgent, SetupRepo, SetupRequest, SetupStep, SetupTracker,
-};
+use ensemble_core::config::setup::{run_setup_checks, SetupRequest, SetupTracker};
+
+fn validation_request(
+    tracker: &TrackerChoice,
+    repos: &[RepoEntry],
+    agents: &[AgentEntry],
+    steps: &[PipelineStep],
+) -> SetupRequest {
+    let mut setup_tracker: SetupTracker = tracker.into();
+    if let SetupTracker::GitHub { api_token, .. } = &mut setup_tracker {
+        *api_token = None;
+    }
+
+    SetupRequest {
+        tracker: setup_tracker,
+        repos: repos.iter().map(Into::into).collect(),
+        agents: agents.iter().map(Into::into).collect(),
+        steps: steps.iter().map(Into::into).collect(),
+        on_success: "Done".to_string(),   // Not used by checks
+        on_failure: "Failed".to_string(), // Not used by checks
+    }
+}
 
 pub async fn run_validation(
     tracker: &TrackerChoice,
@@ -14,63 +33,7 @@ pub async fn run_validation(
 ) -> Result<bool, inquire::InquireError> {
     println!("\nValidating configuration...\n");
 
-    // Convert CLI types to setup types
-    let setup_tracker = match tracker {
-        TrackerChoice::TodoFile { path } => SetupTracker::TodoFile { path: path.clone() },
-        TrackerChoice::GitHub {
-            repository,
-            project_number,
-            api_key_env,
-            active_states,
-            terminal_states,
-            ..
-        } => SetupTracker::GitHub {
-            repository: repository.clone(),
-            project_number: *project_number,
-            api_key_env: api_key_env.clone(),
-            api_token: None, // Token is handled separately
-            active_states: active_states.clone(),
-            terminal_states: terminal_states.clone(),
-        },
-    };
-
-    let setup_repos: Vec<SetupRepo> = repos
-        .iter()
-        .map(|r| SetupRepo {
-            path: r.path.clone(),
-            branch: r.branch.clone(),
-        })
-        .collect();
-
-    let setup_agents: Vec<SetupAgent> = agents
-        .iter()
-        .map(|a| SetupAgent {
-            role: a.role.clone(),
-            acpx_agent: a.acpx_agent.clone(),
-            model: a.model.clone(),
-            prompt: None,
-            prompt_file: None,
-        })
-        .collect();
-
-    let setup_steps: Vec<SetupStep> = steps
-        .iter()
-        .map(|s| SetupStep {
-            name: s.name.clone(),
-            agent_role: s.agent_role.clone(),
-            depends: s.depends.clone(),
-            tracker_state: s.tracker_state.clone(),
-        })
-        .collect();
-
-    let request = SetupRequest {
-        tracker: setup_tracker,
-        repos: setup_repos,
-        agents: setup_agents,
-        steps: setup_steps,
-        on_success: "Done".to_string(),   // Not used by checks
-        on_failure: "Failed".to_string(), // Not used by checks
-    };
+    let request = validation_request(tracker, repos, agents, steps);
 
     // Run the shared setup checks
     let checks = run_setup_checks(&request).await;
@@ -96,4 +59,79 @@ pub async fn run_validation(
     inquire::Confirm::new("Write config anyway?")
         .with_default(false)
         .prompt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn validation_request_uses_shared_conversions_and_omits_github_token() {
+        let tracker = TrackerChoice::GitHub {
+            repository: "acme/frontend".to_string(),
+            project_number: Some(42),
+            api_key_env: "GITHUB_TOKEN".to_string(),
+            api_token: Some("secret".to_string()),
+            active_states: vec!["Todo".to_string()],
+            terminal_states: vec!["Done".to_string()],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        };
+        let repos = vec![RepoEntry {
+            path: PathBuf::from("/tmp/repo-a"),
+            branch: "main".to_string(),
+        }];
+        let agents = vec![AgentEntry {
+            role: "builder".to_string(),
+            acpx_agent: "claude".to_string(),
+            model: Some("sonnet".to_string()),
+        }];
+        let steps = vec![PipelineStep {
+            name: "implement".to_string(),
+            agent_role: "builder".to_string(),
+            depends: vec![],
+            tracker_state: Some("In Progress".to_string()),
+        }];
+
+        let request = validation_request(&tracker, &repos, &agents, &steps);
+
+        assert_eq!(request.repos.len(), 1);
+        assert_eq!(request.repos[0].path, PathBuf::from("/tmp/repo-a"));
+        assert_eq!(request.repos[0].branch, "main");
+        assert_eq!(request.agents.len(), 1);
+        assert_eq!(request.agents[0].role, "builder");
+        assert_eq!(request.agents[0].acpx_agent, "claude");
+        assert_eq!(request.agents[0].model.as_deref(), Some("sonnet"));
+        assert_eq!(request.agents[0].prompt, None);
+        assert_eq!(request.agents[0].prompt_file, None);
+        assert_eq!(request.steps.len(), 1);
+        assert_eq!(request.steps[0].name, "implement");
+        assert_eq!(request.steps[0].agent_role, "builder");
+        assert_eq!(
+            request.steps[0].tracker_state.as_deref(),
+            Some("In Progress")
+        );
+        assert_eq!(request.on_success, "Done");
+        assert_eq!(request.on_failure, "Failed");
+
+        match request.tracker {
+            SetupTracker::GitHub {
+                repository,
+                project_number,
+                api_key_env,
+                api_token,
+                active_states,
+                terminal_states,
+            } => {
+                assert_eq!(repository, "acme/frontend");
+                assert_eq!(project_number, Some(42));
+                assert_eq!(api_key_env, "GITHUB_TOKEN");
+                assert_eq!(api_token, None);
+                assert_eq!(active_states, vec!["Todo"]);
+                assert_eq!(terminal_states, vec!["Done"]);
+            }
+            other => panic!("expected github tracker, got {other:?}"),
+        }
+    }
 }

--- a/crates/ensemble-cli/src/commands/init/validate.rs
+++ b/crates/ensemble-cli/src/commands/init/validate.rs
@@ -48,6 +48,8 @@ pub async fn run_validation(
             role: a.role.clone(),
             acpx_agent: a.acpx_agent.clone(),
             model: a.model.clone(),
+            prompt: None,
+            prompt_file: None,
         })
         .collect();
 
@@ -71,7 +73,7 @@ pub async fn run_validation(
     };
 
     // Run the shared setup checks
-    let checks = run_setup_checks(&request);
+    let checks = run_setup_checks(&request).await;
 
     let mut failures = 0;
     for check in &checks {

--- a/crates/ensemble-cli/src/commands/web.rs
+++ b/crates/ensemble-cli/src/commands/web.rs
@@ -187,7 +187,14 @@ pub async fn execute(args: WebArgs) -> ExitCode {
         }
     };
 
-    let actual_addr = listener.local_addr().unwrap();
+    let actual_addr = match listener.local_addr() {
+        Ok(addr) => addr,
+        Err(e) => {
+            error!(error = %e, "failed to get local address");
+            eprintln!("error: failed to get local address: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
     info!(
         addr = %actual_addr,
         "HTTP server listening. Open http://{} in your browser",

--- a/crates/ensemble-cli/src/embedded_ui.rs
+++ b/crates/ensemble-cli/src/embedded_ui.rs
@@ -11,7 +11,9 @@ struct SpaAssets;
 /// Serve an embedded file by path, returning 404 if not found
 #[allow(dead_code)]
 pub fn serve_file(path: &str) -> impl IntoResponse {
-    serve_file_response(path, |asset_path| SpaAssets::get(asset_path).map(|f| f.data))
+    serve_file_response(path, |asset_path| {
+        SpaAssets::get(asset_path).map(|f| f.data)
+    })
 }
 
 /// Serve the SPA with fallback to index.html for client-side routing

--- a/crates/ensemble-cli/src/embedded_ui.rs
+++ b/crates/ensemble-cli/src/embedded_ui.rs
@@ -11,33 +11,20 @@ struct SpaAssets;
 /// Serve an embedded file by path, returning 404 if not found
 #[allow(dead_code)]
 pub fn serve_file(path: &str) -> impl IntoResponse {
-    serve_file_response(path, |asset_path| {
-        SpaAssets::get(asset_path)
-            .map(|file| file.data.into_owned().into_boxed_slice())
-            .map(Box::leak)
-            .map(|bytes| &*bytes)
-    })
+    serve_file_response(path, |asset_path| SpaAssets::get(asset_path).map(|f| f.data))
 }
 
 /// Serve the SPA with fallback to index.html for client-side routing
 pub async fn serve_spa(uri: Uri) -> impl IntoResponse {
     serve_spa_response(uri.path(), |asset_path| {
-        SpaAssets::get(asset_path)
-            .map(|file| file.data.into_owned().into_boxed_slice())
-            .map(Box::leak)
-            .map(|bytes| &*bytes)
+        SpaAssets::get(asset_path).map(|f| f.data)
     })
 }
 
 /// Check if the SPA is available (assets were embedded)
 #[allow(dead_code)]
 pub fn spa_available() -> bool {
-    core_spa_available(|asset_path| {
-        SpaAssets::get(asset_path)
-            .map(|file| file.data.into_owned().into_boxed_slice())
-            .map(Box::leak)
-            .map(|bytes| &*bytes)
-    })
+    core_spa_available(|asset_path| SpaAssets::get(asset_path).map(|f| f.data))
 }
 
 /// Router for serving embedded SPA

--- a/crates/ensemble-cli/src/embedded_ui.rs
+++ b/crates/ensemble-cli/src/embedded_ui.rs
@@ -1,7 +1,6 @@
-use axum::{
-    body::Body,
-    http::{header, StatusCode, Uri},
-    response::{IntoResponse, Response},
+use axum::{http::Uri, response::IntoResponse};
+use ensemble_core::ui::{
+    serve_file_response, serve_spa_response, spa_available as core_spa_available,
 };
 use rust_embed::RustEmbed;
 
@@ -9,85 +8,36 @@ use rust_embed::RustEmbed;
 #[folder = "assets/spa"]
 struct SpaAssets;
 
-/// Normalize a request path for embedded asset lookup.
-/// Strips leading/trailing slashes and treats empty paths as "index.html".
-fn normalize_path(path: &str) -> &str {
-    let trimmed = path.trim_matches('/');
-    if trimmed.is_empty() {
-        "index.html"
-    } else {
-        trimmed
-    }
-}
-
 /// Serve an embedded file by path, returning 404 if not found
 #[allow(dead_code)]
 pub fn serve_file(path: &str) -> impl IntoResponse {
-    let path = normalize_path(path);
-    match SpaAssets::get(path) {
-        Some(file) => {
-            let content_type = mime_guess::from_path(path).first_or_octet_stream();
-            Response::builder()
-                .header(header::CONTENT_TYPE, content_type.as_ref())
-                .body(Body::from(file.data))
-                .unwrap()
-        }
-        None => Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .body(Body::from("Not found"))
-            .unwrap(),
-    }
+    serve_file_response(path, |asset_path| {
+        SpaAssets::get(asset_path)
+            .map(|file| file.data.into_owned().into_boxed_slice())
+            .map(Box::leak)
+            .map(|bytes| &*bytes)
+    })
 }
 
 /// Serve the SPA with fallback to index.html for client-side routing
 pub async fn serve_spa(uri: Uri) -> impl IntoResponse {
-    let path = normalize_path(uri.path());
-
-    // Try exact path first
-    if let Some(file) = SpaAssets::get(path) {
-        let content_type = mime_guess::from_path(path).first_or_octet_stream();
-        return Response::builder()
-            .header(header::CONTENT_TYPE, content_type.as_ref())
-            .body(Body::from(file.data))
-            .unwrap();
-    }
-
-    // Try with .html extension
-    let html_path = format!("{}.html", path);
-    if let Some(file) = SpaAssets::get(&html_path) {
-        return Response::builder()
-            .header(header::CONTENT_TYPE, "text/html")
-            .body(Body::from(file.data))
-            .unwrap();
-    }
-
-    // Try index.html in directory
-    let dir_index = format!("{}/index.html", path);
-    if let Some(file) = SpaAssets::get(&dir_index) {
-        return Response::builder()
-            .header(header::CONTENT_TYPE, "text/html")
-            .body(Body::from(file.data))
-            .unwrap();
-    }
-
-    // Fallback to root index.html (SPA behavior)
-    if let Some(file) = SpaAssets::get("index.html") {
-        Response::builder()
-            .header(header::CONTENT_TYPE, "text/html")
-            .body(Body::from(file.data))
-            .unwrap()
-    } else {
-        Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .body(Body::from("index.html not found - UI may not be built"))
-            .unwrap()
-    }
+    serve_spa_response(uri.path(), |asset_path| {
+        SpaAssets::get(asset_path)
+            .map(|file| file.data.into_owned().into_boxed_slice())
+            .map(Box::leak)
+            .map(|bytes| &*bytes)
+    })
 }
 
 /// Check if the SPA is available (assets were embedded)
 #[allow(dead_code)]
 pub fn spa_available() -> bool {
-    SpaAssets::get("index.html").is_some()
+    core_spa_available(|asset_path| {
+        SpaAssets::get(asset_path)
+            .map(|file| file.data.into_owned().into_boxed_slice())
+            .map(Box::leak)
+            .map(|bytes| &*bytes)
+    })
 }
 
 /// Router for serving embedded SPA
@@ -98,39 +48,40 @@ pub fn spa_router() -> axum::Router {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ensemble_core::ui::normalize_spa_path;
 
     #[test]
     fn test_normalize_path_strips_leading_slash() {
-        assert_eq!(normalize_path("/assets/app.js"), "assets/app.js");
+        assert_eq!(normalize_spa_path("/assets/app.js"), "assets/app.js");
     }
 
     #[test]
     fn test_normalize_path_strips_trailing_slash() {
-        assert_eq!(normalize_path("assets/"), "assets");
+        assert_eq!(normalize_spa_path("assets/"), "assets");
     }
 
     #[test]
     fn test_normalize_path_strips_both_slashes() {
-        assert_eq!(normalize_path("/assets/app.js/"), "assets/app.js");
+        assert_eq!(normalize_spa_path("/assets/app.js/"), "assets/app.js");
     }
 
     #[test]
     fn test_normalize_path_empty_becomes_index() {
-        assert_eq!(normalize_path(""), "index.html");
+        assert_eq!(normalize_spa_path(""), "index.html");
     }
 
     #[test]
     fn test_normalize_path_root_slash_becomes_index() {
-        assert_eq!(normalize_path("/"), "index.html");
+        assert_eq!(normalize_spa_path("/"), "index.html");
     }
 
     #[test]
     fn test_normalize_path_no_slashes_unchanged() {
-        assert_eq!(normalize_path("style.css"), "style.css");
+        assert_eq!(normalize_spa_path("style.css"), "style.css");
     }
 
     #[test]
     fn test_normalize_path_nested_unchanged() {
-        assert_eq!(normalize_path("assets/js/app.js"), "assets/js/app.js");
+        assert_eq!(normalize_spa_path("assets/js/app.js"), "assets/js/app.js");
     }
 }

--- a/crates/ensemble-cli/src/embedded_ui.rs
+++ b/crates/ensemble-cli/src/embedded_ui.rs
@@ -47,7 +47,6 @@ pub fn spa_router() -> axum::Router {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ensemble_core::ui::normalize_spa_path;
 
     #[test]

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -25,8 +25,8 @@ futures-util = { workspace = true }
 utoipa = { workspace = true }
 dirs = { workspace = true }
 dotenvy = { workspace = true }
-shellexpand = "3"
-shlex = "1"
+shellexpand = { workspace = true }
+mime_guess = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -26,6 +26,7 @@ utoipa = { workspace = true }
 dirs = { workspace = true }
 dotenvy = { workspace = true }
 shellexpand = { workspace = true }
+shlex = "1"
 mime_guess = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -935,8 +935,16 @@ custom_root:
     }
 
     #[test]
-    fn redact_secrets_handles_equals_separator() {
+    fn redact_secrets_redacts_literal_secret() {
         let yaml = "secret: mysecretvalue";
+        let redacted = redact_secrets(yaml);
+        assert!(!redacted.contains("mysecretvalue"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_secrets_handles_equals_separator() {
+        let yaml = "secret=mysecretvalue";
         let redacted = redact_secrets(yaml);
         assert!(!redacted.contains("mysecretvalue"));
         assert!(redacted.contains("[REDACTED]"));

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -27,7 +27,7 @@ fn redact_secrets(yaml: &str) -> String {
                     let sep_pos = trimmed.find(':').or_else(|| trimmed.find('=')).unwrap();
                     let value = trimmed[sep_pos + 1..].trim();
                     if !value.starts_with('$') {
-                        return format!("{}{} [REDACTED]", indent, &trimmed[..sep_pos + 1]);
+                        return format!("{}{} \"[REDACTED]\"", indent, &trimmed[..sep_pos + 1]);
                     }
                 }
             }

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -213,7 +213,7 @@ pub async fn get_setup_agents(
     State(_state): State<AppState>,
 ) -> (StatusCode, Json<SetupAgentsResponse>) {
     // Discover available agents
-    match crate::config::setup::discover_available_agents() {
+    match crate::config::setup::discover_available_agents().await {
         Ok(agents) => {
             let agent_infos: Vec<DiscoveredAgentInfo> = agents
                 .into_iter()
@@ -267,7 +267,7 @@ pub async fn validate_setup(
     State(_state): State<AppState>,
     Json(request): Json<ValidateSetupRequest>,
 ) -> (StatusCode, Json<ValidateSetupResponse>) {
-    let checks = crate::config::setup::run_setup_checks(&request.setup);
+    let checks = crate::config::setup::run_setup_checks(&request.setup).await;
     let can_save = crate::config::setup::setup_can_save(&checks);
 
     let response = ValidateSetupResponse { checks, can_save };
@@ -302,7 +302,7 @@ pub async fn save_setup(
     let current = state.config_runtime.document_state.read().await.clone();
 
     // First validate the setup
-    let checks = crate::config::setup::run_setup_checks(&request.setup);
+    let checks = crate::config::setup::run_setup_checks(&request.setup).await;
     if !crate::config::setup::setup_can_save(&checks) {
         let mut response = ConfigStateResponse::from_state(&current);
         response.issues.push(ValidationIssue {
@@ -669,6 +669,8 @@ on_failure: Failed
                     role: "builder".to_string(),
                     acpx_agent: "claude".to_string(),
                     model: None,
+                    prompt: None,
+                    prompt_file: None,
                 }],
                 steps: vec![crate::config::setup::SetupStep {
                     name: "build".to_string(),
@@ -832,6 +834,8 @@ custom_root:
                     role: "builder".to_string(),
                     acpx_agent: "codex".to_string(),
                     model: Some("sonnet".to_string()),
+                    prompt: None,
+                    prompt_file: None,
                 }],
                 steps: vec![crate::config::setup::SetupStep {
                     name: "build".to_string(),

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -10,6 +10,33 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
+/// Redact literal secret values from YAML text.
+/// Preserves `$ENV_VAR` references (they're not actual secrets in the file).
+/// Patterns matched (case-insensitive, as YAML keys): api_key, token, password, secret.
+fn redact_secrets(yaml: &str) -> String {
+    let secret_keys = ["api_key", "token", "password", "secret"];
+    yaml.lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            let indent = &line[..line.len() - trimmed.len()];
+            let lower = trimmed.to_lowercase();
+            for &key in &secret_keys {
+                let prefix = format!("{key}:");
+                let prefix_eq = format!("{key}=");
+                if lower.starts_with(&prefix) || lower.starts_with(&prefix_eq) {
+                    let sep_pos = trimmed.find(':').or_else(|| trimmed.find('=')).unwrap();
+                    let value = trimmed[sep_pos + 1..].trim();
+                    if !value.starts_with('$') {
+                        return format!("{}{} [REDACTED]", indent, &trimmed[..sep_pos + 1]);
+                    }
+                }
+            }
+            line.to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Request to validate YAML content.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct ValidateYamlRequest {
@@ -45,7 +72,7 @@ impl ConfigStateResponse {
         Self {
             state: state_str.to_string(),
             config_path: state.path.display().to_string(),
-            raw_yaml: state.raw_yaml.clone(),
+            raw_yaml: state.raw_yaml.as_ref().map(|y| redact_secrets(y)),
             issues: state.validation.issues.clone(),
             active_config: state.active_config.clone(),
             guided_form,
@@ -112,20 +139,18 @@ pub async fn save_yaml(
     State(state): State<AppState>,
     Json(request): Json<SaveYamlRequest>,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
+    let mut doc_state = state.config_runtime.document_state.write().await;
+
     match save_raw_yaml_atomically(&state.config_runtime.config_path, &request.raw_yaml) {
         Ok(new_state) => {
-            // Update the runtime state
-            *state.config_runtime.document_state.write().await = new_state.clone();
+            *doc_state = new_state.clone();
             let response = ConfigStateResponse::from_state(&new_state);
             (StatusCode::OK, Json(response))
         }
-        Err(e) => {
-            let current = state.config_runtime.document_state.read().await.clone();
-            (
-                StatusCode::BAD_REQUEST,
-                Json(build_error_response(&current, &e)),
-            )
-        }
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(build_error_response(&doc_state, &e)),
+        ),
     }
 }
 
@@ -299,12 +324,12 @@ pub async fn save_setup(
     State(state): State<AppState>,
     Json(request): Json<SaveSetupRequest>,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
-    let current = state.config_runtime.document_state.read().await.clone();
+    let mut doc_state = state.config_runtime.document_state.write().await;
 
     // First validate the setup
     let checks = crate::config::setup::run_setup_checks(&request.setup).await;
     if !crate::config::setup::setup_can_save(&checks) {
-        let mut response = ConfigStateResponse::from_state(&current);
+        let mut response = ConfigStateResponse::from_state(&doc_state);
         response.issues.push(ValidationIssue {
             kind: crate::config::draft::ValidationIssueKind::Config,
             message: "Setup validation failed".to_string(),
@@ -316,14 +341,14 @@ pub async fn save_setup(
     }
 
     let artifacts = match crate::config::setup::merge_setup_request(
-        current.raw_yaml.as_deref(),
+        doc_state.raw_yaml.as_deref(),
         &request.setup,
     ) {
         Ok(artifacts) => artifacts,
         Err(e) => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(build_error_response(&current, &e)),
+                Json(build_error_response(&doc_state, &e)),
             )
         }
     };
@@ -338,19 +363,19 @@ pub async fn save_setup(
         Ok(()) => {
             match crate::config::draft::load_config_state(&state.config_runtime.config_path) {
                 Ok(new_state) => {
-                    *state.config_runtime.document_state.write().await = new_state.clone();
+                    *doc_state = new_state.clone();
                     let response = ConfigStateResponse::from_state(&new_state);
                     (StatusCode::OK, Json(response))
                 }
                 Err(e) => (
                     StatusCode::BAD_REQUEST,
-                    Json(build_error_response(&current, &e)),
+                    Json(build_error_response(&doc_state, &e)),
                 ),
             }
         }
         Err(e) => (
             StatusCode::BAD_REQUEST,
-            Json(build_error_response(&current, &e)),
+            Json(build_error_response(&doc_state, &e)),
         ),
     }
 }
@@ -531,13 +556,14 @@ pub async fn save_guided_form(
     State(state): State<AppState>,
     Json(request): Json<SaveGuidedFormRequest>,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
+    let mut doc_state = state.config_runtime.document_state.write().await;
+
     // First, merge the guided form with the base YAML
     let merged_yaml =
         match crate::config::form::apply_guided_form(&request.base_raw_yaml, &request.form) {
             Ok(yaml) => yaml,
             Err(e) => {
-                let current = state.config_runtime.document_state.read().await.clone();
-                let mut response = ConfigStateResponse::from_state(&current);
+                let mut response = ConfigStateResponse::from_state(&doc_state);
                 response.issues.push(crate::config::draft::ValidationIssue {
                     kind: crate::config::draft::ValidationIssueKind::Config,
                     message: format!("Form merge failed: {}", e),
@@ -555,18 +581,14 @@ pub async fn save_guided_form(
         &merged_yaml,
     ) {
         Ok(new_state) => {
-            // Update the runtime state
-            *state.config_runtime.document_state.write().await = new_state.clone();
+            *doc_state = new_state.clone();
             let response = ConfigStateResponse::from_state(&new_state);
             (StatusCode::OK, Json(response))
         }
-        Err(e) => {
-            let current = state.config_runtime.document_state.read().await.clone();
-            (
-                StatusCode::BAD_REQUEST,
-                Json(build_error_response(&current, &e)),
-            )
-        }
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(build_error_response(&doc_state, &e)),
+        ),
     }
 }
 
@@ -885,5 +907,45 @@ custom_root:
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(response.issues.iter().any(|issue| issue.section == "setup"));
+    }
+
+    #[test]
+    fn redact_secrets_redacts_literal_api_key() {
+        let yaml = "tracker:\n  kind: github\n  api_key: ghp_secret123";
+        let redacted = redact_secrets(yaml);
+        assert!(redacted.contains("[REDACTED]"));
+        assert!(!redacted.contains("ghp_secret123"));
+    }
+
+    #[test]
+    fn redact_secrets_preserves_env_var_reference() {
+        let yaml = "tracker:\n  api_key: $GITHUB_TOKEN";
+        let redacted = redact_secrets(yaml);
+        assert!(redacted.contains("$GITHUB_TOKEN"));
+        assert!(!redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_secrets_redacts_token_and_password() {
+        let yaml = "auth:\n  token: abc123\n  password: hunter2";
+        let redacted = redact_secrets(yaml);
+        assert!(!redacted.contains("abc123"));
+        assert!(!redacted.contains("hunter2"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_secrets_handles_equals_separator() {
+        let yaml = "secret: mysecretvalue";
+        let redacted = redact_secrets(yaml);
+        assert!(!redacted.contains("mysecretvalue"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_secrets_preserves_indentation() {
+        let yaml = "tracker:\n  api_key: ghp_secret";
+        let redacted = redact_secrets(yaml);
+        assert!(redacted.starts_with("tracker:\n  api_key:"));
     }
 }

--- a/crates/ensemble-core/src/api/fs_handler.rs
+++ b/crates/ensemble-core/src/api/fs_handler.rs
@@ -1,0 +1,440 @@
+use crate::api::handlers::ApiError;
+use crate::api::router::AppState;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Query parameters for the directory listing endpoint.
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    pub path: Option<String>,
+}
+
+/// A single entry in a directory listing response.
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct FsEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub path: String,
+}
+
+/// Response body for GET /api/v1/fs/list.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ListResponse {
+    pub entries: Vec<FsEntry>,
+    pub truncated: bool,
+}
+
+const MAX_ENTRIES: usize = 500;
+
+/// GET /api/v1/fs/list
+///
+/// Lists directory contents restricted to the user's home directory.
+/// Returns entries sorted with directories first, then files, alphabetically within each group.
+#[utoipa::path(
+    get,
+    path = "/api/v1/fs/list",
+    operation_id = "listDirectory",
+    params(
+        ("path" = String, Query, description = "Directory path to list")
+    ),
+    responses(
+        (status = 200, description = "Directory listing", body = ListResponse),
+        (status = 400, description = "Missing path parameter", body = ApiError),
+        (status = 403, description = "Path outside home directory", body = ApiError),
+        (status = 404, description = "Path does not exist", body = ApiError),
+        (status = 500, description = "I/O error", body = ApiError)
+    ),
+    tag = "filesystem"
+)]
+pub async fn list_directory(
+    State(_state): State<AppState>,
+    Query(query): Query<ListQuery>,
+) -> impl IntoResponse {
+    let path_str = match query.path {
+        Some(p) => p,
+        None => {
+            let error = ApiError::new("missing_parameter", "path parameter is required");
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::to_value(error).unwrap()),
+            )
+                .into_response();
+        }
+    };
+
+    let home_dir = match dirs::home_dir() {
+        Some(h) => h,
+        None => {
+            let error = ApiError::new("internal_error", "could not determine home directory");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::to_value(error).unwrap()),
+            )
+                .into_response();
+        }
+    };
+
+    let target = PathBuf::from(&path_str);
+
+    // Resolve symlinks for the target path itself
+    let canonical_target = if target.exists() {
+        match std::fs::canonicalize(&target) {
+            Ok(c) => c,
+            Err(e) => {
+                let error = ApiError::new("io_error", &format!("failed to resolve path: {e}"));
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::to_value(error).unwrap()),
+                )
+                    .into_response();
+            }
+        }
+    } else {
+        // Path doesn't exist — check if parent can be canonicalized
+        if let Some(parent) = target.parent() {
+            if parent.exists() {
+                // Path doesn't exist within a valid parent
+                let error = ApiError::new("not_found", "path does not exist");
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::to_value(error).unwrap()),
+                )
+                    .into_response();
+            }
+        }
+        let error = ApiError::new("not_found", "path does not exist");
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::to_value(error).unwrap()),
+        )
+            .into_response();
+    };
+
+    // Check that the canonical target is within home directory
+    let canonical_home = match std::fs::canonicalize(&home_dir) {
+        Ok(c) => c,
+        Err(e) => {
+            let error = ApiError::new(
+                "internal_error",
+                &format!("failed to resolve home directory: {e}"),
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::to_value(error).unwrap()),
+            )
+                .into_response();
+        }
+    };
+
+    if !canonical_target.starts_with(&canonical_home) {
+        let error = ApiError::new("forbidden", "path is outside the home directory");
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::to_value(error).unwrap()),
+        )
+            .into_response();
+    }
+
+    if !canonical_target.is_dir() {
+        let error = ApiError::new("not_found", "path is not a directory");
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::to_value(error).unwrap()),
+        )
+            .into_response();
+    }
+
+    // Read directory contents
+    let entries = match std::fs::read_dir(&canonical_target) {
+        Ok(rd) => rd,
+        Err(e) => {
+            let error = ApiError::new("io_error", &format!("failed to read directory: {e}"));
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::to_value(error).unwrap()),
+            )
+                .into_response();
+        }
+    };
+
+    let mut dirs: Vec<FsEntry> = Vec::new();
+    let mut files: Vec<FsEntry> = Vec::new();
+
+    for entry_result in entries {
+        let entry = match entry_result {
+            Ok(e) => e,
+            Err(e) => {
+                let error =
+                    ApiError::new("io_error", &format!("failed to read directory entry: {e}"));
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::to_value(error).unwrap()),
+                )
+                    .into_response();
+            }
+        };
+
+        let entry_path = entry.path();
+
+        // Resolve symlinks and check if the resolved path is within home
+        let canonical_entry = match std::fs::canonicalize(&entry_path) {
+            Ok(c) => c,
+            Err(_) => continue, // Skip entries we can't canonicalize
+        };
+
+        if !canonical_entry.starts_with(&canonical_home) {
+            // Symlink escapes home — exclude from results
+            continue;
+        }
+
+        let is_dir = canonical_entry.is_dir();
+        let name = entry.file_name().to_string_lossy().to_string();
+        let path = entry_path.to_string_lossy().to_string();
+
+        let fs_entry = FsEntry { name, is_dir, path };
+
+        if is_dir {
+            dirs.push(fs_entry);
+        } else {
+            files.push(fs_entry);
+        }
+    }
+
+    // Sort alphabetically within each group
+    dirs.sort_by(|a, b| a.name.cmp(&b.name));
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut all_entries = dirs;
+    all_entries.extend(files);
+
+    let truncated = all_entries.len() > MAX_ENTRIES;
+    all_entries.truncate(MAX_ENTRIES);
+
+    let response = ListResponse {
+        entries: all_entries,
+        truncated,
+    };
+
+    (StatusCode::OK, Json(response)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::router::{AppState, ConfigRuntime};
+    use crate::config::draft::{ConfigDocumentState, ConfigStateKind, DraftValidationReport};
+    use crate::observability::events::EventBus;
+    use crate::orchestrator::state::OrchestratorState;
+    use axum::body::to_bytes;
+    use axum::response::IntoResponse;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn test_app_state() -> AppState {
+        let state = OrchestratorState::new(30000, 10);
+        let config_path = PathBuf::from("ensemble.yaml");
+        let document_state = Arc::new(RwLock::new(ConfigDocumentState {
+            path: config_path.clone(),
+            kind: ConfigStateKind::Parsed,
+            raw_yaml: None,
+            document: None,
+            active_config: None,
+            validation: DraftValidationReport::default(),
+        }));
+
+        AppState {
+            orchestrator_state: Arc::new(RwLock::new(state)),
+            refresh_requested: Arc::new(tokio::sync::Notify::new()),
+            workspace_root: "/tmp/workspaces".to_string(),
+            history_path: PathBuf::from("/tmp/history.jsonl"),
+            event_bus: EventBus::new(),
+            config_runtime: ConfigRuntime {
+                config_path,
+                document_state,
+            },
+        }
+    }
+
+    async fn call_and_extract(response: impl IntoResponse) -> (StatusCode, serde_json::Value) {
+        let response = response.into_response();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        (status, json)
+    }
+
+    fn test_home_base() -> PathBuf {
+        let home = dirs::home_dir().expect("home dir required");
+        home.join(".ensemble_fs_test")
+    }
+
+    struct TestHomeCleanup(PathBuf);
+
+    impl Drop for TestHomeCleanup {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn setup_test_home(name: &str) -> (PathBuf, TestHomeCleanup) {
+        let base = test_home_base();
+        let dir = base.join(name);
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let cleanup = TestHomeCleanup(dir.clone());
+        (dir, cleanup)
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_valid_path() {
+        let (home_dir, _cleanup) = setup_test_home("valid_path");
+        std::fs::create_dir_all(home_dir.join("subdir_a")).unwrap();
+        std::fs::create_dir_all(home_dir.join("subdir_b")).unwrap();
+        std::fs::write(home_dir.join("file_b.txt"), "content").unwrap();
+        std::fs::write(home_dir.join("file_a.txt"), "content").unwrap();
+
+        let app_state = test_app_state();
+        let query = ListQuery {
+            path: Some(home_dir.to_string_lossy().to_string()),
+        };
+
+        let response = list_directory(State(app_state), Query(query)).await;
+        let (status, body) = call_and_extract(response).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.get("entries").is_some());
+        assert!(!body["truncated"].as_bool().unwrap());
+
+        let entries: Vec<FsEntry> = serde_json::from_value(body["entries"].clone()).unwrap();
+        assert_eq!(entries.len(), 4);
+
+        assert_eq!(entries[0].name, "subdir_a");
+        assert!(entries[0].is_dir);
+        assert_eq!(entries[1].name, "subdir_b");
+        assert!(entries[1].is_dir);
+        assert_eq!(entries[2].name, "file_a.txt");
+        assert!(!entries[2].is_dir);
+        assert_eq!(entries[3].name, "file_b.txt");
+        assert!(!entries[3].is_dir);
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_path_outside_home() {
+        let app_state = test_app_state();
+        let query = ListQuery {
+            path: Some("/usr/bin".to_string()),
+        };
+
+        let response = list_directory(State(app_state), Query(query)).await;
+        let (status, body) = call_and_extract(response).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["error"]["code"], "forbidden");
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_nonexistent_path() {
+        let (home_dir, _cleanup) = setup_test_home("nonexistent");
+
+        let app_state = test_app_state();
+        let query = ListQuery {
+            path: Some(
+                home_dir
+                    .join("does_not_exist")
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+        };
+
+        let response = list_directory(State(app_state), Query(query)).await;
+        let (status, body) = call_and_extract(response).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["error"]["code"], "not_found");
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_missing_path() {
+        let app_state = test_app_state();
+        let query = ListQuery { path: None };
+
+        let response = list_directory(State(app_state), Query(query)).await;
+        let (status, body) = call_and_extract(response).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "missing_parameter");
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_symlink_escape() {
+        let (home_dir, _cleanup) = setup_test_home("symlink_escape");
+
+        let outside = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(outside.path().join("outside_dir")).unwrap();
+
+        std::os::unix::fs::symlink(
+            outside.path().join("outside_dir"),
+            home_dir.join("escape_link"),
+        )
+        .unwrap();
+
+        std::fs::create_dir_all(home_dir.join("normal_dir")).unwrap();
+
+        let app_state = test_app_state();
+        let query = ListQuery {
+            path: Some(home_dir.to_string_lossy().to_string()),
+        };
+
+        let response = list_directory(State(app_state), Query(query)).await;
+        let (status, body) = call_and_extract(response).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let entries: Vec<FsEntry> = serde_json::from_value(body["entries"].clone()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "normal_dir");
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_truncation() {
+        let (home_dir, _cleanup) = setup_test_home("truncation");
+
+        for i in 0..600 {
+            std::fs::write(home_dir.join(format!("file_{i:04}.txt")), "content").unwrap();
+        }
+
+        let app_state = test_app_state();
+        let query = ListQuery {
+            path: Some(home_dir.to_string_lossy().to_string()),
+        };
+
+        let response = list_directory(State(app_state), Query(query)).await;
+        let (status, body) = call_and_extract(response).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let entries: Vec<FsEntry> = serde_json::from_value(body["entries"].clone()).unwrap();
+        let truncated = body["truncated"].as_bool().unwrap();
+
+        assert_eq!(entries.len(), MAX_ENTRIES);
+        assert!(truncated);
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_empty() {
+        let (home_dir, _cleanup) = setup_test_home("empty");
+
+        let app_state = test_app_state();
+        let query = ListQuery {
+            path: Some(home_dir.to_string_lossy().to_string()),
+        };
+
+        let response = list_directory(State(app_state), Query(query)).await;
+        let (status, body) = call_and_extract(response).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let entries: Vec<FsEntry> = serde_json::from_value(body["entries"].clone()).unwrap();
+        let truncated = body["truncated"].as_bool().unwrap();
+
+        assert!(entries.is_empty());
+        assert!(!truncated);
+    }
+}

--- a/crates/ensemble-core/src/api/fs_handler.rs
+++ b/crates/ensemble-core/src/api/fs_handler.rs
@@ -80,48 +80,127 @@ pub async fn list_directory(
 
     let target = PathBuf::from(&path_str);
 
-    // Resolve symlinks for the target path itself
-    let canonical_target = if target.exists() {
-        match std::fs::canonicalize(&target) {
-            Ok(c) => c,
-            Err(e) => {
-                let error = ApiError::new("io_error", &format!("failed to resolve path: {e}"));
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::to_value(error).unwrap()),
-                )
-                    .into_response();
-            }
-        }
-    } else {
-        // Path doesn't exist — check if parent can be canonicalized
-        if let Some(parent) = target.parent() {
-            if parent.exists() {
-                // Path doesn't exist within a valid parent
-                let error = ApiError::new("not_found", "path does not exist");
-                return (
+    // Wrap all blocking I/O in spawn_blocking
+    let result =
+        tokio::task::spawn_blocking(move || -> Result<Vec<FsEntry>, (StatusCode, ApiError)> {
+            // Resolve symlinks for the target path itself
+            let canonical_target = if target.exists() {
+                match std::fs::canonicalize(&target) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return Err((
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            ApiError::new("io_error", &format!("failed to resolve path: {e}")),
+                        ));
+                    }
+                }
+            } else {
+                return Err((
                     StatusCode::NOT_FOUND,
-                    Json(serde_json::to_value(error).unwrap()),
-                )
-                    .into_response();
-            }
-        }
-        let error = ApiError::new("not_found", "path does not exist");
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::to_value(error).unwrap()),
-        )
-            .into_response();
-    };
+                    ApiError::new("not_found", "path does not exist"),
+                ));
+            };
 
-    // Check that the canonical target is within home directory
-    let canonical_home = match std::fs::canonicalize(&home_dir) {
-        Ok(c) => c,
+            // Check that the canonical target is within home directory
+            let canonical_home = match std::fs::canonicalize(&home_dir) {
+                Ok(c) => c,
+                Err(e) => {
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        ApiError::new(
+                            "internal_error",
+                            &format!("failed to resolve home directory: {e}"),
+                        ),
+                    ));
+                }
+            };
+
+            if !canonical_target.starts_with(&canonical_home) {
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    ApiError::new("forbidden", "path is outside the home directory"),
+                ));
+            }
+
+            if !canonical_target.is_dir() {
+                return Err((
+                    StatusCode::NOT_FOUND,
+                    ApiError::new("not_found", "path is not a directory"),
+                ));
+            }
+
+            // Read directory contents
+            let entries = match std::fs::read_dir(&canonical_target) {
+                Ok(rd) => rd,
+                Err(e) => {
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        ApiError::new("io_error", &format!("failed to read directory: {e}")),
+                    ));
+                }
+            };
+
+            let mut dirs: Vec<FsEntry> = Vec::new();
+            let mut files: Vec<FsEntry> = Vec::new();
+
+            for entry_result in entries {
+                let entry = match entry_result {
+                    Ok(e) => e,
+                    Err(e) => {
+                        return Err((
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            ApiError::new(
+                                "io_error",
+                                &format!("failed to read directory entry: {e}"),
+                            ),
+                        ));
+                    }
+                };
+
+                let entry_path = entry.path();
+
+                // Resolve symlinks and check if the resolved path is within home
+                let canonical_entry = match std::fs::canonicalize(&entry_path) {
+                    Ok(c) => c,
+                    Err(_) => continue, // Skip entries we can't canonicalize
+                };
+
+                if !canonical_entry.starts_with(&canonical_home) {
+                    // Symlink escapes home — exclude from results
+                    continue;
+                }
+
+                let is_dir = canonical_entry.is_dir();
+                let name = entry.file_name().to_string_lossy().to_string();
+                let path = entry_path.to_string_lossy().to_string();
+
+                let fs_entry = FsEntry { name, is_dir, path };
+
+                if is_dir {
+                    dirs.push(fs_entry);
+                } else {
+                    files.push(fs_entry);
+                }
+            }
+
+            // Sort alphabetically within each group
+            dirs.sort_by(|a, b| a.name.cmp(&b.name));
+            files.sort_by(|a, b| a.name.cmp(&b.name));
+
+            let mut all_entries = dirs;
+            all_entries.extend(files);
+
+            Ok(all_entries)
+        })
+        .await;
+
+    let mut all_entries = match result {
+        Ok(Ok(entries)) => entries,
+        Ok(Err((status, error))) => {
+            return (status, Json(serde_json::to_value(error).unwrap())).into_response();
+        }
         Err(e) => {
-            let error = ApiError::new(
-                "internal_error",
-                &format!("failed to resolve home directory: {e}"),
-            );
+            let error = ApiError::new("internal_error", &format!("task join error: {e}"));
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::to_value(error).unwrap()),
@@ -129,87 +208,6 @@ pub async fn list_directory(
                 .into_response();
         }
     };
-
-    if !canonical_target.starts_with(&canonical_home) {
-        let error = ApiError::new("forbidden", "path is outside the home directory");
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::to_value(error).unwrap()),
-        )
-            .into_response();
-    }
-
-    if !canonical_target.is_dir() {
-        let error = ApiError::new("not_found", "path is not a directory");
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::to_value(error).unwrap()),
-        )
-            .into_response();
-    }
-
-    // Read directory contents
-    let entries = match std::fs::read_dir(&canonical_target) {
-        Ok(rd) => rd,
-        Err(e) => {
-            let error = ApiError::new("io_error", &format!("failed to read directory: {e}"));
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::to_value(error).unwrap()),
-            )
-                .into_response();
-        }
-    };
-
-    let mut dirs: Vec<FsEntry> = Vec::new();
-    let mut files: Vec<FsEntry> = Vec::new();
-
-    for entry_result in entries {
-        let entry = match entry_result {
-            Ok(e) => e,
-            Err(e) => {
-                let error =
-                    ApiError::new("io_error", &format!("failed to read directory entry: {e}"));
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::to_value(error).unwrap()),
-                )
-                    .into_response();
-            }
-        };
-
-        let entry_path = entry.path();
-
-        // Resolve symlinks and check if the resolved path is within home
-        let canonical_entry = match std::fs::canonicalize(&entry_path) {
-            Ok(c) => c,
-            Err(_) => continue, // Skip entries we can't canonicalize
-        };
-
-        if !canonical_entry.starts_with(&canonical_home) {
-            // Symlink escapes home — exclude from results
-            continue;
-        }
-
-        let is_dir = canonical_entry.is_dir();
-        let name = entry.file_name().to_string_lossy().to_string();
-        let path = entry_path.to_string_lossy().to_string();
-
-        let fs_entry = FsEntry { name, is_dir, path };
-
-        if is_dir {
-            dirs.push(fs_entry);
-        } else {
-            files.push(fs_entry);
-        }
-    }
-
-    // Sort alphabetically within each group
-    dirs.sort_by(|a, b| a.name.cmp(&b.name));
-    files.sort_by(|a, b| a.name.cmp(&b.name));
-
-    let mut all_entries = dirs;
-    all_entries.extend(files);
 
     let truncated = all_entries.len() > MAX_ENTRIES;
     all_entries.truncate(MAX_ENTRIES);

--- a/crates/ensemble-core/src/api/fs_handler.rs
+++ b/crates/ensemble-core/src/api/fs_handler.rs
@@ -78,27 +78,50 @@ pub async fn list_directory(
         }
     };
 
-    let target = PathBuf::from(&path_str);
+    let response = list_directory_inner(path_str, home_dir).await;
+    response.into_response()
+}
 
-    // Wrap all blocking I/O in spawn_blocking
+async fn list_directory_inner(
+    path_str: String,
+    home_dir: PathBuf,
+) -> (StatusCode, Json<serde_json::Value>) {
     let result =
         tokio::task::spawn_blocking(move || -> Result<Vec<FsEntry>, (StatusCode, ApiError)> {
-            // Resolve symlinks for the target path itself
-            let canonical_target = if target.exists() {
-                match std::fs::canonicalize(&target) {
-                    Ok(c) => c,
-                    Err(e) => {
+            // Expand ~ to home directory
+            let expanded = shellexpand::tilde(&path_str);
+            let target = PathBuf::from(expanded.as_ref());
+
+            // Resolve symlinks — canonicalize returns Err if path doesn't exist
+            let canonical_target = match std::fs::canonicalize(&target) {
+                Ok(c) => c,
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::NotFound {
                         return Err((
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            ApiError::new("io_error", &format!("failed to resolve path: {e}")),
+                            StatusCode::NOT_FOUND,
+                            ApiError::new("not_found", "path does not exist"),
+                        ));
+                    }
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        ApiError::new("io_error", &format!("failed to resolve path: {e}")),
+                    ));
+                }
+            };
+
+            // If target resolved to a file, use its parent directory
+            let canonical_target = if canonical_target.is_file() {
+                match canonical_target.parent() {
+                    Some(parent) => parent.to_path_buf(),
+                    None => {
+                        return Err((
+                            StatusCode::BAD_REQUEST,
+                            ApiError::new("bad_request", "file path has no parent directory"),
                         ));
                     }
                 }
             } else {
-                return Err((
-                    StatusCode::NOT_FOUND,
-                    ApiError::new("not_found", "path does not exist"),
-                ));
+                canonical_target
             };
 
             // Check that the canonical target is within home directory
@@ -197,15 +220,14 @@ pub async fn list_directory(
     let mut all_entries = match result {
         Ok(Ok(entries)) => entries,
         Ok(Err((status, error))) => {
-            return (status, Json(serde_json::to_value(error).unwrap())).into_response();
+            return (status, Json(serde_json::to_value(error).unwrap()));
         }
         Err(e) => {
             let error = ApiError::new("internal_error", &format!("task join error: {e}"));
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::to_value(error).unwrap()),
-            )
-                .into_response();
+            );
         }
     };
 
@@ -217,91 +239,33 @@ pub async fn list_directory(
         truncated,
     };
 
-    (StatusCode::OK, Json(response)).into_response()
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(response).unwrap()),
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::router::{AppState, ConfigRuntime};
-    use crate::config::draft::{ConfigDocumentState, ConfigStateKind, DraftValidationReport};
-    use crate::observability::events::EventBus;
-    use crate::orchestrator::state::OrchestratorState;
-    use axum::body::to_bytes;
-    use axum::response::IntoResponse;
-    use std::sync::Arc;
-    use tokio::sync::RwLock;
+    use axum::http::StatusCode;
 
-    fn test_app_state() -> AppState {
-        let state = OrchestratorState::new(30000, 10);
-        let config_path = PathBuf::from("ensemble.yaml");
-        let document_state = Arc::new(RwLock::new(ConfigDocumentState {
-            path: config_path.clone(),
-            kind: ConfigStateKind::Parsed,
-            raw_yaml: None,
-            document: None,
-            active_config: None,
-            validation: DraftValidationReport::default(),
-        }));
-
-        AppState {
-            orchestrator_state: Arc::new(RwLock::new(state)),
-            refresh_requested: Arc::new(tokio::sync::Notify::new()),
-            workspace_root: "/tmp/workspaces".to_string(),
-            history_path: PathBuf::from("/tmp/history.jsonl"),
-            event_bus: EventBus::new(),
-            config_runtime: ConfigRuntime {
-                config_path,
-                document_state,
-            },
-        }
-    }
-
-    async fn call_and_extract(response: impl IntoResponse) -> (StatusCode, serde_json::Value) {
-        let response = response.into_response();
-        let status = response.status();
-        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        (status, json)
-    }
-
-    fn test_home_base() -> PathBuf {
-        let home = dirs::home_dir().expect("home dir required");
-        home.join(".ensemble_fs_test")
-    }
-
-    struct TestHomeCleanup(PathBuf);
-
-    impl Drop for TestHomeCleanup {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
-
-    fn setup_test_home(name: &str) -> (PathBuf, TestHomeCleanup) {
-        let base = test_home_base();
-        let dir = base.join(name);
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        let cleanup = TestHomeCleanup(dir.clone());
-        (dir, cleanup)
+    async fn call_list(path: Option<&str>, home: &PathBuf) -> (StatusCode, serde_json::Value) {
+        let path_str = path.unwrap_or("").to_string();
+        let (status, Json(body)) = list_directory_inner(path_str, home.clone()).await;
+        (status, body)
     }
 
     #[tokio::test]
     async fn test_list_directory_valid_path() {
-        let (home_dir, _cleanup) = setup_test_home("valid_path");
-        std::fs::create_dir_all(home_dir.join("subdir_a")).unwrap();
-        std::fs::create_dir_all(home_dir.join("subdir_b")).unwrap();
-        std::fs::write(home_dir.join("file_b.txt"), "content").unwrap();
-        std::fs::write(home_dir.join("file_a.txt"), "content").unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        std::fs::create_dir_all(home.join("subdir_a")).unwrap();
+        std::fs::create_dir_all(home.join("subdir_b")).unwrap();
+        std::fs::write(home.join("file_b.txt"), "content").unwrap();
+        std::fs::write(home.join("file_a.txt"), "content").unwrap();
 
-        let app_state = test_app_state();
-        let query = ListQuery {
-            path: Some(home_dir.to_string_lossy().to_string()),
-        };
-
-        let response = list_directory(State(app_state), Query(query)).await;
-        let (status, body) = call_and_extract(response).await;
+        let (status, body) = call_list(Some(home.to_str().unwrap()), &home).await;
         assert_eq!(status, StatusCode::OK);
         assert!(body.get("entries").is_some());
         assert!(!body["truncated"].as_bool().unwrap());
@@ -321,70 +285,39 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_directory_path_outside_home() {
-        let app_state = test_app_state();
-        let query = ListQuery {
-            path: Some("/usr/bin".to_string()),
-        };
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
 
-        let response = list_directory(State(app_state), Query(query)).await;
-        let (status, body) = call_and_extract(response).await;
+        let (status, body) = call_list(Some("/usr/bin"), &home).await;
         assert_eq!(status, StatusCode::FORBIDDEN);
         assert_eq!(body["error"]["code"], "forbidden");
     }
 
     #[tokio::test]
     async fn test_list_directory_nonexistent_path() {
-        let (home_dir, _cleanup) = setup_test_home("nonexistent");
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
 
-        let app_state = test_app_state();
-        let query = ListQuery {
-            path: Some(
-                home_dir
-                    .join("does_not_exist")
-                    .to_string_lossy()
-                    .to_string(),
-            ),
-        };
-
-        let response = list_directory(State(app_state), Query(query)).await;
-        let (status, body) = call_and_extract(response).await;
+        let nonexistent = home.join("does_not_exist");
+        let (status, body) = call_list(nonexistent.to_str(), &home).await;
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(body["error"]["code"], "not_found");
     }
 
     #[tokio::test]
-    async fn test_list_directory_missing_path() {
-        let app_state = test_app_state();
-        let query = ListQuery { path: None };
-
-        let response = list_directory(State(app_state), Query(query)).await;
-        let (status, body) = call_and_extract(response).await;
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert_eq!(body["error"]["code"], "missing_parameter");
-    }
-
-    #[tokio::test]
     async fn test_list_directory_symlink_escape() {
-        let (home_dir, _cleanup) = setup_test_home("symlink_escape");
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
 
         let outside = tempfile::TempDir::new().unwrap();
         std::fs::create_dir_all(outside.path().join("outside_dir")).unwrap();
 
-        std::os::unix::fs::symlink(
-            outside.path().join("outside_dir"),
-            home_dir.join("escape_link"),
-        )
-        .unwrap();
+        std::os::unix::fs::symlink(outside.path().join("outside_dir"), home.join("escape_link"))
+            .unwrap();
 
-        std::fs::create_dir_all(home_dir.join("normal_dir")).unwrap();
+        std::fs::create_dir_all(home.join("normal_dir")).unwrap();
 
-        let app_state = test_app_state();
-        let query = ListQuery {
-            path: Some(home_dir.to_string_lossy().to_string()),
-        };
-
-        let response = list_directory(State(app_state), Query(query)).await;
-        let (status, body) = call_and_extract(response).await;
+        let (status, body) = call_list(Some(home.to_str().unwrap()), &home).await;
         assert_eq!(status, StatusCode::OK);
 
         let entries: Vec<FsEntry> = serde_json::from_value(body["entries"].clone()).unwrap();
@@ -394,19 +327,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_directory_truncation() {
-        let (home_dir, _cleanup) = setup_test_home("truncation");
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
 
         for i in 0..600 {
-            std::fs::write(home_dir.join(format!("file_{i:04}.txt")), "content").unwrap();
+            std::fs::write(home.join(format!("file_{i:04}.txt")), "content").unwrap();
         }
 
-        let app_state = test_app_state();
-        let query = ListQuery {
-            path: Some(home_dir.to_string_lossy().to_string()),
-        };
-
-        let response = list_directory(State(app_state), Query(query)).await;
-        let (status, body) = call_and_extract(response).await;
+        let (status, body) = call_list(Some(home.to_str().unwrap()), &home).await;
         assert_eq!(status, StatusCode::OK);
 
         let entries: Vec<FsEntry> = serde_json::from_value(body["entries"].clone()).unwrap();
@@ -418,15 +346,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_directory_empty() {
-        let (home_dir, _cleanup) = setup_test_home("empty");
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
 
-        let app_state = test_app_state();
-        let query = ListQuery {
-            path: Some(home_dir.to_string_lossy().to_string()),
-        };
-
-        let response = list_directory(State(app_state), Query(query)).await;
-        let (status, body) = call_and_extract(response).await;
+        let (status, body) = call_list(Some(home.to_str().unwrap()), &home).await;
         assert_eq!(status, StatusCode::OK);
 
         let entries: Vec<FsEntry> = serde_json::from_value(body["entries"].clone()).unwrap();
@@ -434,5 +357,37 @@ mod tests {
 
         assert!(entries.is_empty());
         assert!(!truncated);
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_lists_visible_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        std::fs::write(home.join("visible.txt"), "content").unwrap();
+
+        let (status, body) = call_list(Some(home.to_str().unwrap()), &home).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let entries: Vec<FsEntry> = serde_json::from_value(body["entries"].clone()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "visible.txt");
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_uses_parent_for_file_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        std::fs::write(home.join("target_file.txt"), "content").unwrap();
+        std::fs::write(home.join("sibling.txt"), "content").unwrap();
+
+        let file_path = home.join("target_file.txt");
+        let (status, body) = call_list(file_path.to_str(), &home).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let entries: Vec<FsEntry> = serde_json::from_value(body["entries"].clone()).unwrap();
+        assert_eq!(entries.len(), 2);
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"target_file.txt"));
+        assert!(names.contains(&"sibling.txt"));
     }
 }

--- a/crates/ensemble-core/src/api/mod.rs
+++ b/crates/ensemble-core/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod config_edit_handler;
 pub mod config_handler;
 pub mod controls;
 pub mod conversation;
+pub mod fs_handler;
 pub mod handlers;
 pub mod history_handler;
 pub mod openapi;

--- a/crates/ensemble-core/src/api/openapi.rs
+++ b/crates/ensemble-core/src/api/openapi.rs
@@ -25,6 +25,7 @@ use utoipa::OpenApi;
         crate::api::conversation::get_conversation_message,
         crate::api::controls::post_stop,
         crate::api::controls::post_retry,
+        crate::api::fs_handler::list_directory,
     ),
     components(schemas(
         // Snapshot types
@@ -98,6 +99,9 @@ use utoipa::OpenApi;
         // Conversation types
         crate::api::conversation::ConversationResponse,
         crate::api::conversation::ConversationMessage,
+        // Filesystem types
+        crate::api::fs_handler::ListResponse,
+        crate::api::fs_handler::FsEntry,
     )),
     tags(
         (name = "state", description = "Runtime state"),
@@ -106,6 +110,7 @@ use utoipa::OpenApi;
         (name = "history", description = "Completion history"),
         (name = "config", description = "Configuration"),
         (name = "conversation", description = "Agent conversation logs"),
+        (name = "filesystem", description = "File browser"),
     )
 )]
 pub struct ApiDoc;

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -1,5 +1,6 @@
 use crate::api::{
-    config_edit_handler, config_handler, controls, conversation, handlers, history_handler, ws,
+    config_edit_handler, config_handler, controls, conversation, fs_handler, handlers,
+    history_handler, ws,
 };
 use crate::config::draft::ConfigDocumentState;
 use crate::observability::events::EventBus;
@@ -70,6 +71,7 @@ pub fn create_api_router(state: AppState) -> Router {
                 .patch(handlers::method_not_allowed),
         )
         .route("/history", get(history_handler::get_history))
+        .route("/fs/list", get(fs_handler::list_directory))
         .route("/config", get(config_handler::get_config))
         // Config YAML endpoints
         .route(

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -80,7 +80,7 @@ pub fn parse_raw_yaml(path: PathBuf, raw_yaml: String) -> ConfigDocumentState {
                 Ok(mut config) => {
                     let mut report = validate_document(&document);
                     let mut config_valid = true;
-                    if let Err(e) = config.resolve_env_from(config_dir) {
+                    if let Err(e) = config.resolve_env_from(config_dir, &Default::default()) {
                         report.issues.push(config_error_to_validation_issue(e));
                         config_valid = false;
                     }

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -49,7 +49,7 @@ fn default_max_cycles() -> u32 {
 }
 
 /// Tracker configuration: which issue tracker to use and how to connect to it.
-#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+#[derive(Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct TrackerConfig {
     pub kind: String,
     #[serde(default = "default_active_states")]
@@ -73,6 +73,22 @@ fn default_active_states() -> Vec<String> {
 
 fn default_terminal_states() -> Vec<String> {
     vec!["Done".to_string(), "Closed".to_string()]
+}
+
+impl std::fmt::Debug for TrackerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrackerConfig")
+            .field("kind", &self.kind)
+            .field("active_states", &self.active_states)
+            .field("terminal_states", &self.terminal_states)
+            .field("path", &self.path)
+            .field("endpoint", &self.endpoint)
+            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .field("repository", &self.repository)
+            .field("project_number", &self.project_number)
+            .field("labels_filter", &self.labels_filter)
+            .finish()
+    }
 }
 
 /// Per-agent definition: which executor to use and what prompt to send.
@@ -253,31 +269,36 @@ impl Default for AgentRuntimeConfig {
 /// Resolve `$VAR_NAME` in a string value to its environment variable.
 /// Returns the literal string if it doesn't start with `$`.
 /// Returns None if the env var is empty or unset.
-fn resolve_env_var(value: &str) -> Option<String> {
+/// Falls back to `dotenv_map` when the env var is not in the process environment.
+fn resolve_env_var(value: &str, dotenv_map: &HashMap<String, String>) -> Option<String> {
     if let Some(var_name) = value.strip_prefix('$') {
         match std::env::var(var_name) {
             Ok(v) if !v.is_empty() => Some(v),
-            _ => None,
+            _ => dotenv_map.get(var_name).filter(|v| !v.is_empty()).cloned(),
         }
     } else {
         Some(value.to_string())
     }
 }
 
-/// Expand `~` to home directory in a path string.
-fn expand_tilde(path_str: &str) -> PathBuf {
-    if let Some(rest) = path_str.strip_prefix('~') {
-        if let Ok(home) = std::env::var("HOME") {
-            return PathBuf::from(home).join(rest.strip_prefix('/').unwrap_or(rest));
-        }
-    }
-    PathBuf::from(path_str)
-}
-
 /// Resolve a path string: expand `$VAR` then `~`.
 /// Returns `None` if the path references an unset/empty env var.
-fn resolve_path(path_str: &str) -> Option<PathBuf> {
-    resolve_env_var(path_str).map(|resolved| expand_tilde(&resolved))
+fn resolve_path(path_str: &str, dotenv_map: &HashMap<String, String>) -> Option<PathBuf> {
+    resolve_env_var(path_str, dotenv_map)
+        .map(|resolved| PathBuf::from(shellexpand::tilde(&resolved).as_ref()))
+}
+
+/// Read a `.env` file into a local map without mutating the process environment.
+/// Best-effort: returns an empty map on any error.
+fn read_dotenv(path: &Path) -> HashMap<String, String> {
+    dotenvy::from_path_iter(path)
+        .ok()
+        .map(|iter| {
+            iter.filter_map(Result::ok)
+                .filter(|(_, value)| !value.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 impl EnsembleConfig {
@@ -289,9 +310,8 @@ impl EnsembleConfig {
     /// - `workspace.root`
     /// - `agents.*.prompt_template`
     /// - `repos[*].path`
-    pub fn resolve_env(&mut self) {
-        self.resolve_env_from(Path::new("."))
-            .expect("CWD should always be available");
+    pub fn resolve_env(&mut self) -> Result<(), crate::error::ConfigError> {
+        self.resolve_env_from(Path::new("."), &HashMap::new())
     }
 
     /// Resolve environment variables and rebase relative paths from the config directory.
@@ -300,13 +320,17 @@ impl EnsembleConfig {
     /// 1. Resolves `$VAR` and `~` in all path fields
     /// 2. Rebase relative paths to be relative to the config directory
     /// 3. Sets default TODO path for todo_file tracker if not specified
-    pub fn resolve_env_from(&mut self, config_dir: &Path) -> Result<(), crate::error::ConfigError> {
+    pub fn resolve_env_from(
+        &mut self,
+        config_dir: &Path,
+        dotenv_map: &HashMap<String, String>,
+    ) -> Result<(), crate::error::ConfigError> {
         // tracker.api_key: $VAR resolution
         if let Some(ref raw) = self.tracker.api_key {
-            self.tracker.api_key = resolve_env_var(raw);
-        } else {
-            // Try canonical env var
-            self.tracker.api_key = resolve_env_var("$GITHUB_TOKEN");
+            self.tracker.api_key = resolve_env_var(raw, dotenv_map);
+        } else if self.tracker.kind == "github" {
+            // Only auto-resolve $GITHUB_TOKEN for github tracker
+            self.tracker.api_key = resolve_env_var("$GITHUB_TOKEN", dotenv_map);
         }
 
         // tracker.path: $VAR + ~ expansion, with default for todo_file
@@ -316,7 +340,7 @@ impl EnsembleConfig {
 
         if let Some(ref path) = self.tracker.path {
             let path_str = path.to_string_lossy();
-            let resolved = resolve_path(&path_str);
+            let resolved = resolve_path(&path_str, dotenv_map);
             self.tracker.path = resolved.map(|p| {
                 if p.is_absolute() {
                     p
@@ -328,7 +352,7 @@ impl EnsembleConfig {
 
         // workspace.root: $VAR + ~ expansion + rebase
         if let Some(ref root) = self.workspace.root {
-            let resolved = resolve_path(root);
+            let resolved = resolve_path(root, dotenv_map);
             self.workspace.root = resolved.map(|p| {
                 let final_path = if p.is_absolute() {
                     p
@@ -342,7 +366,7 @@ impl EnsembleConfig {
         // repos[*].path: $VAR + ~ expansion + rebase
         for repo in &mut self.repos {
             let path_str = &repo.path;
-            if let Some(resolved) = resolve_path(path_str) {
+            if let Some(resolved) = resolve_path(path_str, dotenv_map) {
                 let final_path = if resolved.is_absolute() {
                     resolved
                 } else {
@@ -356,7 +380,7 @@ impl EnsembleConfig {
         for agent in self.agents.values_mut() {
             if let Some(ref path) = agent.prompt_template {
                 let path_str = path.to_string_lossy();
-                let resolved = resolve_path(&path_str);
+                let resolved = resolve_path(&path_str, dotenv_map);
                 agent.prompt_template = resolved.map(|p| {
                     if p.is_absolute() {
                         p
@@ -379,12 +403,7 @@ impl EnsembleConfig {
 /// 3. Resolves environment variables and rebases relative paths from the config directory
 pub fn load_config(path: &std::path::Path) -> Result<EnsembleConfig, crate::error::ConfigError> {
     let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
-
-    // Load .env from config directory (best-effort, don't fail if missing)
-    let env_path = config_dir.join(".env");
-    if env_path.exists() {
-        let _ = dotenvy::from_path(&env_path);
-    }
+    let dotenv_map = read_dotenv(&config_dir.join(".env"));
 
     let content = std::fs::read_to_string(path).map_err(|_| {
         crate::error::ConfigError::MissingConfigFile {
@@ -392,7 +411,7 @@ pub fn load_config(path: &std::path::Path) -> Result<EnsembleConfig, crate::erro
         }
     })?;
     let mut config = parse_config(&content)?;
-    config.resolve_env_from(config_dir)?;
+    config.resolve_env_from(config_dir, &dotenv_map)?;
     Ok(config)
 }
 
@@ -728,7 +747,7 @@ on_success: Done
 on_failure: Failed
 "#;
         let mut config = parse_config(yaml).unwrap();
-        config.resolve_env();
+        config.resolve_env().unwrap();
         assert_eq!(config.tracker.api_key.as_deref(), Some("secret123"));
         std::env::remove_var("ENSEMBLE_TEST_KEY_2B");
     }
@@ -753,7 +772,7 @@ on_success: Done
 on_failure: Failed
 "#;
         let mut config = parse_config(yaml).unwrap();
-        config.resolve_env();
+        config.resolve_env().unwrap();
         assert_eq!(config.tracker.api_key, None);
         std::env::remove_var("ENSEMBLE_EMPTY_2B");
     }
@@ -776,7 +795,7 @@ on_success: Done
 on_failure: Failed
 "#;
         let mut config = parse_config(yaml).unwrap();
-        config.resolve_env();
+        config.resolve_env().unwrap();
         let home = std::env::var("HOME").unwrap();
         assert_eq!(
             config.tracker.path.unwrap(),
@@ -914,7 +933,7 @@ workspace:
   root: ~/workspaces
 "#;
         let mut config = parse_config(yaml).unwrap();
-        config.resolve_env();
+        config.resolve_env().unwrap();
         let home = std::env::var("HOME").unwrap();
         let expected = format!("{}/workspaces", home);
         assert_eq!(config.workspace.root.as_deref(), Some(expected.as_str()));
@@ -992,7 +1011,7 @@ on_success: Done
 on_failure: Failed
 "#;
         let mut config = parse_config(yaml).unwrap();
-        config.resolve_env();
+        config.resolve_env().unwrap();
         assert_eq!(config.repos[0].path, "/test/repo");
         std::env::remove_var("ENSEMBLE_TEST_REPO");
     }
@@ -1017,7 +1036,7 @@ on_success: Done
 on_failure: Failed
 "#;
         let mut config = parse_config(yaml).unwrap();
-        config.resolve_env();
+        config.resolve_env().unwrap();
         let home = std::env::var("HOME").unwrap();
         assert_eq!(config.repos[0].path, format!("{}/projects/myrepo", home));
     }
@@ -1126,6 +1145,60 @@ on_failure: Failed
         // Process env var should take precedence over .env
         assert_eq!(config.tracker.api_key.as_deref(), Some("from-process"));
 
+        std::env::remove_var("GITHUB_TOKEN");
+    }
+
+    #[test]
+    fn test_load_config_uses_sibling_dotenv_without_mutating_process_env() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "GITHUB_TOKEN=from-dotenv\n").unwrap();
+        std::env::remove_var("GITHUB_TOKEN");
+
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            r#"
+tracker:
+  kind: github
+  repository: acme/repo
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        let config = load_config(&dir.path().join("config.yaml")).unwrap();
+        assert_eq!(config.tracker.api_key.as_deref(), Some("from-dotenv"));
+        assert!(std::env::var("GITHUB_TOKEN").is_err());
+    }
+
+    #[test]
+    fn test_resolve_env_does_not_fallback_to_github_token_for_non_github_tracker() {
+        std::env::set_var("GITHUB_TOKEN", "from-process");
+        let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+
+        let mut config = parse_config(yaml).unwrap();
+        config.resolve_env().unwrap();
+
+        assert_eq!(config.tracker.api_key, None);
         std::env::remove_var("GITHUB_TOKEN");
     }
 }

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -9,11 +9,8 @@ use crate::error::ConfigError;
 use serde::{Deserialize, Serialize};
 
 /// Helper to convert Option<T> to serde_yaml::Value
-fn opt_to_value<T: Into<serde_yaml::Value>>(opt: Option<T>) -> serde_yaml::Value {
-    match opt {
-        Some(v) => v.into(),
-        None => serde_yaml::Value::Null,
-    }
+fn opt_to_value<T: Into<serde_yaml::Value>>(opt: Option<T>) -> Option<serde_yaml::Value> {
+    opt.map(|v| v.into())
 }
 
 /// Guided form representation for structured config editing.
@@ -249,25 +246,52 @@ pub fn apply_guided_form(
         }
     };
 
-    // Update tracker section
-    let tracker_mapping = get_or_create_mapping(mapping, "tracker");
-    replace_known_fields(
-        tracker_mapping,
-        [
-            ("kind", form.tracker.kind.clone().into()),
-            ("path", opt_to_value(form.tracker.path.clone())),
-            ("repository", opt_to_value(form.tracker.repository.clone())),
-            ("project_number", opt_to_value(form.tracker.project_number)),
-            ("api_key", opt_to_value(form.tracker.api_key.clone())),
-            ("endpoint", opt_to_value(form.tracker.endpoint.clone())),
-            ("active_states", form.tracker.active_states.clone().into()),
-            (
-                "terminal_states",
-                form.tracker.terminal_states.clone().into(),
-            ),
-            ("labels_filter", form.tracker.labels_filter.clone().into()),
-        ],
-    );
+    // Update tracker section — merge into existing mapping to preserve unknown fields
+    let tracker_val = mapping
+        .entry("tracker".into())
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if let serde_yaml::Value::Mapping(ref mut tm) = *tracker_val {
+        tm.insert("kind".into(), form.tracker.kind.clone().into());
+        if let Some(v) = opt_to_value(form.tracker.path.clone()) {
+            tm.insert("path".into(), v);
+        } else {
+            tm.remove("path");
+        }
+        if let Some(v) = opt_to_value(form.tracker.repository.clone()) {
+            tm.insert("repository".into(), v);
+        } else {
+            tm.remove("repository");
+        }
+        if let Some(v) = opt_to_value(form.tracker.project_number) {
+            tm.insert("project_number".into(), v);
+        } else {
+            tm.remove("project_number");
+        }
+        if let Some(v) = opt_to_value(form.tracker.api_key.clone()) {
+            tm.insert("api_key".into(), v);
+        } else {
+            tm.remove("api_key");
+        }
+        if let Some(v) = opt_to_value(form.tracker.endpoint.clone()) {
+            tm.insert("endpoint".into(), v);
+        } else {
+            tm.remove("endpoint");
+        }
+        tm.insert(
+            "active_states".into(),
+            form.tracker.active_states.clone().into(),
+        );
+        tm.insert(
+            "terminal_states".into(),
+            form.tracker.terminal_states.clone().into(),
+        );
+        if form.tracker.kind == "github" {
+            tm.insert(
+                "labels_filter".into(),
+                form.tracker.labels_filter.clone().into(),
+            );
+        }
+    }
 
     // Update repos section
     let repos_seq: Vec<serde_yaml::Value> = form
@@ -287,34 +311,53 @@ pub fn apply_guided_form(
             repo_mapping.into()
         })
         .collect();
-    mapping.insert("repos".into(), repos_seq.into());
+    if !repos_seq.is_empty() {
+        mapping.insert("repos".into(), repos_seq.into());
+    }
 
-    // Update agents section
-    let existing_agents = mapping
-        .get("agents")
-        .and_then(serde_yaml::Value::as_mapping)
-        .cloned()
-        .unwrap_or_default();
-    let agents_mapping = serde_yaml::Mapping::from_iter(form.agents.iter().map(|a| {
-        let mut agent_mapping = existing_agents
-            .get(serde_yaml::Value::String(a.name.clone()))
-            .and_then(serde_yaml::Value::as_mapping)
-            .cloned()
-            .unwrap_or_default();
-        replace_known_fields(
-            &mut agent_mapping,
-            [
-                ("executor", opt_to_value(a.executor.clone())),
-                ("model", opt_to_value(a.model.clone())),
-                ("acpx_agent", opt_to_value(a.acpx_agent.clone())),
-                ("prompt", opt_to_value(a.prompt.clone())),
-                ("prompt_template", opt_to_value(a.prompt_template.clone())),
-                ("reasoning_level", opt_to_value(a.reasoning_level.clone())),
-            ],
-        );
-        (a.name.clone().into(), agent_mapping.into())
-    }));
-    mapping.insert("agents".into(), agents_mapping.into());
+    // Update agents section — merge into existing mappings to preserve unknown fields
+    let agents_val = mapping
+        .entry("agents".into())
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if let serde_yaml::Value::Mapping(ref mut agents_map) = *agents_val {
+        for a in &form.agents {
+            let agent_val = agents_map
+                .entry(a.name.clone().into())
+                .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+            if let serde_yaml::Value::Mapping(ref mut am) = *agent_val {
+                if let Some(v) = opt_to_value(a.executor.clone()) {
+                    am.insert("executor".into(), v);
+                } else {
+                    am.remove("executor");
+                }
+                if let Some(v) = opt_to_value(a.model.clone()) {
+                    am.insert("model".into(), v);
+                } else {
+                    am.remove("model");
+                }
+                if let Some(v) = opt_to_value(a.acpx_agent.clone()) {
+                    am.insert("acpx_agent".into(), v);
+                } else {
+                    am.remove("acpx_agent");
+                }
+                if let Some(v) = opt_to_value(a.prompt.clone()) {
+                    am.insert("prompt".into(), v);
+                } else {
+                    am.remove("prompt");
+                }
+                if let Some(v) = opt_to_value(a.prompt_template.clone()) {
+                    am.insert("prompt_template".into(), v);
+                } else {
+                    am.remove("prompt_template");
+                }
+                if let Some(v) = opt_to_value(a.reasoning_level.clone()) {
+                    am.insert("reasoning_level".into(), v);
+                } else {
+                    am.remove("reasoning_level");
+                }
+            }
+        }
+    }
 
     // Update steps section
     let steps_seq: Vec<serde_yaml::Value> = form
@@ -343,79 +386,104 @@ pub fn apply_guided_form(
         .collect();
     mapping.insert("steps".into(), steps_seq.into());
 
-    // Update runtime settings
-    replace_known_fields(
-        get_or_create_mapping(mapping, "concurrency"),
-        [
-            (
-                "max_concurrent_agents",
-                form.runtime.concurrency.max_concurrent_agents.into(),
-            ),
-            (
-                "max_step_parallelism",
-                form.runtime.concurrency.max_step_parallelism.into(),
-            ),
-        ],
-    );
+    // Update concurrency
+    let concurrency_val = mapping
+        .entry("concurrency".into())
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if let serde_yaml::Value::Mapping(ref mut cm) = *concurrency_val {
+        cm.insert(
+            "max_concurrent_agents".into(),
+            form.runtime.concurrency.max_concurrent_agents.into(),
+        );
+        cm.insert(
+            "max_step_parallelism".into(),
+            form.runtime.concurrency.max_step_parallelism.into(),
+        );
+    }
 
-    replace_known_fields(
-        get_or_create_mapping(mapping, "polling"),
-        [("interval_ms", form.runtime.polling.interval_ms.into())],
-    );
+    // Update polling
+    let polling_val = mapping
+        .entry("polling".into())
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if let serde_yaml::Value::Mapping(ref mut pm) = *polling_val {
+        pm.insert(
+            "interval_ms".into(),
+            form.runtime.polling.interval_ms.into(),
+        );
+    }
 
-    replace_known_fields(
-        get_or_create_mapping(mapping, "workspace"),
-        [("root", opt_to_value(form.runtime.workspace.root.clone()))],
-    );
+    // Update workspace
+    let workspace_val = mapping
+        .entry("workspace".into())
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if let serde_yaml::Value::Mapping(ref mut wm) = *workspace_val {
+        if let Some(v) = opt_to_value(form.runtime.workspace.root.clone()) {
+            wm.insert("root".into(), v);
+        } else {
+            wm.remove("root");
+        }
+    }
 
-    replace_known_fields(
-        get_or_create_mapping(mapping, "hooks"),
-        [
-            (
-                "after_create",
-                opt_to_value(form.runtime.hooks.after_create.clone()),
-            ),
-            (
-                "before_run",
-                opt_to_value(form.runtime.hooks.before_run.clone()),
-            ),
-            (
-                "after_run",
-                opt_to_value(form.runtime.hooks.after_run.clone()),
-            ),
-            (
-                "before_remove",
-                opt_to_value(form.runtime.hooks.before_remove.clone()),
-            ),
-            ("timeout_ms", form.runtime.hooks.timeout_ms.into()),
-        ],
-    );
+    // Update hooks
+    let hooks_val = mapping
+        .entry("hooks".into())
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if let serde_yaml::Value::Mapping(ref mut hm) = *hooks_val {
+        if let Some(v) = opt_to_value(form.runtime.hooks.after_create.clone()) {
+            hm.insert("after_create".into(), v);
+        } else {
+            hm.remove("after_create");
+        }
+        if let Some(v) = opt_to_value(form.runtime.hooks.before_run.clone()) {
+            hm.insert("before_run".into(), v);
+        } else {
+            hm.remove("before_run");
+        }
+        if let Some(v) = opt_to_value(form.runtime.hooks.after_run.clone()) {
+            hm.insert("after_run".into(), v);
+        } else {
+            hm.remove("after_run");
+        }
+        if let Some(v) = opt_to_value(form.runtime.hooks.before_remove.clone()) {
+            hm.insert("before_remove".into(), v);
+        } else {
+            hm.remove("before_remove");
+        }
+        hm.insert("timeout_ms".into(), form.runtime.hooks.timeout_ms.into());
+    }
 
-    replace_known_fields(
-        get_or_create_mapping(mapping, "agent"),
-        [
-            ("max_turns", form.runtime.agent.max_turns.into()),
-            (
-                "max_retry_backoff_ms",
-                form.runtime.agent.max_retry_backoff_ms.into(),
-            ),
-            ("command", form.runtime.agent.command.clone().into()),
-            (
-                "session_mode",
-                form.runtime.agent.session_mode.clone().into(),
-            ),
-            (
-                "permission_policy",
-                form.runtime.agent.permission_policy.clone().into(),
-            ),
-            ("turn_timeout_ms", form.runtime.agent.turn_timeout_ms.into()),
-            ("read_timeout_ms", form.runtime.agent.read_timeout_ms.into()),
-            (
-                "stall_timeout_ms",
-                form.runtime.agent.stall_timeout_ms.into(),
-            ),
-        ],
-    );
+    // Update agent runtime
+    let agent_val = mapping
+        .entry("agent".into())
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if let serde_yaml::Value::Mapping(ref mut am) = *agent_val {
+        am.insert("max_turns".into(), form.runtime.agent.max_turns.into());
+        am.insert(
+            "max_retry_backoff_ms".into(),
+            form.runtime.agent.max_retry_backoff_ms.into(),
+        );
+        am.insert("command".into(), form.runtime.agent.command.clone().into());
+        am.insert(
+            "session_mode".into(),
+            form.runtime.agent.session_mode.clone().into(),
+        );
+        am.insert(
+            "permission_policy".into(),
+            form.runtime.agent.permission_policy.clone().into(),
+        );
+        am.insert(
+            "turn_timeout_ms".into(),
+            form.runtime.agent.turn_timeout_ms.into(),
+        );
+        am.insert(
+            "read_timeout_ms".into(),
+            form.runtime.agent.read_timeout_ms.into(),
+        );
+        am.insert(
+            "stall_timeout_ms".into(),
+            form.runtime.agent.stall_timeout_ms.into(),
+        );
+    }
 
     // Update max_cycles
     mapping.insert("max_cycles".into(), form.runtime.max_cycles.into());
@@ -588,41 +656,85 @@ on_failure: Failed
     }
 
     #[test]
-    fn apply_guided_form_preserves_unknown_nested_fields_in_managed_sections() {
-        let mut form = guided_form_with_workspace_root("/tmp/ws");
-        form.repos = vec![GuidedRepoForm {
-            path: "new-repo".to_string(),
-            branch: "main".to_string(),
-            git_remote: "origin".to_string(),
-        }];
-
+    fn apply_guided_form_preserves_unknown_fields_in_sections() {
         let raw = r#"
 tracker:
   kind: todo_file
-  path: old.md
-  custom_tracker_field: keep-me
-repos:
-  - path: old-repo
-    branch: old-branch
-    custom_repo_field: keep-me
+  custom_tracker_field: "keep me"
 agents:
   builder:
     acpx_agent: claude
-    prompt: old prompt
-    custom_agent_field: keep-me
+    prompt: hello
+    custom_agent_field: 42
 steps:
   - name: implement
     agent: builder
-    custom_step_field: keep-me
+concurrency:
+  max_concurrent_agents: 4
+  max_step_parallelism: 2
+  custom_concurrency_field: true
 on_success: Done
 on_failure: Failed
 "#;
 
-        let merged = apply_guided_form(raw, &form).unwrap();
+        let merged = apply_guided_form(raw, &guided_form_with_workspace_root("/tmp/ws")).unwrap();
+        assert!(merged.contains("custom_tracker_field: keep me"));
+        assert!(merged.contains("custom_agent_field: 42"));
+        assert!(merged.contains("custom_concurrency_field: true"));
+    }
 
-        assert!(merged.contains("custom_tracker_field: keep-me"));
-        assert!(merged.contains("custom_repo_field: keep-me"));
-        assert!(merged.contains("custom_agent_field: keep-me"));
-        assert!(merged.contains("custom_step_field: keep-me"));
+    #[test]
+    fn apply_guided_form_omits_none_fields() {
+        let raw = r#"
+tracker:
+  kind: todo_file
+  path: /some/path
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: hello
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+
+        let form = guided_form_with_workspace_root("/tmp/ws");
+        // form.tracker.path is None, so the existing path should be removed
+        let merged = apply_guided_form(raw, &form).unwrap();
+        // Parse back and check path is gone
+        let val: serde_yaml::Value = serde_yaml::from_str(&merged).unwrap();
+        let tracker = val.get("tracker").unwrap().as_mapping().unwrap();
+        assert!(
+            !tracker.contains_key("path"),
+            "path should be removed when form value is None"
+        );
+    }
+
+    #[test]
+    fn apply_guided_form_skips_labels_filter_for_todo_file() {
+        let raw = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: hello
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+
+        let form = guided_form_with_workspace_root("/tmp/ws");
+        let merged = apply_guided_form(raw, &form).unwrap();
+        let val: serde_yaml::Value = serde_yaml::from_str(&merged).unwrap();
+        let tracker = val.get("tracker").unwrap().as_mapping().unwrap();
+        assert!(
+            !tracker.contains_key("labels_filter"),
+            "labels_filter should not be written for todo_file tracker"
+        );
     }
 }

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -508,28 +508,16 @@ pub fn apply_guided_form(
     })
 }
 
-fn get_or_create_mapping<'a>(
-    mapping: &'a mut serde_yaml::Mapping,
-    key: &str,
-) -> &'a mut serde_yaml::Mapping {
-    let value = mapping
-        .entry(serde_yaml::Value::String(key.to_string()))
-        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
-    if !matches!(value, serde_yaml::Value::Mapping(_)) {
-        *value = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-    }
-    match value {
-        serde_yaml::Value::Mapping(inner) => inner,
-        _ => unreachable!(),
-    }
-}
-
 fn replace_known_fields<const N: usize>(
     mapping: &mut serde_yaml::Mapping,
     fields: [(&str, serde_yaml::Value); N],
 ) {
     for (key, value) in fields {
-        mapping.insert(key.into(), value);
+        if value.is_null() {
+            mapping.remove(key);
+        } else {
+            mapping.insert(key.into(), value);
+        }
     }
 }
 

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -290,6 +290,8 @@ pub fn apply_guided_form(
                 "labels_filter".into(),
                 form.tracker.labels_filter.clone().into(),
             );
+        } else {
+            tm.remove("labels_filter");
         }
     }
 
@@ -313,6 +315,8 @@ pub fn apply_guided_form(
         .collect();
     if !repos_seq.is_empty() {
         mapping.insert("repos".into(), repos_seq.into());
+    } else {
+        mapping.remove("repos");
     }
 
     // Update agents section — merge into existing mappings to preserve unknown fields

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -295,7 +295,7 @@ pub async fn run_setup_checks(request: &SetupRequest) -> Vec<SetupCheck> {
     // Check repos
     for repo in &request.repos {
         let exists = repo.path.join(".git").exists();
-        let branch_ok = std::process::Command::new("git")
+        let branch_ok = tokio::process::Command::new("git")
             .args([
                 "rev-parse",
                 "--verify",
@@ -303,6 +303,7 @@ pub async fn run_setup_checks(request: &SetupRequest) -> Vec<SetupCheck> {
             ])
             .current_dir(&repo.path)
             .output()
+            .await
             .map(|o| o.status.success())
             .unwrap_or(false);
 
@@ -526,23 +527,32 @@ pub async fn discover_agent_capabilities(agent: &str) -> AgentCapabilities {
 
 // --- Internal helper functions ---
 
-fn generate_yaml(request: &SetupRequest) -> String {
-    let mut yaml = String::new();
-
-    // Tracker section
-    yaml.push_str("tracker:\n");
+/// Build a tracker YAML mapping from a setup request.
+/// Shared between `generate_yaml` and `update_yaml_from_request`.
+fn build_tracker_mapping(request: &SetupRequest) -> serde_yaml::Mapping {
+    let mut tracker_map = serde_yaml::Mapping::new();
     match &request.tracker {
         SetupTracker::TodoFile { path } => {
-            yaml.push_str("  kind: todo_file\n");
-            yaml.push_str(&format!("  path: {}\n", path.display()));
-            yaml.push_str("  active_states:\n");
-            yaml.push_str("    - Todo\n");
-            yaml.push_str("    - In Progress\n");
-            yaml.push_str("  terminal_states:\n");
-            yaml.push_str(&format!("    - {}\n", request.on_success));
+            tracker_map.insert("kind".into(), serde_yaml::Value::String("todo_file".into()));
+            tracker_map.insert(
+                "path".into(),
+                serde_yaml::Value::String(path.display().to_string()),
+            );
+            tracker_map.insert(
+                "active_states".into(),
+                serde_yaml::Value::Sequence(vec![
+                    serde_yaml::Value::String("Todo".into()),
+                    serde_yaml::Value::String("In Progress".into()),
+                ]),
+            );
+            let mut terminals = vec![serde_yaml::Value::String(request.on_success.clone())];
             if request.on_failure != request.on_success {
-                yaml.push_str(&format!("    - {}\n", request.on_failure));
+                terminals.push(serde_yaml::Value::String(request.on_failure.clone()));
             }
+            tracker_map.insert(
+                "terminal_states".into(),
+                serde_yaml::Value::Sequence(terminals),
+            );
         }
         SetupTracker::GitHub {
             repository,
@@ -552,79 +562,156 @@ fn generate_yaml(request: &SetupRequest) -> String {
             terminal_states,
             ..
         } => {
-            yaml.push_str("  kind: github\n");
-            yaml.push_str(&format!("  repository: {}\n", repository));
-            yaml.push_str(&format!("  api_key: ${}\n", api_key_env));
+            tracker_map.insert("kind".into(), serde_yaml::Value::String("github".into()));
+            tracker_map.insert(
+                "repository".into(),
+                serde_yaml::Value::String(repository.clone()),
+            );
+            tracker_map.insert(
+                "api_key".into(),
+                serde_yaml::Value::String(format!("${}", api_key_env)),
+            );
             if let Some(n) = project_number {
-                yaml.push_str(&format!("  project_number: {}\n", n));
+                tracker_map.insert(
+                    "project_number".into(),
+                    serde_yaml::Value::Number((*n).into()),
+                );
             }
-            yaml.push_str("  active_states:\n");
-            for s in active_states {
-                yaml.push_str(&format!("    - {}\n", s));
-            }
-            yaml.push_str("  terminal_states:\n");
-            for s in terminal_states {
-                yaml.push_str(&format!("    - {}\n", s));
-            }
+            tracker_map.insert(
+                "active_states".into(),
+                serde_yaml::Value::Sequence(
+                    active_states
+                        .iter()
+                        .map(|s| serde_yaml::Value::String(s.clone()))
+                        .collect(),
+                ),
+            );
+            tracker_map.insert(
+                "terminal_states".into(),
+                serde_yaml::Value::Sequence(
+                    terminal_states
+                        .iter()
+                        .map(|s| serde_yaml::Value::String(s.clone()))
+                        .collect(),
+                ),
+            );
         }
     }
+    tracker_map
+}
+
+fn generate_yaml(request: &SetupRequest) -> String {
+    let mut doc = serde_yaml::Mapping::new();
+
+    // Tracker section
+    doc.insert(
+        "tracker".into(),
+        serde_yaml::Value::Mapping(build_tracker_mapping(request)),
+    );
 
     // Repos section
     if !request.repos.is_empty() {
-        yaml.push_str("\nrepos:\n");
-        for repo in &request.repos {
-            yaml.push_str(&format!("  - path: {}\n", repo.path.display()));
-            yaml.push_str(&format!("    branch: {}\n", repo.branch));
-        }
+        let repos_seq: Vec<serde_yaml::Value> = request
+            .repos
+            .iter()
+            .map(|repo| {
+                let mut repo_map = serde_yaml::Mapping::new();
+                repo_map.insert(
+                    "path".into(),
+                    serde_yaml::Value::String(repo.path.display().to_string()),
+                );
+                repo_map.insert(
+                    "branch".into(),
+                    serde_yaml::Value::String(repo.branch.clone()),
+                );
+                serde_yaml::Value::Mapping(repo_map)
+            })
+            .collect();
+        doc.insert("repos".into(), serde_yaml::Value::Sequence(repos_seq));
     }
 
     // Agents section
-    yaml.push_str("\nagents:\n");
+    let mut agents_map = serde_yaml::Mapping::new();
     for agent in &request.agents {
-        yaml.push_str(&format!("  {}:\n", agent.role));
-        yaml.push_str(&format!("    acpx_agent: {}\n", agent.acpx_agent));
+        let mut agent_map = serde_yaml::Mapping::new();
+        agent_map.insert(
+            "acpx_agent".into(),
+            serde_yaml::Value::String(agent.acpx_agent.clone()),
+        );
         if let Some(ref model) = agent.model {
-            yaml.push_str(&format!("    model: {}\n", model));
+            agent_map.insert("model".into(), serde_yaml::Value::String(model.clone()));
         }
         // Emit prompt or prompt_template based on agent config
         // If both are set, prompt takes precedence and prompt_file is silently ignored
         if let Some(ref prompt) = agent.prompt {
-            let quoted = serde_yaml::to_string(&prompt)
-                .unwrap_or_else(|_| format!("\"{}\"", prompt.replace('\\', "\\\\").replace('"', "\\\"")));
-            yaml.push_str(&format!("    prompt: {}", quoted.trim_end()));
+            agent_map.insert("prompt".into(), serde_yaml::Value::String(prompt.clone()));
         } else if let Some(ref prompt_file) = agent.prompt_file {
-            let quoted = serde_yaml::to_string(&prompt_file)
-                .unwrap_or_else(|_| format!("\"{}\"", prompt_file.replace('\\', "\\\\").replace('"', "\\\"")));
-            yaml.push_str(&format!("    prompt_template: {}", quoted.trim_end()));
+            agent_map.insert(
+                "prompt_template".into(),
+                serde_yaml::Value::String(prompt_file.clone()),
+            );
         } else {
-            let template_path = format!("templates/{}.liquid", find_step_for_agent(&agent.role, &request.steps));
-            let quoted = serde_yaml::to_string(&template_path).unwrap_or_else(|_| format!("\"{}\"", template_path));
-            yaml.push_str(&format!("    prompt_template: {}", quoted.trim_end()));
+            let template_path = format!(
+                "templates/{}.liquid",
+                find_step_for_agent(&agent.role, &request.steps)
+            );
+            agent_map.insert(
+                "prompt_template".into(),
+                serde_yaml::Value::String(template_path),
+            );
         }
-        yaml.push('\n');
+        agents_map.insert(
+            agent.role.clone().into(),
+            serde_yaml::Value::Mapping(agent_map),
+        );
     }
+    doc.insert("agents".into(), serde_yaml::Value::Mapping(agents_map));
 
     // Steps section
-    yaml.push_str("\nsteps:\n");
-    for step in &request.steps {
-        yaml.push_str(&format!("  - name: {}\n", step.name));
-        yaml.push_str(&format!("    agent: {}\n", step.agent_role));
-        if !step.depends.is_empty() {
-            yaml.push_str("    depends:\n");
-            for dep in &step.depends {
-                yaml.push_str(&format!("      - {}\n", dep));
+    let steps_seq: Vec<serde_yaml::Value> = request
+        .steps
+        .iter()
+        .map(|step| {
+            let mut step_map = serde_yaml::Mapping::new();
+            step_map.insert("name".into(), serde_yaml::Value::String(step.name.clone()));
+            step_map.insert(
+                "agent".into(),
+                serde_yaml::Value::String(step.agent_role.clone()),
+            );
+            if !step.depends.is_empty() {
+                step_map.insert(
+                    "depends".into(),
+                    serde_yaml::Value::Sequence(
+                        step.depends
+                            .iter()
+                            .map(|d| serde_yaml::Value::String(d.clone()))
+                            .collect(),
+                    ),
+                );
             }
-        }
-        if let Some(ref state) = step.tracker_state {
-            yaml.push_str(&format!("    tracker_state: {}\n", state));
-        }
-    }
+            if let Some(ref state) = step.tracker_state {
+                step_map.insert(
+                    "tracker_state".into(),
+                    serde_yaml::Value::String(state.clone()),
+                );
+            }
+            serde_yaml::Value::Mapping(step_map)
+        })
+        .collect();
+    doc.insert("steps".into(), serde_yaml::Value::Sequence(steps_seq));
 
     // Transitions
-    yaml.push_str(&format!("\non_success: {}\n", request.on_success));
-    yaml.push_str(&format!("on_failure: {}\n", request.on_failure));
+    doc.insert(
+        "on_success".into(),
+        serde_yaml::Value::String(request.on_success.clone()),
+    );
+    doc.insert(
+        "on_failure".into(),
+        serde_yaml::Value::String(request.on_failure.clone()),
+    );
 
-    yaml
+    serde_yaml::to_string(&serde_yaml::Value::Mapping(doc))
+        .unwrap_or_else(|e| panic!("failed to serialize YAML: {e}"))
 }
 
 /// Generate a template for the given step name.
@@ -767,9 +854,10 @@ async fn probe_agent_capabilities(agent_name: &str) -> AgentCapabilities {
     let session_name = "ensemble-probe";
 
     // Create session
-    let output = std::process::Command::new("acpx")
+    let output = tokio::process::Command::new("acpx")
         .args([agent_name, "sessions", "ensure", "--name", session_name])
-        .output();
+        .output()
+        .await;
 
     let session_id = match output {
         Ok(ref o) if o.status.success() => {
@@ -787,23 +875,25 @@ async fn probe_agent_capabilities(agent_name: &str) -> AgentCapabilities {
     let caps = read_session_capabilities(&session_id).await;
 
     // Close session (best-effort)
-    let _ = std::process::Command::new("acpx")
+    let _ = tokio::process::Command::new("acpx")
         .args([agent_name, "sessions", "close", session_name])
-        .output();
+        .output()
+        .await;
 
     caps
 }
 
 async fn read_session_capabilities(session_id: &str) -> AgentCapabilities {
-    let acpx_dir = dirs::home_dir()
-        .map(|h| h.join(".acpx").join("sessions"))
-        .unwrap_or_default();
+    let Some(home) = dirs::home_dir() else {
+        return AgentCapabilities::default();
+    };
+    let acpx_dir = home.join(".acpx").join("sessions");
 
     let session_file = acpx_dir.join(format!("{}.json", session_id));
 
     // Wait for the session file to appear and become parseable
     for _ in 0..20 {
-        if let Ok(content) = std::fs::read_to_string(&session_file) {
+        if let Ok(content) = tokio::fs::read_to_string(&session_file).await {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
                 // Once the acpx object is present, return whatever we have.
                 if json.get("acpx").is_some() {
@@ -1005,13 +1095,14 @@ fn update_yaml_from_request(
             reason: "document is not a mapping".to_string(),
         })?;
 
-    // Update tracker section
+    // Update tracker section — build fresh from request, preserving unknown keys
     let existing_tracker_mapping = mapping
         .get("tracker")
         .and_then(|value| value.as_mapping())
         .cloned()
         .unwrap_or_default();
     let mut tracker_mapping = existing_tracker_mapping;
+    // Remove setup-managed keys before reinserting
     for key in [
         "kind",
         "path",
@@ -1023,76 +1114,10 @@ fn update_yaml_from_request(
     ] {
         tracker_mapping.remove(serde_yaml::Value::String(key.to_string()));
     }
-    match &request.tracker {
-        SetupTracker::TodoFile { path } => {
-            tracker_mapping.insert(
-                "kind".into(),
-                serde_yaml::Value::String("todo_file".to_string()),
-            );
-            tracker_mapping.insert(
-                "path".into(),
-                serde_yaml::Value::String(path.display().to_string()),
-            );
-            tracker_mapping.insert(
-                "active_states".into(),
-                serde_yaml::Value::Sequence(vec![
-                    serde_yaml::Value::String("Todo".to_string()),
-                    serde_yaml::Value::String("In Progress".to_string()),
-                ]),
-            );
-            tracker_mapping.insert(
-                "terminal_states".into(),
-                serde_yaml::Value::Sequence(vec![
-                    serde_yaml::Value::String(request.on_success.clone()),
-                    serde_yaml::Value::String(request.on_failure.clone()),
-                ]),
-            );
-        }
-        SetupTracker::GitHub {
-            repository,
-            project_number,
-            api_key_env,
-            active_states,
-            terminal_states,
-            ..
-        } => {
-            tracker_mapping.insert(
-                "kind".into(),
-                serde_yaml::Value::String("github".to_string()),
-            );
-            tracker_mapping.insert(
-                "repository".into(),
-                serde_yaml::Value::String(repository.clone()),
-            );
-            tracker_mapping.insert(
-                "api_key".into(),
-                serde_yaml::Value::String(format!("${}", api_key_env)),
-            );
-            if let Some(n) = project_number {
-                tracker_mapping.insert(
-                    "project_number".into(),
-                    serde_yaml::Value::Number(serde_yaml::Number::from(*n)),
-                );
-            }
-            tracker_mapping.insert(
-                "active_states".into(),
-                serde_yaml::Value::Sequence(
-                    active_states
-                        .iter()
-                        .map(|s| serde_yaml::Value::String(s.clone()))
-                        .collect(),
-                ),
-            );
-            tracker_mapping.insert(
-                "terminal_states".into(),
-                serde_yaml::Value::Sequence(
-                    terminal_states
-                        .iter()
-                        .map(|s| serde_yaml::Value::String(s.clone()))
-                        .collect(),
-                ),
-            );
-        }
+    // Merge in fresh tracker data (shared with generate_yaml)
+    let new_tracker = build_tracker_mapping(request);
+    for (key, value) in new_tracker {
+        tracker_mapping.insert(key, value);
     }
     mapping.insert(
         "tracker".into(),
@@ -1119,13 +1144,13 @@ fn update_yaml_from_request(
         mapping.insert("repos".into(), serde_yaml::Value::Sequence(repos_seq));
     }
 
-    // Update agents section
+    // Update agents section — merge request agents into existing, preserving untouched agents
     let existing_agents = mapping
         .get("agents")
         .and_then(|value| value.as_mapping())
         .cloned()
         .unwrap_or_default();
-    let mut agents_map = serde_yaml::Mapping::new();
+    let mut agents_map = existing_agents.clone();
     for agent in &request.agents {
         let mut agent_config = existing_agents
             .get(serde_yaml::Value::String(agent.role.clone()))
@@ -1164,13 +1189,15 @@ fn update_yaml_from_request(
     }
     mapping.insert("agents".into(), serde_yaml::Value::Mapping(agents_map));
 
-    // Update steps section
+    // Update steps section — merge request steps into existing, preserving untouched steps
     let existing_steps = mapping
         .get("steps")
         .and_then(|value| value.as_sequence())
         .cloned()
         .unwrap_or_default();
-    let steps_seq: Vec<serde_yaml::Value> = request
+    let request_step_names: std::collections::HashSet<&str> =
+        request.steps.iter().map(|s| s.name.as_str()).collect();
+    let mut steps_seq: Vec<serde_yaml::Value> = request
         .steps
         .iter()
         .map(|s| {
@@ -1207,6 +1234,16 @@ fn update_yaml_from_request(
             serde_yaml::Value::Mapping(step_map)
         })
         .collect();
+    // Append existing steps not covered by the request
+    for existing in &existing_steps {
+        if let Some(map) = existing.as_mapping() {
+            if let Some(name) = map.get("name").and_then(|v| v.as_str()) {
+                if !request_step_names.contains(name) {
+                    steps_seq.push(existing.clone());
+                }
+            }
+        }
+    }
     mapping.insert("steps".into(), serde_yaml::Value::Sequence(steps_seq));
 
     // Update transitions
@@ -1419,8 +1456,15 @@ on_failure: Failed
 
         let artifacts = build_setup_artifacts(&request);
 
-        assert!(artifacts.raw_yaml.contains("prompt: \"Build it.\""));
-        assert!(!artifacts.raw_yaml.contains("prompt_template"));
+        // Verify YAML is valid and contains the prompt
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&artifacts.raw_yaml).unwrap();
+        let agents = parsed.get("agents").unwrap().as_mapping().unwrap();
+        let builder = agents.get("builder").unwrap().as_mapping().unwrap();
+        assert_eq!(
+            builder.get("prompt").unwrap().as_str().unwrap(),
+            "Build it."
+        );
+        assert!(builder.get("prompt_template").is_none());
     }
 
     #[test]
@@ -1449,8 +1493,14 @@ on_failure: Failed
 
         let artifacts = build_setup_artifacts(&request);
 
-        assert!(artifacts.raw_yaml.contains("prompt_template: \"templates/custom.liquid\""));
-        assert!(!artifacts.raw_yaml.contains("prompt:"));
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&artifacts.raw_yaml).unwrap();
+        let agents = parsed.get("agents").unwrap().as_mapping().unwrap();
+        let builder = agents.get("builder").unwrap().as_mapping().unwrap();
+        assert_eq!(
+            builder.get("prompt_template").unwrap().as_str().unwrap(),
+            "templates/custom.liquid"
+        );
+        assert!(builder.get("prompt").is_none());
     }
 
     #[test]
@@ -1513,8 +1563,14 @@ on_failure: Failed
 
         let artifacts = build_setup_artifacts(&request);
 
-        assert!(artifacts.raw_yaml.contains("prompt: \"Inline prompt\""));
-        assert!(!artifacts.raw_yaml.contains("ignored"));
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&artifacts.raw_yaml).unwrap();
+        let agents = parsed.get("agents").unwrap().as_mapping().unwrap();
+        let builder = agents.get("builder").unwrap().as_mapping().unwrap();
+        assert_eq!(
+            builder.get("prompt").unwrap().as_str().unwrap(),
+            "Inline prompt"
+        );
+        assert!(builder.get("prompt_template").is_none());
     }
 
     #[test]
@@ -1538,7 +1594,10 @@ on_failure: Failed
 
         assert_eq!(request.agents.len(), 1);
         assert_eq!(request.agents[0].role, "builder");
-        assert_eq!(request.agents[0].prompt_file, Some("templates/custom.liquid".to_string()));
+        assert_eq!(
+            request.agents[0].prompt_file,
+            Some("templates/custom.liquid".to_string())
+        );
         assert_eq!(request.agents[0].prompt, None);
     }
 
@@ -2098,5 +2157,184 @@ on_failure: Failed
             version.is_empty(),
             "timeout should cause version to return empty string"
         );
+    }
+
+    #[test]
+    fn merge_preserves_existing_agents_not_in_request() {
+        let existing_yaml = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+  reviewer:
+    acpx_agent: codex
+    prompt: "Review it."
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+
+        let request = SetupRequest {
+            tracker: SetupTracker::TodoFile {
+                path: PathBuf::from("TODO.md"),
+            },
+            repos: vec![],
+            agents: vec![SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "claude".to_string(),
+                model: Some("opus".to_string()),
+                prompt: None,
+                prompt_file: None,
+            }],
+            steps: vec![SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        };
+
+        let artifacts = merge_setup_request(Some(existing_yaml), &request).unwrap();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&artifacts.raw_yaml).unwrap();
+        let agents = parsed.get("agents").unwrap().as_mapping().unwrap();
+
+        // builder should be updated with new model
+        let builder = agents.get("builder").unwrap().as_mapping().unwrap();
+        assert_eq!(builder.get("model").unwrap().as_str().unwrap(), "opus");
+
+        // reviewer should be preserved (not in request)
+        let reviewer = agents.get("reviewer").unwrap().as_mapping().unwrap();
+        assert_eq!(
+            reviewer.get("acpx_agent").unwrap().as_str().unwrap(),
+            "codex"
+        );
+    }
+
+    #[test]
+    fn merge_preserves_existing_steps_not_in_request() {
+        let existing_yaml = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  builder:
+    acpx_agent: claude
+steps:
+  - name: build
+    agent: builder
+  - name: review
+    agent: reviewer
+    custom_field: keep
+on_success: Done
+on_failure: Failed
+"#;
+
+        let request = SetupRequest {
+            tracker: SetupTracker::TodoFile {
+                path: PathBuf::from("TODO.md"),
+            },
+            repos: vec![],
+            agents: vec![SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "claude".to_string(),
+                model: None,
+                prompt: None,
+                prompt_file: None,
+            }],
+            steps: vec![SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                depends: vec![],
+                tracker_state: Some("In Progress".to_string()),
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        };
+
+        let artifacts = merge_setup_request(Some(existing_yaml), &request).unwrap();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&artifacts.raw_yaml).unwrap();
+        let steps = parsed.get("steps").unwrap().as_sequence().unwrap();
+
+        // Should have both build (updated) and review (preserved)
+        assert_eq!(steps.len(), 2);
+
+        // build step should be updated
+        let build = steps
+            .iter()
+            .find(|s| s.get("name").and_then(|n| n.as_str()) == Some("build"))
+            .unwrap();
+        assert_eq!(
+            build.get("tracker_state").unwrap().as_str().unwrap(),
+            "In Progress"
+        );
+
+        // review step should be preserved with custom field
+        let review = steps
+            .iter()
+            .find(|s| s.get("name").and_then(|n| n.as_str()) == Some("review"))
+            .unwrap();
+        assert_eq!(
+            review.get("custom_field").unwrap().as_str().unwrap(),
+            "keep"
+        );
+    }
+
+    #[test]
+    fn merge_deduplicates_terminal_states_when_equal() {
+        let existing_yaml = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  builder:
+    acpx_agent: claude
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Done
+"#;
+
+        let request = SetupRequest {
+            tracker: SetupTracker::TodoFile {
+                path: PathBuf::from("TODO.md"),
+            },
+            repos: vec![],
+            agents: vec![SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "claude".to_string(),
+                model: None,
+                prompt: None,
+                prompt_file: None,
+            }],
+            steps: vec![SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Done".to_string(),
+        };
+
+        let artifacts = merge_setup_request(Some(existing_yaml), &request).unwrap();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&artifacts.raw_yaml).unwrap();
+        let tracker = parsed.get("tracker").unwrap().as_mapping().unwrap();
+        let terminal_states = tracker
+            .get("terminal_states")
+            .unwrap()
+            .as_sequence()
+            .unwrap();
+
+        // Should have only one "Done" entry, not two
+        assert_eq!(terminal_states.len(), 1);
+        assert_eq!(terminal_states[0].as_str().unwrap(), "Done");
     }
 }

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -49,6 +49,10 @@ pub struct SetupAgent {
     pub role: String,
     pub acpx_agent: String,
     pub model: Option<String>,
+    /// Inline prompt text (optional)
+    pub prompt: Option<String>,
+    /// Path to prompt template file (optional, maps to prompt_template in config)
+    pub prompt_file: Option<String>,
 }
 
 /// Pipeline step entry for setup.
@@ -234,15 +238,21 @@ pub fn write_setup_artifacts(
 }
 
 /// Run setup checks and return the results.
-pub fn run_setup_checks(request: &SetupRequest) -> Vec<SetupCheck> {
+pub async fn run_setup_checks(request: &SetupRequest) -> Vec<SetupCheck> {
     let mut checks = Vec::new();
 
     // Check acpx is installed
-    let acpx_ok = std::process::Command::new("acpx")
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
+    let acpx_ok = tokio::time::timeout(
+        tokio::time::Duration::from_secs(8),
+        tokio::process::Command::new("acpx")
+            .arg("--version")
+            .output(),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok())
+    .map(|o| o.status.success())
+    .unwrap_or(false);
     checks.push(SetupCheck {
         kind: SetupCheckKind::Environment,
         label: "acpx".to_string(),
@@ -319,11 +329,17 @@ pub fn run_setup_checks(request: &SetupRequest) -> Vec<SetupCheck> {
 
     // Check agents
     for agent in &request.agents {
-        let healthy = std::process::Command::new("acpx")
-            .args(["--agent", &agent.acpx_agent, "--version"])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
+        let healthy = tokio::time::timeout(
+            tokio::time::Duration::from_secs(8),
+            tokio::process::Command::new("acpx")
+                .args(["--agent", &agent.acpx_agent, "--version"])
+                .output(),
+        )
+        .await
+        .ok()
+        .and_then(|r| r.ok())
+        .map(|o| o.status.success())
+        .unwrap_or(false);
 
         checks.push(SetupCheck {
             kind: SetupCheckKind::Environment,
@@ -472,7 +488,7 @@ pub fn merge_setup_request(
 }
 
 /// Discover available agents from the system.
-pub fn discover_available_agents() -> Result<Vec<DiscoveredAgent>, ConfigError> {
+pub async fn discover_available_agents() -> Result<Vec<DiscoveredAgent>, ConfigError> {
     let known_agents: &[(&str, &str)] = &[
         ("claude", "Claude Code"),
         ("codex", "Codex CLI"),
@@ -490,8 +506,8 @@ pub fn discover_available_agents() -> Result<Vec<DiscoveredAgent>, ConfigError> 
     let mut available = Vec::new();
 
     for (name, label) in known_agents {
-        if probe_agent(name) {
-            let version = get_agent_version(name);
+        if probe_agent(name).await {
+            let version = get_agent_version(name).await;
             available.push(DiscoveredAgent {
                 name: name.to_string(),
                 label: label.to_string(),
@@ -696,24 +712,34 @@ fn validate_dag(steps: &[SetupStep]) -> Result<(), ConfigError> {
     Ok(())
 }
 
-fn probe_agent(name: &str) -> bool {
-    let output = std::process::Command::new("acpx")
-        .args(["--agent", name, "--version"])
-        .output();
+async fn probe_agent(name: &str) -> bool {
+    let timeout = tokio::time::Duration::from_secs(8);
+    let result = tokio::time::timeout(timeout, async {
+        tokio::process::Command::new("acpx")
+            .args(["--agent", name, "--version"])
+            .output()
+            .await
+    })
+    .await;
 
-    match output {
-        Ok(o) => o.status.success(),
-        Err(_) => false,
+    match result {
+        Ok(Ok(o)) => o.status.success(),
+        _ => false,
     }
 }
 
-fn get_agent_version(name: &str) -> String {
-    let output = std::process::Command::new("acpx")
-        .args(["--agent", name, "--version"])
-        .output();
+async fn get_agent_version(name: &str) -> String {
+    let timeout = tokio::time::Duration::from_secs(8);
+    let result = tokio::time::timeout(timeout, async {
+        tokio::process::Command::new("acpx")
+            .args(["--agent", name, "--version"])
+            .output()
+            .await
+    })
+    .await;
 
-    match output {
-        Ok(o) if o.status.success() => {
+    match result {
+        Ok(Ok(o)) if o.status.success() => {
             let v = String::from_utf8_lossy(&o.stdout).trim().to_string();
             if v.is_empty() {
                 String::new()
@@ -893,6 +919,8 @@ fn extract_agents(doc: &serde_yaml::Value) -> Result<Vec<SetupAgent>, ConfigErro
                         role: role.to_string(),
                         acpx_agent: acpx_agent.to_string(),
                         model,
+                        prompt: None,
+                        prompt_file: None,
                     })
                 })
                 .collect::<Vec<_>>()
@@ -1202,6 +1230,8 @@ mod tests {
                 role: "builder".to_string(),
                 acpx_agent: "claude".to_string(),
                 model: None,
+                prompt: None,
+                prompt_file: None,
             }],
             steps: vec![SetupStep {
                 name: "implement".to_string(),
@@ -1238,6 +1268,8 @@ mod tests {
                 role: "builder".to_string(),
                 acpx_agent: "claude".to_string(),
                 model: Some("sonnet".to_string()),
+                prompt: None,
+                prompt_file: None,
             }],
             steps: vec![SetupStep {
                 name: "implement".to_string(),
@@ -1276,6 +1308,8 @@ mod tests {
                 role: "builder".to_string(),
                 acpx_agent: "claude".to_string(),
                 model: None,
+                prompt: None,
+                prompt_file: None,
             }],
             steps: vec![SetupStep {
                 name: "implement".to_string(),
@@ -1415,6 +1449,8 @@ custom_section:
                 role: "builder".to_string(),
                 acpx_agent: "claude".to_string(),
                 model: Some("opus".to_string()),
+                prompt: None,
+                prompt_file: None,
             }],
             steps: vec![SetupStep {
                 name: "build".to_string(),
@@ -1471,6 +1507,8 @@ on_failure: Failed
                 role: "builder".to_string(),
                 acpx_agent: "codex".to_string(),
                 model: Some("sonnet".to_string()),
+                prompt: None,
+                prompt_file: None,
             }],
             steps: vec![SetupStep {
                 name: "build".to_string(),
@@ -1792,5 +1830,94 @@ on_failure: Failed
         assert_eq!(request.agents[0].model.as_deref(), Some("sonnet"));
         assert_eq!(request.steps.len(), 1);
         assert_eq!(request.steps[0].name, "build");
+    }
+
+    #[tokio::test]
+    async fn probe_agent_returns_true_when_acpx_succeeds() {
+        let result = probe_agent("claude").await;
+        assert!(result, "probe_agent should return true when acpx succeeds");
+    }
+
+    #[tokio::test]
+    async fn get_agent_version_returns_version_when_acpx_succeeds() {
+        let result = get_agent_version("claude").await;
+        assert!(
+            !result.is_empty(),
+            "get_agent_version should return version when acpx succeeds"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_wrapper_completes_before_timeout() {
+        let timeout = tokio::time::Duration::from_millis(500);
+        let result: Result<Result<std::process::Output, std::io::Error>, _> =
+            tokio::time::timeout(timeout, async {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                Ok(std::process::Output {
+                    status: std::process::ExitStatus::default(),
+                    stdout: vec![],
+                    stderr: vec![],
+                })
+            })
+            .await;
+
+        assert!(result.is_ok(), "should complete before timeout");
+    }
+
+    #[tokio::test]
+    async fn timeout_wrapper_expires_on_slow_operation() {
+        let timeout = tokio::time::Duration::from_millis(50);
+        let result: Result<Result<std::process::Output, std::io::Error>, _> =
+            tokio::time::timeout(timeout, async {
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                Ok(std::process::Output {
+                    status: std::process::ExitStatus::default(),
+                    stdout: vec![],
+                    stderr: vec![],
+                })
+            })
+            .await;
+
+        assert!(
+            result.is_err(),
+            "timeout should expire before slow operation completes"
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_agent_timeout_pattern_returns_false() {
+        let timeout = tokio::time::Duration::from_millis(50);
+        let result = tokio::time::timeout(timeout, async {
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            tokio::process::Command::new("true").output().await
+        })
+        .await;
+
+        let success = match result {
+            Ok(Ok(o)) => o.status.success(),
+            _ => false,
+        };
+        assert!(!success, "timeout should cause probe to return false");
+    }
+
+    #[tokio::test]
+    async fn get_agent_version_timeout_pattern_returns_empty() {
+        let timeout = tokio::time::Duration::from_millis(50);
+        let result = tokio::time::timeout(timeout, async {
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            tokio::process::Command::new("true").output().await
+        })
+        .await;
+
+        let version = match result {
+            Ok(Ok(o)) if o.status.success() => {
+                String::from_utf8_lossy(&o.stdout).trim().to_string()
+            }
+            _ => String::new(),
+        };
+        assert!(
+            version.is_empty(),
+            "timeout should cause version to return empty string"
+        );
     }
 }

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -1144,13 +1144,14 @@ fn update_yaml_from_request(
         mapping.insert("repos".into(), serde_yaml::Value::Sequence(repos_seq));
     }
 
-    // Update agents section — merge request agents into existing, preserving untouched agents
+    // Update agents section — replace entirely with request data (authoritative),
+    // but preserve unknown fields within each retained agent entry.
     let existing_agents = mapping
         .get("agents")
         .and_then(|value| value.as_mapping())
         .cloned()
         .unwrap_or_default();
-    let mut agents_map = existing_agents.clone();
+    let mut agents_map = serde_yaml::Mapping::new();
     for agent in &request.agents {
         let mut agent_config = existing_agents
             .get(serde_yaml::Value::String(agent.role.clone()))
@@ -2068,21 +2069,6 @@ on_failure: Failed
         assert_eq!(request.agents[0].model.as_deref(), Some("sonnet"));
         assert_eq!(request.steps.len(), 1);
         assert_eq!(request.steps[0].name, "build");
-    }
-
-    #[tokio::test]
-    async fn probe_agent_returns_true_when_acpx_succeeds() {
-        let result = probe_agent("claude").await;
-        assert!(result, "probe_agent should return true when acpx succeeds");
-    }
-
-    #[tokio::test]
-    async fn get_agent_version_returns_version_when_acpx_succeeds() {
-        let result = get_agent_version("claude").await;
-        assert!(
-            !result.is_empty(),
-            "get_agent_version should return version when acpx succeeds"
-        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -2151,7 +2151,7 @@ on_failure: Failed
     }
 
     #[test]
-    fn merge_preserves_existing_agents_not_in_request() {
+    fn merge_replaces_agents_authoritatively() {
         let existing_yaml = r#"
 tracker:
   kind: todo_file
@@ -2200,12 +2200,12 @@ on_failure: Failed
         let builder = agents.get("builder").unwrap().as_mapping().unwrap();
         assert_eq!(builder.get("model").unwrap().as_str().unwrap(), "opus");
 
-        // reviewer should be preserved (not in request)
-        let reviewer = agents.get("reviewer").unwrap().as_mapping().unwrap();
-        assert_eq!(
-            reviewer.get("acpx_agent").unwrap().as_str().unwrap(),
-            "codex"
+        // reviewer should NOT be preserved (not in request — authoritative replacement)
+        assert!(
+            agents.get("reviewer").is_none(),
+            "reviewer should be removed since it's not in the request"
         );
+        assert_eq!(agents.len(), 1, "only builder should remain in agents");
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -586,10 +586,22 @@ fn generate_yaml(request: &SetupRequest) -> String {
         if let Some(ref model) = agent.model {
             yaml.push_str(&format!("    model: {}\n", model));
         }
-        yaml.push_str(&format!(
-            "    prompt_template: templates/{}.liquid\n",
-            find_step_for_agent(&agent.role, &request.steps)
-        ));
+        // Emit prompt or prompt_template based on agent config
+        // If both are set, prompt takes precedence and prompt_file is silently ignored
+        if let Some(ref prompt) = agent.prompt {
+            let quoted = serde_yaml::to_string(&prompt)
+                .unwrap_or_else(|_| format!("\"{}\"", prompt.replace('\\', "\\\\").replace('"', "\\\"")));
+            yaml.push_str(&format!("    prompt: {}", quoted.trim_end()));
+        } else if let Some(ref prompt_file) = agent.prompt_file {
+            let quoted = serde_yaml::to_string(&prompt_file)
+                .unwrap_or_else(|_| format!("\"{}\"", prompt_file.replace('\\', "\\\\").replace('"', "\\\"")));
+            yaml.push_str(&format!("    prompt_template: {}", quoted.trim_end()));
+        } else {
+            let template_path = format!("templates/{}.liquid", find_step_for_agent(&agent.role, &request.steps));
+            let quoted = serde_yaml::to_string(&template_path).unwrap_or_else(|_| format!("\"{}\"", template_path));
+            yaml.push_str(&format!("    prompt_template: {}", quoted.trim_end()));
+        }
+        yaml.push('\n');
     }
 
     // Steps section
@@ -915,12 +927,20 @@ fn extract_agents(doc: &serde_yaml::Value) -> Result<Vec<SetupAgent>, ConfigErro
                         .get("model")
                         .and_then(|m| m.as_str())
                         .map(String::from);
+                    let prompt = config
+                        .get("prompt")
+                        .and_then(|p| p.as_str())
+                        .map(String::from);
+                    let prompt_file = config
+                        .get("prompt_template")
+                        .and_then(|p| p.as_str())
+                        .map(String::from);
                     Some(SetupAgent {
                         role: role.to_string(),
                         acpx_agent: acpx_agent.to_string(),
                         model,
-                        prompt: None,
-                        prompt_file: None,
+                        prompt,
+                        prompt_file,
                     })
                 })
                 .collect::<Vec<_>>()
@@ -1122,11 +1142,21 @@ fn update_yaml_from_request(
         if let Some(ref model) = agent.model {
             agent_config.insert("model".into(), serde_yaml::Value::String(model.clone()));
         }
-        let template_name = find_step_for_agent(&agent.role, &request.steps);
-        agent_config.insert(
-            "prompt_template".into(),
-            serde_yaml::Value::String(format!("templates/{}.liquid", template_name)),
-        );
+        // Emit prompt or prompt_template based on agent config
+        if let Some(ref prompt) = agent.prompt {
+            agent_config.insert("prompt".into(), serde_yaml::Value::String(prompt.clone()));
+        } else if let Some(ref prompt_file) = agent.prompt_file {
+            agent_config.insert(
+                "prompt_template".into(),
+                serde_yaml::Value::String(prompt_file.clone()),
+            );
+        } else {
+            let template_name = find_step_for_agent(&agent.role, &request.steps);
+            agent_config.insert(
+                "prompt_template".into(),
+                serde_yaml::Value::String(format!("templates/{}.liquid", template_name)),
+            );
+        }
         agents_map.insert(
             serde_yaml::Value::String(agent.role.clone()),
             serde_yaml::Value::Mapping(agent_config),
@@ -1361,6 +1391,155 @@ on_failure: Failed
         assert_eq!(request.steps.len(), 1);
         assert_eq!(request.steps[0].name, "build");
         assert_eq!(request.on_success, "Done");
+    }
+
+    #[test]
+    fn build_setup_artifacts_emits_inline_prompt() {
+        let request = SetupRequest {
+            tracker: SetupTracker::TodoFile {
+                path: PathBuf::from("TODO.md"),
+            },
+            repos: vec![],
+            agents: vec![SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "claude".to_string(),
+                model: None,
+                prompt: Some("Build it.".to_string()),
+                prompt_file: None,
+            }],
+            steps: vec![SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        };
+
+        let artifacts = build_setup_artifacts(&request);
+
+        assert!(artifacts.raw_yaml.contains("prompt: \"Build it.\""));
+        assert!(!artifacts.raw_yaml.contains("prompt_template"));
+    }
+
+    #[test]
+    fn build_setup_artifacts_emits_prompt_template() {
+        let request = SetupRequest {
+            tracker: SetupTracker::TodoFile {
+                path: PathBuf::from("TODO.md"),
+            },
+            repos: vec![],
+            agents: vec![SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "claude".to_string(),
+                model: None,
+                prompt: None,
+                prompt_file: Some("templates/custom.liquid".to_string()),
+            }],
+            steps: vec![SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        };
+
+        let artifacts = build_setup_artifacts(&request);
+
+        assert!(artifacts.raw_yaml.contains("prompt_template: \"templates/custom.liquid\""));
+        assert!(!artifacts.raw_yaml.contains("prompt:"));
+    }
+
+    #[test]
+    fn build_setup_artifacts_prompt_with_special_chars() {
+        let request = SetupRequest {
+            tracker: SetupTracker::TodoFile {
+                path: PathBuf::from("TODO.md"),
+            },
+            repos: vec![],
+            agents: vec![SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "claude".to_string(),
+                model: None,
+                prompt: Some("Build it: use #hashtags and \"quotes\"".to_string()),
+                prompt_file: None,
+            }],
+            steps: vec![SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        };
+
+        let artifacts = build_setup_artifacts(&request);
+
+        // Should be properly quoted so YAML parses correctly
+        let reparsed: serde_yaml::Value = serde_yaml::from_str(&artifacts.raw_yaml).unwrap();
+        let agents = reparsed.get("agents").unwrap().as_mapping().unwrap();
+        let builder = agents.get("builder").unwrap().as_mapping().unwrap();
+        let prompt = builder.get("prompt").unwrap().as_str().unwrap();
+        assert_eq!(prompt, "Build it: use #hashtags and \"quotes\"");
+    }
+
+    #[test]
+    fn build_setup_artifacts_prompt_takes_precedence_over_prompt_file() {
+        let request = SetupRequest {
+            tracker: SetupTracker::TodoFile {
+                path: PathBuf::from("TODO.md"),
+            },
+            repos: vec![],
+            agents: vec![SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "claude".to_string(),
+                model: None,
+                prompt: Some("Inline prompt".to_string()),
+                prompt_file: Some("templates/ignored.liquid".to_string()),
+            }],
+            steps: vec![SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        };
+
+        let artifacts = build_setup_artifacts(&request);
+
+        assert!(artifacts.raw_yaml.contains("prompt: \"Inline prompt\""));
+        assert!(!artifacts.raw_yaml.contains("ignored"));
+    }
+
+    #[test]
+    fn extract_setup_defaults_from_yaml_with_prompt_file() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  builder:
+    acpx_agent: claude
+    prompt_template: templates/custom.liquid
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+
+        let request = extract_setup_defaults(yaml).unwrap();
+
+        assert_eq!(request.agents.len(), 1);
+        assert_eq!(request.agents[0].role, "builder");
+        assert_eq!(request.agents[0].prompt_file, Some("templates/custom.liquid".to_string()));
+        assert_eq!(request.agents[0].prompt, None);
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -295,17 +295,22 @@ pub async fn run_setup_checks(request: &SetupRequest) -> Vec<SetupCheck> {
     // Check repos
     for repo in &request.repos {
         let exists = repo.path.join(".git").exists();
-        let branch_ok = tokio::process::Command::new("git")
-            .args([
-                "rev-parse",
-                "--verify",
-                &format!("refs/heads/{}", repo.branch),
-            ])
-            .current_dir(&repo.path)
-            .output()
-            .await
-            .map(|o| o.status.success())
-            .unwrap_or(false);
+        let branch_ok = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            tokio::process::Command::new("git")
+                .args([
+                    "rev-parse",
+                    "--verify",
+                    &format!("refs/heads/{}", repo.branch),
+                ])
+                .current_dir(&repo.path)
+                .output(),
+        )
+        .await
+        {
+            Ok(Ok(output)) => output.status.success(),
+            _ => false,
+        };
 
         let passed = exists && branch_ok;
         let detail = if passed {

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -7,4 +7,5 @@ pub mod observability;
 pub mod orchestrator;
 pub mod pipeline;
 pub mod tracker;
+pub mod ui;
 pub mod workspace;

--- a/crates/ensemble-core/src/ui.rs
+++ b/crates/ensemble-core/src/ui.rs
@@ -1,0 +1,103 @@
+use axum::{
+    body::Body,
+    http::{header, StatusCode},
+    response::Response,
+};
+
+pub struct ResolvedSpaAsset {
+    pub path: String,
+    pub content_type: String,
+    pub bytes: Vec<u8>,
+}
+
+pub fn normalize_spa_path(path: &str) -> &str {
+    let trimmed = path.trim_matches('/');
+    if trimmed.is_empty() {
+        "index.html"
+    } else {
+        trimmed
+    }
+}
+
+pub fn resolve_spa_asset<F>(path: &str, mut get_asset: F) -> ResolvedSpaAsset
+where
+    F: FnMut(&str) -> Option<&'static [u8]>,
+{
+    let normalized = normalize_spa_path(path);
+
+    for candidate in [
+        normalized.to_string(),
+        format!("{normalized}.html"),
+        format!("{normalized}/index.html"),
+        "index.html".to_string(),
+    ] {
+        if let Some(bytes) = get_asset(&candidate) {
+            return ResolvedSpaAsset {
+                content_type: content_type_for_path(&candidate).to_string(),
+                path: candidate,
+                bytes: bytes.to_vec(),
+            };
+        }
+    }
+
+    ResolvedSpaAsset {
+        path: "index.html".to_string(),
+        content_type: "text/plain; charset=utf-8".to_string(),
+        bytes: b"index.html not found - UI may not be built".to_vec(),
+    }
+}
+
+pub fn serve_file_response<F>(path: &str, mut get_asset: F) -> Response<Body>
+where
+    F: FnMut(&str) -> Option<&'static [u8]>,
+{
+    let normalized = normalize_spa_path(path);
+    match get_asset(normalized) {
+        Some(bytes) => build_response(StatusCode::OK, content_type_for_path(normalized), bytes),
+        None => build_response(
+            StatusCode::NOT_FOUND,
+            "text/plain; charset=utf-8",
+            &b"Not found"[..],
+        ),
+    }
+}
+
+pub fn serve_spa_response<F>(path: &str, get_asset: F) -> Response<Body>
+where
+    F: FnMut(&str) -> Option<&'static [u8]>,
+{
+    let resolved = resolve_spa_asset(path, get_asset);
+    let status = if resolved.path == "index.html"
+        && resolved.bytes == b"index.html not found - UI may not be built"
+    {
+        StatusCode::NOT_FOUND
+    } else {
+        StatusCode::OK
+    };
+
+    build_response(status, &resolved.content_type, resolved.bytes)
+}
+
+pub fn spa_available<F>(mut get_asset: F) -> bool
+where
+    F: FnMut(&str) -> Option<&'static [u8]>,
+{
+    get_asset("index.html").is_some()
+}
+
+fn content_type_for_path(path: &str) -> &str {
+    mime_guess::from_path(path)
+        .first_raw()
+        .unwrap_or("application/octet-stream")
+}
+
+fn build_response<T>(status: StatusCode, content_type: &str, body: T) -> Response<Body>
+where
+    T: Into<Body>,
+{
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, content_type)
+        .body(body.into())
+        .expect("static SPA response should be valid")
+}

--- a/crates/ensemble-core/src/ui.rs
+++ b/crates/ensemble-core/src/ui.rs
@@ -3,6 +3,7 @@ use axum::{
     http::{header, StatusCode},
     response::Response,
 };
+use std::borrow::Cow;
 
 pub struct ResolvedSpaAsset {
     pub path: String,
@@ -21,7 +22,7 @@ pub fn normalize_spa_path(path: &str) -> &str {
 
 pub fn resolve_spa_asset<F>(path: &str, mut get_asset: F) -> ResolvedSpaAsset
 where
-    F: FnMut(&str) -> Option<&'static [u8]>,
+    F: FnMut(&str) -> Option<Cow<'static, [u8]>>,
 {
     let normalized = normalize_spa_path(path);
 
@@ -35,7 +36,7 @@ where
             return ResolvedSpaAsset {
                 content_type: content_type_for_path(&candidate).to_string(),
                 path: candidate,
-                bytes: bytes.to_vec(),
+                bytes: bytes.into_owned(),
             };
         }
     }
@@ -49,22 +50,26 @@ where
 
 pub fn serve_file_response<F>(path: &str, mut get_asset: F) -> Response<Body>
 where
-    F: FnMut(&str) -> Option<&'static [u8]>,
+    F: FnMut(&str) -> Option<Cow<'static, [u8]>>,
 {
     let normalized = normalize_spa_path(path);
     match get_asset(normalized) {
-        Some(bytes) => build_response(StatusCode::OK, content_type_for_path(normalized), bytes),
+        Some(bytes) => build_response(
+            StatusCode::OK,
+            content_type_for_path(normalized),
+            bytes.into_owned(),
+        ),
         None => build_response(
             StatusCode::NOT_FOUND,
             "text/plain; charset=utf-8",
-            &b"Not found"[..],
+            b"Not found".to_vec(),
         ),
     }
 }
 
 pub fn serve_spa_response<F>(path: &str, get_asset: F) -> Response<Body>
 where
-    F: FnMut(&str) -> Option<&'static [u8]>,
+    F: FnMut(&str) -> Option<Cow<'static, [u8]>>,
 {
     let resolved = resolve_spa_asset(path, get_asset);
     let status = if resolved.path == "index.html"
@@ -80,7 +85,7 @@ where
 
 pub fn spa_available<F>(mut get_asset: F) -> bool
 where
-    F: FnMut(&str) -> Option<&'static [u8]>,
+    F: FnMut(&str) -> Option<Cow<'static, [u8]>>,
 {
     get_asset("index.html").is_some()
 }
@@ -99,5 +104,10 @@ where
         .status(status)
         .header(header::CONTENT_TYPE, content_type)
         .body(body.into())
-        .expect("static SPA response should be valid")
+        .unwrap_or_else(|_| {
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::from("failed to build response"))
+                .expect("fallback response should be valid")
+        })
 }

--- a/crates/ensemble-core/src/ui.rs
+++ b/crates/ensemble-core/src/ui.rs
@@ -20,7 +20,7 @@ pub fn normalize_spa_path(path: &str) -> &str {
     }
 }
 
-pub fn resolve_spa_asset<F>(path: &str, mut get_asset: F) -> ResolvedSpaAsset
+pub fn resolve_spa_asset<F>(path: &str, mut get_asset: F) -> Option<ResolvedSpaAsset>
 where
     F: FnMut(&str) -> Option<Cow<'static, [u8]>>,
 {
@@ -33,19 +33,15 @@ where
         "index.html".to_string(),
     ] {
         if let Some(bytes) = get_asset(&candidate) {
-            return ResolvedSpaAsset {
+            return Some(ResolvedSpaAsset {
                 content_type: content_type_for_path(&candidate).to_string(),
                 path: candidate,
                 bytes: bytes.into_owned(),
-            };
+            });
         }
     }
 
-    ResolvedSpaAsset {
-        path: "index.html".to_string(),
-        content_type: "text/plain; charset=utf-8".to_string(),
-        bytes: b"index.html not found - UI may not be built".to_vec(),
-    }
+    None
 }
 
 pub fn serve_file_response<F>(path: &str, mut get_asset: F) -> Response<Body>
@@ -71,16 +67,14 @@ pub fn serve_spa_response<F>(path: &str, get_asset: F) -> Response<Body>
 where
     F: FnMut(&str) -> Option<Cow<'static, [u8]>>,
 {
-    let resolved = resolve_spa_asset(path, get_asset);
-    let status = if resolved.path == "index.html"
-        && resolved.bytes == b"index.html not found - UI may not be built"
-    {
-        StatusCode::NOT_FOUND
-    } else {
-        StatusCode::OK
-    };
-
-    build_response(status, &resolved.content_type, resolved.bytes)
+    match resolve_spa_asset(path, get_asset) {
+        Some(resolved) => build_response(StatusCode::OK, &resolved.content_type, resolved.bytes),
+        None => build_response(
+            StatusCode::NOT_FOUND,
+            "text/plain; charset=utf-8",
+            b"index.html not found - UI may not be built".to_vec(),
+        ),
+    }
 }
 
 pub fn spa_available<F>(mut get_asset: F) -> bool

--- a/crates/ensemble-core/tests/embedded_spa.rs
+++ b/crates/ensemble-core/tests/embedded_spa.rs
@@ -1,0 +1,30 @@
+use ensemble_core::ui::{normalize_spa_path, resolve_spa_asset};
+
+#[test]
+fn normalize_spa_path_maps_root_to_index() {
+    assert_eq!(normalize_spa_path("/"), "index.html");
+    assert_eq!(normalize_spa_path(""), "index.html");
+}
+
+#[test]
+fn resolve_spa_asset_checks_html_and_directory_fallbacks() {
+    let resolved = resolve_spa_asset("/settings", |path| match path {
+        "settings.html" => Some(b"settings".as_slice()),
+        _ => None,
+    });
+
+    assert_eq!(resolved.path, "settings.html");
+    assert_eq!(resolved.content_type, "text/html");
+    assert_eq!(resolved.bytes, b"settings");
+}
+
+#[test]
+fn resolve_spa_asset_falls_back_to_root_index() {
+    let resolved = resolve_spa_asset("/missing", |path| match path {
+        "index.html" => Some(b"root-index".as_slice()),
+        _ => None,
+    });
+
+    assert_eq!(resolved.path, "index.html");
+    assert_eq!(resolved.bytes, b"root-index");
+}

--- a/crates/ensemble-core/tests/embedded_spa.rs
+++ b/crates/ensemble-core/tests/embedded_spa.rs
@@ -1,4 +1,5 @@
 use ensemble_core::ui::{normalize_spa_path, resolve_spa_asset};
+use std::borrow::Cow;
 
 #[test]
 fn normalize_spa_path_maps_root_to_index() {
@@ -9,7 +10,7 @@ fn normalize_spa_path_maps_root_to_index() {
 #[test]
 fn resolve_spa_asset_checks_html_and_directory_fallbacks() {
     let resolved = resolve_spa_asset("/settings", |path| match path {
-        "settings.html" => Some(b"settings".as_slice()),
+        "settings.html" => Some(Cow::Borrowed(b"settings".as_slice())),
         _ => None,
     });
 
@@ -21,7 +22,7 @@ fn resolve_spa_asset_checks_html_and_directory_fallbacks() {
 #[test]
 fn resolve_spa_asset_falls_back_to_root_index() {
     let resolved = resolve_spa_asset("/missing", |path| match path {
-        "index.html" => Some(b"root-index".as_slice()),
+        "index.html" => Some(Cow::Borrowed(b"root-index".as_slice())),
         _ => None,
     });
 

--- a/crates/ensemble-core/tests/embedded_spa.rs
+++ b/crates/ensemble-core/tests/embedded_spa.rs
@@ -12,7 +12,8 @@ fn resolve_spa_asset_checks_html_and_directory_fallbacks() {
     let resolved = resolve_spa_asset("/settings", |path| match path {
         "settings.html" => Some(Cow::Borrowed(b"settings".as_slice())),
         _ => None,
-    });
+    })
+    .expect("should find settings.html");
 
     assert_eq!(resolved.path, "settings.html");
     assert_eq!(resolved.content_type, "text/html");
@@ -24,8 +25,15 @@ fn resolve_spa_asset_falls_back_to_root_index() {
     let resolved = resolve_spa_asset("/missing", |path| match path {
         "index.html" => Some(Cow::Borrowed(b"root-index".as_slice())),
         _ => None,
-    });
+    })
+    .expect("should fall back to index.html");
 
     assert_eq!(resolved.path, "index.html");
     assert_eq!(resolved.bytes, b"root-index");
+}
+
+#[test]
+fn resolve_spa_asset_returns_none_when_nothing_found() {
+    let result = resolve_spa_asset("/missing", |_path| None);
+    assert!(result.is_none());
 }

--- a/crates/ensemble-desktop/Cargo.toml
+++ b/crates/ensemble-desktop/Cargo.toml
@@ -13,7 +13,7 @@ tauri = { version = "2", features = [] }
 rust-embed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-mime_guess = "2"
+mime_guess = { workspace = true }
 axum = { workspace = true }
 url = "2"
 thiserror = { workspace = true }

--- a/crates/ensemble-desktop/src/embedded_ui.rs
+++ b/crates/ensemble-desktop/src/embedded_ui.rs
@@ -36,7 +36,6 @@ pub fn spa_router() -> axum::Router {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ensemble_core::ui::normalize_spa_path;
 
     #[test]

--- a/crates/ensemble-desktop/src/embedded_ui.rs
+++ b/crates/ensemble-desktop/src/embedded_ui.rs
@@ -1,14 +1,7 @@
 //! Embedded SPA UI serving for the desktop app.
-//!
-//! NOTE: This file duplicates the embedded_ui implementation in ensemble-cli.
-//! This duplication should be extracted to ensemble-core for shared use
-//! between CLI and desktop. See: crates/ensemble-cli/src/embedded_ui.rs
 
-use axum::{
-    body::Body,
-    http::{header, StatusCode, Uri},
-    response::{IntoResponse, Response},
-};
+use axum::{http::Uri, response::IntoResponse};
+use ensemble_core::ui::{serve_spa_response, spa_available as core_spa_available};
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
@@ -17,64 +10,23 @@ struct SpaAssets;
 
 /// Check if SPA is available
 pub fn spa_available() -> bool {
-    SpaAssets::get("index.html").is_some()
-}
-
-/// Normalize a request path for embedded asset lookup.
-/// Strips leading/trailing slashes and treats empty paths as "index.html".
-fn normalize_path(path: &str) -> &str {
-    let trimmed = path.trim_matches('/');
-    if trimmed.is_empty() {
-        "index.html"
-    } else {
-        trimmed
-    }
+    core_spa_available(|asset_path| {
+        SpaAssets::get(asset_path)
+            .map(|file| file.data.into_owned().into_boxed_slice())
+            .map(Box::leak)
+            .map(|bytes| &*bytes)
+    })
 }
 
 /// Serve the SPA with fallback to index.html for client-side routing.
 /// This is an axum-compatible handler that mirrors the CLI embedded_ui implementation.
 pub async fn serve_spa(uri: Uri) -> impl IntoResponse {
-    let path = normalize_path(uri.path());
-
-    // Try exact path first
-    if let Some(file) = SpaAssets::get(path) {
-        let content_type = mime_guess::from_path(path).first_or_octet_stream();
-        return Response::builder()
-            .header(header::CONTENT_TYPE, content_type.as_ref())
-            .body(Body::from(file.data))
-            .unwrap();
-    }
-
-    // Try with .html extension
-    let html_path = format!("{}.html", path);
-    if let Some(file) = SpaAssets::get(&html_path) {
-        return Response::builder()
-            .header(header::CONTENT_TYPE, "text/html")
-            .body(Body::from(file.data))
-            .unwrap();
-    }
-
-    // Try index.html in directory
-    let dir_index = format!("{}/index.html", path);
-    if let Some(file) = SpaAssets::get(&dir_index) {
-        return Response::builder()
-            .header(header::CONTENT_TYPE, "text/html")
-            .body(Body::from(file.data))
-            .unwrap();
-    }
-
-    // Fallback to root index.html (SPA behavior)
-    if let Some(file) = SpaAssets::get("index.html") {
-        Response::builder()
-            .header(header::CONTENT_TYPE, "text/html")
-            .body(Body::from(file.data))
-            .unwrap()
-    } else {
-        Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .body(Body::from("index.html not found - UI may not be built"))
-            .unwrap()
-    }
+    serve_spa_response(uri.path(), |asset_path| {
+        SpaAssets::get(asset_path)
+            .map(|file| file.data.into_owned().into_boxed_slice())
+            .map(Box::leak)
+            .map(|bytes| &*bytes)
+    })
 }
 
 /// Router for serving embedded SPA
@@ -85,39 +37,40 @@ pub fn spa_router() -> axum::Router {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ensemble_core::ui::normalize_spa_path;
 
     #[test]
     fn test_normalize_path_strips_leading_slash() {
-        assert_eq!(normalize_path("/assets/app.js"), "assets/app.js");
+        assert_eq!(normalize_spa_path("/assets/app.js"), "assets/app.js");
     }
 
     #[test]
     fn test_normalize_path_strips_trailing_slash() {
-        assert_eq!(normalize_path("assets/"), "assets");
+        assert_eq!(normalize_spa_path("assets/"), "assets");
     }
 
     #[test]
     fn test_normalize_path_strips_both_slashes() {
-        assert_eq!(normalize_path("/assets/app.js/"), "assets/app.js");
+        assert_eq!(normalize_spa_path("/assets/app.js/"), "assets/app.js");
     }
 
     #[test]
     fn test_normalize_path_empty_becomes_index() {
-        assert_eq!(normalize_path(""), "index.html");
+        assert_eq!(normalize_spa_path(""), "index.html");
     }
 
     #[test]
     fn test_normalize_path_root_slash_becomes_index() {
-        assert_eq!(normalize_path("/"), "index.html");
+        assert_eq!(normalize_spa_path("/"), "index.html");
     }
 
     #[test]
     fn test_normalize_path_no_slashes_unchanged() {
-        assert_eq!(normalize_path("style.css"), "style.css");
+        assert_eq!(normalize_spa_path("style.css"), "style.css");
     }
 
     #[test]
     fn test_normalize_path_nested_unchanged() {
-        assert_eq!(normalize_path("assets/js/app.js"), "assets/js/app.js");
+        assert_eq!(normalize_spa_path("assets/js/app.js"), "assets/js/app.js");
     }
 }

--- a/crates/ensemble-desktop/src/embedded_ui.rs
+++ b/crates/ensemble-desktop/src/embedded_ui.rs
@@ -10,22 +10,14 @@ struct SpaAssets;
 
 /// Check if SPA is available
 pub fn spa_available() -> bool {
-    core_spa_available(|asset_path| {
-        SpaAssets::get(asset_path)
-            .map(|file| file.data.into_owned().into_boxed_slice())
-            .map(Box::leak)
-            .map(|bytes| &*bytes)
-    })
+    core_spa_available(|asset_path| SpaAssets::get(asset_path).map(|f| f.data))
 }
 
 /// Serve the SPA with fallback to index.html for client-side routing.
 /// This is an axum-compatible handler that mirrors the CLI embedded_ui implementation.
 pub async fn serve_spa(uri: Uri) -> impl IntoResponse {
     serve_spa_response(uri.path(), |asset_path| {
-        SpaAssets::get(asset_path)
-            .map(|file| file.data.into_owned().into_boxed_slice())
-            .map(Box::leak)
-            .map(|bytes| &*bytes)
+        SpaAssets::get(asset_path).map(|f| f.data)
     })
 }
 

--- a/crates/ensemble-desktop/src/main.rs
+++ b/crates/ensemble-desktop/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use ensemble_core::observability::events::EventBus;
 use tauri::Manager;
 use tracing::{info, warn};
 
@@ -45,23 +46,36 @@ fn main() {
         "Resolved configuration paths"
     );
 
-    // Create Tokio runtime for the server
-    let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
+    // Create a single shared EventBus for both orchestrator and server
+    let event_bus = EventBus::new();
 
-    // Start the local HTTP server
-    let desktop_server = rt
-        .block_on(start_desktop_server(
-            resolved.config_dir.clone(),
+    // Initialize orchestrator before the Tauri builder so we don't block the UI thread.
+    // Use tauri::async_runtime::block_on instead of a manual tokio runtime.
+    let orchestrator = if resolved.config_path.exists() {
+        tauri::async_runtime::block_on(DesktopOrchestrator::new(
             resolved.config_path.clone(),
+            event_bus.clone(),
         ))
-        .unwrap_or_else(|e| {
-            eprintln!("Error: Failed to start desktop server: {}", e);
-            std::process::exit(1);
-        });
+        .ok()
+    } else {
+        info!("No config found - app running in setup mode");
+        None
+    };
+
+    // Start the local HTTP server using Tauri's async runtime
+    let desktop_server = tauri::async_runtime::block_on(start_desktop_server(
+        resolved.config_dir.clone(),
+        resolved.config_path.clone(),
+        event_bus.clone(),
+    ))
+    .unwrap_or_else(|e| {
+        eprintln!("Error: Failed to start desktop server: {}", e);
+        std::process::exit(1);
+    });
 
     info!(url = %desktop_server.url, "Desktop server started");
 
-    // Store server URL and runtime for use in Tauri setup
+    // Store server URL for use in Tauri setup
     let server_url = desktop_server.url.clone();
 
     tauri::Builder::default()
@@ -78,28 +92,13 @@ fn main() {
             .build()
             .expect("Failed to create main window");
 
-            // Initialize orchestrator if we have a valid config
-            rt.block_on(async {
-                if resolved.config_path.exists() {
-                    match DesktopOrchestrator::new(resolved.config_path.clone()).await {
-                        Ok(orchestrator) => {
-                            app.manage(orchestrator);
-                            info!("Orchestrator initialized successfully");
-                        }
-                        Err(e) => {
-                            warn!(
-                                error = %e,
-                                "Failed to initialize orchestrator - app will run in setup mode"
-                            );
-                        }
-                    }
-                } else {
-                    info!("No config found - app running in setup mode");
-                }
-            });
-
-            // Store runtime handle
-            app.manage(rt);
+            // Register orchestrator if it was initialized successfully
+            if let Some(orch) = orchestrator {
+                app.manage(orch);
+                info!("Orchestrator registered with Tauri app state");
+            } else if resolved.config_path.exists() {
+                warn!("Failed to initialize orchestrator - app will run in setup mode");
+            }
 
             info!("Ensemble Desktop initialized successfully");
             Ok(())

--- a/crates/ensemble-desktop/src/orchestrator.rs
+++ b/crates/ensemble-desktop/src/orchestrator.rs
@@ -22,7 +22,7 @@ use crate::error::DesktopError;
 pub struct DesktopOrchestrator {
     pub state: Arc<RwLock<OrchestratorState>>,
     pub event_bus: EventBus,
-    pub config_path: String,
+    pub config_path: PathBuf,
 }
 
 impl DesktopOrchestrator {
@@ -30,7 +30,7 @@ impl DesktopOrchestrator {
     ///
     /// This validates the config and builds the DAG, returning an error
     /// if the config is invalid.
-    pub async fn new(config_path: PathBuf) -> Result<Self, DesktopError> {
+    pub async fn new(config_path: PathBuf, event_bus: EventBus) -> Result<Self, DesktopError> {
         info!(config_path = %config_path.display(), "Initializing desktop orchestrator from config.yaml");
 
         // Load config
@@ -54,8 +54,8 @@ impl DesktopOrchestrator {
 
         Ok(Self {
             state,
-            event_bus: EventBus::new(),
-            config_path: config_path.display().to_string(),
+            event_bus,
+            config_path,
         })
     }
 
@@ -106,7 +106,7 @@ on_failure: Failed
         let mut file = std::fs::File::create(&config_path).unwrap();
         file.write_all(valid_config.as_bytes()).unwrap();
 
-        let orchestrator = DesktopOrchestrator::new(config_path).await;
+        let orchestrator = DesktopOrchestrator::new(config_path, EventBus::new()).await;
         assert!(orchestrator.is_ok());
     }
 
@@ -125,7 +125,7 @@ steps: []
         let mut file = std::fs::File::create(&config_path).unwrap();
         file.write_all(invalid_config.as_bytes()).unwrap();
 
-        let orchestrator = DesktopOrchestrator::new(config_path).await;
+        let orchestrator = DesktopOrchestrator::new(config_path, EventBus::new()).await;
         assert!(orchestrator.is_err());
     }
 }

--- a/crates/ensemble-desktop/src/server.rs
+++ b/crates/ensemble-desktop/src/server.rs
@@ -15,24 +15,26 @@ use tracing::{error, info, warn};
 
 use ensemble_core::api::router::{create_api_router, AppState, ConfigRuntime};
 use ensemble_core::config::draft::load_config_state;
-use ensemble_core::config::draft::ConfigDocumentState;
+use ensemble_core::config::draft::{ConfigDocumentState, ConfigStateKind, DraftValidationReport};
+use ensemble_core::config::ensemble::{ConcurrencyConfig, PollingConfig};
 use ensemble_core::observability::events::EventBus;
 use ensemble_core::orchestrator::state::OrchestratorState;
 
 use crate::embedded_ui::spa_router;
 use crate::error::DesktopError;
 
-/// Default poll interval in milliseconds (30 seconds).
-const DEFAULT_POLL_INTERVAL_MS: u64 = 30000;
-
-/// Default maximum number of concurrent agents.
-const DEFAULT_MAX_CONCURRENT_AGENTS: u32 = 10;
-
 /// Desktop server handle containing the URL and shutdown handle.
 pub struct DesktopServer {
     pub url: url::Url,
-    #[allow(dead_code)]
-    pub shutdown: tokio::task::JoinHandle<()>,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl Drop for DesktopServer {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
 }
 
 /// Start the local HTTP server for the desktop app.
@@ -48,6 +50,7 @@ pub struct DesktopServer {
 pub async fn start_desktop_server(
     config_dir: PathBuf,
     config_path: PathBuf,
+    event_bus: EventBus,
 ) -> Result<DesktopServer, DesktopError> {
     info!(
         config_dir = %config_dir.display(),
@@ -60,14 +63,13 @@ pub async fn start_desktop_server(
         Ok(state) => state,
         Err(e) => {
             error!(error = %e, path = %config_path.display(), "Failed to load config state");
-            // Create a default missing state
-            ensemble_core::config::draft::ConfigDocumentState {
+            ConfigDocumentState {
                 path: config_path.clone(),
-                kind: ensemble_core::config::draft::ConfigStateKind::Missing,
+                kind: ConfigStateKind::Missing,
                 raw_yaml: None,
                 document: None,
                 active_config: None,
-                validation: ensemble_core::config::draft::DraftValidationReport::default(),
+                validation: DraftValidationReport::default(),
             }
         }
     };
@@ -103,7 +105,7 @@ pub async fn start_desktop_server(
         refresh_requested: refresh_notify.clone(),
         workspace_root,
         history_path,
-        event_bus: EventBus::new(),
+        event_bus,
         config_runtime: ConfigRuntime {
             config_path,
             document_state: Arc::new(RwLock::new(document_state)),
@@ -127,7 +129,7 @@ pub async fn start_desktop_server(
             source: e,
         })?;
 
-    let actual_addr = listener.local_addr().unwrap();
+    let actual_addr = listener.local_addr()?;
     let server_url = url::Url::parse(&format!("http://{}", actual_addr))?;
 
     info!(
@@ -136,15 +138,20 @@ pub async fn start_desktop_server(
     );
 
     // Start server in background
-    let shutdown = tokio::spawn(async move {
-        if let Err(e) = axum::serve(listener, router).await {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let server = axum::serve(listener, router).with_graceful_shutdown(async {
+            let _ = shutdown_rx.await;
+        });
+
+        if let Err(e) = server.await {
             error!(error = %e, "HTTP server error");
         }
     });
 
     Ok(DesktopServer {
         url: server_url,
-        shutdown,
+        shutdown: Some(shutdown_tx),
     })
 }
 
@@ -158,9 +165,11 @@ fn create_orchestrator_state(
             config.concurrency.max_concurrent_agents,
         )))
     } else {
+        let polling = PollingConfig::default();
+        let concurrency = ConcurrencyConfig::default();
         Arc::new(RwLock::new(OrchestratorState::new(
-            DEFAULT_POLL_INTERVAL_MS,
-            DEFAULT_MAX_CONCURRENT_AGENTS,
+            polling.interval_ms,
+            concurrency.max_concurrent_agents,
         )))
     }
 }
@@ -197,16 +206,14 @@ mod tests {
         let config_path = temp_dir.path().join("config.yaml");
 
         // Server should start even without config
-        let server = start_desktop_server(temp_dir.path().to_path_buf(), config_path)
-            .await
-            .expect("Server should start with missing config");
+        let server =
+            start_desktop_server(temp_dir.path().to_path_buf(), config_path, EventBus::new())
+                .await
+                .expect("Server should start with missing config");
 
         // URL should be valid
         assert_eq!(server.url.scheme(), "http");
         assert!(server.url.host().is_some());
-
-        // Cleanup
-        server.shutdown.abort();
     }
 
     #[tokio::test]
@@ -232,15 +239,13 @@ on_failure: Failed
         std::fs::write(&config_path, valid_config).unwrap();
 
         // Server should start with valid config
-        let server = start_desktop_server(temp_dir.path().to_path_buf(), config_path)
-            .await
-            .expect("Server should start with valid config");
+        let server =
+            start_desktop_server(temp_dir.path().to_path_buf(), config_path, EventBus::new())
+                .await
+                .expect("Server should start with valid config");
 
         // URL should be valid
         assert_eq!(server.url.scheme(), "http");
         assert!(server.url.host().is_some());
-
-        // Cleanup
-        server.shutdown.abort();
     }
 }

--- a/crates/ensemble-desktop/tests/e2e.rs
+++ b/crates/ensemble-desktop/tests/e2e.rs
@@ -105,7 +105,7 @@ tracker:
   path: TODO.md
 agents:
   coder:
-    model: claude-sonnet-4-20250514
+    model: test-model-fake
     prompt: "You are a helpful coding assistant."
     executor: local
 steps:
@@ -128,8 +128,7 @@ on_failure: "Failed"
         .spawn()
         .expect("Failed to launch app binary");
 
-    // Give the app a few seconds to initialize
-    std::thread::sleep(Duration::from_secs(3));
+    wait_for_startup(&mut child, Duration::from_secs(10)).expect("app should stay running");
 
     // Check if the process is still running
     let result = check_app_running(&mut child);
@@ -168,8 +167,7 @@ fn app_stays_running_when_config_missing() {
         .spawn()
         .expect("Failed to launch app binary");
 
-    // Give the app a few seconds to initialize the HTTP server
-    std::thread::sleep(Duration::from_secs(3));
+    wait_for_startup(&mut child, Duration::from_secs(10)).expect("app should stay running");
 
     // Check if the process is still running (it should be now!)
     let result = check_app_running_with_message(
@@ -234,6 +232,19 @@ fn binary_name() -> &'static str {
     } else {
         "ensemble-desktop"
     }
+}
+
+fn wait_for_startup(child: &mut std::process::Child, timeout: Duration) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Some(status) = child.try_wait().map_err(|e| e.to_string())? {
+            return Err(format!("process exited early with status {status}"));
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    Ok(())
 }
 
 fn restore_env(key: &str, value: Option<std::ffi::OsString>) {

--- a/crates/ensemble-ui/src-ui/src/components/config/FileBrowser.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/FileBrowser.test.tsx
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FileBrowser from "./FileBrowser";
+import { renderWithProviders } from "@/test/render";
+
+function jsonResponse(data: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  } as Response);
+}
+
+function jsonErrorResponse(status: number, message: string) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: { code: "test_error", message } }),
+  } as Response);
+}
+
+describe("FileBrowser", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders dialog when open", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({ entries: [], truncated: false })));
+
+    renderWithProviders(
+      <FileBrowser
+        mode="file"
+        onSelect={() => {}}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("Select a File")).toBeInTheDocument();
+  });
+
+  it("does not render dialog when closed", () => {
+    vi.stubGlobal("fetch", vi.fn());
+
+    renderWithProviders(
+      <FileBrowser
+        mode="file"
+        onSelect={() => {}}
+        open={false}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText("Select a File")).not.toBeInTheDocument();
+  });
+
+  it("shows loading state", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+
+    renderWithProviders(
+      <FileBrowser
+        mode="file"
+        onSelect={() => {}}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("shows error state", async () => {
+    vi.stubGlobal("fetch", vi.fn(() =>
+      jsonErrorResponse(500, "Internal server error"),
+    ));
+
+    renderWithProviders(
+      <FileBrowser
+        mode="file"
+        onSelect={() => {}}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("Internal server error")).toBeInTheDocument();
+  });
+
+  it("breadcrumb navigation works", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes("path=%2F") && !url.includes("path=%2Fhome")) {
+        return jsonResponse({
+          entries: [
+            { name: "home", is_dir: true, path: "/home" },
+          ],
+          truncated: false,
+        });
+      }
+      if (url.includes("path=%2Fhome")) {
+        return jsonResponse({
+          entries: [
+            { name: "user", is_dir: true, path: "/home/user" },
+          ],
+          truncated: false,
+        });
+      }
+      return jsonResponse({ entries: [], truncated: false });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithProviders(
+      <FileBrowser
+        mode="directory"
+        onSelect={() => {}}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    // Wait for initial load
+    expect(await screen.findByText("home")).toBeInTheDocument();
+
+    // Navigate into /home by double-clicking the list item
+    const homeItem = screen.getByText("home");
+    await user.dblClick(homeItem);
+
+    // Wait for navigation - should show /home contents
+    await waitFor(() => {
+      expect(screen.getByText("user")).toBeInTheDocument();
+    }, { timeout: 2000 });
+
+    // Verify breadcrumb shows / and home
+    expect(screen.getByText("home")).toBeInTheDocument();
+
+    // Click root breadcrumb to go back
+    const rootBreadcrumb = screen.getAllByText("/")[0];
+    expect(rootBreadcrumb).toBeDefined();
+    await user.click(rootBreadcrumb!);
+
+    // Should be back at root
+    await waitFor(() => {
+      expect(screen.getByText("home")).toBeInTheDocument();
+    }, { timeout: 2000 });
+  });
+
+  it("selection works in file mode", async () => {
+    const user = userEvent.setup();
+    const selectMock = vi.fn();
+    const openChangeMock = vi.fn();
+
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({
+      entries: [
+        { name: "src", is_dir: true, path: "/home/user/src" },
+        { name: "config.yaml", is_dir: false, path: "/home/user/config.yaml" },
+      ],
+      truncated: false,
+    })));
+
+    renderWithProviders(
+      <FileBrowser
+        mode="file"
+        onSelect={selectMock}
+        open={true}
+        onOpenChange={openChangeMock}
+      />,
+    );
+
+    // Wait for entries to load
+    expect(await screen.findByText("config.yaml")).toBeInTheDocument();
+
+    // In file mode, directories are shown but not selectable
+    // Click the file to select it
+    await user.click(screen.getByText("config.yaml"));
+
+    // Select button should now be enabled
+    const selectButton = screen.getByRole("button", { name: "Select" });
+    expect(selectButton).toBeEnabled();
+
+    // Click Select
+    await user.click(selectButton);
+
+    // onSelect should be called with the file path
+    expect(selectMock).toHaveBeenCalledWith("/home/user/config.yaml");
+    expect(openChangeMock).toHaveBeenCalledWith(false);
+  });
+
+  it("selection works in directory mode", async () => {
+    const user = userEvent.setup();
+    const selectMock = vi.fn();
+    const openChangeMock = vi.fn();
+
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({
+      entries: [
+        { name: "src", is_dir: true, path: "/home/user/src" },
+        { name: "config.yaml", is_dir: false, path: "/home/user/config.yaml" },
+      ],
+      truncated: false,
+    })));
+
+    renderWithProviders(
+      <FileBrowser
+        mode="directory"
+        onSelect={selectMock}
+        open={true}
+        onOpenChange={openChangeMock}
+      />,
+    );
+
+    // Wait for entries to load - in directory mode only dirs are shown
+    expect(await screen.findByText("src")).toBeInTheDocument();
+    expect(screen.queryByText("config.yaml")).not.toBeInTheDocument();
+
+    // Click the directory to select it
+    await user.click(screen.getByText("src"));
+
+    // Select button should now be enabled
+    const selectButton = screen.getByRole("button", { name: "Select" });
+    expect(selectButton).toBeEnabled();
+
+    // Click Select
+    await user.click(selectButton);
+
+    // onSelect should be called with the directory path
+    expect(selectMock).toHaveBeenCalledWith("/home/user/src");
+    expect(openChangeMock).toHaveBeenCalledWith(false);
+  });
+
+  it("Select button is disabled when nothing is selected", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({
+      entries: [
+        { name: "src", is_dir: true, path: "/home/user/src" },
+      ],
+      truncated: false,
+    })));
+
+    renderWithProviders(
+      <FileBrowser
+        mode="directory"
+        onSelect={() => {}}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    // Wait for entries to load
+    expect(await screen.findByText("src")).toBeInTheDocument();
+
+    // Select button should be disabled
+    const selectButton = screen.getByRole("button", { name: "Select" });
+    expect(selectButton).toBeDisabled();
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/components/config/FileBrowser.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/FileBrowser.tsx
@@ -1,0 +1,234 @@
+import { useState, useEffect, useCallback } from "react";
+import { Dialog } from "@base-ui/react";
+import { Button } from "@/components/ui/button";
+
+interface FsEntry {
+  name: string;
+  is_dir: boolean;
+  path: string;
+}
+
+interface FsListResponse {
+  entries: FsEntry[];
+  truncated: boolean;
+}
+
+interface FileBrowserProps {
+  mode: "file" | "directory";
+  onSelect: (path: string) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  initialPath?: string;
+}
+
+type FetchState = "idle" | "loading" | "error";
+
+function getBreadcrumbSegments(currentPath: string): { label: string; path: string }[] {
+  if (currentPath === "/") return [{ label: "/", path: "/" }];
+  const segments = currentPath.split("/").filter(Boolean);
+  const breadcrumbs: { label: string; path: string }[] = [{ label: "/", path: "/" }];
+  let accumulated = "";
+  for (const segment of segments) {
+    accumulated += `/${segment}`;
+    breadcrumbs.push({ label: segment, path: accumulated });
+  }
+  return breadcrumbs;
+}
+
+export default function FileBrowser({
+  mode,
+  onSelect,
+  open,
+  onOpenChange,
+  title,
+  initialPath,
+}: FileBrowserProps) {
+  const defaultPath = initialPath || "/";
+  const [currentPath, setCurrentPath] = useState(defaultPath);
+  const [entries, setEntries] = useState<FsEntry[]>([]);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [fetchState, setFetchState] = useState<FetchState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [truncated, setTruncated] = useState(false);
+
+  const fetchDirectory = useCallback(async (path: string) => {
+    setFetchState("loading");
+    setErrorMessage(null);
+    setSelectedPath(null);
+    try {
+      const res = await fetch(`/api/v1/fs/list?path=${encodeURIComponent(path)}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => null) as Record<string, unknown> | null;
+        const errorMessage =
+          body &&
+          typeof body.error === "object" &&
+          body.error !== null &&
+          typeof (body.error as Record<string, string>).message === "string"
+            ? (body.error as Record<string, string>).message
+            : `HTTP ${res.status}`;
+        setErrorMessage(errorMessage ?? `HTTP ${res.status}`);
+        setFetchState("error");
+        setEntries([]);
+        return;
+      }
+      const data: FsListResponse = await res.json();
+      setEntries(data.entries);
+      setTruncated(data.truncated);
+      setFetchState("idle");
+    } catch {
+      setErrorMessage("Failed to fetch directory contents");
+      setFetchState("error");
+      setEntries([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setCurrentPath(defaultPath);
+      setSelectedPath(null);
+      setEntries([]);
+      fetchDirectory(defaultPath);
+    }
+  }, [open, fetchDirectory, defaultPath]);
+
+  const handleNavigate = (path: string) => {
+    setCurrentPath(path);
+    fetchDirectory(path);
+  };
+
+  const handleDoubleClick = (entry: FsEntry) => {
+    if (entry.is_dir) {
+      handleNavigate(entry.path);
+    }
+  };
+
+  const handleClick = (entry: FsEntry) => {
+    if (mode === "file" && !entry.is_dir) {
+      setSelectedPath(entry.path);
+    } else if (mode === "directory" && entry.is_dir) {
+      setSelectedPath(entry.path);
+    }
+  };
+
+  const handleSelect = () => {
+    if (selectedPath) {
+      onSelect(selectedPath);
+      onOpenChange(false);
+    }
+  };
+
+  const breadcrumbSegments = getBreadcrumbSegments(currentPath);
+
+  const displayEntries = mode === "directory"
+    ? (entries ?? []).filter((e) => e.is_dir)
+    : entries ?? [];
+
+  const dialogTitle = title || (mode === "file" ? "Select a File" : "Select a Directory");
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(isOpen: boolean) => onOpenChange(isOpen)}
+      modal
+    >
+      <Dialog.Backdrop className="fixed inset-0 bg-black/50 z-40" />
+      <Dialog.Portal>
+        <Dialog.Popup
+          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-background border rounded-lg shadow-lg w-full max-w-2xl max-h-[80vh] flex flex-col"
+        >
+          <div className="p-4 border-b">
+            <Dialog.Title className="text-lg font-medium">
+              {dialogTitle}
+            </Dialog.Title>
+          </div>
+
+          {/* Breadcrumb */}
+          <div className="px-4 py-2 border-b flex items-center gap-1 text-sm overflow-x-auto">
+            {breadcrumbSegments.map((segment, index) => (
+              <span key={segment.path} className="flex items-center gap-1">
+                {index > 0 && <span className="text-muted-foreground">/</span>}
+                <button
+                  type="button"
+                  className="text-primary hover:underline cursor-pointer disabled:opacity-50"
+                  onClick={() => handleNavigate(segment.path)}
+                  disabled={segment.path === currentPath}
+                >
+                  {segment.label}
+                </button>
+              </span>
+            ))}
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto p-2 min-h-0">
+            {fetchState === "loading" && (
+              <div className="flex items-center justify-center py-8 text-muted-foreground">
+                Loading...
+              </div>
+            )}
+
+            {fetchState === "error" && (
+              <div className="flex items-center justify-center py-8 text-destructive">
+                {errorMessage || "An error occurred"}
+              </div>
+            )}
+
+            {fetchState === "idle" && displayEntries.length === 0 && (
+              <div className="flex items-center justify-center py-8 text-muted-foreground">
+                This directory is empty
+              </div>
+            )}
+
+            {fetchState === "idle" && displayEntries.length > 0 && (
+              <ul className="space-y-0.5">
+                {displayEntries.map((entry) => {
+                  const isSelected = selectedPath === entry.path;
+                  const isSelectable =
+                    (mode === "file" && !entry.is_dir) ||
+                    (mode === "directory" && entry.is_dir);
+
+                  return (
+                    <li
+                      key={entry.path}
+                      className={`flex items-center gap-2 px-3 py-1.5 rounded cursor-pointer text-sm ${
+                        isSelected
+                          ? "bg-primary/10 text-primary"
+                          : isSelectable
+                            ? "hover:bg-muted"
+                            : "text-muted-foreground cursor-default"
+                      }`}
+                      onClick={() => handleClick(entry)}
+                      onDoubleClick={() => handleDoubleClick(entry)}
+                    >
+                      <span className="shrink-0">
+                        {entry.is_dir ? "\uD83D\uDCC1" : "\uD83D\uDCC4"}
+                      </span>
+                      <span className="truncate">{entry.name}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+
+            {truncated && (
+              <div className="text-xs text-muted-foreground mt-2 px-3">
+                Results truncated
+              </div>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="p-4 border-t flex justify-end gap-2">
+            <Dialog.Close render={<Button variant="outline" />}>
+              Cancel
+            </Dialog.Close>
+            <Button onClick={handleSelect} disabled={!selectedPath}>
+              Select
+            </Button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/components/config/FileBrowser.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/FileBrowser.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Dialog } from "@base-ui/react";
 import { Button } from "@/components/ui/button";
+import { File, Folder } from "lucide-react";
 
 interface FsEntry {
   name: string;
@@ -23,6 +24,10 @@ interface FileBrowserProps {
 }
 
 type FetchState = "idle" | "loading" | "error";
+
+function hasParentTraversal(path: string) {
+  return path.split("/").some((segment) => segment === "..");
+}
 
 function getBreadcrumbSegments(currentPath: string): { label: string; path: string }[] {
   if (currentPath === "/") return [{ label: "/", path: "/" }];
@@ -53,6 +58,12 @@ export default function FileBrowser({
   const [truncated, setTruncated] = useState(false);
 
   const fetchDirectory = useCallback(async (path: string) => {
+    if (hasParentTraversal(path)) {
+      setErrorMessage("Parent directory traversal is not allowed");
+      setFetchState("error");
+      setEntries([]);
+      return;
+    }
     setFetchState("loading");
     setErrorMessage(null);
     setSelectedPath(null);
@@ -132,8 +143,8 @@ export default function FileBrowser({
       onOpenChange={(isOpen: boolean) => onOpenChange(isOpen)}
       modal
     >
-      <Dialog.Backdrop className="fixed inset-0 bg-black/50 z-40" />
       <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 bg-black/50 z-40" />
         <Dialog.Popup
           className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-background border rounded-lg shadow-lg w-full max-w-2xl max-h-[80vh] flex flex-col"
         >
@@ -202,7 +213,7 @@ export default function FileBrowser({
                       onDoubleClick={() => handleDoubleClick(entry)}
                     >
                       <span className="shrink-0">
-                        {entry.is_dir ? "\uD83D\uDCC1" : "\uD83D\uDCC4"}
+                        {entry.is_dir ? <Folder className="h-4 w-4" /> : <File className="h-4 w-4" />}
                       </span>
                       <span className="truncate">{entry.name}</span>
                     </li>

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
@@ -111,8 +111,9 @@ export default function GuidedEditor({
   const [trackerPathBrowserOpen, setTrackerPathBrowserOpen] = useState(false);
 
   useEffect(() => {
-    setDisplayedIssues(issues);
-  }, [issues]);
+    setForm(initialForm);
+    setIsDirty(false);
+  }, [initialForm]);
 
   const handleFormChange = (updates: Partial<GuidedForm>) => {
     setForm((prev) => ({ ...prev, ...updates }));
@@ -120,18 +121,13 @@ export default function GuidedEditor({
   };
 
   const handleValidate = async () => {
-    setIsValidating(true);
+      setIsValidating(true);
     try {
-      try {
-        const nextIssues = await onValidate(form, baseRawYaml);
-        setDisplayedIssues(nextIssues);
-        setLastValidation({
-          timestamp: new Date(),
-          issues: nextIssues,
-        });
-      } catch {
-        // Keep the last visible issues when validation fails.
-      }
+      const validatedIssues = await onValidate(form, baseRawYaml);
+      setLastValidation({
+        timestamp: new Date(),
+        issues: validatedIssues,
+      });
     } finally {
       setIsValidating(false);
     }
@@ -216,7 +212,7 @@ export default function GuidedEditor({
                 <ul className="mt-2 space-y-1 text-sm text-red-700 dark:text-red-300">
                   {displayedIssues.map((issue, i) => (
                     <li key={i}>
-                      {issue.section && `${issue.section}: `}
+              {issue.section ? `${issue.section}: ` : ""}
                       {issue.message}
                     </li>
                   ))}
@@ -410,7 +406,7 @@ export default function GuidedEditor({
                   handleFormChange({
                     runtime: {
                       ...form.runtime,
-                      max_cycles: parseInt(e.target.value) || 0,
+                      max_cycles: parseInt(e.target.value, 10) || 0,
                     },
                   })
                 }
@@ -428,7 +424,7 @@ export default function GuidedEditor({
                       ...form.runtime,
                       concurrency: {
                         ...form.runtime.concurrency,
-                        max_concurrent_agents: parseInt(e.target.value) || 0,
+                          max_concurrent_agents: parseInt(e.target.value, 10) || 0,
                       },
                     },
                   })
@@ -446,7 +442,7 @@ export default function GuidedEditor({
                     runtime: {
                       ...form.runtime,
                       polling: {
-                        interval_ms: parseInt(e.target.value) || 0,
+                        interval_ms: parseInt(e.target.value, 10) || 0,
                       },
                     },
                   })

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
@@ -3,7 +3,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { AlertCircle, Save, RotateCcw, Check } from "lucide-react";
+import { AlertCircle, Save, RotateCcw, Check, FileText } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import FileBrowser from "./FileBrowser";
 import WorkflowEditor from "./WorkflowEditor";
 import type { ValidationIssue } from "@/generated/models";
 
@@ -106,6 +108,7 @@ export default function GuidedEditor({
     timestamp: Date;
     issues: ValidationIssue[];
   } | null>(null);
+  const [trackerPathBrowserOpen, setTrackerPathBrowserOpen] = useState(false);
 
   useEffect(() => {
     setDisplayedIssues(issues);
@@ -231,24 +234,54 @@ export default function GuidedEditor({
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <label htmlFor="tracker-kind" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Kind</label>
-              <Input
-                id="tracker-kind"
+              <Select
                 value={form.tracker.kind}
-                onChange={(e) =>
+                onValueChange={(v: string | null) =>
                   handleFormChange({
-                    tracker: { ...form.tracker, kind: e.target.value },
+                    tracker: { ...form.tracker, kind: v ?? "todo_file" },
                   })
                 }
-              />
+              >
+                <SelectTrigger id="tracker-kind">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="todo_file">Todo File</SelectItem>
+                  <SelectItem value="github">GitHub Project</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
             <div className="space-y-2">
               <label htmlFor="tracker-path" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Path (optional)</label>
-              <Input
-                id="tracker-path"
-                value={form.tracker.path || ""}
-                onChange={(e) =>
+              <div className="flex gap-2">
+                <Input
+                  id="tracker-path"
+                  value={form.tracker.path || ""}
+                  onChange={(e) =>
+                    handleFormChange({
+                      tracker: { ...form.tracker, path: e.target.value || undefined },
+                    })
+                  }
+                  className="flex-1"
+                />
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => setTrackerPathBrowserOpen(true)}
+                  title="Browse for file"
+                >
+                  <FileText className="h-4 w-4" />
+                </Button>
+              </div>
+              <FileBrowser
+                open={trackerPathBrowserOpen}
+                onOpenChange={setTrackerPathBrowserOpen}
+                mode="file"
+                title="Select Tracker File"
+                initialPath={form.tracker.path || "~"}
+                onSelect={(path) =>
                   handleFormChange({
-                    tracker: { ...form.tracker, path: e.target.value || undefined },
+                    tracker: { ...form.tracker, path },
                   })
                 }
               />

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
@@ -124,6 +124,7 @@ export default function GuidedEditor({
       setIsValidating(true);
     try {
       const validatedIssues = await onValidate(form, baseRawYaml);
+      setDisplayedIssues(validatedIssues);
       setLastValidation({
         timestamp: new Date(),
         issues: validatedIssues,

--- a/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.test.tsx
@@ -127,24 +127,19 @@ describe("SetupWizard", () => {
     await user.clear(branchInput);
     await user.type(branchInput, "main");
 
-    // Add the repository by clicking the icon button (no accessible name)
-    const addButtons = screen.getAllByRole("button").filter(btn => 
-      btn.className.includes("size-8")
-    );
-    expect(addButtons.length).toBeGreaterThan(0);
-    await user.click(addButtons[0]!);
+    await user.click(screen.getByRole("button", { name: /add repository/i }));
 
     // Navigate to Agents step
     await user.click(screen.getByRole("button", { name: /next/i }));
 
     // Fill in agent fields - wait for agents to load (skip loading check since mock is synchronous)
     await waitFor(() => {
-      const agentSelect = screen.getByRole("combobox");
+      const agentSelect = screen.getByLabelText("Agent");
       expect(agentSelect).toBeInTheDocument();
     });
 
     // Select an agent from dropdown
-    const agentSelect = screen.getByRole("combobox");
+    const agentSelect = screen.getByLabelText("Agent");
     await user.click(agentSelect);
     const builderOption = await screen.findByText(/builder agent/i);
     await user.click(builderOption);

--- a/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
@@ -315,7 +315,7 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
               onChange={(e) => setDraft(prev => ({
                 ...prev,
                 tracker: { 
-                  ...DEFAULT_GH_TRACKER,
+                  ...prev.tracker,
                   project_number: e.target.value ? parseInt(e.target.value, 10) : null,
                 } as SetupTracker,
               }))}

--- a/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
@@ -439,13 +439,21 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
                         agents: prev.agents.filter((_, i) => i !== index),
                       }));
                       setCustomAgents(prev => {
-                        const updated = { ...prev };
-                        delete updated[index];
+                        const updated: Record<number, boolean> = {};
+                        for (const [k, v] of Object.entries(prev)) {
+                          const numK = Number(k);
+                          if (numK < index) updated[numK] = v;
+                          else if (numK > index) updated[numK - 1] = v;
+                        }
                         return updated;
                       });
                       setPromptModes(prev => {
-                        const updated = { ...prev };
-                        delete updated[index];
+                        const updated: Record<number, "inline" | "file"> = {};
+                        for (const [k, v] of Object.entries(prev)) {
+                          const numK = Number(k);
+                          if (numK < index) updated[numK] = v;
+                          else if (numK > index) updated[numK - 1] = v;
+                        }
                         return updated;
                       });
                     }}

--- a/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useGetSetupDefaults, useGetSetupAgents } from "@/generated/api/config/config";
 import { useValidateSetupMutation, useSaveSetupMutation } from "@/hooks";
+import FileBrowser from "./FileBrowser";
 import type { 
   SetupTracker, 
   SetupRepo, 
@@ -19,7 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Plus, Trash2, CheckCircle2, AlertCircle } from "lucide-react";
+import { Plus, Trash2, CheckCircle2, AlertCircle, FolderOpen, FileText } from "lucide-react";
 
 type WizardStep = "tracker" | "repos" | "agents" | "workflow" | "validation";
 
@@ -52,7 +53,7 @@ const DEFAULT_GH_TRACKER: SetupTracker = {
 const DEFAULT_DRAFT: SetupDraft = {
   tracker: { ...DEFAULT_TODO_TRACKER },
   repos: [],
-  agents: [{ role: "implement", acpx_agent: "", model: null }],
+  agents: [{ role: "implement", acpx_agent: "", model: null, prompt: null, prompt_file: null }],
   steps: [{ name: "implement", agent_role: "implement", depends: [], tracker_state: null }],
   onSuccess: "done",
   onFailure: "paused",
@@ -68,6 +69,18 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
   const [repoPathInput, setRepoPathInput] = useState("");
   const [repoBranchInput, setRepoBranchInput] = useState("main");
   const hasVisitedWorkflow = useRef(false);
+
+  // File browser states
+  const [todoPathBrowserOpen, setTodoPathBrowserOpen] = useState(false);
+  const [repoPathBrowserOpen, setRepoPathBrowserOpen] = useState(false);
+  const [promptFileBrowserOpen, setPromptFileBrowserOpen] = useState(false);
+  const [activePromptAgentIndex, setActivePromptAgentIndex] = useState<number | null>(null);
+
+  // Custom agent tracking
+  const [customAgents, setCustomAgents] = useState<Record<number, boolean>>({});
+
+  // Prompt mode tracking for each agent (UI-only state)
+  const [promptModes, setPromptModes] = useState<Record<number, "inline" | "file">>({});
 
   const { data: defaultsData, isLoading: isLoadingDefaults } = useGetSetupDefaults({
     query: { enabled: true },
@@ -239,14 +252,36 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
       {draft.tracker.kind === "todo_file" ? (
         <div className="space-y-2">
           <label className="text-sm font-medium" htmlFor="todo-path">Path</label>
-          <Input
-            id="todo-path"
-            value={draft.tracker.path}
-            onChange={(e) => setDraft(prev => ({
+          <div className="flex gap-2">
+            <Input
+              id="todo-path"
+              value={draft.tracker.path}
+              onChange={(e) => setDraft(prev => ({
+                ...prev,
+                tracker: { kind: "todo_file", path: e.target.value },
+              }))}
+              placeholder="/path/to/todo.md"
+              className="flex-1"
+            />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setTodoPathBrowserOpen(true)}
+              title="Browse for file"
+            >
+              <FileText className="h-4 w-4" />
+            </Button>
+          </div>
+          <FileBrowser
+            open={todoPathBrowserOpen}
+            onOpenChange={setTodoPathBrowserOpen}
+            mode="file"
+            title="Select Todo File"
+            initialPath={draft.tracker.path || "~"}
+            onSelect={(path) => setDraft(prev => ({
               ...prev,
-              tracker: { kind: "todo_file", path: e.target.value },
+              tracker: { kind: "todo_file", path },
             }))}
-            placeholder="/path/to/todo.md"
           />
         </div>
       ) : (
@@ -310,7 +345,16 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
             }
           }}
           aria-label="Repository path"
+          className="flex-1"
         />
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => setRepoPathBrowserOpen(true)}
+          title="Browse for directory"
+        >
+          <FolderOpen className="h-4 w-4" />
+        </Button>
         <Input
           placeholder="Branch"
           value={repoBranchInput}
@@ -326,6 +370,15 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
           <Plus className="h-4 w-4" />
         </Button>
       </div>
+
+      <FileBrowser
+        open={repoPathBrowserOpen}
+        onOpenChange={setRepoPathBrowserOpen}
+        mode="directory"
+        title="Select Repository Directory"
+        initialPath={repoPathInput || "~"}
+        onSelect={(path) => setRepoPathInput(path)}
+      />
 
       {draft.repos.length === 0 ? (
         <p className="text-sm text-muted-foreground">No repositories added yet.</p>
@@ -361,68 +414,54 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
         <p className="text-sm text-muted-foreground">Loading available agents...</p>
       ) : (
         <>
-          {(() => {
-            const discoveredAgents = agentsData?.data?.agents ?? [];
-
-            return draft.agents.map((agent, index) => (
-              <div key={index} className="p-4 rounded-lg border space-y-3">
-                <div className="flex items-center justify-between">
-                  <span className="font-medium">Agent {index + 1}</span>
-                  {draft.agents.length > 1 && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setDraft(prev => ({
+          {draft.agents.map((agent, index) => {
+            const isCustom = customAgents[index] || (agent.acpx_agent && !agentsData?.data?.agents?.find((a: DiscoveredAgentInfo) => a.name === agent.acpx_agent));
+            const promptMode = promptModes[index] || "inline";
+            
+            return (
+            <div key={index} className="p-4 rounded-lg border space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="font-medium">Agent {index + 1}</span>
+                {draft.agents.length > 1 && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => {
+                      setDraft(prev => ({
                         ...prev,
                         agents: prev.agents.filter((_, i) => i !== index),
-                      }))}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  )}
+                      }));
+                      setCustomAgents(prev => {
+                        const updated = { ...prev };
+                        delete updated[index];
+                        return updated;
+                      });
+                      setPromptModes(prev => {
+                        const updated = { ...prev };
+                        delete updated[index];
+                        return updated;
+                      });
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+              
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <label className="text-sm" htmlFor={`agent-role-${index}`}>Role</label>
+                  <Input
+                    id={`agent-role-${index}`}
+                    value={agent.role}
+                    onChange={(e) => setDraft(prev => {
+                      const newAgents = [...prev.agents];
+                      newAgents[index] = { ...agent, role: e.target.value };
+                      return { ...prev, agents: newAgents };
+                    })}
+                    placeholder="e.g., implement, review"
+                  />
                 </div>
-                
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-2">
-                    <label className="text-sm">Role</label>
-                    <Input
-                      value={agent.role}
-                      onChange={(e) => setDraft(prev => {
-                        const newAgents = [...prev.agents];
-                        newAgents[index] = { ...agent, role: e.target.value };
-                        return { ...prev, agents: newAgents };
-                      })}
-                      placeholder="e.g., implement, review"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className="text-sm">Agent</label>
-                    <Select
-                      value={agent.acpx_agent}
-                      onValueChange={(value) => {
-                        if (value) {
-                          setDraft(prev => {
-                            const newAgents = [...prev.agents];
-                            newAgents[index] = { ...agent, acpx_agent: value };
-                            return { ...prev, agents: newAgents };
-                          });
-                        }
-                      }}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select agent" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {discoveredAgents.map((discoveredAgent: DiscoveredAgentInfo) => (
-                          <SelectItem key={discoveredAgent.name} value={discoveredAgent.name}>
-                            {discoveredAgent.label} ({discoveredAgent.version})
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-
                 <div className="space-y-2">
                   <label className="text-sm">Model (optional)</label>
                   <Input
@@ -435,16 +474,177 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
                     placeholder="e.g., gpt-4"
                   />
                 </div>
+                <div className="space-y-2">
+                  <label className="text-sm" htmlFor={`agent-select-${index}`}>Agent</label>
+                  <Select
+                    value={isCustom ? "__custom__" : agent.acpx_agent}
+                    onValueChange={(value) => {
+                      if (value === "__custom__") {
+                        setCustomAgents(prev => ({ ...prev, [index]: true }));
+                        setDraft(prev => {
+                          const newAgents = [...prev.agents];
+                          newAgents[index] = { ...agent, acpx_agent: "" };
+                          return { ...prev, agents: newAgents };
+                        });
+                      } else if (value) {
+                        setCustomAgents(prev => ({ ...prev, [index]: false }));
+                        setDraft(prev => {
+                          const newAgents = [...prev.agents];
+                          newAgents[index] = { ...agent, acpx_agent: value };
+                          return { ...prev, agents: newAgents };
+                        });
+                      }
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select agent" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {agentsData?.data?.agents?.map((discoveredAgent: DiscoveredAgentInfo) => (
+                        <SelectItem key={discoveredAgent.name} value={discoveredAgent.name}>
+                          {discoveredAgent.label} ({discoveredAgent.version})
+                        </SelectItem>
+                      ))}
+                      <SelectItem value="__custom__">Custom...</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
-            ));
-          })()}
+
+              {isCustom && (
+                <div className="space-y-2">
+                  <label className="text-sm">Custom Agent Name</label>
+                  <Input
+                    value={agent.acpx_agent}
+                    onChange={(e) => setDraft(prev => {
+                      const newAgents = [...prev.agents];
+                      newAgents[index] = { ...agent, acpx_agent: e.target.value };
+                      return { ...prev, agents: newAgents };
+                    })}
+                    placeholder="e.g., my-custom-agent"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Custom agents are not validated — ensure this agent is installed and accessible via acpx.
+                  </p>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <label className="text-sm" htmlFor={`agent-model-${index}`}>Model (optional)</label>
+                <Input
+                  id={`agent-model-${index}`}
+                  value={agent.model || ""}
+                  onChange={(e) => setDraft(prev => {
+                    const newAgents = [...prev.agents];
+                    newAgents[index] = { ...agent, model: e.target.value || null };
+                    return { ...prev, agents: newAgents };
+                  })}
+                  placeholder="e.g., gpt-4"
+                />
+              </div>
+
+              {/* Prompt Configuration */}
+              <div className="space-y-2 pt-2 border-t">
+                <label className="text-sm">Prompt Configuration</label>
+                <Select
+                  value={promptMode}
+                  onValueChange={(value) => {
+                    setPromptModes(prev => ({ ...prev, [index]: value as "inline" | "file" }));
+                    // Clear the other field when switching
+                    setDraft(prev => {
+                      const newAgents = [...prev.agents];
+                      newAgents[index] = { 
+                        ...agent, 
+                        prompt: value === "file" ? null : agent.prompt,
+                        prompt_file: value === "inline" ? null : agent.prompt_file,
+                      };
+                      return { ...prev, agents: newAgents };
+                    });
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="inline">Inline text</SelectItem>
+                    <SelectItem value="file">File path</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                {promptMode === "inline" ? (
+                  <textarea
+                    className="w-full min-h-[100px] p-2 text-sm border rounded-md bg-background"
+                    placeholder="Enter prompt content..."
+                    value={agent.prompt || ""}
+                    onChange={(e) => setDraft(prev => {
+                      const newAgents = [...prev.agents];
+                      newAgents[index] = { ...agent, prompt: e.target.value };
+                      return { ...prev, agents: newAgents };
+                    })}
+                  />
+                ) : (
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="/path/to/prompt.liquid"
+                      value={agent.prompt_file || ""}
+                      onChange={(e) => setDraft(prev => {
+                        const newAgents = [...prev.agents];
+                        newAgents[index] = { ...agent, prompt_file: e.target.value };
+                        return { ...prev, agents: newAgents };
+                      })}
+                      className="flex-1"
+                    />
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => {
+                        setActivePromptAgentIndex(index);
+                        setPromptFileBrowserOpen(true);
+                      }}
+                      title="Browse for prompt file"
+                    >
+                      <FileText className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+            );
+          })}
+
+          <FileBrowser
+            open={promptFileBrowserOpen}
+            onOpenChange={(open) => {
+              setPromptFileBrowserOpen(open);
+              if (!open) setActivePromptAgentIndex(null);
+            }}
+            mode="file"
+            title="Select Prompt File"
+            initialPath={activePromptAgentIndex !== null 
+              ? draft.agents[activePromptAgentIndex]?.prompt_file || "~" 
+              : "~"}
+            onSelect={(path) => {
+              if (activePromptAgentIndex !== null) {
+                setDraft(prev => {
+                  const newAgents = [...prev.agents];
+                  newAgents[activePromptAgentIndex] = { 
+                    ...newAgents[activePromptAgentIndex]!, 
+                    prompt_file: path 
+                  };
+                  return { ...prev, agents: newAgents };
+                });
+              }
+            }}
+          />
 
           <Button
             variant="outline"
-            onClick={() => setDraft(prev => ({
-              ...prev,
-              agents: [...prev.agents, { role: "agent", acpx_agent: "", model: null }],
-            }))}
+            onClick={() => {
+              setDraft(prev => ({
+                ...prev,
+                agents: [...prev.agents, { role: "agent", acpx_agent: "", model: null, prompt: null, prompt_file: null }],
+              }));
+            }}
           >
             <Plus className="h-4 w-4 mr-2" />
             Add Agent

--- a/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@/generated/models";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { 
   Select,
@@ -213,6 +214,10 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
     }
   }, [draft.agents, currentStep]);
 
+  useEffect(() => {
+    hasVisitedWorkflow.current = false;
+  }, [draft.agents]);
+
   const handleTrackerKindChange = (value: TrackerKind) => {
     if (value === "todo_file") {
       setDraft(prev => ({
@@ -310,8 +315,8 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
               onChange={(e) => setDraft(prev => ({
                 ...prev,
                 tracker: { 
-                  ...prev.tracker,
-                  project_number: e.target.value ? parseInt(e.target.value) : null,
+                  ...DEFAULT_GH_TRACKER,
+                  project_number: e.target.value ? parseInt(e.target.value, 10) : null,
                 } as SetupTracker,
               }))}
             />
@@ -352,6 +357,7 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
           size="icon"
           onClick={() => setRepoPathBrowserOpen(true)}
           title="Browse for directory"
+          aria-label="Browse for repository directory"
         >
           <FolderOpen className="h-4 w-4" />
         </Button>
@@ -366,6 +372,7 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
           variant="outline"
           size="icon"
           onClick={handleAddRepo}
+          aria-label="Add repository"
         >
           <Plus className="h-4 w-4" />
         </Button>
@@ -463,18 +470,6 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-sm">Model (optional)</label>
-                  <Input
-                    value={agent.model || ""}
-                    onChange={(e) => setDraft(prev => {
-                      const newAgents = [...prev.agents];
-                      newAgents[index] = { ...agent, model: e.target.value || null };
-                      return { ...prev, agents: newAgents };
-                    })}
-                    placeholder="e.g., gpt-4"
-                  />
-                </div>
-                <div className="space-y-2">
                   <label className="text-sm" htmlFor={`agent-select-${index}`}>Agent</label>
                   <Select
                     value={isCustom ? "__custom__" : agent.acpx_agent}
@@ -496,7 +491,7 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
                       }
                     }}
                   >
-                    <SelectTrigger>
+                    <SelectTrigger id={`agent-select-${index}`}>
                       <SelectValue placeholder="Select agent" />
                     </SelectTrigger>
                     <SelectContent>
@@ -545,7 +540,7 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
 
               {/* Prompt Configuration */}
               <div className="space-y-2 pt-2 border-t">
-                <label className="text-sm">Prompt Configuration</label>
+                <label className="text-sm" htmlFor={`prompt-mode-${index}`}>Prompt Configuration</label>
                 <Select
                   value={promptMode}
                   onValueChange={(value) => {
@@ -562,7 +557,7 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
                     });
                   }}
                 >
-                  <SelectTrigger>
+                  <SelectTrigger id={`prompt-mode-${index}`}>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -572,8 +567,8 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
                 </Select>
 
                 {promptMode === "inline" ? (
-                  <textarea
-                    className="w-full min-h-[100px] p-2 text-sm border rounded-md bg-background"
+                  <Textarea
+                    className="min-h-[100px]"
                     placeholder="Enter prompt content..."
                     value={agent.prompt || ""}
                     onChange={(e) => setDraft(prev => {
@@ -624,12 +619,20 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
               ? draft.agents[activePromptAgentIndex]?.prompt_file || "~" 
               : "~"}
             onSelect={(path) => {
-              if (activePromptAgentIndex !== null) {
+              if (
+                activePromptAgentIndex !== null
+                && activePromptAgentIndex >= 0
+                && activePromptAgentIndex < draft.agents.length
+              ) {
                 setDraft(prev => {
                   const newAgents = [...prev.agents];
-                  newAgents[activePromptAgentIndex] = { 
-                    ...newAgents[activePromptAgentIndex]!, 
-                    prompt_file: path 
+                  const selectedAgent = newAgents[activePromptAgentIndex];
+                  if (!selectedAgent) {
+                    return prev;
+                  }
+                  newAgents[activePromptAgentIndex] = {
+                    ...selectedAgent,
+                    prompt_file: path,
                   };
                   return { ...prev, agents: newAgents };
                 });

--- a/crates/ensemble-ui/src-ui/src/components/config/ValidationPanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/ValidationPanel.tsx
@@ -27,7 +27,7 @@ export default function ValidationPanel({
             className="text-sm text-destructive/90 flex items-start gap-2"
           >
             <span className="font-mono text-xs bg-destructive/20 px-1.5 py-0.5 rounded">
-              {issue.section}
+              {issue.section ?? ""}
               {issue.field && `.${issue.field}`}
             </span>
             <span>{issue.message}</span>

--- a/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.tsx
@@ -116,7 +116,7 @@ export default function WorkflowEditor({ value, onChange }: WorkflowEditorProps)
 
           return (
             <div
-              key={index}
+              key={step.name || `${index}`}
               className="flex items-start gap-3 p-4 border rounded-lg bg-card"
             >
               <div className="flex flex-col gap-1">

--- a/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/YamlEditor.tsx
@@ -87,6 +87,7 @@ export default function YamlEditor({
             onChange={handleChange}
             basicSetup={{ lineNumbers: true, foldGutter: true }}
             className="text-sm"
+            height="480px"
           />
         </div>
 
@@ -114,7 +115,7 @@ export default function YamlEditor({
         </div>
         <Button
           onClick={handleSave}
-          disabled={isValidating || isSaving || (isRecoveryMode && validationIssues.length > 0)}
+          disabled={isValidating || isSaving || issues.length > 0}
         >
           {isSaving ? "Saving..." : "Save"}
         </Button>

--- a/crates/ensemble-ui/src-ui/src/components/ui/textarea.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex min-h-24 w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 dark:bg-input/30 dark:disabled:bg-input/80",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/crates/ensemble-ui/src-ui/src/hooks.ts
+++ b/crates/ensemble-ui/src-ui/src/hooks.ts
@@ -4,6 +4,7 @@ import { useGetState, getGetStateQueryKey } from "./generated/api/state/state";
 import { useGetIssueDetail } from "./generated/api/issues/issues";
 import { useGetConfig } from "./generated/api/config/config";
 import { useGetHistory } from "./generated/api/history/history";
+import { useListDirectory } from "./generated/api/filesystem/filesystem";
 import {
   usePostRefresh,
   usePostStop,
@@ -225,3 +226,6 @@ export function useSaveGuidedFormMutation() {
     isPending: generatedMutation.isPending,
   };
 }
+
+// Re-export filesystem hook for convenience
+export { useListDirectory };

--- a/crates/ensemble-ui/src-ui/src/hooks.ts
+++ b/crates/ensemble-ui/src-ui/src/hooks.ts
@@ -107,15 +107,6 @@ export function useHistoryQuery(params: GetHistoryParams) {
   });
 }
 
-export function useConfigQuery() {
-  return useGetConfig<ConfigStateResponse>({
-    query: {
-      staleTime: 60_000,
-      select: (resp) => resp.data as ConfigStateResponse,
-    },
-  });
-}
-
 export function useConfigStateQuery() {
   return useGetConfig<ConfigStateResponse>({
     query: {

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -1,4 +1,5 @@
 import { useConfigStateQuery, useValidateGuidedFormMutation, useSaveGuidedFormMutation, useValidateYamlDraftMutation, useSaveYamlDraftMutation } from "@/hooks";
+import type { GuidedConfigForm } from "@/generated/models";
 import type { ValidationIssue } from "@/generated/models";
 import SetupWizard from "@/components/config/SetupWizard";
 import YamlEditor from "@/components/config/YamlEditor";
@@ -7,6 +8,48 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Edit2, FileText, Settings } from "lucide-react";
+
+function toGuidedForm(form: GuidedConfigForm): GuidedForm {
+  return {
+    tracker: {
+      ...form.tracker,
+      path: form.tracker.path ?? undefined,
+      repository: form.tracker.repository ?? undefined,
+      project_number: form.tracker.project_number ?? undefined,
+      api_key: form.tracker.api_key ?? undefined,
+      endpoint: form.tracker.endpoint ?? undefined,
+    },
+    repos: form.repos.map((repo) => ({ ...repo })),
+    agents: form.agents.map((agent) => ({
+      ...agent,
+      acpx_agent: agent.acpx_agent ?? undefined,
+      executor: agent.executor ?? undefined,
+      model: agent.model ?? undefined,
+      prompt: agent.prompt ?? undefined,
+      prompt_template: agent.prompt_template ?? undefined,
+      reasoning_level: agent.reasoning_level ?? undefined,
+    })),
+    steps: form.steps.map((step) => ({
+      ...step,
+      tracker_state: step.tracker_state ?? undefined,
+    })),
+    runtime: {
+      ...form.runtime,
+      workspace: {
+        ...form.runtime.workspace,
+        root: form.runtime.workspace.root ?? undefined,
+      },
+      hooks: {
+        ...form.runtime.hooks,
+        after_create: form.runtime.hooks.after_create ?? undefined,
+        before_run: form.runtime.hooks.before_run ?? undefined,
+        after_run: form.runtime.hooks.after_run ?? undefined,
+        before_remove: form.runtime.hooks.before_remove ?? undefined,
+      },
+    },
+    transitions: { ...form.transitions },
+  };
+}
 
 export default function ConfigPage() {
   const { data, isLoading, isError, refetch } = useConfigStateQuery();
@@ -21,9 +64,9 @@ export default function ConfigPage() {
   const validateYamlMutation = useValidateYamlDraftMutation();
   const saveYamlMutation = useSaveYamlDraftMutation();
 
-  const handleValidateGuided = async (form: GuidedForm, baseRawYaml: string) => {
+  const handleValidateGuided = async (form: GuidedForm, baseRawYaml: string): Promise<ValidationIssue[]> => {
     const response = await validateGuidedFormMutation.mutateAsync({ baseRawYaml, form });
-    setDisplayedIssues(response.data.issues);
+    await refetch();
     return response.data.issues;
   };
 
@@ -32,9 +75,9 @@ export default function ConfigPage() {
     await refetch();
   };
 
-  const handleValidateYaml = async (yaml: string) => {
+  const handleValidateYaml = async (yaml: string): Promise<ValidationIssue[]> => {
     const response = await validateYamlMutation.mutateAsync({ data: { raw_yaml: yaml } });
-    setDisplayedIssues(response.data.issues);
+    await refetch();
     return response.data.issues;
   };
 
@@ -42,14 +85,6 @@ export default function ConfigPage() {
     await saveYamlMutation.mutateAsync({ data: { raw_yaml: yaml } });
     await refetch();
   };
-
-  const handleReset = () => {
-    // Reset handled internally by editors
-  };
-
-  useEffect(() => {
-    setDisplayedIssues(issues);
-  }, [issues]);
 
   if (isLoading) {
     return <div className="text-center py-12 text-muted-foreground">Loading configuration...</div>;
@@ -91,7 +126,9 @@ export default function ConfigPage() {
           issues={issues}
           onValidate={handleValidateYaml}
           onSave={handleSaveYaml}
-          onReset={handleReset}
+          onReset={() => {
+            void refetch();
+          }}
         />
       </div>
     );
@@ -165,12 +202,14 @@ export default function ConfigPage() {
             <div className="mt-4">
               {activeTab === "guided" && guidedForm && (
                 <GuidedEditor
-                  initialForm={guidedForm as GuidedForm}
+                  initialForm={toGuidedForm(guidedForm)}
                   baseRawYaml={rawYaml || ""}
                   issues={displayedIssues}
                   onValidate={handleValidateGuided}
                   onSave={handleSaveGuided}
-                  onReset={handleReset}
+                  onReset={() => {
+                    void refetch();
+                  }}
                 />
               )}
               {activeTab === "yaml" && rawYaml && (
@@ -180,7 +219,9 @@ export default function ConfigPage() {
                   issues={displayedIssues}
                   onValidate={handleValidateYaml}
                   onSave={handleSaveYaml}
-                  onReset={handleReset}
+                  onReset={() => {
+                    void refetch();
+                  }}
                 />
               )}
             </div>

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -66,23 +66,27 @@ export default function ConfigPage() {
 
   const handleValidateGuided = async (form: GuidedForm, baseRawYaml: string): Promise<ValidationIssue[]> => {
     const response = await validateGuidedFormMutation.mutateAsync({ baseRawYaml, form });
+    setDisplayedIssues(response.data.issues);
     await refetch();
     return response.data.issues;
   };
 
   const handleSaveGuided = async (form: GuidedForm, baseRawYaml: string) => {
     await saveGuidedFormMutation.mutateAsync({ baseRawYaml, form });
+    setDisplayedIssues([]);
     await refetch();
   };
 
   const handleValidateYaml = async (yaml: string): Promise<ValidationIssue[]> => {
     const response = await validateYamlMutation.mutateAsync({ data: { raw_yaml: yaml } });
+    setDisplayedIssues(response.data.issues);
     await refetch();
     return response.data.issues;
   };
 
   const handleSaveYaml = async (yaml: string) => {
     await saveYamlMutation.mutateAsync({ data: { raw_yaml: yaml } });
+    setDisplayedIssues([]);
     await refetch();
   };
 
@@ -103,8 +107,9 @@ export default function ConfigPage() {
     [guidedForm]
   );
 
-  const hasIssues = displayedIssues.length > 0;
+  const hasIssues = (displayedIssues.length > 0 || issues.length > 0);
   const isEditable = state === "parsed";
+  const bannerIssues = displayedIssues.length > 0 ? displayedIssues : issues;
 
   // Missing config - show setup mode
   if (state === "missing" || showSetupWizard) {
@@ -161,7 +166,7 @@ export default function ConfigPage() {
               </p>
               {hasIssues && (
                 <ul className="mt-2 space-y-2">
-                  {displayedIssues.map((issue: ValidationIssue, i: number) => (
+                  {bannerIssues.map((issue: ValidationIssue, i: number) => (
                     <li key={i} className="text-sm text-red-600 dark:text-red-400">{issue.message}</li>
                   ))}
                 </ul>

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -4,7 +4,7 @@ import type { ValidationIssue } from "@/generated/models";
 import SetupWizard from "@/components/config/SetupWizard";
 import YamlEditor from "@/components/config/YamlEditor";
 import GuidedEditor, { type GuidedForm } from "@/components/config/GuidedEditor";
-import { useEffect, useState } from "react";
+import { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Edit2, FileText, Settings } from "lucide-react";
@@ -98,6 +98,10 @@ export default function ConfigPage() {
 
   const { state, raw_yaml: rawYaml } = data;
   const guidedForm = data.guided_form;
+  const memoizedForm = useMemo(
+    () => (guidedForm ? toGuidedForm(guidedForm) : null),
+    [guidedForm]
+  );
 
   const hasIssues = displayedIssues.length > 0;
   const isEditable = state === "parsed";
@@ -200,9 +204,9 @@ export default function ConfigPage() {
               </button>
             </div>
             <div className="mt-4">
-              {activeTab === "guided" && guidedForm && (
+              {activeTab === "guided" && memoizedForm && (
                 <GuidedEditor
-                  initialForm={toGuidedForm(guidedForm)}
+                  initialForm={memoizedForm}
                   baseRawYaml={rawYaml || ""}
                   issues={displayedIssues}
                   onValidate={handleValidateGuided}

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigStatus.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigStatus.tsx
@@ -1,11 +1,12 @@
-import { useConfigQuery } from "@/hooks";
+import { useConfigStateQuery } from "@/hooks";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
 
 export default function ConfigStatus() {
-  const { data, isLoading, isError } = useConfigQuery();
+  const { data, isLoading, isError } = useConfigStateQuery();
 
   if (isLoading) {
     return <div className="text-center py-12 text-muted-foreground">Loading configuration...</div>;
@@ -37,13 +38,13 @@ export default function ConfigStatus() {
             : "bg-red-50 dark:bg-red-900/30 border-red-200 dark:border-red-800",
       )}>
         <div className="flex items-center gap-2">
-          <span className={cn("text-lg", 
-            isValid ? "text-green-600 dark:text-green-400" : 
-            hasIssues ? "text-yellow-600 dark:text-yellow-400" :
-            "text-red-600 dark:text-red-400"
-          )}>
-            {isValid ? "✓" : hasIssues ? "⚠" : "✗"}
-          </span>
+          {isValid ? (
+            <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400" />
+          ) : hasIssues ? (
+            <AlertTriangle className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+          ) : (
+            <XCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+          )}
           <span className={cn("font-medium", 
             isValid ? "text-green-800 dark:text-green-200" :
             hasIssues ? "text-yellow-800 dark:text-yellow-200" :

--- a/crates/ensemble-ui/src-ui/src/pages/Dashboard.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
-import { useStateQuery, useRefreshMutation, useRetryMutation, useNextPollCountdown } from "@/hooks";
+import { useStateQuery, useRefreshMutation, useRetryMutation, useNextPollCountdown, useConfigStateQuery } from "@/hooks";
+import { Navigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import RunningTable from "@/components/RunningTable";
@@ -6,6 +7,11 @@ import RetryQueue from "@/components/RetryQueue";
 import AgentTotals from "@/components/AgentTotals";
 
 export default function Dashboard() {
+  const { data: configState } = useConfigStateQuery();
+  if (configState?.state === "missing") {
+    return <Navigate to="/config" replace />;
+  }
+
   const { data, isLoading, isError, error } = useStateQuery();
   const refreshMutation = useRefreshMutation();
   const retryMutation = useRetryMutation();

--- a/crates/ensemble-ui/src-ui/vitest.config.ts
+++ b/crates/ensemble-ui/src-ui/vitest.config.ts
@@ -1,6 +1,9 @@
-import path from "path";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],

--- a/docs/superpowers/specs/2026-04-03-web-app-init-setup-bug-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-03-web-app-init-setup-bug-fixes-design.md
@@ -1,0 +1,123 @@
+# Web App Init/Setup Bug Fixes Design
+
+## Summary
+
+Fix 7 bugs in the Ensemble web app's configuration setup flow: dashboard redirect, tracker type display, file browsers for paths, agent discovery timeout, custom agent option, and agent prompt configuration.
+
+## Bug Fixes
+
+### 1. Dashboard redirect when no config
+
+**Problem**: Opening the app shows an empty dashboard when config is missing instead of guiding the user to setup.
+
+**Fix**: In `Dashboard.tsx`, add `useConfigStateQuery()` (already used by `Layout.tsx` and `ConfigPage.tsx`) and render `<Navigate to="/config" replace />` when `state === "missing"`. The config query is already polled every 3 seconds, so no new API calls needed.
+
+**Files**: `crates/ensemble-ui/src-ui/src/pages/Dashboard.tsx`
+
+### 2. Tracker type shows raw key instead of label
+
+**Problem**: In `GuidedEditor.tsx`, the tracker `kind` field is a plain text input showing `"todo_file"` instead of a human-readable label.
+
+**Fix**: Replace the `<Input>` with a `<Select>` component that maps:
+- `todo_file` → "Todo File"
+- `github` → "GitHub Project"
+
+**Files**: `crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx`
+
+### 3-4. File browsers for Tracker path and Repository path
+
+**Problem**: Path fields in both `SetupWizard.tsx` and `GuidedEditor.tsx` are plain text inputs with no way to browse the filesystem.
+
+**Backend**: Add `GET /api/v1/fs/list?path=/some/path` endpoint.
+- Lists directory contents (directories and files), sorted: directories first, then files, alphabetically within each group
+- Restricted to home directory and below for safety. Home directory = `dirs::home_dir()` (the user running the server). Symlinks are resolved via `std::fs::canonicalize()` before checking the home boundary. Symlinks that resolve outside home are excluded from results.
+- Returns `{ entries: [{ name, is_dir, path }] }` limited to 500 entries (truncated with `truncated: true` flag if exceeded)
+- If path is outside home dir, returns 403
+- Error responses follow the existing `ApiError` format: `{ code: string, message: string }`
+
+**Frontend**: Create a reusable `FileBrowser` component.
+- Modal dialog (`Dialog` from Radix UI) with directory listing, breadcrumb navigation, and select button
+- Accepts a `mode` prop: `"file"` (select files only) or `"directory"` (select directories only)
+- Double-click directories to navigate, single-click items to select (filtered by mode)
+- "Browse" button next to path inputs in SetupWizard (tracker step uses `"file"` mode, repos step uses `"directory"` mode) and GuidedEditor (tracker section uses `"file"` mode)
+
+**Files**:
+- Backend: `crates/ensemble-core/src/api/fs_handler.rs` (new), `crates/ensemble-core/src/api/mod.rs` (add `pub mod fs_handler`), `crates/ensemble-core/src/api/router.rs`
+- Frontend: `crates/ensemble-ui/src-ui/src/components/config/FileBrowser.tsx` (new)
+- Updated: `SetupWizard.tsx`, `GuidedEditor.tsx`
+
+### 5. Agent discovery timeout
+
+**Problem**: `probe_agent()` in `setup.rs` uses `std::process::Command` with no timeout. If `acpx` hangs for any agent, the entire discovery blocks indefinitely. The same issue affects `get_agent_version()` and the health checks in `run_setup_checks()`.
+
+**Fix**: Convert `probe_agent()` and `get_agent_version()` to use `tokio::process::Command` with `tokio::time::timeout` at 8 seconds per agent. The `run_setup_checks()` health checks also use blocking commands and should be converted similarly.
+
+**Files**: `crates/ensemble-core/src/config/setup.rs`
+
+### 6. Custom agent option
+
+**Problem**: The agent dropdown only shows discovered agents. Users cannot specify a custom agent not in the known list.
+
+**Fix**: Add "Custom" option at the bottom of the agent select dropdown. When selected, show a text input for the custom agent name. The `acpx_agent` field stores the custom name. The existing setup validation already runs an agent health check that will catch invalid custom names, so no additional backend changes needed. The UI should show a subtle warning when a custom name is entered: "Custom agents are not validated — ensure this agent is installed and accessible via acpx."
+
+**Files**: `crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx`
+
+### 7. Agent prompt configuration
+
+**Problem**: No way to set a prompt or prompt file for agents in the setup wizard.
+
+**Fix**: Add a prompt section to each agent card with:
+- Toggle between "Inline text" and "File path"
+- Inline: textarea for prompt content
+- File: text input with browse button (reuses FileBrowser component in `"file"` mode)
+- Store as `prompt` (string) or `prompt_file` (string path) in `SetupAgent`. When saving to YAML, `prompt_file` maps to the existing `prompt_template` field in the config schema.
+
+**Files**: `crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx`
+
+## API Changes
+
+### New endpoint: `GET /api/v1/fs/list`
+
+**Query parameters**:
+- `path` (required): Directory path to list
+
+**Response** (200):
+```json
+{
+  "entries": [
+    { "name": "src", "is_dir": true, "path": "/home/user/project/src" },
+    { "name": "Cargo.toml", "is_dir": false, "path": "/home/user/project/Cargo.toml" }
+  ]
+}
+```
+
+**Errors**:
+- 400: Missing path parameter
+- 403: Path outside home directory
+- 404: Path does not exist
+- 500: I/O error
+
+## Model Changes
+
+### `SetupAgent` (frontend type)
+Add optional fields:
+- `prompt?: string` — inline prompt text
+- `prompt_file?: string` — path to prompt template file
+
+## Implementation Order
+
+1. Backend: File browser API endpoint + tests
+2. Backend: Agent discovery timeout + tests
+3. Frontend: Dashboard redirect
+4. Frontend: Tracker type label in GuidedEditor
+5. Frontend: FileBrowser component + tests
+6. Frontend: File browser integration in SetupWizard
+7. Frontend: File browser integration in GuidedEditor
+8. Frontend: Custom agent option in SetupWizard
+9. Frontend: Agent prompt configuration in SetupWizard
+
+## Test Strategy
+
+- **Backend**: Unit tests for `fs/list` endpoint (valid path, path outside home, nonexistent path, symlink escape)
+- **Backend**: Unit tests for `probe_agent()` timeout behavior
+- **Frontend**: Component tests for `FileBrowser` navigation, mode filtering, and selection


### PR DESCRIPTION
## Summary
- harden config setup and editing across `ensemble-core`, `ensemble-cli`, and `ensemble-desktop`, including safer YAML handling, redaction, atomic saves, and improved config-dir migration behavior
- fix desktop and web setup regressions in the UI and backend, including file browsing, guided editor validation, setup wizard flow, server startup handling, and E2E stability
- extract shared embedded SPA serving logic into `ensemble-core` while keeping per-binary embedded assets in the CLI and desktop crates

## Test Plan
- [x] `cargo test --workspace --quiet`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `pnpm test` in `crates/ensemble-ui/src-ui`