### PR TITLE
Start shared orchestrator runtime across web, desktop, and run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ ensemble/
 │       └── src/
 │           ├── main.rs           # Tauri entry point, runtime management
 │           ├── embedded_ui.rs    # rust-embed SPA serving for Tauri
-│           └── orchestrator.rs   # Desktop orchestrator integration
+│           └── orchestrator.rs   # Legacy desktop orchestrator wrapper (prefer shared bootstrap in server.rs)
 └── .github/workflows/ci.yml     # CI: check, test, clippy, fmt
 ```
 
@@ -134,5 +134,7 @@ This bumps versions in `Cargo.toml` + `tauri.conf.json`, commits, tags, and push
 - **Config directory based**: All runtime config lives in a configuration directory containing `config.yaml`. `EnsembleConfig` provides typed access with defaults and `$ENV_VAR` resolution. The config directory is resolved via `--config-dir`, `ENSEMBLE_CONFIG_DIR`, or platform defaults. Agent definitions, step DAG, and prompt references are all defined in `config.yaml`. Relative paths are resolved from the config directory.
 - **Agent model discovery**: During `ensemble init`, acpx agent sessions are probed to discover available models. The selected model is stored as `model` in `AgentConfig` and emitted in `ensemble.yaml`.
 - **Multi-agent pipelines**: Named agents run through a step DAG (GitHub Actions-style: sequential by default, `depends` for parallelism). The orchestrator drives state transitions at step boundaries and collects verdicts from review agents.
+- **Shared orchestrator startup**: `ensemble run`, `ensemble web`, and desktop/Tauri should all start the same real orchestrator runtime path. Do not add placeholder poll loops or separate per-frontend orchestrator implementations when the shared bootstrap can be reused.
+- **Manual refresh behavior**: Refresh, retry, and resume controls should signal the orchestrator loop to run a tick; do not implement ad-hoc polling/state mutation in API or UI handlers that bypasses the orchestrator.
 - **Workspace isolation**: Each issue gets a directory under a configurable root, keyed by sanitized identifier. Workspaces are reused across retries and cleaned up on completion.
 - **Hook lifecycle**: Shell hooks (after_create, before_run, after_run, before_remove) run in workspace directories with configurable timeouts. Non-fatal hooks use best-effort mode.

--- a/crates/ensemble-cli/src/commands/run.rs
+++ b/crates/ensemble-cli/src/commands/run.rs
@@ -1,13 +1,11 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
-use std::sync::Arc;
-use tokio::sync::RwLock;
 use tracing::{error, info};
 
-use ensemble_core::config::ensemble::{load_config, validate_config};
+use ensemble_core::api::bootstrap::{build_app_state, start_orchestrator_for_app};
+use ensemble_core::config::draft::load_config_document_or_missing;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
-use ensemble_core::orchestrator::state::OrchestratorState;
-use ensemble_core::pipeline::dag::build_dag;
+use ensemble_core::observability::events::EventBus;
 
 #[derive(Debug, Clone)]
 pub struct RunArgs {
@@ -44,49 +42,52 @@ pub async fn execute(args: RunArgs) -> ExitCode {
         "starting ensemble in headless mode"
     );
 
-    // Load and validate config.yaml
-    let config = match load_config(&resolved.config_path) {
-        Ok(cfg) => cfg,
+    let document_state = load_config_document_or_missing(&resolved.config_path);
+    let prepared = build_app_state(
+        resolved.config_path.clone(),
+        document_state,
+        EventBus::new(),
+    );
+
+    if !prepared.has_runnable_config {
+        error!(
+            path = %resolved.config_path.display(),
+            "failed to load a runnable config"
+        );
+        eprintln!(
+            "error: failed to load a runnable config from {}",
+            resolved.config_path.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    {
+        let document_state = prepared
+            .app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await;
+        let config = document_state.active_config.as_ref().unwrap();
+        info!(
+            tracker_kind = %config.tracker.kind,
+            poll_interval_ms = config.polling.interval_ms,
+            max_concurrent = config.concurrency.max_concurrent_agents,
+            "config loaded successfully"
+        );
+    }
+
+    let orchestrator_runtime = match start_orchestrator_for_app(&prepared.app_state).await {
+        Ok(Some(runtime)) => runtime,
+        Ok(None) => unreachable!("runnable config should start an orchestrator"),
         Err(e) => {
-            error!(error = %e, path = %resolved.config_path.display(), "failed to load config");
-            eprintln!(
-                "error: failed to load {}: {}",
-                resolved.config_path.display(),
-                e
-            );
+            error!(error = %e, "failed to start orchestrator");
+            eprintln!("error: failed to start orchestrator: {}", e);
             return ExitCode::FAILURE;
         }
     };
 
-    if let Err(e) = validate_config(&config) {
-        error!(error = %e, "config validation failed");
-        eprintln!("error: config validation failed: {}", e);
-        return ExitCode::FAILURE;
-    }
-
-    if let Err(e) = build_dag(&config.steps) {
-        error!(error = %e, "step DAG validation failed");
-        eprintln!("error: step DAG validation failed: {}", e);
-        return ExitCode::FAILURE;
-    }
-
-    info!(
-        tracker_kind = %config.tracker.kind,
-        poll_interval_ms = config.polling.interval_ms,
-        max_concurrent = config.concurrency.max_concurrent_agents,
-        "config loaded successfully"
-    );
-
-    // Create orchestrator state
-    let _orchestrator_state = Arc::new(RwLock::new(OrchestratorState::new(
-        config.polling.interval_ms,
-        config.concurrency.max_concurrent_agents,
-    )));
-
-    let _refresh_notify = Arc::new(tokio::sync::Notify::new());
-
-    // TODO: Start orchestrator poll loop (Plan 3 wires this up).
-    info!("ensemble is running in headless mode (orchestrator loop placeholder, press Ctrl+C to stop)");
+    info!("ensemble is running in headless mode (press Ctrl+C to stop)");
 
     // Wait for shutdown signal (ctrl-c)
     match tokio::signal::ctrl_c().await {
@@ -98,6 +99,7 @@ pub async fn execute(args: RunArgs) -> ExitCode {
         }
     }
 
+    orchestrator_runtime.shutdown().await;
     info!("ensemble shut down cleanly");
     ExitCode::SUCCESS
 }

--- a/crates/ensemble-cli/src/commands/run.rs
+++ b/crates/ensemble-cli/src/commands/run.rs
@@ -3,7 +3,7 @@ use std::process::ExitCode;
 use tracing::{error, info};
 
 use ensemble_core::api::bootstrap::{
-    build_app_state, replace_registered_orchestrator, take_registered_orchestrator,
+    build_app_state, start_or_replace_registered_orchestrator, take_registered_orchestrator,
 };
 use ensemble_core::config::draft::load_config_document_or_missing;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
@@ -79,7 +79,7 @@ pub async fn execute(args: RunArgs) -> ExitCode {
         );
     }
 
-    match replace_registered_orchestrator(&prepared.app_state).await {
+    match start_or_replace_registered_orchestrator(&prepared.app_state).await {
         Ok(true) => {}
         Ok(false) => {
             error!("runnable config did not produce an orchestrator runtime");

--- a/crates/ensemble-cli/src/commands/run.rs
+++ b/crates/ensemble-cli/src/commands/run.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use tracing::{error, info};
 
-use ensemble_core::api::bootstrap::{build_app_state, start_orchestrator_for_app};
+use ensemble_core::api::bootstrap::{
+    build_app_state, replace_registered_orchestrator, take_registered_orchestrator,
+};
 use ensemble_core::config::draft::load_config_document_or_missing;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
 use ensemble_core::observability::events::EventBus;
@@ -77,15 +79,19 @@ pub async fn execute(args: RunArgs) -> ExitCode {
         );
     }
 
-    let orchestrator_runtime = match start_orchestrator_for_app(&prepared.app_state).await {
-        Ok(Some(runtime)) => runtime,
-        Ok(None) => unreachable!("runnable config should start an orchestrator"),
+    match replace_registered_orchestrator(&prepared.app_state).await {
+        Ok(true) => {}
+        Ok(false) => {
+            error!("runnable config did not produce an orchestrator runtime");
+            eprintln!("error: runnable config did not produce an orchestrator runtime");
+            return ExitCode::FAILURE;
+        }
         Err(e) => {
             error!(error = %e, "failed to start orchestrator");
             eprintln!("error: failed to start orchestrator: {}", e);
             return ExitCode::FAILURE;
         }
-    };
+    }
 
     info!("ensemble is running in headless mode (press Ctrl+C to stop)");
 
@@ -99,7 +105,9 @@ pub async fn execute(args: RunArgs) -> ExitCode {
         }
     }
 
-    orchestrator_runtime.shutdown().await;
+    if let Some(runtime) = take_registered_orchestrator(&prepared.app_state) {
+        runtime.shutdown().await;
+    }
     info!("ensemble shut down cleanly");
     ExitCode::SUCCESS
 }

--- a/crates/ensemble-cli/src/commands/web.rs
+++ b/crates/ensemble-cli/src/commands/web.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use tracing::{error, info, warn};
 
-use ensemble_core::api::bootstrap::build_app_state;
+use ensemble_core::api::bootstrap::{build_app_state, start_orchestrator_for_app};
 use ensemble_core::api::router::create_api_router;
 use ensemble_core::config::draft::load_config_document_or_missing;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
@@ -116,6 +116,21 @@ pub async fn execute(args: WebArgs) -> ExitCode {
     }
     let has_runnable_config = prepared.has_runnable_config;
     let app_state = prepared.app_state;
+    let orchestrator_runtime = if has_runnable_config {
+        match start_orchestrator_for_app(&app_state).await {
+            Ok(runtime) => {
+                info!("orchestrator started");
+                runtime
+            }
+            Err(e) => {
+                error!(error = %e, "failed to start orchestrator");
+                eprintln!("error: failed to start orchestrator: {}", e);
+                return ExitCode::FAILURE;
+            }
+        }
+    } else {
+        None
+    };
 
     // Create combined router: API routes + SPA fallback
     let api_router = create_api_router(app_state);
@@ -186,10 +201,7 @@ pub async fn execute(args: WebArgs) -> ExitCode {
         }
     });
 
-    // Only start orchestrator if we have a valid config
-    if has_runnable_config {
-        info!("orchestrator can start (loop placeholder)");
-    } else {
+    if !has_runnable_config {
         info!("orchestrator disabled - waiting for valid config via setup wizard");
     }
 
@@ -207,6 +219,9 @@ pub async fn execute(args: WebArgs) -> ExitCode {
 
     // Clean shutdown
     server_handle.abort();
+    if let Some(runtime) = orchestrator_runtime {
+        runtime.shutdown().await;
+    }
     info!("HTTP server stopped");
 
     info!("ensemble shut down cleanly");

--- a/crates/ensemble-cli/src/commands/web.rs
+++ b/crates/ensemble-cli/src/commands/web.rs
@@ -4,7 +4,8 @@ use std::process::ExitCode;
 use tracing::{error, info, warn};
 
 use ensemble_core::api::bootstrap::{
-    build_app_state, replace_registered_orchestrator, take_registered_orchestrator,
+    build_app_state, clear_registered_orchestrator, start_or_replace_registered_orchestrator,
+    take_registered_orchestrator,
 };
 use ensemble_core::api::router::create_api_router;
 use ensemble_core::config::draft::load_config_document_or_missing;
@@ -119,7 +120,7 @@ pub async fn execute(args: WebArgs) -> ExitCode {
     let has_runnable_config = prepared.has_runnable_config;
     let app_state = prepared.app_state;
     if has_runnable_config {
-        match replace_registered_orchestrator(&app_state).await {
+        match start_or_replace_registered_orchestrator(&app_state).await {
             Ok(true) => info!("orchestrator started"),
             Ok(false) => {
                 error!("runnable config did not produce an orchestrator runtime");
@@ -133,7 +134,7 @@ pub async fn execute(args: WebArgs) -> ExitCode {
             }
         }
     } else {
-        *app_state.orchestrator_runtime.lock().unwrap() = None;
+        clear_registered_orchestrator(&app_state).await;
     }
 
     // Create combined router: API routes + SPA fallback

--- a/crates/ensemble-cli/src/commands/web.rs
+++ b/crates/ensemble-cli/src/commands/web.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use tracing::{error, info, warn};
 
-use ensemble_core::api::bootstrap::{build_app_state, start_orchestrator_for_app};
+use ensemble_core::api::bootstrap::{
+    build_app_state, replace_registered_orchestrator, take_registered_orchestrator,
+};
 use ensemble_core::api::router::create_api_router;
 use ensemble_core::config::draft::load_config_document_or_missing;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
@@ -116,11 +118,13 @@ pub async fn execute(args: WebArgs) -> ExitCode {
     }
     let has_runnable_config = prepared.has_runnable_config;
     let app_state = prepared.app_state;
-    let orchestrator_runtime = if has_runnable_config {
-        match start_orchestrator_for_app(&app_state).await {
-            Ok(runtime) => {
-                info!("orchestrator started");
-                runtime
+    if has_runnable_config {
+        match replace_registered_orchestrator(&app_state).await {
+            Ok(true) => info!("orchestrator started"),
+            Ok(false) => {
+                error!("runnable config did not produce an orchestrator runtime");
+                eprintln!("error: runnable config did not produce an orchestrator runtime");
+                return ExitCode::FAILURE;
             }
             Err(e) => {
                 error!(error = %e, "failed to start orchestrator");
@@ -129,11 +133,11 @@ pub async fn execute(args: WebArgs) -> ExitCode {
             }
         }
     } else {
-        None
-    };
+        *app_state.orchestrator_runtime.lock().unwrap() = None;
+    }
 
     // Create combined router: API routes + SPA fallback
-    let api_router = create_api_router(app_state);
+    let api_router = create_api_router(app_state.clone());
     let spa_router = spa_router();
 
     let router = api_router.merge(spa_router);
@@ -219,7 +223,7 @@ pub async fn execute(args: WebArgs) -> ExitCode {
 
     // Clean shutdown
     server_handle.abort();
-    if let Some(runtime) = orchestrator_runtime {
+    if let Some(runtime) = take_registered_orchestrator(&app_state) {
         runtime.shutdown().await;
     }
     info!("HTTP server stopped");

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -1,15 +1,43 @@
+use crate::agent::{AcpAgentRunner, AgentRunner};
 use crate::api::router::{AppState, ConfigRuntime};
 use crate::config::draft::ConfigDocumentState;
 use crate::config::ensemble::{default_workspace_root, ConcurrencyConfig, PollingConfig};
+use crate::error::EnsembleError;
 use crate::observability::events::EventBus;
 use crate::orchestrator::state::OrchestratorState;
+use crate::orchestrator::Orchestrator;
+use crate::tracker::{create_tracker, IssueTracker};
+use crate::workspace::manager::WorkspaceManager;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, RwLock};
+use tokio::task::JoinHandle;
 
 pub struct PreparedApp {
     pub app_state: AppState,
     pub has_runnable_config: bool,
+}
+
+pub struct OrchestratorRuntime {
+    shutdown_tx: mpsc::Sender<()>,
+    task: JoinHandle<()>,
+}
+
+impl OrchestratorRuntime {
+    pub fn request_shutdown(&self) {
+        let _ = self.shutdown_tx.try_send(());
+    }
+
+    pub fn abort(self) {
+        self.request_shutdown();
+        self.task.abort();
+    }
+
+    pub async fn shutdown(self) {
+        self.request_shutdown();
+        let _ = self.task.await;
+    }
 }
 
 pub fn orchestrator_state_from_document(
@@ -70,6 +98,53 @@ pub fn build_app_state(
         app_state,
         has_runnable_config,
     }
+}
+
+pub async fn start_orchestrator_for_app(
+    app_state: &AppState,
+) -> Result<Option<OrchestratorRuntime>, EnsembleError> {
+    let active_config = {
+        app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await
+            .active_config
+            .clone()
+    };
+
+    let Some(config) = active_config else {
+        return Ok(None);
+    };
+
+    let config = Arc::new(RwLock::new(config.clone()));
+    let tracker: Arc<dyn IssueTracker> = Arc::from(create_tracker(&config.read().await.tracker)?);
+    let agent_runner: Arc<dyn AgentRunner> = Arc::new(AcpAgentRunner::new(Arc::clone(&config)));
+    let workspace_mgr = WorkspaceManager::new(
+        Path::new(&app_state.workspace_root),
+        Some(config.read().await.repos.clone()),
+    )?;
+    let config_dir = app_state
+        .config_runtime
+        .config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
+    let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+    let mut orchestrator = Orchestrator::new_with_state(
+        Arc::clone(&app_state.orchestrator_state),
+        config,
+        tracker,
+        agent_runner,
+        workspace_mgr,
+        config_dir,
+        Arc::clone(&app_state.refresh_requested),
+        shutdown_rx,
+    );
+    let task = tokio::spawn(async move {
+        orchestrator.run().await;
+    });
+
+    Ok(Some(OrchestratorRuntime { shutdown_tx, task }))
 }
 
 #[cfg(test)]
@@ -138,6 +213,56 @@ mod tests {
         assert_eq!(
             built.app_state.history_path,
             PathBuf::from(&built.app_state.workspace_root).join("ensemble_history.jsonl")
+        );
+    }
+
+    #[tokio::test]
+    async fn start_orchestrator_for_app_returns_none_without_active_config() {
+        let config_path = PathBuf::from("/tmp/missing-config.yaml");
+        let built = build_app_state(
+            config_path.clone(),
+            missing_config_state(config_path),
+            EventBus::new(),
+        );
+
+        let runtime = start_orchestrator_for_app(&built.app_state).await.unwrap();
+
+        assert!(runtime.is_none());
+    }
+
+    #[tokio::test]
+    async fn start_orchestrator_for_app_updates_shared_state_after_first_tick() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let todo_path = temp_dir.path().join("TODO.md");
+        let config_path = temp_dir.path().join("config.yaml");
+        let yaml = format!(
+            "tracker:\n  kind: todo_file\n  path: {}\n  active_states: [Todo]\n  terminal_states: [Done]\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\npolling:\n  interval_ms: 60000\n",
+            todo_path.display()
+        );
+        let document_state = parse_raw_yaml(config_path.clone(), yaml);
+        let built = build_app_state(config_path, document_state, EventBus::new());
+
+        let runtime = start_orchestrator_for_app(&built.app_state)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let ticked = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let last_tick_at = built.app_state.orchestrator_state.read().await.last_tick_at;
+                if last_tick_at.is_some() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        runtime.shutdown().await;
+
+        assert!(
+            ticked.is_ok(),
+            "orchestrator did not record an initial tick"
         );
     }
 }

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -2,7 +2,7 @@ use crate::agent::{AcpAgentRunner, AgentRunner};
 use crate::api::router::{AppState, ConfigRuntime};
 use crate::config::draft::ConfigDocumentState;
 use crate::config::ensemble::{default_workspace_root, ConcurrencyConfig, PollingConfig};
-use crate::error::EnsembleError;
+use crate::error::{ConfigError, EnsembleError};
 use crate::observability::events::EventBus;
 use crate::orchestrator::state::OrchestratorState;
 use crate::orchestrator::Orchestrator;
@@ -26,6 +26,7 @@ pub struct OrchestratorRuntime {
 
 impl OrchestratorRuntime {
     pub fn request_shutdown(&self) {
+        // Capacity is 1; if a shutdown request is already queued, nothing else is needed.
         let _ = self.shutdown_tx.try_send(());
     }
 
@@ -84,6 +85,7 @@ pub fn build_app_state(
 
     let app_state = AppState {
         orchestrator_state: orchestrator_state_from_document(&document_state),
+        orchestrator_runtime: Arc::new(std::sync::Mutex::new(None)),
         refresh_requested: Arc::new(tokio::sync::Notify::new()),
         workspace_root,
         history_path,
@@ -128,7 +130,8 @@ pub async fn start_orchestrator_for_app(
         .config_runtime
         .config_path
         .parent()
-        .unwrap_or_else(|| Path::new("."));
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or(ConfigError::ConfigDirUnavailable)?;
     let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
     let mut orchestrator = Orchestrator::new_with_state(
         Arc::clone(&app_state.orchestrator_state),
@@ -145,6 +148,21 @@ pub async fn start_orchestrator_for_app(
     });
 
     Ok(Some(OrchestratorRuntime { shutdown_tx, task }))
+}
+
+pub fn take_registered_orchestrator(app_state: &AppState) -> Option<OrchestratorRuntime> {
+    app_state.orchestrator_runtime.lock().unwrap().take()
+}
+
+pub async fn replace_registered_orchestrator(app_state: &AppState) -> Result<bool, EnsembleError> {
+    if let Some(runtime) = take_registered_orchestrator(app_state) {
+        runtime.shutdown().await;
+    }
+
+    let runtime = start_orchestrator_for_app(app_state).await?;
+    let started = runtime.is_some();
+    *app_state.orchestrator_runtime.lock().unwrap() = runtime;
+    Ok(started)
 }
 
 #[cfg(test)]

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -11,6 +11,7 @@ use crate::workspace::manager::WorkspaceManager;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::MutexGuard;
 use tokio::sync::{mpsc, RwLock};
 use tokio::task::JoinHandle;
 
@@ -28,6 +29,11 @@ pub struct OrchestratorRuntime {
 /// and never holds the mutex guard across `.await`. A tokio mutex would add async overhead
 /// without improving correctness for these tiny critical sections.
 pub type RegisteredOrchestrator = Arc<std::sync::Mutex<Option<OrchestratorRuntime>>>;
+
+struct PreparedOrchestratorRuntime {
+    orchestrator: Orchestrator,
+    shutdown_tx: mpsc::Sender<()>,
+}
 
 impl OrchestratorRuntime {
     pub fn request_shutdown(&self) {
@@ -107,9 +113,26 @@ pub fn build_app_state(
     }
 }
 
-pub async fn start_orchestrator_for_app(
+fn config_dir_for_path(config_path: &Path) -> Result<PathBuf, ConfigError> {
+    match config_path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => Ok(parent.to_path_buf()),
+        Some(_) if config_path.is_relative() => Ok(PathBuf::from(".")),
+        _ => Err(ConfigError::ConfigDirUnavailable),
+    }
+}
+
+fn registered_orchestrator_guard(
     app_state: &AppState,
-) -> Result<Option<OrchestratorRuntime>, EnsembleError> {
+) -> MutexGuard<'_, Option<OrchestratorRuntime>> {
+    app_state
+        .orchestrator_runtime
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+async fn prepare_orchestrator_runtime(
+    app_state: &AppState,
+) -> Result<Option<PreparedOrchestratorRuntime>, EnsembleError> {
     let active_config = {
         app_state
             .config_runtime
@@ -131,14 +154,9 @@ pub async fn start_orchestrator_for_app(
         Path::new(&app_state.workspace_root),
         Some(config.read().await.repos.clone()),
     )?;
-    let config_dir = app_state
-        .config_runtime
-        .config_path
-        .parent()
-        .filter(|path| !path.as_os_str().is_empty())
-        .ok_or(ConfigError::ConfigDirUnavailable)?;
+    let config_dir = config_dir_for_path(&app_state.config_runtime.config_path)?;
     let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
-    let mut orchestrator = Orchestrator::new_with_state(
+    let orchestrator = Orchestrator::new_with_state(
         OrchestratorRuntimeParts {
             state: Arc::clone(&app_state.orchestrator_state),
             config,
@@ -147,18 +165,38 @@ pub async fn start_orchestrator_for_app(
             workspace_mgr,
             refresh_requested: Arc::clone(&app_state.refresh_requested),
         },
-        config_dir,
+        &config_dir,
         shutdown_rx,
     );
+
+    Ok(Some(PreparedOrchestratorRuntime {
+        orchestrator,
+        shutdown_tx,
+    }))
+}
+
+fn launch_orchestrator_runtime(prepared: PreparedOrchestratorRuntime) -> OrchestratorRuntime {
+    let PreparedOrchestratorRuntime {
+        mut orchestrator,
+        shutdown_tx,
+    } = prepared;
     let task = tokio::spawn(async move {
         orchestrator.run().await;
     });
 
-    Ok(Some(OrchestratorRuntime { shutdown_tx, task }))
+    OrchestratorRuntime { shutdown_tx, task }
+}
+
+pub async fn start_orchestrator_for_app(
+    app_state: &AppState,
+) -> Result<Option<OrchestratorRuntime>, EnsembleError> {
+    Ok(prepare_orchestrator_runtime(app_state)
+        .await?
+        .map(launch_orchestrator_runtime))
 }
 
 pub fn take_registered_orchestrator(app_state: &AppState) -> Option<OrchestratorRuntime> {
-    app_state.orchestrator_runtime.lock().unwrap().take()
+    registered_orchestrator_guard(app_state).take()
 }
 
 pub async fn clear_registered_orchestrator(app_state: &AppState) {
@@ -170,13 +208,14 @@ pub async fn clear_registered_orchestrator(app_state: &AppState) {
 pub async fn start_or_replace_registered_orchestrator(
     app_state: &AppState,
 ) -> Result<bool, EnsembleError> {
+    let prepared = prepare_orchestrator_runtime(app_state).await?;
+    let started = prepared.is_some();
+
     if let Some(runtime) = take_registered_orchestrator(app_state) {
         runtime.shutdown().await;
     }
 
-    let runtime = start_orchestrator_for_app(app_state).await?;
-    let started = runtime.is_some();
-    *app_state.orchestrator_runtime.lock().unwrap() = runtime;
+    *registered_orchestrator_guard(app_state) = prepared.map(launch_orchestrator_runtime);
     Ok(started)
 }
 
@@ -185,6 +224,7 @@ mod tests {
     use super::*;
     use crate::config::draft::{missing_config_state, parse_raw_yaml};
     use crate::observability::events::EventBus;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     fn valid_config_yaml(workspace_root: Option<&str>) -> String {
         let workspace = workspace_root
@@ -325,5 +365,88 @@ mod tests {
             .lock()
             .unwrap()
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn start_or_replace_keeps_existing_runtime_when_rebuild_fails() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let todo_path = temp_dir.path().join("TODO.md");
+        let config_path = temp_dir.path().join("config.yaml");
+        let initial_yaml = format!(
+            "tracker:\n  kind: todo_file\n  path: {}\n  active_states: [Todo]\n  terminal_states: [Done]\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n",
+            todo_path.display()
+        );
+        let document_state = parse_raw_yaml(config_path.clone(), initial_yaml);
+        let built = build_app_state(config_path.clone(), document_state, EventBus::new());
+
+        let runtime = start_orchestrator_for_app(&built.app_state)
+            .await
+            .unwrap()
+            .unwrap();
+        *built.app_state.orchestrator_runtime.lock().unwrap() = Some(runtime);
+
+        let bad_yaml = "tracker:\n  kind: todo_file\n  path: /definitely/missing/dir/TODO.md\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n";
+        let next_state = parse_raw_yaml(config_path, bad_yaml.to_string());
+        *built.app_state.config_runtime.document_state.write().await = next_state;
+
+        let result = start_or_replace_registered_orchestrator(&built.app_state).await;
+
+        assert!(result.is_err(), "expected restart to fail");
+        assert!(
+            built
+                .app_state
+                .orchestrator_runtime
+                .lock()
+                .unwrap()
+                .is_some(),
+            "expected existing runtime to stay registered on restart failure"
+        );
+
+        if let Some(runtime) = take_registered_orchestrator(&built.app_state) {
+            runtime.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn start_orchestrator_for_app_accepts_relative_config_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let todo_path = temp_dir.path().join("TODO.md");
+        let config_path = PathBuf::from("config.yaml");
+        let yaml = format!(
+            "tracker:\n  kind: todo_file\n  path: {}\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n",
+            todo_path.display()
+        );
+        let document_state = parse_raw_yaml(config_path.clone(), yaml);
+        let built = build_app_state(config_path, document_state, EventBus::new());
+
+        let runtime = start_orchestrator_for_app(&built.app_state).await;
+
+        let runtime = runtime
+            .expect("relative config path should not fail")
+            .expect("relative config path should start an orchestrator");
+        runtime.shutdown().await;
+    }
+
+    #[test]
+    fn take_registered_orchestrator_recovers_from_poisoned_mutex() {
+        let config_path = PathBuf::from("/tmp/missing-config.yaml");
+        let built = build_app_state(
+            config_path.clone(),
+            missing_config_state(config_path),
+            EventBus::new(),
+        );
+        let runtime_registry = Arc::clone(&built.app_state.orchestrator_runtime);
+
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = runtime_registry.lock().unwrap();
+            panic!("poison orchestrator runtime mutex");
+        }));
+
+        let runtime = take_registered_orchestrator(&built.app_state);
+
+        assert!(
+            runtime.is_none(),
+            "poisoned mutex should still be recoverable"
+        );
     }
 }

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -5,7 +5,7 @@ use crate::config::ensemble::{default_workspace_root, ConcurrencyConfig, Polling
 use crate::error::{ConfigError, EnsembleError};
 use crate::observability::events::EventBus;
 use crate::orchestrator::state::OrchestratorState;
-use crate::orchestrator::Orchestrator;
+use crate::orchestrator::{Orchestrator, OrchestratorRuntimeParts};
 use crate::tracker::{create_tracker, IssueTracker};
 use crate::workspace::manager::WorkspaceManager;
 use std::path::Path;
@@ -23,6 +23,11 @@ pub struct OrchestratorRuntime {
     shutdown_tx: mpsc::Sender<()>,
     task: JoinHandle<()>,
 }
+
+/// `std::sync::Mutex` is sufficient here because runtime registration only swaps an `Option`
+/// and never holds the mutex guard across `.await`. A tokio mutex would add async overhead
+/// without improving correctness for these tiny critical sections.
+pub type RegisteredOrchestrator = Arc<std::sync::Mutex<Option<OrchestratorRuntime>>>;
 
 impl OrchestratorRuntime {
     pub fn request_shutdown(&self) {
@@ -134,13 +139,15 @@ pub async fn start_orchestrator_for_app(
         .ok_or(ConfigError::ConfigDirUnavailable)?;
     let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
     let mut orchestrator = Orchestrator::new_with_state(
-        Arc::clone(&app_state.orchestrator_state),
-        config,
-        tracker,
-        agent_runner,
-        workspace_mgr,
+        OrchestratorRuntimeParts {
+            state: Arc::clone(&app_state.orchestrator_state),
+            config,
+            tracker,
+            agent_runner,
+            workspace_mgr,
+            refresh_requested: Arc::clone(&app_state.refresh_requested),
+        },
         config_dir,
-        Arc::clone(&app_state.refresh_requested),
         shutdown_rx,
     );
     let task = tokio::spawn(async move {
@@ -154,7 +161,15 @@ pub fn take_registered_orchestrator(app_state: &AppState) -> Option<Orchestrator
     app_state.orchestrator_runtime.lock().unwrap().take()
 }
 
-pub async fn replace_registered_orchestrator(app_state: &AppState) -> Result<bool, EnsembleError> {
+pub async fn clear_registered_orchestrator(app_state: &AppState) {
+    if let Some(runtime) = take_registered_orchestrator(app_state) {
+        runtime.shutdown().await;
+    }
+}
+
+pub async fn start_or_replace_registered_orchestrator(
+    app_state: &AppState,
+) -> Result<bool, EnsembleError> {
     if let Some(runtime) = take_registered_orchestrator(app_state) {
         runtime.shutdown().await;
     }
@@ -282,5 +297,33 @@ mod tests {
             ticked.is_ok(),
             "orchestrator did not record an initial tick"
         );
+    }
+
+    #[tokio::test]
+    async fn clear_registered_orchestrator_removes_stored_runtime() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let todo_path = temp_dir.path().join("TODO.md");
+        let config_path = temp_dir.path().join("config.yaml");
+        let yaml = format!(
+            "tracker:\n  kind: todo_file\n  path: {}\n  active_states: [Todo]\n  terminal_states: [Done]\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n",
+            todo_path.display()
+        );
+        let document_state = parse_raw_yaml(config_path.clone(), yaml);
+        let built = build_app_state(config_path, document_state, EventBus::new());
+
+        let runtime = start_orchestrator_for_app(&built.app_state)
+            .await
+            .unwrap()
+            .unwrap();
+        *built.app_state.orchestrator_runtime.lock().unwrap() = Some(runtime);
+
+        clear_registered_orchestrator(&built.app_state).await;
+
+        assert!(built
+            .app_state
+            .orchestrator_runtime
+            .lock()
+            .unwrap()
+            .is_none());
     }
 }

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -1,4 +1,4 @@
-use crate::api::bootstrap::replace_registered_orchestrator;
+use crate::api::bootstrap::start_or_replace_registered_orchestrator;
 use crate::api::router::AppState;
 use crate::config::draft::{
     parse_raw_yaml, save_raw_yaml_atomically, ConfigDocumentState, ConfigStateKind, ValidationIssue,
@@ -293,7 +293,7 @@ pub async fn save_yaml(
     ) {
         Ok(response) => {
             drop(doc_state);
-            match replace_registered_orchestrator(&state).await {
+            match start_or_replace_registered_orchestrator(&state).await {
                 Ok(_) => (StatusCode::OK, Json(response)),
                 Err(error) => {
                     let doc_state = state.config_runtime.document_state.read().await;
@@ -570,7 +570,7 @@ where
         Ok(()) => match reload_document_state(&mut doc_state, &state.config_runtime.config_path) {
             Ok(response) => {
                 drop(doc_state);
-                match replace_registered_orchestrator(&state).await {
+                match start_or_replace_registered_orchestrator(&state).await {
                     Ok(_) => (StatusCode::OK, Json(response)),
                     Err(error) => {
                         let doc_state = state.config_runtime.document_state.read().await;
@@ -788,7 +788,7 @@ pub async fn save_guided_form(
     ) {
         Ok(response) => {
             drop(doc_state);
-            match replace_registered_orchestrator(&state).await {
+            match start_or_replace_registered_orchestrator(&state).await {
                 Ok(_) => (StatusCode::OK, Json(response)),
                 Err(error) => {
                     let doc_state = state.config_runtime.document_state.read().await;

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -276,7 +276,8 @@ pub struct SaveYamlRequest {
     request_body = SaveYamlRequest,
     responses(
         (status = 200, description = "Save result", body = ConfigStateResponse),
-        (status = 400, description = "Invalid YAML or validation failed")
+        (status = 400, description = "Invalid YAML or validation failed"),
+        (status = 500, description = "Config saved but orchestrator restart failed", body = ConfigStateResponse)
     ),
     tag = "config"
 )]
@@ -519,7 +520,8 @@ pub struct SaveSetupRequest {
     request_body = SaveSetupRequest,
     responses(
         (status = 200, description = "Save result", body = ConfigStateResponse),
-        (status = 400, description = "Setup validation failed")
+        (status = 400, description = "Setup validation failed"),
+        (status = 500, description = "Config saved but orchestrator restart failed", body = ConfigStateResponse)
     ),
     tag = "config"
 )]
@@ -758,7 +760,8 @@ pub struct SaveGuidedFormRequest {
     request_body = SaveGuidedFormRequest,
     responses(
         (status = 200, description = "Save result", body = ConfigStateResponse),
-        (status = 400, description = "Merge or save failed")
+        (status = 400, description = "Merge or save failed"),
+        (status = 500, description = "Config saved but orchestrator restart failed", body = ConfigStateResponse)
     ),
     tag = "config"
 )]

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -1,3 +1,4 @@
+use crate::api::bootstrap::replace_registered_orchestrator;
 use crate::api::router::AppState;
 use crate::config::draft::{
     parse_raw_yaml, save_raw_yaml_atomically, ConfigDocumentState, ConfigStateKind, ValidationIssue,
@@ -290,7 +291,23 @@ pub async fn save_yaml(
         &state.config_runtime.config_path,
         &request.raw_yaml,
     ) {
-        Ok(response) => (StatusCode::OK, Json(response)),
+        Ok(response) => {
+            drop(doc_state);
+            match replace_registered_orchestrator(&state).await {
+                Ok(_) => (StatusCode::OK, Json(response)),
+                Err(error) => {
+                    let doc_state = state.config_runtime.document_state.read().await;
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        current_error_json(
+                            &doc_state,
+                            "runtime",
+                            format!("saved config but failed to restart orchestrator: {error}"),
+                        ),
+                    )
+                }
+            }
+        }
         Err(e) => (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
     }
 }
@@ -551,7 +568,23 @@ where
 
     match crate::config::setup::write_setup_artifacts(root, &request.setup, &artifacts) {
         Ok(()) => match reload_document_state(&mut doc_state, &state.config_runtime.config_path) {
-            Ok(response) => (StatusCode::OK, Json(response)),
+            Ok(response) => {
+                drop(doc_state);
+                match replace_registered_orchestrator(&state).await {
+                    Ok(_) => (StatusCode::OK, Json(response)),
+                    Err(error) => {
+                        let doc_state = state.config_runtime.document_state.read().await;
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            current_error_json(
+                                &doc_state,
+                                "runtime",
+                                format!("saved config but failed to restart orchestrator: {error}"),
+                            ),
+                        )
+                    }
+                }
+            }
             Err(e) => (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
         },
         Err(e) => (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
@@ -753,7 +786,23 @@ pub async fn save_guided_form(
         &state.config_runtime.config_path,
         &merged_yaml,
     ) {
-        Ok(response) => (StatusCode::OK, Json(response)),
+        Ok(response) => {
+            drop(doc_state);
+            match replace_registered_orchestrator(&state).await {
+                Ok(_) => (StatusCode::OK, Json(response)),
+                Err(error) => {
+                    let doc_state = state.config_runtime.document_state.read().await;
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        current_error_json(
+                            &doc_state,
+                            "runtime",
+                            format!("saved config but failed to restart orchestrator: {error}"),
+                        ),
+                    )
+                }
+            }
+        }
         Err(e) => (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
     }
 }
@@ -1674,6 +1723,70 @@ on_failure: Failed
                 .and_then(|config| config.tracker.api_key.clone()),
             Some("ghp_secret123".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn save_yaml_starts_orchestrator_after_valid_config_is_written() {
+        let (state, temp_dir) = test_app_state();
+        let todo_path = temp_dir.path().join("TODO.md");
+        std::fs::write(&todo_path, "## Todo\n").unwrap();
+        let request = SaveYamlRequest {
+            raw_yaml: format!(
+                "tracker:\n  kind: todo_file\n  path: {}\npolling:\n  interval_ms: 1234\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n",
+                todo_path.display()
+            ),
+        };
+
+        let (status, Json(response)) =
+            save_yaml(axum::extract::State(state.clone()), Json(request)).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(response.active_config.is_some());
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if state.orchestrator_state.read().await.last_tick_at.is_some() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("orchestrator should start after saving a valid config");
+    }
+
+    #[tokio::test]
+    async fn save_yaml_restarts_orchestrator_with_updated_poll_interval() {
+        let (state, temp_dir) = test_app_state();
+        let todo_path = temp_dir.path().join("TODO.md");
+        std::fs::write(&todo_path, "## Todo\n").unwrap();
+
+        for interval_ms in [1234_u64, 4321_u64] {
+            let request = SaveYamlRequest {
+                raw_yaml: format!(
+                    "tracker:\n  kind: todo_file\n  path: {}\npolling:\n  interval_ms: {interval_ms}\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n",
+                    todo_path.display()
+                ),
+            };
+
+            let (status, Json(response)) =
+                save_yaml(axum::extract::State(state.clone()), Json(request)).await;
+
+            assert_eq!(status, StatusCode::OK);
+            assert!(response.active_config.is_some());
+
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                loop {
+                    let poll_interval_ms = state.orchestrator_state.read().await.poll_interval_ms;
+                    if poll_interval_ms == interval_ms {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("orchestrator should adopt the saved poll interval");
+        }
     }
 
     #[test]

--- a/crates/ensemble-core/src/api/openapi.rs
+++ b/crates/ensemble-core/src/api/openapi.rs
@@ -154,4 +154,21 @@ mod tests {
             "#/components/schemas/ConfigStateResponse"
         );
     }
+
+    #[test]
+    fn test_openapi_documents_runtime_restart_failures_for_save_endpoints() {
+        let spec: serde_json::Value =
+            serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+
+        for path in [
+            "/api/v1/config/yaml/save",
+            "/api/v1/config/setup/save",
+            "/api/v1/config/form/save",
+        ] {
+            assert!(
+                spec["paths"][path]["post"]["responses"]["500"].is_object(),
+                "expected 500 response to be documented for {path}"
+            );
+        }
+    }
 }

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -12,7 +12,6 @@ use axum::routing::{get, post};
 use axum::Router;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Mutex;
 use tokio::sync::RwLock;
 use utoipa::OpenApi;
 
@@ -29,7 +28,10 @@ pub struct AppState {
     /// The orchestrator state, shared with the orchestrator task via RwLock.
     pub orchestrator_state: Arc<RwLock<OrchestratorState>>,
     /// The currently registered orchestrator runtime for this app instance.
-    pub orchestrator_runtime: Arc<Mutex<Option<crate::api::bootstrap::OrchestratorRuntime>>>,
+    ///
+    /// Runtime registration only swaps ownership of the handle and never awaits while holding
+    /// the lock, so a blocking mutex keeps this cheap and simple.
+    pub orchestrator_runtime: crate::api::bootstrap::RegisteredOrchestrator,
     /// Flag that signals the orchestrator to run an immediate tick.
     /// The orchestrator polls this flag; setting it triggers a refresh.
     pub refresh_requested: Arc<tokio::sync::Notify>,

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -12,6 +12,7 @@ use axum::routing::{get, post};
 use axum::Router;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 use tokio::sync::RwLock;
 use utoipa::OpenApi;
 
@@ -27,6 +28,8 @@ pub struct ConfigRuntime {
 pub struct AppState {
     /// The orchestrator state, shared with the orchestrator task via RwLock.
     pub orchestrator_state: Arc<RwLock<OrchestratorState>>,
+    /// The currently registered orchestrator runtime for this app instance.
+    pub orchestrator_runtime: Arc<Mutex<Option<crate::api::bootstrap::OrchestratorRuntime>>>,
     /// Flag that signals the orchestrator to run an immediate tick.
     /// The orchestrator polls this flag; setting it triggers a refresh.
     pub refresh_requested: Arc<tokio::sync::Notify>,

--- a/crates/ensemble-core/src/api/test_helpers.rs
+++ b/crates/ensemble-core/src/api/test_helpers.rs
@@ -24,6 +24,7 @@ pub(crate) fn parsed_document_state() -> ConfigDocumentState {
 pub(crate) fn app_state_with_document_state(document_state: ConfigDocumentState) -> AppState {
     AppState {
         orchestrator_state: Arc::new(RwLock::new(OrchestratorState::new(30000, 10))),
+        orchestrator_runtime: Arc::new(std::sync::Mutex::new(None)),
         refresh_requested: Arc::new(tokio::sync::Notify::new()),
         workspace_root: "/tmp/workspaces".to_string(),
         history_path: PathBuf::from("/tmp/history.jsonl"),
@@ -41,6 +42,7 @@ pub(crate) fn app_state_with_missing_config(
 ) -> AppState {
     AppState {
         orchestrator_state: Arc::new(RwLock::new(OrchestratorState::new(30000, 10))),
+        orchestrator_runtime: Arc::new(std::sync::Mutex::new(None)),
         refresh_requested: Arc::new(tokio::sync::Notify::new()),
         workspace_root: workspace_root.to_string(),
         history_path: PathBuf::from("/tmp/history.jsonl"),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -58,6 +58,7 @@ pub struct Orchestrator {
     agent_runner: Arc<dyn AgentRunner>,
     workspace_mgr: Arc<WorkspaceManager>,
     interaction_store: InteractionStore,
+    refresh_requested: Arc<tokio::sync::Notify>,
     worker_tx: mpsc::Sender<WorkerEvent>,
     worker_rx: mpsc::Receiver<WorkerEvent>,
     shutdown_rx: mpsc::Receiver<()>,
@@ -73,17 +74,41 @@ impl Orchestrator {
         config_dir: &Path,
         shutdown_rx: mpsc::Receiver<()>,
     ) -> Self {
+        let state = Arc::new(RwLock::new(OrchestratorState::new(30_000, 10)));
+        let refresh_requested = Arc::new(tokio::sync::Notify::new());
+        Self::new_with_state(
+            state,
+            config,
+            tracker,
+            agent_runner,
+            workspace_mgr,
+            config_dir,
+            refresh_requested,
+            shutdown_rx,
+        )
+    }
+
+    /// Create a new Orchestrator using externally managed state and refresh signaling.
+    pub fn new_with_state(
+        state: Arc<RwLock<OrchestratorState>>,
+        config: Arc<RwLock<EnsembleConfig>>,
+        tracker: Arc<dyn IssueTracker>,
+        agent_runner: Arc<dyn AgentRunner>,
+        workspace_mgr: WorkspaceManager,
+        config_dir: &Path,
+        refresh_requested: Arc<tokio::sync::Notify>,
+        shutdown_rx: mpsc::Receiver<()>,
+    ) -> Self {
         let (worker_tx, worker_rx) = mpsc::channel(1000);
 
-        let cfg = OrchestratorState::new(30_000, 10);
-
         Self {
-            state: Arc::new(RwLock::new(cfg)),
+            state,
             config,
             tracker,
             agent_runner,
             interaction_store: InteractionStore::new(config_dir.to_path_buf()),
             workspace_mgr: Arc::new(workspace_mgr),
+            refresh_requested,
             worker_tx,
             worker_rx,
             shutdown_rx,
@@ -151,6 +176,12 @@ impl Orchestrator {
                 // Poll timer
                 _ = sleep(poll_interval) => {
                     debug!("poll tick");
+                    self.handle_tick().await;
+                }
+
+                // Manual refresh signal
+                _ = self.refresh_requested.notified() => {
+                    debug!("manual refresh tick");
                     self.handle_tick().await;
                 }
 
@@ -1934,6 +1965,70 @@ agent:
                 "should have retry or be completed"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn refresh_signal_triggers_an_immediate_tick() {
+        let mut config_value = make_config();
+        config_value.polling.interval_ms = 60_000;
+        let config = Arc::new(RwLock::new(config_value));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let refresh_requested = Arc::new(tokio::sync::Notify::new());
+        let state = Arc::new(RwLock::new(OrchestratorState::new(60_000, 10)));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let mut orchestrator = Orchestrator::new_with_state(
+            Arc::clone(&state),
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            Arc::clone(&refresh_requested),
+            shutdown_rx,
+        );
+
+        let run_handle = tokio::spawn(async move {
+            orchestrator.run().await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if state.read().await.last_tick_at.is_some() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let first_tick_at = state.read().await.last_tick_at.unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        refresh_requested.notify_one();
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let current_tick_at = state.read().await.last_tick_at.unwrap();
+                if current_tick_at > first_tick_at {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        shutdown_tx.send(()).await.unwrap();
+        run_handle.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -64,6 +64,15 @@ pub struct Orchestrator {
     shutdown_rx: mpsc::Receiver<()>,
 }
 
+pub struct OrchestratorRuntimeParts {
+    pub state: Arc<RwLock<OrchestratorState>>,
+    pub config: Arc<RwLock<EnsembleConfig>>,
+    pub tracker: Arc<dyn IssueTracker>,
+    pub agent_runner: Arc<dyn AgentRunner>,
+    pub workspace_mgr: WorkspaceManager,
+    pub refresh_requested: Arc<tokio::sync::Notify>,
+}
+
 impl Orchestrator {
     /// Create a new Orchestrator.
     pub fn new(
@@ -77,38 +86,35 @@ impl Orchestrator {
         let state = Arc::new(RwLock::new(OrchestratorState::new(30_000, 10)));
         let refresh_requested = Arc::new(tokio::sync::Notify::new());
         Self::new_with_state(
-            state,
-            config,
-            tracker,
-            agent_runner,
-            workspace_mgr,
+            OrchestratorRuntimeParts {
+                state,
+                config,
+                tracker,
+                agent_runner,
+                workspace_mgr,
+                refresh_requested,
+            },
             config_dir,
-            refresh_requested,
             shutdown_rx,
         )
     }
 
     /// Create a new Orchestrator using externally managed state and refresh signaling.
     pub fn new_with_state(
-        state: Arc<RwLock<OrchestratorState>>,
-        config: Arc<RwLock<EnsembleConfig>>,
-        tracker: Arc<dyn IssueTracker>,
-        agent_runner: Arc<dyn AgentRunner>,
-        workspace_mgr: WorkspaceManager,
+        parts: OrchestratorRuntimeParts,
         config_dir: &Path,
-        refresh_requested: Arc<tokio::sync::Notify>,
         shutdown_rx: mpsc::Receiver<()>,
     ) -> Self {
         let (worker_tx, worker_rx) = mpsc::channel(1000);
 
         Self {
-            state,
-            config,
-            tracker,
-            agent_runner,
+            state: parts.state,
+            config: parts.config,
+            tracker: parts.tracker,
+            agent_runner: parts.agent_runner,
             interaction_store: InteractionStore::new(config_dir.to_path_buf()),
-            workspace_mgr: Arc::new(workspace_mgr),
-            refresh_requested,
+            workspace_mgr: Arc::new(parts.workspace_mgr),
+            refresh_requested: parts.refresh_requested,
             worker_tx,
             worker_rx,
             shutdown_rx,
@@ -1986,13 +1992,15 @@ agent:
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let mut orchestrator = Orchestrator::new_with_state(
-            Arc::clone(&state),
-            config,
-            tracker,
-            runner,
-            workspace_mgr,
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr,
+                refresh_requested: Arc::clone(&refresh_requested),
+            },
             dir.path(),
-            Arc::clone(&refresh_requested),
             shutdown_rx,
         );
 

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -37,6 +37,7 @@ fn build_app_state(
 ) -> AppState {
     AppState {
         orchestrator_state: Arc::new(RwLock::new(orchestrator_state)),
+        orchestrator_runtime: Arc::new(std::sync::Mutex::new(None)),
         refresh_requested: Arc::new(tokio::sync::Notify::new()),
         workspace_root: temp_dir
             .path()

--- a/crates/ensemble-desktop/src/error.rs
+++ b/crates/ensemble-desktop/src/error.rs
@@ -19,14 +19,6 @@ pub enum DesktopError {
     #[error("Failed to load config: {0}")]
     ConfigLoadFailed(String),
 
-    /// Configuration validation failed.
-    #[error("Config validation failed: {0}")]
-    ConfigValidationFailed(String),
-
-    /// DAG validation failed.
-    #[error("DAG validation failed: {0}")]
-    DagValidationFailed(String),
-
     /// I/O error.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/ensemble-desktop/src/main.rs
+++ b/crates/ensemble-desktop/src/main.rs
@@ -1,17 +1,14 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use ensemble_core::observability::events::EventBus;
-use tauri::Manager;
 use tracing::{info, warn};
 
 mod embedded_ui;
 mod error;
-mod orchestrator;
 mod server;
 
 use embedded_ui::spa_available;
 use ensemble_core::config::location::resolve_config_dir_for_desktop;
-use orchestrator::DesktopOrchestrator;
 use server::start_desktop_server;
 
 fn main() {
@@ -49,19 +46,6 @@ fn main() {
     // Create a single shared EventBus for both orchestrator and server
     let event_bus = EventBus::new();
 
-    // Initialize orchestrator before the Tauri builder so we don't block the UI thread.
-    // Use tauri::async_runtime::block_on instead of a manual tokio runtime.
-    let orchestrator = if resolved.config_path.exists() {
-        tauri::async_runtime::block_on(DesktopOrchestrator::new(
-            resolved.config_path.clone(),
-            event_bus.clone(),
-        ))
-        .ok()
-    } else {
-        info!("No config found - app running in setup mode");
-        None
-    };
-
     // Start the local HTTP server using Tauri's async runtime
     let desktop_server = tauri::async_runtime::block_on(start_desktop_server(
         resolved.config_dir.clone(),
@@ -91,14 +75,6 @@ fn main() {
             .resizable(true)
             .build()
             .expect("Failed to create main window");
-
-            // Register orchestrator if it was initialized successfully
-            if let Some(orch) = orchestrator {
-                app.manage(orch);
-                info!("Orchestrator registered with Tauri app state");
-            } else if resolved.config_path.exists() {
-                warn!("Failed to initialize orchestrator - app will run in setup mode");
-            }
 
             info!("Ensemble Desktop initialized successfully");
             Ok(())

--- a/crates/ensemble-desktop/src/server.rs
+++ b/crates/ensemble-desktop/src/server.rs
@@ -11,7 +11,9 @@
 use std::path::PathBuf;
 use tracing::{error, info, warn};
 
-use ensemble_core::api::bootstrap::build_app_state;
+use ensemble_core::api::bootstrap::{
+    build_app_state, start_orchestrator_for_app, OrchestratorRuntime,
+};
 use ensemble_core::api::router::create_api_router;
 use ensemble_core::config::draft::load_config_document_or_missing;
 use ensemble_core::observability::events::EventBus;
@@ -23,12 +25,16 @@ use crate::error::DesktopError;
 pub struct DesktopServer {
     pub url: url::Url,
     shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    orchestrator: Option<OrchestratorRuntime>,
 }
 
 impl Drop for DesktopServer {
     fn drop(&mut self) {
         if let Some(shutdown) = self.shutdown.take() {
             let _ = shutdown.send(());
+        }
+        if let Some(orchestrator) = self.orchestrator.take() {
+            orchestrator.abort();
         }
     }
 }
@@ -88,6 +94,13 @@ pub async fn start_desktop_server(
         );
     }
     let app_state = prepared.app_state;
+    let orchestrator = if prepared.has_runnable_config {
+        start_orchestrator_for_app(&app_state)
+            .await
+            .map_err(|error| DesktopError::ConfigLoadFailed(error.to_string()))?
+    } else {
+        None
+    };
 
     // Create combined router: API routes + SPA fallback
     let api_router = create_api_router(app_state);
@@ -129,6 +142,7 @@ pub async fn start_desktop_server(
     Ok(DesktopServer {
         url: server_url,
         shutdown: Some(shutdown_tx),
+        orchestrator,
     })
 }
 

--- a/crates/ensemble-desktop/src/server.rs
+++ b/crates/ensemble-desktop/src/server.rs
@@ -12,9 +12,10 @@ use std::path::PathBuf;
 use tracing::{error, info, warn};
 
 use ensemble_core::api::bootstrap::{
-    build_app_state, start_orchestrator_for_app, OrchestratorRuntime,
+    build_app_state, replace_registered_orchestrator, take_registered_orchestrator,
 };
 use ensemble_core::api::router::create_api_router;
+use ensemble_core::api::router::AppState;
 use ensemble_core::config::draft::load_config_document_or_missing;
 use ensemble_core::observability::events::EventBus;
 
@@ -25,7 +26,7 @@ use crate::error::DesktopError;
 pub struct DesktopServer {
     pub url: url::Url,
     shutdown: Option<tokio::sync::oneshot::Sender<()>>,
-    orchestrator: Option<OrchestratorRuntime>,
+    app_state: AppState,
 }
 
 impl Drop for DesktopServer {
@@ -33,7 +34,8 @@ impl Drop for DesktopServer {
         if let Some(shutdown) = self.shutdown.take() {
             let _ = shutdown.send(());
         }
-        if let Some(orchestrator) = self.orchestrator.take() {
+        // Desktop app shutdown is abrupt; abort avoids blocking Drop on async cleanup.
+        if let Some(orchestrator) = take_registered_orchestrator(&self.app_state) {
             orchestrator.abort();
         }
     }
@@ -94,16 +96,14 @@ pub async fn start_desktop_server(
         );
     }
     let app_state = prepared.app_state;
-    let orchestrator = if prepared.has_runnable_config {
-        start_orchestrator_for_app(&app_state)
+    if prepared.has_runnable_config {
+        replace_registered_orchestrator(&app_state)
             .await
-            .map_err(|error| DesktopError::ConfigLoadFailed(error.to_string()))?
-    } else {
-        None
-    };
+            .map_err(|error| DesktopError::ConfigLoadFailed(error.to_string()))?;
+    }
 
     // Create combined router: API routes + SPA fallback
-    let api_router = create_api_router(app_state);
+    let api_router = create_api_router(app_state.clone());
     let spa_router = spa_router();
 
     let router = api_router.merge(spa_router);
@@ -142,7 +142,7 @@ pub async fn start_desktop_server(
     Ok(DesktopServer {
         url: server_url,
         shutdown: Some(shutdown_tx),
-        orchestrator,
+        app_state,
     })
 }
 

--- a/crates/ensemble-desktop/src/server.rs
+++ b/crates/ensemble-desktop/src/server.rs
@@ -34,8 +34,9 @@ impl Drop for DesktopServer {
         if let Some(shutdown) = self.shutdown.take() {
             let _ = shutdown.send(());
         }
-        // DesktopServer owns the only registered runtime handle for this app_state instance, so
-        // taking and aborting it here cannot double-drop a live runtime.
+        // The registered orchestrator handle lives in shared AppState. DesktopServer is
+        // responsible for taking the currently registered runtime for this app_state during
+        // shutdown and aborting it after removing it from the registry.
         // Desktop app shutdown is abrupt; abort avoids blocking Drop on async cleanup.
         if let Some(orchestrator) = take_registered_orchestrator(&self.app_state) {
             orchestrator.abort();

--- a/crates/ensemble-desktop/src/server.rs
+++ b/crates/ensemble-desktop/src/server.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use tracing::{error, info, warn};
 
 use ensemble_core::api::bootstrap::{
-    build_app_state, replace_registered_orchestrator, take_registered_orchestrator,
+    build_app_state, start_or_replace_registered_orchestrator, take_registered_orchestrator,
 };
 use ensemble_core::api::router::create_api_router;
 use ensemble_core::api::router::AppState;
@@ -34,6 +34,8 @@ impl Drop for DesktopServer {
         if let Some(shutdown) = self.shutdown.take() {
             let _ = shutdown.send(());
         }
+        // DesktopServer owns the only registered runtime handle for this app_state instance, so
+        // taking and aborting it here cannot double-drop a live runtime.
         // Desktop app shutdown is abrupt; abort avoids blocking Drop on async cleanup.
         if let Some(orchestrator) = take_registered_orchestrator(&self.app_state) {
             orchestrator.abort();
@@ -97,7 +99,7 @@ pub async fn start_desktop_server(
     }
     let app_state = prepared.app_state;
     if prepared.has_runnable_config {
-        replace_registered_orchestrator(&app_state)
+        start_or_replace_registered_orchestrator(&app_state)
             .await
             .map_err(|error| DesktopError::ConfigLoadFailed(error.to_string()))?;
     }


### PR DESCRIPTION
## Summary
- start the real orchestrator runtime for `ensemble web`, `ensemble run`, and desktop/Tauri using the shared bootstrap path
- wire manual refresh into the orchestrator loop and restart the registered runtime when config saves make config valid or change runtime settings
- tighten runtime lifecycle helpers and tests to satisfy review feedback around startup, shutdown, and shared state wiring

## Test Plan
- [x] cargo test --workspace --exclude ensemble-desktop
- [x] cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- [x] cargo fmt --all -- --check