### PR TITLE
Fix React rules-of-hooks violation on first web app load

### DIFF
--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -90,6 +90,12 @@ export default function ConfigPage() {
     await refetch();
   };
 
+  const guidedForm = data?.guided_form;
+  const memoizedForm = useMemo(
+    () => (guidedForm ? toGuidedForm(guidedForm) : null),
+    [guidedForm]
+  );
+
   if (isLoading) {
     return <div className="text-center py-12 text-muted-foreground">Loading configuration...</div>;
   }
@@ -101,11 +107,6 @@ export default function ConfigPage() {
   if (!data) return null;
 
   const { state, raw_yaml: rawYaml } = data;
-  const guidedForm = data.guided_form;
-  const memoizedForm = useMemo(
-    () => (guidedForm ? toGuidedForm(guidedForm) : null),
-    [guidedForm]
-  );
 
   const hasIssues = (displayedIssues.length > 0 || issues.length > 0);
   const isEditable = state === "parsed";

--- a/crates/ensemble-ui/src-ui/src/pages/Dashboard.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/Dashboard.tsx
@@ -8,14 +8,14 @@ import AgentTotals from "@/components/AgentTotals";
 
 export default function Dashboard() {
   const { data: configState } = useConfigStateQuery();
-  if (configState?.state === "missing") {
-    return <Navigate to="/config" replace />;
-  }
-
   const { data, isLoading, isError, error } = useStateQuery();
   const refreshMutation = useRefreshMutation();
   const retryMutation = useRetryMutation();
   const pollCountdown = useNextPollCountdown(data?.last_tick_at ?? null, data?.poll_interval_ms);
+
+  if (configState?.state === "missing") {
+    return <Navigate to="/config" replace />;
+  }
 
   if (isLoading) {
     return <div className="text-center py-12 text-muted-foreground">Loading...</div>;


### PR DESCRIPTION
## Summary
- Fix React error #300 crash on first web app open by moving hooks before conditional returns in Dashboard and ConfigPage
- Dashboard: moved all hooks before `<Navigate>` redirect for missing config
- ConfigPage: moved `useMemo` before loading/error guards

## Details
React requires hooks to be called in the same order on every render. In `Dashboard.tsx`, an early `<Navigate>` return (when config is missing) ran before 4 hooks, causing the hook count to differ between renders — triggering minified React error #300. The same `useMemo`-after-guard pattern existed in `ConfigPage.tsx`.