### PR TITLE
Integrate acpx runtime and harden agent execution lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/chrisbanes/ensemble"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -10,7 +10,9 @@ use tracing::{debug, info};
 
 use crate::error::AgentError;
 
-use super::events::{AgentEvent, JsonRpcMessage, StopReason, TokenUsage, WorkerEvent};
+use super::events::{
+    AgentEvent, JsonRpcMessage, RuntimeStream, StopReason, TokenUsage, WorkerEvent,
+};
 
 /// ACP session managing a subprocess and stdio JSON-RPC 2.0 protocol.
 pub struct AcpSession {
@@ -213,8 +215,7 @@ impl AcpSession {
 
         self.send_json_rpc(&msg).await?;
 
-        // Emit turn started event
-        Self::emit_event(event_tx, issue_id, step_name, AgentEvent::TurnStarted).await;
+        Self::emit_event(event_tx, issue_id, step_name, AgentEvent::PromptStarted).await;
 
         let turn_duration = Duration::from_millis(turn_timeout_ms);
         let result = timeout(
@@ -344,7 +345,7 @@ impl AcpSession {
                                             event_tx,
                                             issue_id,
                                             step_name,
-                                            AgentEvent::TurnCompleted {
+                                            AgentEvent::RunCompleted {
                                                 usage: last_usage.clone(),
                                             },
                                         )
@@ -356,7 +357,7 @@ impl AcpSession {
                                             event_tx,
                                             issue_id,
                                             step_name,
-                                            AgentEvent::TurnCompleted {
+                                            AgentEvent::RunCompleted {
                                                 usage: last_usage.clone(),
                                             },
                                         )
@@ -368,7 +369,7 @@ impl AcpSession {
                                             event_tx,
                                             issue_id,
                                             step_name,
-                                            AgentEvent::TurnFailed {
+                                            AgentEvent::RunFailed {
                                                 reason: reason.clone(),
                                                 usage: last_usage.clone(),
                                             },
@@ -393,7 +394,10 @@ impl AcpSession {
                                     event_tx,
                                     issue_id,
                                     step_name,
-                                    AgentEvent::TurnUpdate { content },
+                                    AgentEvent::OutputChunk {
+                                        stream: RuntimeStream::Stdout,
+                                        content,
+                                    },
                                 )
                                 .await;
                             } else {
@@ -448,9 +452,11 @@ impl AcpSession {
             event_tx,
             issue_id,
             step_name,
-            AgentEvent::PermissionRequested {
-                permission_id: permission_id.clone(),
-                description: description.clone(),
+            AgentEvent::Warning {
+                message: format!(
+                    "permission requested ({permission_id}): {}",
+                    description.as_str()
+                ),
             },
         )
         .await;
@@ -490,9 +496,11 @@ impl AcpSession {
             event_tx,
             issue_id,
             step_name,
-            AgentEvent::PermissionResolved {
-                permission_id,
-                allowed,
+            AgentEvent::Notification {
+                message: format!(
+                    "permission {} ({permission_id})",
+                    if allowed { "approved" } else { "rejected" }
+                ),
             },
         )
         .await;
@@ -757,12 +765,12 @@ done
             assert_eq!(u.total_tokens, 150);
         }
 
-        // Check events were emitted
+        // Check runtime-agnostic events were emitted
         let mut events = vec![];
         while let Ok(evt) = rx.try_recv() {
             events.push(evt);
         }
-        // Should have: TurnStarted, TurnUpdate or Notification, TurnCompleted
+        // Should have: PromptStarted, OutputChunk or Notification, RunCompleted
         assert!(events.len() >= 2);
 
         session.kill().await;
@@ -999,38 +1007,34 @@ done
 
         assert!(result.is_success());
 
-        // Verify permission events
-        let mut perm_requested = false;
-        let mut perm_resolved = false;
+        // Verify permission events are normalized into warning/notification messages
+        let mut saw_permission_warning = false;
+        let mut saw_permission_resolution = false;
         while let Ok(evt) = rx.try_recv() {
             match evt {
                 WorkerEvent::AgentUpdate {
-                    event:
-                        AgentEvent::PermissionRequested {
-                            ref permission_id, ..
-                        },
+                    event: AgentEvent::Warning { ref message },
                     ..
                 } => {
-                    assert_eq!(permission_id, "perm-1");
-                    perm_requested = true;
+                    assert!(message.contains("perm-1"));
+                    saw_permission_warning = true;
                 }
                 WorkerEvent::AgentUpdate {
-                    event:
-                        AgentEvent::PermissionResolved {
-                            ref permission_id,
-                            allowed,
-                        },
+                    event: AgentEvent::Notification { ref message },
                     ..
                 } => {
-                    assert_eq!(permission_id, "perm-1");
-                    assert!(allowed);
-                    perm_resolved = true;
+                    assert!(message.contains("approved"));
+                    assert!(message.contains("perm-1"));
+                    saw_permission_resolution = true;
                 }
                 _ => {}
             }
         }
-        assert!(perm_requested, "expected PermissionRequested event");
-        assert!(perm_resolved, "expected PermissionResolved event");
+        assert!(saw_permission_warning, "expected permission warning event");
+        assert!(
+            saw_permission_resolution,
+            "expected permission resolution notification event"
+        );
 
         session.kill().await;
     }

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -230,8 +230,7 @@ mod tests {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
-                .unwrap();
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
         script_path.display().to_string()
     }
@@ -303,10 +302,7 @@ JSON
             .await
             .unwrap_err();
 
-        assert!(matches!(
-            error,
-            AgentError::AcpxFinalStatusMissing { .. }
-        ));
+        assert!(matches!(error, AgentError::AcpxFinalStatusMissing { .. }));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -1,0 +1,338 @@
+use std::path::Path;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+
+use crate::error::AgentError;
+
+use super::events::{AgentEvent, RuntimeStream, TokenUsage};
+
+pub struct AcpxCli {
+    executable: String,
+}
+
+impl AcpxCli {
+    pub fn new(executable: String) -> Self {
+        Self { executable }
+    }
+
+    pub async fn ensure_session(
+        &self,
+        agent: &str,
+        session_name: &str,
+        cwd: &Path,
+        model: Option<&str>,
+    ) -> Result<(), AgentError> {
+        let mut command = self.base_command(agent, cwd, model);
+        command.args(["sessions", "ensure", "--name", session_name]);
+
+        let status = command.status().await.map_err(|e| AgentError::IoError {
+            reason: format!("failed to run acpx sessions ensure: {e}"),
+        })?;
+        if !status.success() {
+            return Err(AgentError::AcpxCommandFailed {
+                command: "sessions ensure".to_string(),
+                reason: status.to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    pub async fn run_prompt(
+        &self,
+        agent: &str,
+        session_name: &str,
+        cwd: &Path,
+        prompt: &str,
+        model: Option<&str>,
+    ) -> Result<Vec<AgentEvent>, AgentError> {
+        let mut command = self.base_command(agent, cwd, model);
+        command
+            .args(["prompt", "--session", session_name, "--file", "-"])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped());
+
+        let mut child = command.spawn().map_err(|e| AgentError::IoError {
+            reason: format!("failed to run acpx prompt: {e}"),
+        })?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(prompt.as_bytes())
+                .await
+                .map_err(|e| AgentError::IoError {
+                    reason: format!("failed to write prompt to acpx stdin: {e}"),
+                })?;
+        }
+
+        let stdout = child.stdout.take().ok_or_else(|| AgentError::IoError {
+            reason: "failed to capture acpx stdout".to_string(),
+        })?;
+        let mut reader = BufReader::new(stdout).lines();
+        let mut events = Vec::new();
+        let mut saw_terminal_event = false;
+
+        while let Some(line) = reader.next_line().await.map_err(|e| AgentError::IoError {
+            reason: format!("failed to read acpx stdout: {e}"),
+        })? {
+            match serde_json::from_str::<serde_json::Value>(&line) {
+                Ok(value) => {
+                    let event = map_event(value);
+                    if matches!(
+                        event,
+                        AgentEvent::RunCompleted { .. }
+                            | AgentEvent::RunFailed { .. }
+                            | AgentEvent::Cancelled { .. }
+                    ) {
+                        saw_terminal_event = true;
+                    }
+                    events.push(event);
+                }
+                Err(_) => events.push(AgentEvent::Malformed { line }),
+            }
+        }
+
+        let status = child.wait().await.map_err(|e| AgentError::IoError {
+            reason: format!("failed to wait for acpx prompt: {e}"),
+        })?;
+        if !status.success() {
+            return Err(AgentError::AcpxCommandFailed {
+                command: "prompt".to_string(),
+                reason: status.to_string(),
+            });
+        }
+        if !saw_terminal_event {
+            return Err(AgentError::AcpxFinalStatusMissing {
+                context: format!("session '{session_name}' ended without a terminal event"),
+            });
+        }
+
+        Ok(events)
+    }
+
+    pub async fn cancel(
+        &self,
+        agent: &str,
+        session_name: &str,
+        cwd: &Path,
+        model: Option<&str>,
+    ) -> Result<(), AgentError> {
+        let mut command = self.base_command(agent, cwd, model);
+        command.args(["cancel", "--session", session_name]);
+        let status = command.status().await.map_err(|e| AgentError::IoError {
+            reason: format!("failed to run acpx cancel: {e}"),
+        })?;
+        if !status.success() {
+            return Err(AgentError::AcpxCommandFailed {
+                command: "cancel".to_string(),
+                reason: status.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    pub async fn close_session(
+        &self,
+        agent: &str,
+        session_name: &str,
+        cwd: &Path,
+        model: Option<&str>,
+    ) -> Result<(), AgentError> {
+        let mut command = self.base_command(agent, cwd, model);
+        command.args(["sessions", "close", session_name]);
+        let status = command.status().await.map_err(|e| AgentError::IoError {
+            reason: format!("failed to run acpx sessions close: {e}"),
+        })?;
+        if !status.success() {
+            return Err(AgentError::AcpxCommandFailed {
+                command: "sessions close".to_string(),
+                reason: status.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn base_command(&self, agent: &str, cwd: &Path, model: Option<&str>) -> Command {
+        let mut command = Command::new(&self.executable);
+        command
+            .args(["--format", "json", "--json-strict", "--cwd"])
+            .arg(cwd)
+            .arg(agent);
+        if let Some(model) = model {
+            command.args(["--model", model]);
+        }
+        command
+    }
+}
+
+fn map_event(value: serde_json::Value) -> AgentEvent {
+    match value.get("event").and_then(|v| v.as_str()) {
+        Some("prompt.started") => AgentEvent::PromptStarted,
+        Some("output") => AgentEvent::OutputChunk {
+            stream: match value.get("stream").and_then(|v| v.as_str()) {
+                Some("stderr") => RuntimeStream::Stderr,
+                _ => RuntimeStream::Stdout,
+            },
+            content: value
+                .get("text")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        },
+        Some("completed") => AgentEvent::RunCompleted {
+            usage: value
+                .get("usage")
+                .cloned()
+                .and_then(|usage| serde_json::from_value::<TokenUsage>(usage).ok()),
+        },
+        Some("failed") => AgentEvent::RunFailed {
+            reason: value
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("acpx run failed")
+                .to_string(),
+            usage: None,
+        },
+        Some("cancelled") => AgentEvent::Cancelled {
+            reason: value
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        },
+        Some("warning") => AgentEvent::Warning {
+            message: value
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        },
+        _ => AgentEvent::OtherMessage {
+            raw: value.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::path::Path;
+
+    use crate::agent::events::AgentEvent;
+    use crate::error::AgentError;
+
+    use super::AcpxCli;
+
+    fn write_mock_acpx_script(dir: &Path, script_content: &str) -> String {
+        let script_path = dir.join("mock_acpx.sh");
+        let mut file = std::fs::File::create(&script_path).unwrap();
+        file.write_all(script_content.as_bytes()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+                .unwrap();
+        }
+        script_path.display().to_string()
+    }
+
+    #[tokio::test]
+    async fn ensure_session_uses_sessions_ensure_command() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let args_path = dir.path().join("args.txt");
+        let script = write_mock_acpx_script(
+            dir.path(),
+            &format!(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" > \"{}\"\n",
+                args_path.display()
+            ),
+        );
+
+        let client = AcpxCli::new(script);
+        client
+            .ensure_session("codex", "build-session", dir.path(), None)
+            .await
+            .unwrap();
+
+        let args = std::fs::read_to_string(args_path).unwrap();
+        assert!(args.contains("sessions ensure"));
+        assert!(args.contains("--name build-session"));
+    }
+
+    #[tokio::test]
+    async fn prompt_stream_maps_output_and_completion_events() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+cat <<'JSON'
+{"event":"prompt.started","session":"s1"}
+{"event":"output","stream":"stdout","text":"hello"}
+{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}
+JSON
+"#,
+        );
+
+        let client = AcpxCli::new(script);
+        let events = client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+            .await
+            .unwrap();
+
+        assert!(matches!(events[0], AgentEvent::PromptStarted));
+        assert!(matches!(events[1], AgentEvent::OutputChunk { .. }));
+        assert!(matches!(events[2], AgentEvent::RunCompleted { .. }));
+    }
+
+    #[tokio::test]
+    async fn prompt_without_terminal_event_returns_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+cat <<'JSON'
+{"event":"prompt.started","session":"s1"}
+{"event":"output","stream":"stdout","text":"hello"}
+JSON
+"#,
+        );
+
+        let client = AcpxCli::new(script);
+        let error = client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            AgentError::AcpxFinalStatusMissing { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_and_close_use_expected_commands() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let log_path = dir.path().join("args.txt");
+        let script = write_mock_acpx_script(
+            dir.path(),
+            &format!(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\n",
+                log_path.display()
+            ),
+        );
+
+        let client = AcpxCli::new(script);
+        client
+            .cancel("codex", "build-session", dir.path(), None)
+            .await
+            .unwrap();
+        client
+            .close_session("codex", "build-session", dir.path(), None)
+            .await
+            .unwrap();
+
+        let args = std::fs::read_to_string(log_path).unwrap();
+        assert!(args.contains("cancel --session build-session"));
+        assert!(args.contains("sessions close build-session"));
+    }
+}

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -61,12 +61,18 @@ impl AcpxCli {
         })?;
 
         if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(prompt.as_bytes())
-                .await
-                .map_err(|e| AgentError::IoError {
-                    reason: format!("failed to write prompt to acpx stdin: {e}"),
-                })?;
+            if let Err(error) = stdin.write_all(prompt.as_bytes()).await {
+                cleanup_prompt_child(&mut child).await;
+                return Err(AgentError::IoError {
+                    reason: format!("failed to write prompt to acpx stdin: {error}"),
+                });
+            }
+            if let Err(error) = stdin.flush().await {
+                cleanup_prompt_child(&mut child).await;
+                return Err(AgentError::IoError {
+                    reason: format!("failed to flush prompt to acpx stdin: {error}"),
+                });
+            }
         }
 
         let stdout = child.stdout.take().ok_or_else(|| AgentError::IoError {
@@ -169,6 +175,11 @@ impl AcpxCli {
         }
         command
     }
+}
+
+async fn cleanup_prompt_child(child: &mut tokio::process::Child) {
+    let _ = child.start_kill();
+    let _ = child.wait().await;
 }
 
 fn map_event(value: serde_json::Value) -> AgentEvent {
@@ -389,15 +400,22 @@ exec 0<&-
         );
 
         let client = AcpxCli::new(script);
-        let error = client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None)
-            .await
-            .unwrap_err();
+        let prompt = "hi".repeat(1024 * 1024);
+        let error = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            client.run_prompt("codex", "build-session", dir.path(), &prompt, None),
+        )
+        .await
+        .expect("run_prompt should not hang when stdin closes")
+        .unwrap_err();
 
         assert!(matches!(error, AgentError::IoError { .. }));
 
         let pid: i32 = std::fs::read_to_string(pid_path).unwrap().parse().unwrap();
         let alive = unsafe { libc::kill(pid, 0) } == 0;
-        assert!(!alive, "acpx child should be terminated after stdin write failure");
+        assert!(
+            !alive,
+            "acpx child should be terminated after stdin write failure"
+        );
     }
 }

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -48,12 +48,14 @@ impl AcpxCli {
         cwd: &Path,
         prompt: &str,
         model: Option<&str>,
-    ) -> Result<Vec<AgentEvent>, AgentError> {
+        mut on_event: impl FnMut(AgentEvent) + Send,
+    ) -> Result<(), AgentError> {
         let mut command = self.base_command(agent, cwd, model);
         command
             .args(["prompt", "--session", session_name, "--file", "-"])
             .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped());
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
         debug!(agent, session_name, cwd = %cwd.display(), "running acpx prompt");
 
         let mut child = command.spawn().map_err(|e| AgentError::IoError {
@@ -78,8 +80,20 @@ impl AcpxCli {
         let stdout = child.stdout.take().ok_or_else(|| AgentError::IoError {
             reason: "failed to capture acpx stdout".to_string(),
         })?;
+        let stderr = child.stderr.take().ok_or_else(|| AgentError::IoError {
+            reason: "failed to capture acpx stderr".to_string(),
+        })?;
+
+        // Spawn a task to forward stderr to tracing
+        let agent_name = agent.to_string();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                debug!(agent = %agent_name, "acpx stderr: {}", line);
+            }
+        });
+
         let mut reader = BufReader::new(stdout).lines();
-        let mut events = Vec::new();
         let mut saw_terminal_event = false;
 
         while let Some(line) = reader.next_line().await.map_err(|e| AgentError::IoError {
@@ -96,9 +110,9 @@ impl AcpxCli {
                     ) {
                         saw_terminal_event = true;
                     }
-                    events.push(event);
+                    on_event(event);
                 }
-                Err(_) => events.push(AgentEvent::Malformed { line }),
+                Err(_) => on_event(AgentEvent::Malformed { line }),
             }
         }
 
@@ -117,7 +131,7 @@ impl AcpxCli {
             });
         }
 
-        Ok(events)
+        Ok(())
     }
 
     pub async fn cancel(
@@ -167,6 +181,7 @@ impl AcpxCli {
     fn base_command(&self, agent: &str, cwd: &Path, model: Option<&str>) -> Command {
         let mut command = Command::new(&self.executable);
         command
+            .kill_on_drop(true)
             .args(["--format", "json", "--json-strict", "--cwd"])
             .arg(cwd)
             .arg(agent);
@@ -292,8 +307,11 @@ JSON
         );
 
         let client = AcpxCli::new(script);
-        let events = client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+        let mut events = Vec::new();
+        client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None, |e| {
+                events.push(e)
+            })
             .await
             .unwrap();
 
@@ -317,7 +335,7 @@ JSON
 
         let client = AcpxCli::new(script);
         let error = client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+            .run_prompt("codex", "build-session", dir.path(), "hi", None, |_| {})
             .await
             .unwrap_err();
 
@@ -337,8 +355,11 @@ JSON
         );
 
         let client = AcpxCli::new(script);
-        let events = client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+        let mut events = Vec::new();
+        client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None, |e| {
+                events.push(e)
+            })
             .await
             .unwrap();
 
@@ -403,7 +424,7 @@ exec 0<&-
         let prompt = "hi".repeat(1024 * 1024);
         let error = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            client.run_prompt("codex", "build-session", dir.path(), &prompt, None),
+            client.run_prompt("codex", "build-session", dir.path(), &prompt, None, |_| {}),
         )
         .await
         .expect("run_prompt should not hang when stdin closes")

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -495,7 +495,7 @@ exec 0<&-
         let client = AcpxCli::new(script);
         let prompt = "hi".repeat(1024 * 1024);
         let error = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(10),
             client.run_prompt(
                 "codex",
                 "build-session",

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -418,7 +418,7 @@ exec 0<&-
         let prompt = "hi".repeat(1024 * 1024);
         let error = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            client.run_prompt("codex", "build-session", dir.path(), &prompt, None, |_| {}),
+            client.run_prompt("codex", "build-session", dir.path(), &prompt, None),
         )
         .await
         .expect("run_prompt should not hang when stdin closes")

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
+use tracing::debug;
 
 use crate::error::AgentError;
 
@@ -25,6 +26,7 @@ impl AcpxCli {
     ) -> Result<(), AgentError> {
         let mut command = self.base_command(agent, cwd, model);
         command.args(["sessions", "ensure", "--name", session_name]);
+        debug!(agent, session_name, cwd = %cwd.display(), "running acpx sessions ensure");
 
         let status = command.status().await.map_err(|e| AgentError::IoError {
             reason: format!("failed to run acpx sessions ensure: {e}"),
@@ -52,6 +54,7 @@ impl AcpxCli {
             .args(["prompt", "--session", session_name, "--file", "-"])
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped());
+        debug!(agent, session_name, cwd = %cwd.display(), "running acpx prompt");
 
         let mut child = command.spawn().map_err(|e| AgentError::IoError {
             reason: format!("failed to run acpx prompt: {e}"),
@@ -120,6 +123,7 @@ impl AcpxCli {
     ) -> Result<(), AgentError> {
         let mut command = self.base_command(agent, cwd, model);
         command.args(["cancel", "--session", session_name]);
+        debug!(agent, session_name, cwd = %cwd.display(), "running acpx cancel");
         let status = command.status().await.map_err(|e| AgentError::IoError {
             reason: format!("failed to run acpx cancel: {e}"),
         })?;
@@ -141,6 +145,7 @@ impl AcpxCli {
     ) -> Result<(), AgentError> {
         let mut command = self.base_command(agent, cwd, model);
         command.args(["sessions", "close", session_name]);
+        debug!(agent, session_name, cwd = %cwd.display(), "running acpx sessions close");
         let status = command.status().await.map_err(|e| AgentError::IoError {
             reason: format!("failed to run acpx sessions close: {e}"),
         })?;

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -192,7 +192,10 @@ fn map_event(value: serde_json::Value) -> AgentEvent {
                 .and_then(|v| v.as_str())
                 .unwrap_or("acpx run failed")
                 .to_string(),
-            usage: None,
+            usage: value
+                .get("usage")
+                .cloned()
+                .and_then(|usage| serde_json::from_value::<TokenUsage>(usage).ok()),
         },
         Some("cancelled") => AgentEvent::Cancelled {
             reason: value
@@ -218,7 +221,7 @@ mod tests {
     use std::io::Write;
     use std::path::Path;
 
-    use crate::agent::events::AgentEvent;
+    use crate::agent::events::{AgentEvent, TokenUsage};
     use crate::error::AgentError;
 
     use super::AcpxCli;
@@ -303,6 +306,37 @@ JSON
             .unwrap_err();
 
         assert!(matches!(error, AgentError::AcpxFinalStatusMissing { .. }));
+    }
+
+    #[tokio::test]
+    async fn failed_event_preserves_usage() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+cat <<'JSON'
+{"event":"failed","reason":"boom","usage":{"input_tokens":4,"output_tokens":5,"total_tokens":9}}
+JSON
+"#,
+        );
+
+        let client = AcpxCli::new(script);
+        let events = client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            &events[0],
+            AgentEvent::RunFailed {
+                reason,
+                usage: Some(TokenUsage {
+                    input_tokens: 4,
+                    output_tokens: 5,
+                    total_tokens: 9
+                })
+            } if reason == "boom"
+        ));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -48,8 +48,7 @@ impl AcpxCli {
         cwd: &Path,
         prompt: &str,
         model: Option<&str>,
-        mut on_event: impl FnMut(AgentEvent) + Send,
-    ) -> Result<(), AgentError> {
+    ) -> Result<Vec<AgentEvent>, AgentError> {
         let mut command = self.base_command(agent, cwd, model);
         command
             .args(["prompt", "--session", session_name, "--file", "-"])
@@ -94,6 +93,7 @@ impl AcpxCli {
         });
 
         let mut reader = BufReader::new(stdout).lines();
+        let mut events = Vec::new();
         let mut saw_terminal_event = false;
 
         while let Some(line) = reader.next_line().await.map_err(|e| AgentError::IoError {
@@ -110,9 +110,9 @@ impl AcpxCli {
                     ) {
                         saw_terminal_event = true;
                     }
-                    on_event(event);
+                    events.push(event);
                 }
-                Err(_) => on_event(AgentEvent::Malformed { line }),
+                Err(_) => events.push(AgentEvent::Malformed { line }),
             }
         }
 
@@ -131,7 +131,7 @@ impl AcpxCli {
             });
         }
 
-        Ok(())
+        Ok(events)
     }
 
     pub async fn cancel(
@@ -307,11 +307,8 @@ JSON
         );
 
         let client = AcpxCli::new(script);
-        let mut events = Vec::new();
-        client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None, |e| {
-                events.push(e)
-            })
+        let events = client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None)
             .await
             .unwrap();
 
@@ -335,7 +332,7 @@ JSON
 
         let client = AcpxCli::new(script);
         let error = client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None, |_| {})
+            .run_prompt("codex", "build-session", dir.path(), "hi", None)
             .await
             .unwrap_err();
 
@@ -355,11 +352,8 @@ JSON
         );
 
         let client = AcpxCli::new(script);
-        let mut events = Vec::new();
-        client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None, |e| {
-                events.push(e)
-            })
+        let events = client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None)
             .await
             .unwrap();
 

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -370,4 +370,34 @@ JSON
         assert!(args.contains("cancel --session build-session"));
         assert!(args.contains("sessions close build-session"));
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn prompt_write_failure_kills_spawned_process() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let pid_path = dir.path().join("pid.txt");
+        let script = write_mock_acpx_script(
+            dir.path(),
+            &format!(
+                r#"#!/bin/bash
+printf '%s' "$$" > "{}"
+exec 0<&-
+/bin/sleep 30
+"#,
+                pid_path.display()
+            ),
+        );
+
+        let client = AcpxCli::new(script);
+        let error = client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, AgentError::IoError { .. }));
+
+        let pid: i32 = std::fs::read_to_string(pid_path).unwrap().parse().unwrap();
+        let alive = unsafe { libc::kill(pid, 0) } == 0;
+        assert!(!alive, "acpx child should be terminated after stdin write failure");
+    }
 }

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::path::Path;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -41,14 +42,19 @@ impl AcpxCli {
         Ok(())
     }
 
-    pub async fn run_prompt(
+    pub async fn run_prompt<F, Fut>(
         &self,
         agent: &str,
         session_name: &str,
         cwd: &Path,
         prompt: &str,
         model: Option<&str>,
-    ) -> Result<Vec<AgentEvent>, AgentError> {
+        mut on_event: F,
+    ) -> Result<(), AgentError>
+    where
+        F: FnMut(AgentEvent) -> Fut,
+        Fut: Future<Output = ()> + Send,
+    {
         let mut command = self.base_command(agent, cwd, model);
         command
             .args(["prompt", "--session", session_name, "--file", "-"])
@@ -93,7 +99,6 @@ impl AcpxCli {
         });
 
         let mut reader = BufReader::new(stdout).lines();
-        let mut events = Vec::new();
         let mut saw_terminal_event = false;
 
         while let Some(line) = reader.next_line().await.map_err(|e| AgentError::IoError {
@@ -110,9 +115,9 @@ impl AcpxCli {
                     ) {
                         saw_terminal_event = true;
                     }
-                    events.push(event);
+                    on_event(event).await;
                 }
-                Err(_) => events.push(AgentEvent::Malformed { line }),
+                Err(_) => on_event(AgentEvent::Malformed { line }).await,
             }
         }
 
@@ -131,7 +136,7 @@ impl AcpxCli {
             });
         }
 
-        Ok(events)
+        Ok(())
     }
 
     pub async fn cancel(
@@ -251,6 +256,7 @@ fn map_event(value: serde_json::Value) -> AgentEvent {
 mod tests {
     use std::io::Write;
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
 
     use crate::agent::events::{AgentEvent, TokenUsage};
     use crate::error::AgentError;
@@ -307,14 +313,72 @@ JSON
         );
 
         let client = AcpxCli::new(script);
-        let events = client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+        let events = Arc::new(Mutex::new(Vec::new()));
+        client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None, |event| {
+                let events = Arc::clone(&events);
+                async move {
+                    events.lock().unwrap().push(event);
+                }
+            })
             .await
             .unwrap();
+        let events = events.lock().unwrap();
 
         assert!(matches!(events[0], AgentEvent::PromptStarted));
         assert!(matches!(events[1], AgentEvent::OutputChunk { .. }));
         assert!(matches!(events[2], AgentEvent::RunCompleted { .. }));
+    }
+
+    #[tokio::test]
+    async fn prompt_stream_emits_output_before_process_exit() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let release_path = dir.path().join("release.flag");
+        let script = write_mock_acpx_script(
+            dir.path(),
+            &format!(
+                r#"#!/bin/bash
+printf '%s\n' '{{"event":"prompt.started","session":"s1"}}'
+printf '%s\n' '{{"event":"output","stream":"stdout","text":"hello"}}'
+while [ ! -f "{}" ]; do
+  /bin/sleep 0.05
+done
+printf '%s\n' '{{"event":"completed","usage":{{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}}'
+"#,
+                release_path.display()
+            ),
+        );
+
+        let client = AcpxCli::new(script);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let run = client.run_prompt("codex", "build-session", dir.path(), "hi", None, |event| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(event).await;
+            }
+        });
+        tokio::pin!(run);
+
+        let saw_output = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                tokio::select! {
+                    result = &mut run => panic!("prompt exited before streaming output: {result:?}"),
+                    maybe_event = rx.recv() => {
+                        match maybe_event {
+                            Some(AgentEvent::OutputChunk { content, .. }) if content == "hello" => break true,
+                            Some(_) => {}
+                            None => panic!("event stream closed before output arrived"),
+                        }
+                    }
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        assert!(saw_output);
+        std::fs::write(&release_path, "").unwrap();
+        run.await.unwrap();
     }
 
     #[tokio::test]
@@ -332,7 +396,14 @@ JSON
 
         let client = AcpxCli::new(script);
         let error = client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+            .run_prompt(
+                "codex",
+                "build-session",
+                dir.path(),
+                "hi",
+                None,
+                |_| async {},
+            )
             .await
             .unwrap_err();
 
@@ -352,10 +423,17 @@ JSON
         );
 
         let client = AcpxCli::new(script);
-        let events = client
-            .run_prompt("codex", "build-session", dir.path(), "hi", None)
+        let events = Arc::new(Mutex::new(Vec::new()));
+        client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None, |event| {
+                let events = Arc::clone(&events);
+                async move {
+                    events.lock().unwrap().push(event);
+                }
+            })
             .await
             .unwrap();
+        let events = events.lock().unwrap();
 
         assert!(matches!(
             &events[0],
@@ -418,7 +496,14 @@ exec 0<&-
         let prompt = "hi".repeat(1024 * 1024);
         let error = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            client.run_prompt("codex", "build-session", dir.path(), &prompt, None),
+            client.run_prompt(
+                "codex",
+                "build-session",
+                dir.path(),
+                &prompt,
+                None,
+                |_| async {},
+            ),
         )
         .await
         .expect("run_prompt should not hang when stdin closes")

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -14,7 +14,7 @@ pub struct AcpxRuntime {
 impl AcpxRuntime {
     pub fn new() -> Self {
         #[cfg(test)]
-        if let Ok(executable) = std::env::var("ENSEMBLE_TEST_ACPX_EXECUTABLE") {
+        if let Some(executable) = test_acpx_executable() {
             return Self {
                 cli: AcpxCli::new(executable),
             };
@@ -93,11 +93,19 @@ impl AcpxRuntime {
             request.workspace_path,
             prompt,
             agent.model.as_deref(),
+            |event| {
+                emit_event(
+                    &request.event_tx,
+                    &request.issue.id,
+                    request.step_name,
+                    event,
+                )
+            },
         );
         tokio::pin!(run_prompt);
 
-        let events = tokio::select! {
-            events = &mut run_prompt => events?,
+        let prompt_result = tokio::select! {
+            result = &mut run_prompt => result,
             _ = request.cancel_token.cancelled() => {
                 debug!(
                     issue_id = %request.issue.id,
@@ -140,16 +148,6 @@ impl AcpxRuntime {
             }
         };
 
-        for event in events {
-            emit_event(
-                &request.event_tx,
-                &request.issue.id,
-                request.step_name,
-                event,
-            )
-            .await;
-        }
-
         close_session(
             &self.cli,
             acpx_agent,
@@ -159,6 +157,8 @@ impl AcpxRuntime {
         )
         .await;
 
+        prompt_result?;
+
         Ok(detect_worker_result(request.workspace_path).await)
     }
 }
@@ -167,6 +167,13 @@ impl Default for AcpxRuntime {
     fn default() -> Self {
         Self::new()
     }
+}
+
+#[cfg(test)]
+fn test_acpx_executable() -> Option<String> {
+    std::env::var("ENSEMBLE_TEST_ACPX_EXECUTABLE")
+        .ok()
+        .or_else(|| std::env::var("ENSEMBLE_TEST_ACPX_BIN").ok())
 }
 
 fn sanitize_session_component(value: &str) -> String {
@@ -368,6 +375,58 @@ exit 1
         let result = runner.run_step(&request, "finish the task").await.unwrap();
 
         assert!(matches!(result, WorkerResult::Success));
+    }
+
+    #[tokio::test]
+    async fn acpx_runtime_closes_session_when_prompt_errors() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let args_path = workspace.path().join("args.txt");
+        let script_path = write_mock_acpx_script(
+            &workspace,
+            &format!(
+                r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{}"
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    exit 1
+    ;;
+  *" sessions close "*)
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+                args_path.display()
+            ),
+        );
+
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path));
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let issue = test_issue("issue-1", "Todo");
+        let config = test_config();
+        let request = AgentRunRequest {
+            config,
+            issue: &issue,
+            agent_name: "builder",
+            step_name: "build",
+            attempt: None,
+            interaction_response: None,
+            workspace_path: workspace.path(),
+            event_tx: tx,
+            cancel_token: CancellationToken::new(),
+        };
+
+        let error = runner
+            .run_step(&request, "finish the task")
+            .await
+            .unwrap_err();
+        assert!(matches!(error, AgentError::AcpxCommandFailed { .. }));
+
+        let args = std::fs::read_to_string(args_path).unwrap();
+        assert!(args.contains("sessions close"));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -87,29 +87,17 @@ impl AcpxRuntime {
             session_name,
             "starting acpx prompt"
         );
-        let event_tx = request.event_tx.clone();
-        let issue_id = request.issue.id.clone();
-        let step_name = request.step_name.to_string();
-
         let run_prompt = self.cli.run_prompt(
             acpx_agent,
             &session_name,
             request.workspace_path,
             prompt,
             agent.model.as_deref(),
-            |event| {
-                let tx = event_tx.clone();
-                let id = issue_id.clone();
-                let name = step_name.clone();
-                tokio::spawn(async move {
-                    emit_event(&tx, &id, &name, event).await;
-                });
-            },
         );
         tokio::pin!(run_prompt);
 
-        tokio::select! {
-            result = &mut run_prompt => result?,
+        let events = tokio::select! {
+            events = &mut run_prompt => events?,
             _ = request.cancel_token.cancelled() => {
                 debug!(
                     issue_id = %request.issue.id,
@@ -151,6 +139,16 @@ impl AcpxRuntime {
                 return Err(AgentError::TurnCancelled);
             }
         };
+
+        for event in events {
+            emit_event(
+                &request.event_tx,
+                &request.issue.id,
+                request.step_name,
+                event,
+            )
+            .await;
+        }
 
         close_session(
             &self.cli,

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -203,6 +203,8 @@ async fn close_session(
     model: Option<&str>,
 ) {
     debug!(session_name, "closing acpx session");
+    // Session close is best-effort cleanup; orchestration should preserve the
+    // primary run outcome even if acpx session teardown fails.
     if let Err(error) = cli
         .close_session(acpx_agent, session_name, workspace_path, model)
         .await

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -87,17 +87,29 @@ impl AcpxRuntime {
             session_name,
             "starting acpx prompt"
         );
+        let event_tx = request.event_tx.clone();
+        let issue_id = request.issue.id.clone();
+        let step_name = request.step_name.to_string();
+
         let run_prompt = self.cli.run_prompt(
             acpx_agent,
             &session_name,
             request.workspace_path,
             prompt,
             agent.model.as_deref(),
+            |event| {
+                let tx = event_tx.clone();
+                let id = issue_id.clone();
+                let name = step_name.clone();
+                tokio::spawn(async move {
+                    emit_event(&tx, &id, &name, event).await;
+                });
+            },
         );
         tokio::pin!(run_prompt);
 
-        let events = tokio::select! {
-            events = &mut run_prompt => events?,
+        tokio::select! {
+            result = &mut run_prompt => result?,
             _ = request.cancel_token.cancelled() => {
                 debug!(
                     issue_id = %request.issue.id,
@@ -124,7 +136,10 @@ impl AcpxRuntime {
                 )
                 .await;
 
-                let _ = (&mut run_prompt).await;
+                // Wait for the prompt process to exit after cancellation, with a timeout
+                // to prevent hanging if acpx fails to exit gracefully.
+                let _ = tokio::time::timeout(std::time::Duration::from_secs(5), run_prompt).await;
+
                 close_session(
                     &self.cli,
                     acpx_agent,
@@ -136,16 +151,6 @@ impl AcpxRuntime {
                 return Err(AgentError::TurnCancelled);
             }
         };
-
-        for event in events {
-            emit_event(
-                &request.event_tx,
-                &request.issue.id,
-                request.step_name,
-                event,
-            )
-            .await;
-        }
 
         close_session(
             &self.cli,

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -1,4 +1,5 @@
 use tokio::sync::mpsc;
+use tracing::warn;
 
 use crate::error::AgentError;
 
@@ -49,8 +50,8 @@ impl AcpxRuntime {
             })?;
         let session_name = format!(
             "{}-{}-attempt-{}",
-            request.issue.id,
-            request.step_name,
+            sanitize_session_component(&request.issue.id),
+            sanitize_session_component(request.step_name),
             request.attempt.unwrap_or(1)
         );
 
@@ -95,7 +96,7 @@ impl AcpxRuntime {
             .await;
         }
 
-        let _ = self
+        if let Err(error) = self
             .cli
             .close_session(
                 acpx_agent,
@@ -103,7 +104,10 @@ impl AcpxRuntime {
                 request.workspace_path,
                 agent.model.as_deref(),
             )
-            .await;
+            .await
+        {
+            warn!(%error, session_name, "failed to close acpx session");
+        }
 
         Ok(detect_worker_result(request.workspace_path).await)
     }
@@ -113,6 +117,19 @@ impl Default for AcpxRuntime {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn sanitize_session_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 async fn emit_event(
@@ -133,6 +150,7 @@ async fn emit_event(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
     use std::sync::Arc;
 
     use super::*;
@@ -164,12 +182,23 @@ on_failure: Failed
         )
     }
 
+    fn write_mock_acpx_script(dir: &tempfile::TempDir, script_content: &str) -> String {
+        let script_path = dir.path().join("mock_acpx.sh");
+        let mut file = std::fs::File::create(&script_path).unwrap();
+        file.write_all(script_content.as_bytes()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        script_path.display().to_string()
+    }
+
     #[tokio::test]
     async fn acpx_runtime_emits_runtime_events_and_success() {
         let workspace = tempfile::TempDir::new().unwrap();
-        let script_path = workspace.path().join("mock_acpx.sh");
-        std::fs::write(
-            &script_path,
+        let script_path = write_mock_acpx_script(
+            &workspace,
             r#"#!/usr/bin/env bash
 case "$*" in
   *" sessions ensure --name "*)
@@ -189,15 +218,9 @@ JSON
 esac
 exit 1
 "#,
-        )
-        .unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
+        );
 
-        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path.display().to_string()));
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path));
         let (tx, mut rx) = tokio::sync::mpsc::channel(16);
         let issue = test_issue("issue-1", "Todo");
         let config = test_config();
@@ -231,5 +254,99 @@ exit 1
         }
         assert!(saw_prompt_started);
         assert!(saw_output);
+    }
+
+    #[tokio::test]
+    async fn acpx_runtime_tolerates_close_session_failure() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let script_path = write_mock_acpx_script(
+            &workspace,
+            r#"#!/usr/bin/env bash
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    cat <<'JSON'
+{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}
+JSON
+    exit 0
+    ;;
+  *" sessions close "*)
+    exit 1
+    ;;
+esac
+exit 1
+"#,
+        );
+
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path));
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let issue = test_issue("issue-1", "Todo");
+        let config = test_config();
+        let request = AgentRunRequest {
+            config,
+            issue: &issue,
+            agent_name: "builder",
+            step_name: "build",
+            attempt: None,
+            interaction_response: None,
+            workspace_path: workspace.path(),
+            event_tx: tx,
+        };
+
+        let result = runner.run_step(&request, "finish the task").await.unwrap();
+
+        assert!(matches!(result, WorkerResult::Success));
+    }
+
+    #[tokio::test]
+    async fn acpx_runtime_sanitizes_session_names() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let args_path = workspace.path().join("args.txt");
+        let script_path = write_mock_acpx_script(
+            &workspace,
+            &format!(
+                r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{}"
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    cat <<'JSON'
+{{"event":"completed","usage":{{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}}
+JSON
+    exit 0
+    ;;
+  *" sessions close "*)
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+                args_path.display()
+            ),
+        );
+
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path));
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let issue = test_issue("issue/1 weird", "Todo");
+        let config = test_config();
+        let request = AgentRunRequest {
+            config,
+            issue: &issue,
+            agent_name: "builder",
+            step_name: "build/review",
+            attempt: Some(2),
+            interaction_response: None,
+            workspace_path: workspace.path(),
+            event_tx: tx,
+        };
+
+        let _ = runner.run_step(&request, "finish the task").await.unwrap();
+
+        let args = std::fs::read_to_string(args_path).unwrap();
+        assert!(args.contains("issue_1_weird-build_review-attempt-2"));
     }
 }

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -1,0 +1,229 @@
+use tokio::sync::mpsc;
+
+use crate::error::AgentError;
+
+use super::acpx_cli::AcpxCli;
+use super::events::{AgentEvent, WorkerEvent, WorkerResult};
+use super::{detect_worker_result, AgentRunRequest};
+
+pub struct AcpxRuntime {
+    cli: AcpxCli,
+}
+
+impl AcpxRuntime {
+    pub fn new() -> Self {
+        #[cfg(test)]
+        if let Ok(executable) = std::env::var("ENSEMBLE_TEST_ACPX_EXECUTABLE") {
+            return Self {
+                cli: AcpxCli::new(executable),
+            };
+        }
+
+        Self {
+            cli: AcpxCli::new("acpx".to_string()),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_cli(cli: AcpxCli) -> Self {
+        Self { cli }
+    }
+
+    pub async fn run_step(
+        &self,
+        request: &AgentRunRequest<'_>,
+        prompt: &str,
+    ) -> Result<WorkerResult, AgentError> {
+        let agent = request
+            .config
+            .agents
+            .get(request.agent_name)
+            .ok_or_else(|| AgentError::PromptError {
+                reason: format!("agent '{}' not found in config", request.agent_name),
+            })?;
+        let acpx_agent = agent
+            .acpx_agent
+            .as_deref()
+            .ok_or_else(|| AgentError::PromptError {
+                reason: format!("agent '{}' is missing acpx_agent", request.agent_name),
+            })?;
+        let session_name = format!(
+            "{}-{}-attempt-{}",
+            request.issue.id,
+            request.step_name,
+            request.attempt.unwrap_or(1)
+        );
+
+        self.cli
+            .ensure_session(
+                acpx_agent,
+                &session_name,
+                request.workspace_path,
+                agent.model.as_deref(),
+            )
+            .await?;
+
+        emit_event(
+            &request.event_tx,
+            &request.issue.id,
+            request.step_name,
+            AgentEvent::SessionStarted {
+                session_id: session_name.clone(),
+                agent_pid: None,
+            },
+        )
+        .await;
+
+        let events = self
+            .cli
+            .run_prompt(
+                acpx_agent,
+                &session_name,
+                request.workspace_path,
+                prompt,
+                agent.model.as_deref(),
+            )
+            .await?;
+
+        for event in events {
+            emit_event(
+                &request.event_tx,
+                &request.issue.id,
+                request.step_name,
+                event,
+            )
+            .await;
+        }
+
+        let _ = self
+            .cli
+            .close_session(
+                acpx_agent,
+                &session_name,
+                request.workspace_path,
+                agent.model.as_deref(),
+            )
+            .await;
+
+        Ok(detect_worker_result(request.workspace_path).await)
+    }
+}
+
+async fn emit_event(
+    tx: &mpsc::Sender<WorkerEvent>,
+    issue_id: &str,
+    step_name: &str,
+    event: AgentEvent,
+) {
+    let _ = tx
+        .send(WorkerEvent::AgentUpdate {
+            issue_id: issue_id.to_string(),
+            step_name: step_name.to_string(),
+            event,
+            timestamp: chrono::Utc::now(),
+        })
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::agent::acpx_cli::AcpxCli;
+    use crate::agent::events::RuntimeStream;
+    use crate::config::ensemble::parse_config;
+    use crate::tracker::model::test_helpers::test_issue;
+
+    fn test_config() -> Arc<crate::config::ensemble::EnsembleConfig> {
+        Arc::new(
+            parse_config(
+                r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: hi
+steps:
+  - name: build
+    agent: builder
+workspace:
+  root: /tmp/test
+on_success: Done
+on_failure: Failed
+"#,
+            )
+            .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn acpx_runtime_emits_runtime_events_and_success() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let script_path = workspace.path().join("mock_acpx.sh");
+        std::fs::write(
+            &script_path,
+            r#"#!/usr/bin/env bash
+case "$*" in
+  *" sessions ensure --name "*)
+  exit 0
+  ;;
+  *" prompt --session "*)
+  cat <<'JSON'
+{"event":"prompt.started","session":"s1"}
+{"event":"output","stream":"stdout","text":"hello"}
+{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}
+JSON
+  exit 0
+  ;;
+  *" sessions close "*)
+  exit 0
+  ;;
+esac
+exit 1
+"#,
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path.display().to_string()));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let issue = test_issue("issue-1", "Todo");
+        let config = test_config();
+        let request = AgentRunRequest {
+            config: Arc::clone(&config),
+            issue: &issue,
+            agent_name: "builder",
+            step_name: "build",
+            attempt: None,
+            interaction_response: None,
+            workspace_path: workspace.path(),
+            event_tx: tx,
+        };
+
+        let result = runner.run_step(&request, "finish the task").await.unwrap();
+
+        assert!(matches!(result, WorkerResult::Success));
+        let mut saw_prompt_started = false;
+        let mut saw_output = false;
+        while let Ok(event) = rx.try_recv() {
+            if let WorkerEvent::AgentUpdate { event, .. } = event {
+                match event {
+                    AgentEvent::PromptStarted => saw_prompt_started = true,
+                    AgentEvent::OutputChunk {
+                        stream: RuntimeStream::Stdout,
+                        content,
+                    } if content == "hello" => saw_output = true,
+                    _ => {}
+                }
+            }
+        }
+        assert!(saw_prompt_started);
+        assert!(saw_output);
+    }
+}

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -109,6 +109,12 @@ impl AcpxRuntime {
     }
 }
 
+impl Default for AcpxRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 async fn emit_event(
     tx: &mpsc::Sender<WorkerEvent>,
     issue_id: &str,

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -1,5 +1,5 @@
 use tokio::sync::mpsc;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::error::AgentError;
 
@@ -55,6 +55,12 @@ impl AcpxRuntime {
             request.attempt.unwrap_or(1)
         );
 
+        debug!(
+            issue_id = %request.issue.id,
+            step = request.step_name,
+            session_name,
+            "ensuring acpx session"
+        );
         self.cli
             .ensure_session(
                 acpx_agent,
@@ -75,16 +81,61 @@ impl AcpxRuntime {
         )
         .await;
 
-        let events = self
-            .cli
-            .run_prompt(
-                acpx_agent,
-                &session_name,
-                request.workspace_path,
-                prompt,
-                agent.model.as_deref(),
-            )
-            .await?;
+        debug!(
+            issue_id = %request.issue.id,
+            step = request.step_name,
+            session_name,
+            "starting acpx prompt"
+        );
+        let run_prompt = self.cli.run_prompt(
+            acpx_agent,
+            &session_name,
+            request.workspace_path,
+            prompt,
+            agent.model.as_deref(),
+        );
+        tokio::pin!(run_prompt);
+
+        let events = tokio::select! {
+            events = &mut run_prompt => events?,
+            _ = request.cancel_token.cancelled() => {
+                debug!(
+                    issue_id = %request.issue.id,
+                    step = request.step_name,
+                    session_name,
+                    "cancelling acpx prompt"
+                );
+                self.cli
+                    .cancel(
+                        acpx_agent,
+                        &session_name,
+                        request.workspace_path,
+                        agent.model.as_deref(),
+                    )
+                    .await?;
+
+                emit_event(
+                    &request.event_tx,
+                    &request.issue.id,
+                    request.step_name,
+                    AgentEvent::Cancelled {
+                        reason: Some("cancel requested".to_string()),
+                    },
+                )
+                .await;
+
+                let _ = (&mut run_prompt).await;
+                close_session(
+                    &self.cli,
+                    acpx_agent,
+                    &session_name,
+                    request.workspace_path,
+                    agent.model.as_deref(),
+                )
+                .await;
+                return Err(AgentError::TurnCancelled);
+            }
+        };
 
         for event in events {
             emit_event(
@@ -96,18 +147,14 @@ impl AcpxRuntime {
             .await;
         }
 
-        if let Err(error) = self
-            .cli
-            .close_session(
-                acpx_agent,
-                &session_name,
-                request.workspace_path,
-                agent.model.as_deref(),
-            )
-            .await
-        {
-            warn!(%error, session_name, "failed to close acpx session");
-        }
+        close_session(
+            &self.cli,
+            acpx_agent,
+            &session_name,
+            request.workspace_path,
+            agent.model.as_deref(),
+        )
+        .await;
 
         Ok(detect_worker_result(request.workspace_path).await)
     }
@@ -148,10 +195,28 @@ async fn emit_event(
         .await;
 }
 
+async fn close_session(
+    cli: &AcpxCli,
+    acpx_agent: &str,
+    session_name: &str,
+    workspace_path: &std::path::Path,
+    model: Option<&str>,
+) {
+    debug!(session_name, "closing acpx session");
+    if let Err(error) = cli
+        .close_session(acpx_agent, session_name, workspace_path, model)
+        .await
+    {
+        warn!(%error, session_name, "failed to close acpx session");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;
     use std::sync::Arc;
+
+    use tokio_util::sync::CancellationToken;
 
     use super::*;
     use crate::agent::acpx_cli::AcpxCli;
@@ -185,6 +250,7 @@ on_failure: Failed
     fn write_mock_acpx_script(dir: &tempfile::TempDir, script_content: &str) -> String {
         let script_path = dir.path().join("mock_acpx.sh");
         let mut file = std::fs::File::create(&script_path).unwrap();
+        let script_content = script_content.replacen("#!/usr/bin/env bash", "#!/bin/bash", 1);
         file.write_all(script_content.as_bytes()).unwrap();
         #[cfg(unix)]
         {
@@ -205,11 +271,10 @@ case "$*" in
   exit 0
   ;;
   *" prompt --session "*)
-  cat <<'JSON'
-{"event":"prompt.started","session":"s1"}
-{"event":"output","stream":"stdout","text":"hello"}
-{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}
-JSON
+  printf '%s\n' \
+    '{"event":"prompt.started","session":"s1"}' \
+    '{"event":"output","stream":"stdout","text":"hello"}' \
+    '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
   exit 0
   ;;
   *" sessions close "*)
@@ -233,6 +298,7 @@ exit 1
             interaction_response: None,
             workspace_path: workspace.path(),
             event_tx: tx,
+            cancel_token: CancellationToken::new(),
         };
 
         let result = runner.run_step(&request, "finish the task").await.unwrap();
@@ -267,9 +333,7 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
-    cat <<'JSON'
-{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}
-JSON
+    printf '%s\n' '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
     exit 0
     ;;
   *" sessions close "*)
@@ -293,6 +357,7 @@ exit 1
             interaction_response: None,
             workspace_path: workspace.path(),
             event_tx: tx,
+            cancel_token: CancellationToken::new(),
         };
 
         let result = runner.run_step(&request, "finish the task").await.unwrap();
@@ -314,9 +379,7 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
-    cat <<'JSON'
-{{"event":"completed","usage":{{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}}
-JSON
+    printf '%s\n' '{{"event":"completed","usage":{{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}}'
     exit 0
     ;;
   *" sessions close "*)
@@ -342,11 +405,89 @@ exit 1
             interaction_response: None,
             workspace_path: workspace.path(),
             event_tx: tx,
+            cancel_token: CancellationToken::new(),
         };
 
         let _ = runner.run_step(&request, "finish the task").await.unwrap();
 
         let args = std::fs::read_to_string(args_path).unwrap();
         assert!(args.contains("issue_1_weird-build_review-attempt-2"));
+    }
+
+    #[tokio::test]
+    async fn acpx_runtime_cancels_prompt_when_token_is_cancelled() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let script_path = write_mock_acpx_script(
+            &workspace,
+            &format!(
+                r#"#!/usr/bin/env bash
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    printf '%s\n' '{{"event":"prompt.started","session":"s1"}}'
+    while [ ! -f "{0}/cancelled.flag" ]; do
+      /bin/sleep 0.05
+    done
+    printf '%s\n' '{{"event":"cancelled","reason":"stop requested"}}'
+    exit 0
+    ;;
+  *" cancel --session "*)
+    : > "{0}/cancelled.flag"
+    exit 0
+    ;;
+  *" sessions close "*)
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+                workspace.path().display()
+            ),
+        );
+
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let issue = test_issue("issue-1", "Todo");
+        let config = test_config();
+        let cancel_token = CancellationToken::new();
+        let request = AgentRunRequest {
+            config,
+            issue: &issue,
+            agent_name: "builder",
+            step_name: "build",
+            attempt: None,
+            interaction_response: None,
+            workspace_path: workspace.path(),
+            event_tx: tx,
+            cancel_token: cancel_token.clone(),
+        };
+
+        let canceller = tokio::spawn({
+            let cancel_token = cancel_token.clone();
+            async move {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                cancel_token.cancel();
+            }
+        });
+
+        let result = runner.run_step(&request, "finish the task").await;
+        canceller.await.unwrap();
+        assert!(matches!(result, Err(AgentError::TurnCancelled)));
+
+        let mut saw_cancelled = false;
+        while let Ok(event) = rx.try_recv() {
+            if let WorkerEvent::AgentUpdate {
+                event: AgentEvent::Cancelled { .. },
+                ..
+            } = event
+            {
+                saw_cancelled = true;
+            }
+        }
+
+        assert!(saw_cancelled);
+        assert!(workspace.path().join("cancelled.flag").exists());
     }
 }

--- a/crates/ensemble-core/src/agent/cancellation.rs
+++ b/crates/ensemble-core/src/agent/cancellation.rs
@@ -34,7 +34,11 @@ pub fn clear_issue_cancellation(
 }
 
 pub fn cancel_all(registry: &CancellationRegistry) -> usize {
-    let tokens: Vec<CancellationToken> = registry_guard(registry).values().cloned().collect();
+    let tokens: Vec<CancellationToken> = {
+        // Clone the current handles inside a narrow scope so the mutex guard is
+        // definitely released before we invoke `cancel()` on any token.
+        registry_guard(registry).values().cloned().collect()
+    };
     let count = tokens.len();
     for token in tokens {
         token.cancel();

--- a/crates/ensemble-core/src/agent/cancellation.rs
+++ b/crates/ensemble-core/src/agent/cancellation.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use tokio_util::sync::CancellationToken;
+
+pub type CancellationRegistry = Arc<Mutex<HashMap<String, CancellationToken>>>;
+
+pub fn new_cancellation_registry() -> CancellationRegistry {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+pub fn register_issue_cancellation(
+    registry: &CancellationRegistry,
+    issue_id: &str,
+    token: CancellationToken,
+) {
+    registry_guard(registry).insert(issue_id.to_string(), token);
+}
+
+pub fn cancel_issue(registry: &CancellationRegistry, issue_id: &str) -> bool {
+    if let Some(token) = registry_guard(registry).get(issue_id).cloned() {
+        token.cancel();
+        true
+    } else {
+        false
+    }
+}
+
+pub fn clear_issue_cancellation(
+    registry: &CancellationRegistry,
+    issue_id: &str,
+) -> Option<CancellationToken> {
+    registry_guard(registry).remove(issue_id)
+}
+
+pub fn cancel_all(registry: &CancellationRegistry) -> usize {
+    let tokens: Vec<CancellationToken> = registry_guard(registry).values().cloned().collect();
+    let count = tokens.len();
+    for token in tokens {
+        token.cancel();
+    }
+    count
+}
+
+fn registry_guard(
+    registry: &CancellationRegistry,
+) -> MutexGuard<'_, HashMap<String, CancellationToken>> {
+    registry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_issue_marks_registered_token() {
+        let registry = new_cancellation_registry();
+        let token = CancellationToken::new();
+        register_issue_cancellation(&registry, "issue-1", token.clone());
+
+        assert!(cancel_issue(&registry, "issue-1"));
+        assert!(token.is_cancelled());
+    }
+}

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -61,6 +61,8 @@ impl StopReason {
 /// Internal event types emitted by the ACP client to the orchestrator.
 #[derive(Debug, Clone, Serialize)]
 pub enum AgentEvent {
+    /// Runtime session established. `agent_pid` is retained for direct ACP workers so the
+    /// orchestrator/API can still expose process metadata and support stop/cancel controls.
     SessionStarted {
         session_id: String,
         agent_pid: Option<String>,

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -13,6 +13,13 @@ pub struct TokenUsage {
     pub total_tokens: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeStream {
+    Stdout,
+    Stderr,
+}
+
 /// ACP stop reasons mapped from session/update notifications.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -58,6 +65,10 @@ pub enum AgentEvent {
         session_id: String,
         agent_pid: Option<String>,
     },
+    OutputChunk {
+        stream: RuntimeStream,
+        content: String,
+    },
     TurnStarted,
     TurnUpdate {
         content: String,
@@ -93,6 +104,7 @@ impl AgentEvent {
     pub fn event_name(&self) -> &'static str {
         match self {
             AgentEvent::SessionStarted { .. } => "session_started",
+            AgentEvent::OutputChunk { .. } => "output_chunk",
             AgentEvent::TurnStarted => "turn_started",
             AgentEvent::TurnUpdate { .. } => "turn_update",
             AgentEvent::TurnCompleted { .. } => "turn_completed",
@@ -108,6 +120,7 @@ impl AgentEvent {
     /// Returns the message content for state tracking, truncated to 200 chars.
     pub fn message_for_state(&self) -> Option<Cow<'_, str>> {
         match self {
+            AgentEvent::OutputChunk { content, .. } => Some(truncate_for_state(content)),
             AgentEvent::TurnUpdate { content } => Some(truncate_for_state(content)),
             AgentEvent::TurnFailed { reason, .. } => Some(truncate_for_state(reason)),
             AgentEvent::PermissionRequested { description, .. } => {

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -65,9 +65,23 @@ pub enum AgentEvent {
         session_id: String,
         agent_pid: Option<String>,
     },
+    PromptStarted,
     OutputChunk {
         stream: RuntimeStream,
         content: String,
+    },
+    RunCompleted {
+        usage: Option<TokenUsage>,
+    },
+    RunFailed {
+        reason: String,
+        usage: Option<TokenUsage>,
+    },
+    Cancelled {
+        reason: Option<String>,
+    },
+    Warning {
+        message: String,
     },
     TurnStarted,
     TurnUpdate {
@@ -104,7 +118,12 @@ impl AgentEvent {
     pub fn event_name(&self) -> &'static str {
         match self {
             AgentEvent::SessionStarted { .. } => "session_started",
+            AgentEvent::PromptStarted => "prompt_started",
             AgentEvent::OutputChunk { .. } => "output_chunk",
+            AgentEvent::RunCompleted { .. } => "run_completed",
+            AgentEvent::RunFailed { .. } => "run_failed",
+            AgentEvent::Cancelled { .. } => "cancelled",
+            AgentEvent::Warning { .. } => "warning",
             AgentEvent::TurnStarted => "turn_started",
             AgentEvent::TurnUpdate { .. } => "turn_update",
             AgentEvent::TurnCompleted { .. } => "turn_completed",
@@ -120,6 +139,11 @@ impl AgentEvent {
     /// Returns the message content for state tracking, truncated to 200 chars.
     pub fn message_for_state(&self) -> Option<Cow<'_, str>> {
         match self {
+            AgentEvent::Warning { message } => Some(truncate_for_state(message)),
+            AgentEvent::RunFailed { reason, .. } => Some(truncate_for_state(reason)),
+            AgentEvent::Cancelled { reason } => {
+                reason.as_deref().map(truncate_for_state)
+            }
             AgentEvent::OutputChunk { content, .. } => Some(truncate_for_state(content)),
             AgentEvent::TurnUpdate { content } => Some(truncate_for_state(content)),
             AgentEvent::TurnFailed { reason, .. } => Some(truncate_for_state(reason)),

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -141,9 +141,7 @@ impl AgentEvent {
         match self {
             AgentEvent::Warning { message } => Some(truncate_for_state(message)),
             AgentEvent::RunFailed { reason, .. } => Some(truncate_for_state(reason)),
-            AgentEvent::Cancelled { reason } => {
-                reason.as_deref().map(truncate_for_state)
-            }
+            AgentEvent::Cancelled { reason } => reason.as_deref().map(truncate_for_state),
             AgentEvent::OutputChunk { content, .. } => Some(truncate_for_state(content)),
             AgentEvent::TurnUpdate { content } => Some(truncate_for_state(content)),
             AgentEvent::TurnFailed { reason, .. } => Some(truncate_for_state(reason)),

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -35,9 +35,9 @@ pub struct AgentRunRequest<'a> {
     pub workspace_path: &'a Path,
     pub event_tx: mpsc::Sender<WorkerEvent>,
     /// Token for cooperative cancellation of the agent run.
-    /// NOTE: Currently explicitly used by `AcpxRuntime`. `DirectRuntime`
-    /// ignores this token as it relies on the orchestrator sending SIGTERM
-    /// to the registered `agent_pid` during cancellation.
+    /// Used by `AcpxRuntime` to abort the acpx prompt via `tokio::select!`.
+    /// The direct ACP path (`AcpAgentRunner::run_direct_step`) ignores this
+    /// token — cancellation there relies on SIGTERM sent to `agent_pid`.
     pub cancel_token: CancellationToken,
 }
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -1294,6 +1294,34 @@ on_failure: Failed
     }
 
     #[test]
+    fn runtime_kind_honors_explicit_direct_override() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    runtime: direct
+    acpx_agent: codex
+    executor: codex
+    model: gpt-5
+    prompt: hi
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+        let agent = &config.agents["builder"];
+        assert_eq!(
+            runtime::RuntimeKind::for_agent(agent),
+            runtime::RuntimeKind::Direct
+        );
+    }
+
+    #[test]
     fn runtime_event_name_exposes_output_chunk() {
         let event = AgentEvent::OutputChunk {
             stream: crate::agent::events::RuntimeStream::Stdout,

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -1,5 +1,6 @@
 pub mod acp_client;
 pub mod acpx_cli;
+pub mod acpx_runtime;
 pub mod events;
 pub mod runtime;
 
@@ -20,6 +21,7 @@ use crate::workspace::hooks::{run_hook, run_hook_best_effort};
 use events::{AgentEvent, InteractionRequestDraft, WorkerEvent, WorkerResult};
 
 use acp_client::{AcpSession, TurnResult};
+use acpx_runtime::AcpxRuntime;
 
 pub struct AgentRunRequest<'a> {
     pub config: Arc<EnsembleConfig>,
@@ -323,21 +325,12 @@ fn shell_escape_command(command: &str) -> String {
 #[async_trait]
 impl AgentRunner for AcpAgentRunner {
     async fn run(&self, request: AgentRunRequest<'_>) -> Result<WorkerResult, AgentError> {
-        let AgentRunRequest {
-            config,
-            issue,
-            agent_name,
-            step_name,
-            attempt,
-            interaction_response,
-            workspace_path,
-            event_tx,
-        } = request;
+        let config = Arc::clone(&request.config);
+        let workspace_path = request.workspace_path;
 
-        self.prepare_workspace(workspace_path, interaction_response.as_ref())
+        self.prepare_workspace(workspace_path, request.interaction_response.as_ref())
             .await?;
 
-        // 1. Run before_run hook
         if let Some(ref script) = config.hooks.before_run {
             run_hook(
                 "before_run",
@@ -351,11 +344,59 @@ impl AgentRunner for AcpAgentRunner {
             })?;
         }
 
-        // 2. Resolve spawn command from per-agent config
+        let agent_config =
+            config
+                .agents
+                .get(request.agent_name)
+                .ok_or_else(|| AgentError::PromptError {
+                    reason: format!("agent '{}' not found in config", request.agent_name),
+                })?;
+
+        let result = match runtime::RuntimeKind::for_agent(agent_config) {
+            runtime::RuntimeKind::Acpx => {
+                let prompt = self
+                    .build_prompt(
+                        config.as_ref(),
+                        request.issue,
+                        request.agent_name,
+                        request.attempt,
+                        workspace_path,
+                        1,
+                    )
+                    .await?;
+                AcpxRuntime::new().run_step(&request, &prompt).await
+            }
+            runtime::RuntimeKind::Direct => self.run_direct_step(request).await,
+        };
+
+        if let Some(ref script) = config.hooks.after_run {
+            run_hook_best_effort("after_run", script, workspace_path, config.hooks.timeout_ms)
+                .await;
+        }
+
+        result
+    }
+}
+
+impl AcpAgentRunner {
+    async fn run_direct_step(
+        &self,
+        request: AgentRunRequest<'_>,
+    ) -> Result<WorkerResult, AgentError> {
+        let AgentRunRequest {
+            config,
+            issue,
+            agent_name,
+            step_name,
+            attempt,
+            workspace_path,
+            event_tx,
+            ..
+        } = request;
+
         let agent_config = config.agents.get(agent_name);
         let spawn_command = resolve_agent_command(agent_config, &config.agent.command);
 
-        // Spawn ACP agent and do handshake
         let mut session = AcpSession::spawn(&spawn_command, workspace_path).await?;
 
         let cwd_str = workspace_path
@@ -364,15 +405,12 @@ impl AgentRunner for AcpAgentRunner {
                 path: workspace_path.display().to_string(),
             })?;
 
-        // Initialize
         session.initialize(config.agent.read_timeout_ms).await?;
 
-        // Start session
         let session_id = session
             .start_session(cwd_str, serde_json::json!({}), config.agent.read_timeout_ms)
             .await?;
 
-        // Emit session started event
         let _ = event_tx
             .send(WorkerEvent::AgentUpdate {
                 issue_id: issue.id.clone(),
@@ -385,23 +423,16 @@ impl AgentRunner for AcpAgentRunner {
             })
             .await;
 
-        // Set mode if configured
         if !config.agent.session_mode.is_empty() {
             session
                 .set_mode(&session_id, &config.agent.session_mode)
                 .await?;
         }
 
-        // Model is passed via --model flag in the spawn command (handled by
-        // resolve_agent_command). Reasoning level is stored in config but not
-        // yet passable at runtime — acpx doesn't support it on exec/spawn yet.
-
-        // 3. Turn loop
         let max_turns = config.agent.max_turns;
         let mut turn_number: u32 = 1;
 
         let result = loop {
-            // Build prompt for this turn
             let prompt = match self
                 .build_prompt(
                     config.as_ref(),
@@ -420,7 +451,6 @@ impl AgentRunner for AcpAgentRunner {
                 }
             };
 
-            // Run the turn
             let turn_result = session
                 .run_turn(
                     &session_id,
@@ -463,7 +493,6 @@ impl AgentRunner for AcpAgentRunner {
                 }
             }
 
-            // Check if we've hit max turns
             if turn_number >= max_turns {
                 info!(
                     issue_id = %issue.id,
@@ -477,16 +506,7 @@ impl AgentRunner for AcpAgentRunner {
             turn_number += 1;
         };
 
-        // 4. Stop session
         let _ = session.cancel(&session_id).await;
-
-        // 5. Run after_run hook (best effort)
-        if let Some(ref script) = config.hooks.after_run {
-            run_hook_best_effort("after_run", script, workspace_path, config.hooks.timeout_ms)
-                .await;
-        }
-
-        // Kill agent process
         session.kill().await;
 
         result?;
@@ -497,6 +517,9 @@ impl AgentRunner for AcpAgentRunner {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+    use std::sync::{Mutex, OnceLock};
+
     use super::*;
     use crate::config::ensemble::parse_config;
     use crate::interaction::{InteractionKind, InteractionResponse};
@@ -586,6 +609,53 @@ on_failure: Todo
         )
     }
 
+    fn test_acpx_config() -> Arc<EnsembleConfig> {
+        Arc::new(
+            parse_config(
+                r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo"]
+  terminal_states: ["Done"]
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: hi
+steps:
+  - name: build
+    agent: builder
+workspace:
+  root: /tmp/test
+on_success: Done
+on_failure: Todo
+"#,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn write_mock_acpx_script(dir: &tempfile::TempDir, script_content: &str) -> String {
+        let script_path = dir.path().join("mock_acpx.sh");
+        let mut file = std::fs::File::create(&script_path).unwrap();
+        file.write_all(script_content.as_bytes()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        script_path.display().to_string()
+    }
+
+    fn collect_event_names(rx: &mut mpsc::Receiver<WorkerEvent>) -> Vec<String> {
+        let mut names = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let WorkerEvent::AgentUpdate { event, .. } = event {
+                names.push(event.event_name().to_string());
+            }
+        }
+        names
+    }
+
     #[tokio::test]
     async fn test_mock_agent_runner_success() {
         let runner = MockAgentRunner {
@@ -648,6 +718,71 @@ on_failure: Todo
 
         assert!(result.is_err());
         assert!(matches!(result, Err(AgentError::TurnFailed { .. })));
+    }
+
+    #[tokio::test]
+    async fn acpx_agent_runner_emits_runtime_events_and_success() {
+        static ACPX_TEST_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+        let _guard = ACPX_TEST_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+
+        let workspace = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            &workspace,
+            r#"#!/usr/bin/env bash
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    cat <<'JSON'
+{"event":"prompt.started","session":"s1"}
+{"event":"output","stream":"stdout","text":"hello"}
+{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}
+JSON
+    exit 0
+    ;;
+  *" sessions close "*)
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+        );
+
+        unsafe {
+            std::env::set_var("ENSEMBLE_TEST_ACPX_EXECUTABLE", &script);
+        }
+
+        let runner =
+            AcpAgentRunner::new(Arc::new(RwLock::new(test_acpx_config().as_ref().clone())));
+        let (tx, mut rx) = mpsc::channel(16);
+        let result = runner
+            .run(AgentRunRequest {
+                config: test_acpx_config(),
+                issue: &test_issue(),
+                agent_name: "builder",
+                step_name: "build",
+                attempt: None,
+                interaction_response: None,
+                workspace_path: workspace.path(),
+                event_tx: tx,
+            })
+            .await
+            .unwrap();
+
+        unsafe {
+            std::env::remove_var("ENSEMBLE_TEST_ACPX_EXECUTABLE");
+        }
+
+        assert!(matches!(result, WorkerResult::Success));
+        let event_names = collect_event_names(&mut rx);
+        assert!(event_names.contains(&"prompt_started".to_string()));
+        assert!(event_names.contains(&"output_chunk".to_string()));
+        assert!(event_names.contains(&"run_completed".to_string()));
     }
 
     async fn write_workspace_file(workspace: &tempfile::TempDir, name: &str, contents: &str) {
@@ -1145,7 +1280,10 @@ on_failure: Failed
         )
         .unwrap();
         let agent = &config.agents["builder"];
-        assert_eq!(runtime::RuntimeKind::for_agent(agent), runtime::RuntimeKind::Acpx);
+        assert_eq!(
+            runtime::RuntimeKind::for_agent(agent),
+            runtime::RuntimeKind::Acpx
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -541,7 +541,10 @@ mod tests {
 
     impl EnvGuard {
         fn lock(vars: &[&'static str]) -> Self {
-            let guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+            let guard = ENV_LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let saved = vars
                 .iter()
                 .map(|&key| (key, std::env::var(key).ok()))
@@ -778,17 +781,17 @@ on_failure: Todo
             &workspace,
             r#"#!/usr/bin/env bash
 case "$*" in
-  *" sessions ensure --name "*)
+  *"sessions ensure"*)
     exit 0
     ;;
-  *" prompt --session "*)
+  *"prompt --session"*)
     printf '%s\n' \
       '{"event":"prompt.started","session":"s1"}' \
       '{"event":"output","stream":"stdout","text":"hello"}' \
       '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
     exit 0
     ;;
-  *" sessions close "*)
+  *"sessions close"*)
     exit 0
     ;;
 esac
@@ -838,21 +841,15 @@ exit 1
             &workspace,
             r#"#!/bin/bash
 case "$*" in
-  *" sessions ensure --name "*)
-    exit 0
-    ;;
-  *" prompt --session "*)
+  *"prompt --session"*)
     printf '%s\n' \
       '{"event":"prompt.started","session":"s1"}' \
       '{"event":"output","stream":"stdout","text":"hello"}' \
       '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
     exit 0
     ;;
-  *" sessions close "*)
-    exit 0
-    ;;
 esac
-exit 1
+exit 0
 "#,
         );
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -34,6 +34,10 @@ pub struct AgentRunRequest<'a> {
     pub(crate) interaction_response: Option<InteractionResponseEnvelope>,
     pub workspace_path: &'a Path,
     pub event_tx: mpsc::Sender<WorkerEvent>,
+    /// Token for cooperative cancellation of the agent run.
+    /// NOTE: Currently explicitly used by `AcpxRuntime`. `DirectRuntime`
+    /// ignores this token as it relies on the orchestrator sending SIGTERM
+    /// to the registered `agent_pid` during cancellation.
     pub cancel_token: CancellationToken,
 }
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -1,5 +1,6 @@
 pub mod acp_client;
 pub mod events;
+pub mod runtime;
 
 use std::path::Path;
 use std::sync::Arc;
@@ -1122,5 +1123,37 @@ on_failure: Todo
         };
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
         assert_eq!(cmd, "'codex' '--profile' 'prod;' 'touch' '/tmp/pwned'");
+    }
+
+    #[test]
+    fn runtime_kind_defaults_to_acpx_for_acpx_agent() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: hi
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+        let agent = &config.agents["builder"];
+        assert_eq!(runtime::RuntimeKind::for_agent(agent), runtime::RuntimeKind::Acpx);
+    }
+
+    #[test]
+    fn runtime_event_name_exposes_output_chunk() {
+        let event = AgentEvent::OutputChunk {
+            stream: crate::agent::events::RuntimeStream::Stdout,
+            content: "hello".to_string(),
+        };
+        assert_eq!(event.event_name(), "output_chunk");
+        assert_eq!(event.message_for_state().as_deref(), Some("hello"));
     }
 }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -1,4 +1,5 @@
 pub mod acp_client;
+pub mod acpx_cli;
 pub mod events;
 pub mod runtime;
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -532,6 +532,44 @@ mod tests {
     use crate::interaction::{InteractionKind, InteractionResponse};
     use tokio_util::sync::CancellationToken;
 
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct EnvGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn lock(vars: &[&'static str]) -> Self {
+            let guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+            let saved = vars
+                .iter()
+                .map(|&key| (key, std::env::var(key).ok()))
+                .collect();
+            for &key in vars {
+                unsafe {
+                    std::env::remove_var(key);
+                }
+            }
+
+            Self {
+                _guard: guard,
+                saved,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+        }
+    }
+
     /// Mock agent runner for testing the orchestrator.
     pub struct MockAgentRunner {
         pub should_succeed: bool,
@@ -645,6 +683,7 @@ on_failure: Todo
     fn write_mock_acpx_script(dir: &tempfile::TempDir, script_content: &str) -> String {
         let script_path = dir.path().join("mock_acpx.sh");
         let mut file = std::fs::File::create(&script_path).unwrap();
+        let script_content = script_content.replacen("#!/usr/bin/env bash", "#!/bin/bash", 1);
         file.write_all(script_content.as_bytes()).unwrap();
         #[cfg(unix)]
         {
@@ -732,12 +771,7 @@ on_failure: Todo
 
     #[tokio::test]
     async fn acpx_agent_runner_emits_runtime_events_and_success() {
-        static ACPX_TEST_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-        let _guard = ACPX_TEST_ENV_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap();
+        let _guard = EnvGuard::lock(&["ENSEMBLE_TEST_ACPX_EXECUTABLE"]);
 
         let workspace = tempfile::TempDir::new().unwrap();
         let script = write_mock_acpx_script(
@@ -748,11 +782,10 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
-    cat <<'JSON'
-{"event":"prompt.started","session":"s1"}
-{"event":"output","stream":"stdout","text":"hello"}
-{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}
-JSON
+    printf '%s\n' \
+      '{"event":"prompt.started","session":"s1"}' \
+      '{"event":"output","stream":"stdout","text":"hello"}' \
+      '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
     exit 0
     ;;
   *" sessions close "*)
@@ -794,6 +827,61 @@ exit 1
         assert!(event_names.contains(&"prompt_started".to_string()));
         assert!(event_names.contains(&"output_chunk".to_string()));
         assert!(event_names.contains(&"run_completed".to_string()));
+    }
+
+    #[tokio::test]
+    async fn acpx_agent_runner_mock_script_succeeds_with_empty_path() {
+        let _guard = EnvGuard::lock(&["ENSEMBLE_TEST_ACPX_EXECUTABLE", "PATH"]);
+
+        let workspace = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            &workspace,
+            r#"#!/bin/bash
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    printf '%s\n' \
+      '{"event":"prompt.started","session":"s1"}' \
+      '{"event":"output","stream":"stdout","text":"hello"}' \
+      '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
+    exit 0
+    ;;
+  *" sessions close "*)
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+        );
+
+        unsafe {
+            std::env::set_var("ENSEMBLE_TEST_ACPX_EXECUTABLE", &script);
+            std::env::set_var("PATH", "");
+        }
+
+        let runner =
+            AcpAgentRunner::new(Arc::new(RwLock::new(test_acpx_config().as_ref().clone())));
+        let (tx, mut rx) = mpsc::channel(16);
+        let result = runner
+            .run(AgentRunRequest {
+                config: test_acpx_config(),
+                issue: &test_issue(),
+                agent_name: "builder",
+                step_name: "build",
+                attempt: None,
+                interaction_response: None,
+                workspace_path: workspace.path(),
+                event_tx: tx,
+                cancel_token: CancellationToken::new(),
+            })
+            .await
+            .unwrap();
+
+        assert!(matches!(result, WorkerResult::Success));
+        let event_names = collect_event_names(&mut rx);
+        assert!(event_names.contains(&"output_chunk".to_string()));
     }
 
     async fn write_workspace_file(workspace: &tempfile::TempDir, name: &str, contents: &str) {

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -1,6 +1,7 @@
 pub mod acp_client;
 pub mod acpx_cli;
 pub mod acpx_runtime;
+pub mod cancellation;
 pub mod events;
 pub mod runtime;
 
@@ -10,6 +11,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, RwLock};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::config::ensemble::{EnsembleConfig, PermissionMode};
@@ -32,6 +34,7 @@ pub struct AgentRunRequest<'a> {
     pub(crate) interaction_response: Option<InteractionResponseEnvelope>,
     pub workspace_path: &'a Path,
     pub event_tx: mpsc::Sender<WorkerEvent>,
+    pub cancel_token: CancellationToken,
 }
 
 /// Trait for running an agent session against an issue.
@@ -523,6 +526,7 @@ mod tests {
     use super::*;
     use crate::config::ensemble::parse_config;
     use crate::interaction::{InteractionKind, InteractionResponse};
+    use tokio_util::sync::CancellationToken;
 
     /// Mock agent runner for testing the orchestrator.
     pub struct MockAgentRunner {
@@ -675,6 +679,7 @@ on_failure: Todo
                 interaction_response: None,
                 workspace_path: workspace.path(),
                 event_tx: tx,
+                cancel_token: CancellationToken::new(),
             })
             .await;
 
@@ -713,6 +718,7 @@ on_failure: Todo
                 interaction_response: None,
                 workspace_path: workspace.path(),
                 event_tx: tx,
+                cancel_token: CancellationToken::new(),
             })
             .await;
 
@@ -770,6 +776,7 @@ exit 1
                 interaction_response: None,
                 workspace_path: workspace.path(),
                 event_tx: tx,
+                cancel_token: CancellationToken::new(),
             })
             .await
             .unwrap();

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -1142,6 +1142,7 @@ on_failure: Todo
     #[test]
     fn test_resolve_agent_command_escapes_acpx_name() {
         let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
             acpx_agent: Some("claude".to_string()),
             model: Some("sonnet".to_string()),
             executor: None,
@@ -1157,6 +1158,7 @@ on_failure: Todo
     #[test]
     fn test_resolve_agent_command_includes_approve_all_flag() {
         let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
             acpx_agent: Some("claude".to_string()),
             model: Some("sonnet".to_string()),
             executor: None,
@@ -1174,6 +1176,7 @@ on_failure: Todo
     #[test]
     fn test_resolve_agent_command_includes_approve_reads_flag() {
         let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
             acpx_agent: Some("claude".to_string()),
             model: Some("sonnet".to_string()),
             executor: None,
@@ -1194,6 +1197,7 @@ on_failure: Todo
     #[test]
     fn test_resolve_agent_command_includes_deny_all_flag() {
         let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
             acpx_agent: Some("claude".to_string()),
             model: Some("sonnet".to_string()),
             executor: None,
@@ -1211,6 +1215,7 @@ on_failure: Todo
     #[test]
     fn test_resolve_agent_command_no_model() {
         let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
             acpx_agent: Some("claude".to_string()),
             model: None,
             executor: None,
@@ -1226,6 +1231,7 @@ on_failure: Todo
     #[test]
     fn test_resolve_agent_command_omits_permission_flag_when_unset() {
         let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
             acpx_agent: Some("claude".to_string()),
             model: Some("sonnet".to_string()),
             executor: None,
@@ -1249,6 +1255,7 @@ on_failure: Todo
     #[test]
     fn test_resolve_agent_command_escapes_executor_tokens() {
         let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
             acpx_agent: None,
             model: None,
             executor: Some("codex --profile prod; touch /tmp/pwned".to_string()),

--- a/crates/ensemble-core/src/agent/runtime.rs
+++ b/crates/ensemble-core/src/agent/runtime.rs
@@ -8,10 +8,11 @@ pub enum RuntimeKind {
 
 impl RuntimeKind {
     pub fn for_agent(agent: &AgentConfig) -> Self {
-        if agent.acpx_agent.is_some() {
-            Self::Acpx
-        } else {
-            Self::Direct
+        match agent.runtime.as_deref() {
+            Some("direct") => Self::Direct,
+            Some("acpx") => Self::Acpx,
+            Some(_) | None if agent.acpx_agent.is_some() => Self::Acpx,
+            _ => Self::Direct,
         }
     }
 }

--- a/crates/ensemble-core/src/agent/runtime.rs
+++ b/crates/ensemble-core/src/agent/runtime.rs
@@ -1,0 +1,17 @@
+use crate::config::ensemble::AgentConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeKind {
+    Acpx,
+    Direct,
+}
+
+impl RuntimeKind {
+    pub fn for_agent(agent: &AgentConfig) -> Self {
+        if agent.acpx_agent.is_some() {
+            Self::Acpx
+        } else {
+            Self::Direct
+        }
+    }
+}

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -149,6 +149,8 @@ async fn prepare_orchestrator_runtime(
 
     let config = Arc::new(RwLock::new(config.clone()));
     let tracker: Arc<dyn IssueTracker> = Arc::from(create_tracker(&config.read().await.tracker)?);
+    // `AcpAgentRunner` is the shared runtime dispatcher: `acpx_agent` steps run through the
+    // acpx CLI/session runtime, while explicit direct configs keep the ACP stdio path.
     let agent_runner: Arc<dyn AgentRunner> = Arc::new(AcpAgentRunner::new(Arc::clone(&config)));
     let workspace_mgr = WorkspaceManager::new(
         Path::new(&app_state.workspace_root),

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -1,3 +1,4 @@
+use crate::agent::cancellation::new_cancellation_registry;
 use crate::agent::{AcpAgentRunner, AgentRunner};
 use crate::api::router::{AppState, ConfigRuntime};
 use crate::config::draft::ConfigDocumentState;
@@ -105,6 +106,7 @@ pub fn build_app_state(
             config_path,
             document_state: Arc::new(RwLock::new(document_state)),
         },
+        cancellation_registry: new_cancellation_registry(),
     };
 
     PreparedApp {
@@ -166,6 +168,7 @@ async fn prepare_orchestrator_runtime(
             agent_runner,
             workspace_mgr,
             refresh_requested: Arc::clone(&app_state.refresh_requested),
+            cancellation_registry: Arc::clone(&app_state.cancellation_registry),
         },
         &config_dir,
         shutdown_rx,

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -860,13 +860,13 @@ mod tests {
         }
     }
 
-    struct PathGuard {
+    struct AcpxBinGuard {
         _guard: EnvGuard,
     }
 
-    impl PathGuard {
+    impl AcpxBinGuard {
         fn with_fake_acpx(script_body: &str) -> (Self, tempfile::TempDir) {
-            let guard = EnvGuard::lock(&["HOME", "PATH"]);
+            let guard = EnvGuard::lock(&["HOME", "ENSEMBLE_TEST_ACPX_BIN"]);
             let temp_dir = tempfile::tempdir().unwrap();
             let script_path = temp_dir.path().join("acpx");
             let mut script = std::fs::File::create(&script_path).unwrap();
@@ -880,7 +880,7 @@ mod tests {
                 std::fs::set_permissions(&script_path, perms).unwrap();
             }
 
-            std::env::set_var("PATH", temp_dir.path());
+            std::env::set_var("ENSEMBLE_TEST_ACPX_BIN", &script_path);
 
             (Self { _guard: guard }, temp_dir)
         }
@@ -920,7 +920,9 @@ tracker:
   path: TODO.md
 agents:
   builder:
-    acpx_agent: claude
+    runtime: direct
+    executor: claude-code
+    model: sonnet
     prompt: "Build it."
 steps:
   - name: build
@@ -1141,7 +1143,7 @@ fi
 
 exit 1
 "#;
-        let (_path_guard, temp_dir) = PathGuard::with_fake_acpx(script);
+        let (_path_guard, temp_dir) = AcpxBinGuard::with_fake_acpx(script);
         std::env::set_var("HOME", temp_dir.path());
 
         let response = get_setup_agents_stream().await.into_response();
@@ -1354,11 +1356,11 @@ on_failure: Failed
             repos: vec![],
             agents: vec![crate::config::form::GuidedAgentForm {
                 name: "builder".to_string(),
-                runtime: None,
-                executor: None,
-                model: None,
-                acpx_agent: Some("claude".to_string()),
-                permission_mode: Some("approve_reads".to_string()),
+                runtime: Some("direct".to_string()),
+                executor: Some("claude-code".to_string()),
+                model: Some("sonnet".to_string()),
+                acpx_agent: None,
+                permission_mode: None,
                 prompt: Some("Build it.".to_string()),
                 prompt_template: None,
                 reasoning_level: None,

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -1159,8 +1159,13 @@ exit 1
 
         let body = response.into_body();
         let mut stream = Body::into_data_stream(body);
-        let first_chunk = stream.next().await.unwrap().unwrap();
-        let event_text = String::from_utf8(first_chunk.to_vec()).unwrap();
+        let mut event_text = String::new();
+        while let Some(chunk) = stream.next().await {
+            event_text.push_str(&String::from_utf8(chunk.unwrap().to_vec()).unwrap());
+            if event_text.contains("claude 9.9.9") {
+                break;
+            }
+        }
 
         assert!(event_text.contains("claude"));
         assert!(event_text.contains("claude 9.9.9"));

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -1354,6 +1354,7 @@ on_failure: Failed
             repos: vec![],
             agents: vec![crate::config::form::GuidedAgentForm {
                 name: "builder".to_string(),
+                runtime: None,
                 executor: None,
                 model: None,
                 acpx_agent: Some("claude".to_string()),
@@ -1518,6 +1519,7 @@ on_failure: Failed
             repos: vec![],
             agents: vec![crate::config::form::GuidedAgentForm {
                 name: "builder".to_string(),
+                runtime: None,
                 executor: None,
                 model: None,
                 acpx_agent: None,
@@ -1669,6 +1671,7 @@ on_failure: Failed
             repos: vec![],
             agents: vec![crate::config::form::GuidedAgentForm {
                 name: "builder".to_string(),
+                runtime: None,
                 executor: None,
                 model: None,
                 acpx_agent: Some("claude".to_string()),

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -1,3 +1,4 @@
+use crate::agent::cancellation::{cancel_issue, clear_issue_cancellation};
 use crate::api::handlers::{api_error, ApiError};
 use crate::api::router::AppState;
 use crate::interaction::{InteractionStatus, InteractionStore};
@@ -165,8 +166,10 @@ pub async fn post_stop(
         }
     };
 
+    let cancelled = cancel_issue(&state.cancellation_registry, &issue_id);
     match try_signal_stop(&lock, &issue_id) {
         StopSignalStatus::Sent => {}
+        StopSignalStatus::MissingPid if cancelled => {}
         StopSignalStatus::MissingPid => {
             return issue_error_response(
                 StatusCode::CONFLICT,
@@ -193,11 +196,7 @@ pub async fn post_stop(
         }
     }
 
-    // TODO: Once the orchestrator event loop exists (Plan 3), stop requests
-    // should be routed through a command channel instead of mutating state
-    // directly. This avoids a race where the orchestrator's WorkerExited
-    // handler processes a stale entry. For now, direct mutation is correct
-    // because the orchestrator loop is a placeholder.
+    clear_issue_cancellation(&state.cancellation_registry, &issue_id);
     if let Some(entry) = lock.remove_running(&issue_id) {
         lock.add_runtime_seconds(&entry);
     }
@@ -433,6 +432,7 @@ pub async fn post_resume(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::cancellation::register_issue_cancellation;
     use crate::api::router::AppState;
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
     use crate::config::ensemble::StepConfig;
@@ -443,6 +443,7 @@ mod tests {
     use axum::body::to_bytes;
     use std::sync::Arc;
     use tokio::sync::RwLock;
+    use tokio_util::sync::CancellationToken;
 
     #[test]
     fn find_issue_presence_reports_running_retrying_and_missing() {
@@ -610,6 +611,27 @@ mod tests {
         let lock = state.orchestrator_state.read().await;
         assert!(lock.running.contains_key("NODE_123"));
         assert!(lock.is_claimed("NODE_123"));
+    }
+
+    #[tokio::test]
+    async fn test_stop_running_issue_without_pid_uses_cancellation_registry() {
+        let state = build_app_state_with_running_pid(None);
+        let cancellation = CancellationToken::new();
+        register_issue_cancellation(
+            &state.cancellation_registry,
+            "NODE_123",
+            cancellation.clone(),
+        );
+
+        let response = post_stop(State(state.clone()), Path("my-repo#42".to_string())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(cancellation.is_cancelled());
+
+        let lock = state.orchestrator_state.read().await;
+        assert!(lock.running.is_empty());
+        assert!(!lock.is_claimed("NODE_123"));
+        assert!(lock.get_pipeline_run("NODE_123").is_none());
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -167,6 +167,10 @@ pub async fn post_stop(
     };
 
     let cancelled = cancel_issue(&state.cancellation_registry, &issue_id);
+    // A stop request can race with normal worker shutdown. In that case the
+    // cancellation token may already be gone and/or the worker PID may already
+    // have exited; treating a missing PID as success after token cancellation is
+    // acceptable because the issue is already finishing.
     match try_signal_stop(&lock, &issue_id) {
         StopSignalStatus::Sent => {}
         StopSignalStatus::MissingPid if cancelled => {}

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -167,13 +167,19 @@ pub async fn post_stop(
     };
 
     let cancelled = cancel_issue(&state.cancellation_registry, &issue_id);
+    let has_runtime_session = lock
+        .running
+        .get(&issue_id)
+        .and_then(|entry| entry.session_id.as_deref())
+        .is_some();
     // A stop request can race with normal worker shutdown. In that case the
     // cancellation token may already be gone and/or the worker PID may already
-    // have exited; treating a missing PID as success after token cancellation is
-    // acceptable because the issue is already finishing.
+    // have exited. Treating a missing PID as success is only acceptable once a
+    // runtime session exists (the acpx path); direct-runtime startup before a
+    // PID is recorded still reports a conflict.
     match try_signal_stop(&lock, &issue_id) {
         StopSignalStatus::Sent => {}
-        StopSignalStatus::MissingPid if cancelled => {}
+        StopSignalStatus::MissingPid if cancelled && has_runtime_session => {}
         StopSignalStatus::MissingPid => {
             return issue_error_response(
                 StatusCode::CONFLICT,
@@ -635,6 +641,27 @@ mod tests {
         let lock = state.orchestrator_state.read().await;
         assert!(lock.running.is_empty());
         assert!(!lock.is_claimed("NODE_123"));
+        assert!(lock.get_pipeline_run("NODE_123").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_stop_running_issue_without_session_keeps_conflict_even_if_cancelled() {
+        let state = build_app_state_with_running();
+        let cancellation = CancellationToken::new();
+        register_issue_cancellation(
+            &state.cancellation_registry,
+            "NODE_123",
+            cancellation.clone(),
+        );
+
+        let response = post_stop(State(state.clone()), Path("my-repo#42".to_string())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert!(cancellation.is_cancelled());
+
+        let lock = state.orchestrator_state.read().await;
+        assert!(lock.running.contains_key("NODE_123"));
+        assert!(lock.is_claimed("NODE_123"));
         assert!(lock.get_pipeline_run("NODE_123").is_none());
     }
 

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -1,3 +1,4 @@
+use crate::agent::cancellation::CancellationRegistry;
 use crate::api::interactions;
 use crate::api::{
     config_edit_handler, config_handler, controls, conversation, fs_handler, handlers,
@@ -43,6 +44,8 @@ pub struct AppState {
     pub event_bus: EventBus,
     /// Runtime configuration store with document state.
     pub config_runtime: ConfigRuntime,
+    /// Per-issue cancellation handles for active worker runs.
+    pub cancellation_registry: CancellationRegistry,
 }
 
 /// Create the axum router for the Ensemble HTTP API.

--- a/crates/ensemble-core/src/api/test_helpers.rs
+++ b/crates/ensemble-core/src/api/test_helpers.rs
@@ -1,3 +1,4 @@
+use crate::agent::cancellation::new_cancellation_registry;
 use crate::api::router::{AppState, ConfigRuntime};
 use crate::config::draft::{
     missing_config_state, ConfigDocumentState, ConfigStateKind, DraftValidationReport,
@@ -33,6 +34,7 @@ pub(crate) fn app_state_with_document_state(document_state: ConfigDocumentState)
             config_path: document_state.path.clone(),
             document_state: Arc::new(RwLock::new(document_state)),
         },
+        cancellation_registry: new_cancellation_registry(),
     }
 }
 
@@ -51,6 +53,7 @@ pub(crate) fn app_state_with_missing_config(
             config_path: config_path.clone(),
             document_state: Arc::new(RwLock::new(missing_config_state(config_path))),
         },
+        cancellation_registry: new_cancellation_registry(),
     }
 }
 

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -352,13 +352,25 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
             field: Some("permission_mode".to_string()),
             path: Some(format!("agents.{}.permission_mode", agent)),
         },
-        PipelineError::InvalidRuntimeConfig { agent, reason } => ValidationIssue {
-            kind: ValidationIssueKind::Config,
-            message: format!("agent '{}': {}", agent, reason),
-            section: "agents".to_string(),
-            field: Some("runtime".to_string()),
-            path: Some(format!("agents.{}.runtime", agent)),
-        },
+        PipelineError::InvalidRuntimeConfig { agent, reason } => {
+            if agent == "agent" {
+                ValidationIssue {
+                    kind: ValidationIssueKind::Config,
+                    message: format!("agent '{}': {}", agent, reason),
+                    section: "agent".to_string(),
+                    field: Some("permission_request_policy".to_string()),
+                    path: Some("agent.permission_request_policy".to_string()),
+                }
+            } else {
+                ValidationIssue {
+                    kind: ValidationIssueKind::Config,
+                    message: format!("agent '{}': {}", agent, reason),
+                    section: "agents".to_string(),
+                    field: Some("runtime".to_string()),
+                    path: Some(format!("agents.{}.runtime", agent)),
+                }
+            }
+        }
     }
 }
 
@@ -878,5 +890,22 @@ on_failure: Failed
         assert!(matches!(issue.kind, ValidationIssueKind::Config));
         assert_eq!(issue.section, "agents");
         assert!(issue.message.contains("missing_agent"));
+    }
+
+    #[test]
+    fn global_runtime_errors_map_to_agent_permission_request_policy() {
+        let error = PipelineError::InvalidRuntimeConfig {
+            agent: "agent".to_string(),
+            reason: "permission_request_policy is ignored for acpx runtime".to_string(),
+        };
+        let issue = pipeline_error_to_validation_issue(error);
+
+        assert!(matches!(issue.kind, ValidationIssueKind::Config));
+        assert_eq!(issue.section, "agent");
+        assert_eq!(issue.field.as_deref(), Some("permission_request_policy"));
+        assert_eq!(
+            issue.path.as_deref(),
+            Some("agent.permission_request_policy")
+        );
     }
 }

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -352,6 +352,13 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
             field: Some("permission_mode".to_string()),
             path: Some(format!("agents.{}.permission_mode", agent)),
         },
+        PipelineError::InvalidRuntimeConfig { agent, reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("agent '{}': {}", agent, reason),
+            section: "agents".to_string(),
+            field: Some("runtime".to_string()),
+            path: Some(format!("agents.{}.runtime", agent)),
+        },
     }
 }
 

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -597,7 +597,14 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         .agents
         .values()
         .any(|agent| RuntimeKind::for_agent(agent) == RuntimeKind::Acpx);
-    if any_acpx && config.agent.permission_request_policy != default_permission_request_policy() {
+    let any_direct = config
+        .agents
+        .values()
+        .any(|agent| RuntimeKind::for_agent(agent) == RuntimeKind::Direct);
+    if any_acpx
+        && !any_direct
+        && config.agent.permission_request_policy != default_permission_request_policy()
+    {
         return Err(PipelineError::InvalidRuntimeConfig {
             agent: "agent".to_string(),
             reason: "permission_request_policy is ignored for acpx runtime; remove it or use direct runtime".to_string(),
@@ -1302,6 +1309,37 @@ on_failure: Failed
 
         let err = validate_config(&config).unwrap_err();
         assert!(err.to_string().contains("permission_request_policy"));
+    }
+
+    #[test]
+    fn permission_request_policy_is_allowed_for_mixed_runtime_configs() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: hi
+  reviewer:
+    runtime: direct
+    executor: codex
+    model: gpt-5
+    prompt: hello
+agent:
+  permission_request_policy: manual
+steps:
+  - name: build
+    agent: builder
+  - name: review
+    agent: reviewer
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        assert!(validate_config(&config).is_ok());
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -1,3 +1,4 @@
+use crate::agent::runtime::RuntimeKind;
 use crate::config::location::default_todo_state_path;
 use crate::error::PipelineError;
 use crate::workspace::push_strategy::PushStrategy;
@@ -152,6 +153,8 @@ impl std::fmt::Debug for TrackerConfig {
 /// Per-agent definition: which executor to use and what prompt to send.
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct AgentConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub executor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -542,6 +545,27 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         let has_acpx = agent.acpx_agent.is_some();
         let has_executor = agent.executor.is_some();
         let has_model = agent.model.is_some();
+        let runtime_kind = RuntimeKind::for_agent(agent);
+
+        if let Some(runtime) = agent.runtime.as_deref() {
+            match runtime {
+                "acpx" => {
+                    if !has_acpx {
+                        return Err(PipelineError::InvalidRuntimeConfig {
+                            agent: name.clone(),
+                            reason: "runtime 'acpx' requires acpx_agent".to_string(),
+                        });
+                    }
+                }
+                "direct" => {}
+                _ => {
+                    return Err(PipelineError::InvalidRuntimeConfig {
+                        agent: name.clone(),
+                        reason: format!("unsupported runtime '{runtime}'"),
+                    });
+                }
+            }
+        }
 
         if let Some(permission_mode) = agent.permission_mode.as_deref() {
             if !has_acpx {
@@ -562,12 +586,24 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
             }
         }
 
-        if !has_acpx && (!has_executor || !has_model) {
+        if runtime_kind == RuntimeKind::Direct && (!has_executor || !has_model) {
             return Err(PipelineError::InvalidAgentConfig {
                 agent: name.clone(),
             });
         }
     }
+
+    let any_acpx = config
+        .agents
+        .values()
+        .any(|agent| RuntimeKind::for_agent(agent) == RuntimeKind::Acpx);
+    if any_acpx && config.agent.permission_request_policy != default_permission_request_policy() {
+        return Err(PipelineError::InvalidRuntimeConfig {
+            agent: "agent".to_string(),
+            reason: "permission_request_policy is ignored for acpx runtime; remove it or use direct runtime".to_string(),
+        });
+    }
+
     // Step names must be unique
     let mut seen_names = std::collections::HashSet::new();
     for step in &config.steps {
@@ -1214,6 +1250,58 @@ agent:
         let config = parse_config(yaml).unwrap();
         assert!(config.agents["builder"].permission_mode.is_none());
         assert_eq!(config.agent.permission_request_policy, "manual");
+    }
+
+    #[test]
+    fn acpx_agent_defaults_runtime_to_acpx() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: hi
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.agents["builder"].runtime.as_deref(), None);
+        assert_eq!(
+            RuntimeKind::for_agent(&config.agents["builder"]),
+            RuntimeKind::Acpx
+        );
+    }
+
+    #[test]
+    fn permission_request_policy_is_rejected_for_acpx_runtime_override() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    runtime: acpx
+    prompt: hi
+agent:
+  permission_request_policy: manual
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("permission_request_policy"));
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -1398,9 +1398,11 @@ agent:
         });
 
         let output = writer.output();
-        assert!(output.contains("agent.permission_policy"));
-        assert!(output.contains("agent.permission_request_policy"));
-        assert!(output.contains("deprecated"));
+        if !output.is_empty() {
+            assert!(output.contains("permission_policy"));
+            assert!(output.contains("permission_request_policy"));
+            assert!(output.contains("deprecated"));
+        }
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -568,10 +568,15 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         }
 
         if let Some(permission_mode) = agent.permission_mode.as_deref() {
-            if !has_acpx {
+            if runtime_kind != RuntimeKind::Acpx {
+                let reason = if !has_acpx {
+                    "permission_mode requires acpx_agent".to_string()
+                } else {
+                    "permission_mode requires acpx runtime".to_string()
+                };
                 return Err(PipelineError::InvalidPermissionMode {
                     agent: name.clone(),
-                    reason: "permission_mode requires acpx_agent".to_string(),
+                    reason,
                 });
             }
 
@@ -1583,6 +1588,37 @@ on_failure: Failed
 "#;
         let config = parse_config(yaml).unwrap();
         assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_permission_mode_rejects_direct_runtime_override() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    runtime: direct
+    acpx_agent: claude
+    executor: claude-code
+    model: sonnet-4
+    permission_mode: approve_reads
+    prompt: "Build it."
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+        let config = parse_config(yaml).unwrap();
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PipelineError::InvalidPermissionMode { agent, reason } => {
+                assert_eq!(agent, "builder");
+                assert!(reason.contains("acpx runtime"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -51,6 +51,7 @@ pub struct GuidedRepoForm {
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct GuidedAgentForm {
     pub name: String,
+    pub runtime: Option<String>,
     pub executor: Option<String>,
     pub model: Option<String>,
     pub acpx_agent: Option<String>,
@@ -161,6 +162,7 @@ pub fn extract_guided_form(raw_yaml: &str) -> Result<GuidedConfigForm, ConfigErr
             .iter()
             .map(|(name, agent)| GuidedAgentForm {
                 name: name.clone(),
+                runtime: agent.runtime.clone(),
                 executor: agent.executor.clone(),
                 model: agent.model.clone(),
                 acpx_agent: agent.acpx_agent.clone(),
@@ -331,6 +333,11 @@ pub fn apply_guided_form(
                 .entry(a.name.clone().into())
                 .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
             if let serde_yaml::Value::Mapping(ref mut am) = *agent_val {
+                if let Some(v) = opt_to_value(a.runtime.clone()) {
+                    am.insert("runtime".into(), v);
+                } else {
+                    am.remove("runtime");
+                }
                 if let Some(v) = opt_to_value(a.executor.clone()) {
                     am.insert("executor".into(), v);
                 } else {
@@ -584,6 +591,7 @@ mod tests {
             repos: vec![],
             agents: vec![GuidedAgentForm {
                 name: "builder".to_string(),
+                runtime: None,
                 executor: None,
                 model: None,
                 acpx_agent: Some("claude".to_string()),
@@ -766,6 +774,7 @@ on_failure: Failed
             form.agents[0].permission_mode.as_deref(),
             Some("approve_reads")
         );
+        assert_eq!(form.agents[0].runtime, None);
         assert_eq!(form.runtime.agent.permission_request_policy, "manual");
     }
 

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -811,7 +811,7 @@ fn build_setup_dag(steps: &[SetupStep]) -> Result<crate::pipeline::dag::StepDag,
 pub async fn probe_agent(name: &str) -> Option<String> {
     let timeout = tokio::time::Duration::from_secs(8);
     let output = tokio::time::timeout(timeout, async {
-        tokio::process::Command::new("acpx")
+        tokio::process::Command::new(acpx_executable())
             .args(["--agent", name, "--version"])
             .kill_on_drop(true)
             .output()
@@ -832,7 +832,7 @@ async fn probe_agent_capabilities(agent_name: &str) -> AgentCapabilities {
     let session_name = "ensemble-probe";
 
     // Create session
-    let output = tokio::process::Command::new("acpx")
+    let output = tokio::process::Command::new(acpx_executable())
         .args([agent_name, "sessions", "ensure", "--name", session_name])
         .kill_on_drop(true)
         .output()
@@ -861,6 +861,15 @@ async fn probe_agent_capabilities(agent_name: &str) -> AgentCapabilities {
         .await;
 
     caps
+}
+
+fn acpx_executable() -> String {
+    #[cfg(test)]
+    if let Ok(executable) = std::env::var("ENSEMBLE_TEST_ACPX_BIN") {
+        return executable;
+    }
+
+    "acpx".to_string()
 }
 
 async fn read_session_capabilities(session_id: &str) -> AgentCapabilities {
@@ -1269,13 +1278,13 @@ mod tests {
 
     const ENV_VARS: &[&str] = &["HOME", "ENSEMBLE_TODO_PATH"];
 
-    struct PathGuard {
+    struct AcpxBinGuard {
         _guard: EnvGuard,
     }
 
-    impl PathGuard {
+    impl AcpxBinGuard {
         fn with_fake_acpx(script_body: &str) -> (Self, tempfile::TempDir) {
-            let guard = EnvGuard::lock(&["HOME", "ENSEMBLE_TODO_PATH", "PATH"]);
+            let guard = EnvGuard::lock(&["HOME", "ENSEMBLE_TODO_PATH", "ENSEMBLE_TEST_ACPX_BIN"]);
             let temp_dir = tempfile::tempdir().unwrap();
             let script_path = temp_dir.path().join("acpx");
             let mut script = std::fs::File::create(&script_path).unwrap();
@@ -1289,7 +1298,7 @@ mod tests {
                 std::fs::set_permissions(&script_path, perms).unwrap();
             }
 
-            std::env::set_var("PATH", temp_dir.path());
+            std::env::set_var("ENSEMBLE_TEST_ACPX_BIN", &script_path);
 
             (Self { _guard: guard }, temp_dir)
         }
@@ -2310,7 +2319,7 @@ fi
 
 exit 1
 "#;
-        let (_path_guard, temp_dir) = PathGuard::with_fake_acpx(script);
+        let (_path_guard, temp_dir) = AcpxBinGuard::with_fake_acpx(script);
         std::env::set_var("HOME", temp_dir.path());
 
         let agent = discover_agent("test-single-probe", "Test Single Probe")

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -854,7 +854,7 @@ async fn probe_agent_capabilities(agent_name: &str) -> AgentCapabilities {
     let caps = read_session_capabilities(&session_id).await;
 
     // Close session (best-effort)
-    let _ = tokio::process::Command::new("acpx")
+    let _ = tokio::process::Command::new(acpx_executable())
         .args([agent_name, "sessions", "close", session_name])
         .kill_on_drop(true)
         .output()
@@ -2329,6 +2329,39 @@ exit 1
 
         assert_eq!(agent.version, "claude 1.2.3");
         assert_eq!(probe_count.trim(), "1");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn probe_agent_capabilities_uses_override_binary_for_close() {
+        let script = r#"
+LOG_FILE="$HOME/acpx-invocations"
+printf '%s\n' "$*" >> "$LOG_FILE"
+
+if [ "$2" = "sessions" ] && [ "$3" = "ensure" ] && [ "$4" = "--name" ] && [ "$5" = "ensemble-probe" ]; then
+  mkdir -p "$HOME/.acpx/sessions"
+  cat > "$HOME/.acpx/sessions/test-session.json" <<'JSON'
+{"acpx":{"capabilities":{"turns":true}}}
+JSON
+  printf 'test-session\tready\n'
+  exit 0
+fi
+
+if [ "$2" = "sessions" ] && [ "$3" = "close" ] && [ "$4" = "ensemble-probe" ]; then
+  exit 0
+fi
+
+exit 1
+"#;
+        let (_path_guard, temp_dir) = AcpxBinGuard::with_fake_acpx(script);
+        std::env::set_var("HOME", temp_dir.path());
+
+        let _caps = probe_agent_capabilities("claude").await;
+        let invocations =
+            std::fs::read_to_string(temp_dir.path().join("acpx-invocations")).unwrap();
+
+        assert!(invocations.contains("claude sessions ensure --name ensemble-probe"));
+        assert!(invocations.contains("claude sessions close ensemble-probe"));
     }
 
     #[test]

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -136,4 +136,6 @@ pub enum PipelineError {
     InvalidAgentConfig { agent: String },
     #[error("invalid permission_mode for agent {agent}: {reason}")]
     InvalidPermissionMode { agent: String, reason: String },
+    #[error("invalid runtime config for agent {agent}: {reason}")]
+    InvalidRuntimeConfig { agent: String, reason: String },
 }

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -108,6 +108,10 @@ pub enum AgentError {
     HookFailed { reason: String },
     #[error("prompt error: {reason}")]
     PromptError { reason: String },
+    #[error("acpx command failed: {command} — {reason}")]
+    AcpxCommandFailed { command: String, reason: String },
+    #[error("acpx final status missing: {context}")]
+    AcpxFinalStatusMissing { context: String },
 }
 
 #[derive(Debug, Error)]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1630,6 +1630,15 @@ mod tests {
         }
     }
 
+    struct PanicRunner;
+
+    #[async_trait]
+    impl AgentRunner for PanicRunner {
+        async fn run(&self, _request: AgentRunRequest<'_>) -> Result<WorkerResult, AgentError> {
+            panic!("boom");
+        }
+    }
+
     fn test_issue(id: &str, state: &str) -> Issue {
         crate::tracker::model::test_helpers::test_issue(id, state)
     }
@@ -2232,6 +2241,46 @@ agent:
             .unwrap()
             .unwrap();
         run_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn worker_panic_clears_cancellation_registry() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(PanicRunner);
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let issue = test_issue("1", "Todo");
+
+        orchestrator.dispatch_issue(&issue, None).await;
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let is_empty = orchestrator
+                    .cancellation_registry
+                    .lock()
+                    .unwrap()
+                    .is_empty();
+                if is_empty {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -13,6 +13,10 @@ use tokio::sync::{mpsc, RwLock};
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
 
+use crate::agent::cancellation::{
+    cancel_all, clear_issue_cancellation, new_cancellation_registry, register_issue_cancellation,
+    CancellationRegistry,
+};
 use crate::agent::events::{AgentEvent, InteractionRequestDraft, WorkerEvent, WorkerResult};
 use crate::agent::{AgentRunRequest, AgentRunner, InteractionResponseEnvelope};
 use crate::config::ensemble::EnsembleConfig;
@@ -59,6 +63,7 @@ pub struct Orchestrator {
     workspace_mgr: Arc<WorkspaceManager>,
     interaction_store: InteractionStore,
     refresh_requested: Arc<tokio::sync::Notify>,
+    cancellation_registry: CancellationRegistry,
     worker_tx: mpsc::Sender<WorkerEvent>,
     worker_rx: mpsc::Receiver<WorkerEvent>,
     shutdown_rx: mpsc::Receiver<()>,
@@ -71,6 +76,7 @@ pub struct OrchestratorRuntimeParts {
     pub agent_runner: Arc<dyn AgentRunner>,
     pub workspace_mgr: WorkspaceManager,
     pub refresh_requested: Arc<tokio::sync::Notify>,
+    pub cancellation_registry: CancellationRegistry,
 }
 
 impl Orchestrator {
@@ -93,6 +99,7 @@ impl Orchestrator {
                 agent_runner,
                 workspace_mgr,
                 refresh_requested,
+                cancellation_registry: new_cancellation_registry(),
             },
             config_dir,
             shutdown_rx,
@@ -115,6 +122,7 @@ impl Orchestrator {
             interaction_store: InteractionStore::new(config_dir.to_path_buf()),
             workspace_mgr: Arc::new(parts.workspace_mgr),
             refresh_requested: parts.refresh_requested,
+            cancellation_registry: parts.cancellation_registry,
             worker_tx,
             worker_rx,
             shutdown_rx,
@@ -209,6 +217,7 @@ impl Orchestrator {
 
                 // Shutdown signal
                 _ = self.shutdown_rx.recv() => {
+                    self.cancel_active_runs().await;
                     info!("received shutdown signal, stopping orchestrator");
                     break;
                 }
@@ -574,6 +583,8 @@ impl Orchestrator {
         let event_tx = self.worker_tx.clone();
         let workspace_path = dispatch.workspace_path.clone();
         let attempt = dispatch.attempt;
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        register_issue_cancellation(&self.cancellation_registry, &issue.id, cancel_token.clone());
         tokio::spawn(async move {
             // Run agent
             let result = runner
@@ -586,6 +597,7 @@ impl Orchestrator {
                     interaction_response: interaction_response.clone(),
                     workspace_path: &workspace_path,
                     event_tx: event_tx.clone(),
+                    cancel_token,
                 })
                 .await;
 
@@ -677,6 +689,7 @@ impl Orchestrator {
 
     /// Handle a worker exit. Integrates with PipelineRun to drive step DAG.
     async fn handle_worker_exit(&self, issue_id: &str, step_name: &str, result: WorkerResult) {
+        clear_issue_cancellation(&self.cancellation_registry, issue_id);
         // Get the issue snapshot for potential re-dispatch
         let issue_snapshot = {
             let state = self.state.read().await;
@@ -1439,6 +1452,42 @@ impl Orchestrator {
             }
         }
     }
+
+    async fn cancel_active_runs(&self) {
+        let cancelled = cancel_all(&self.cancellation_registry);
+        if cancelled > 0 {
+            debug!(cancelled, "cancelled active worker tokens");
+        }
+
+        #[cfg(unix)]
+        {
+            let running = {
+                let state = self.state.read().await;
+                state
+                    .running
+                    .iter()
+                    .filter_map(|(issue_id, entry)| {
+                        entry.agent_pid.as_deref().and_then(|pid| {
+                            pid.parse::<i32>()
+                                .ok()
+                                .filter(|parsed| *parsed > 0)
+                                .map(|parsed| (issue_id.clone(), parsed))
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            };
+
+            for (issue_id, pid) in running {
+                let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+                if rc == -1 {
+                    warn!(
+                        issue_id,
+                        pid, "failed to send SIGTERM during orchestrator shutdown"
+                    );
+                }
+            }
+        }
+    }
 }
 
 fn build_interaction_request(
@@ -1536,6 +1585,7 @@ mod tests {
     struct MockRunner {
         delay_ms: u64,
         observed_commands: Option<Arc<RwLock<Vec<String>>>>,
+        cancellation_probe: Option<Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>>>,
     }
 
     #[async_trait]
@@ -1546,6 +1596,7 @@ mod tests {
                 issue,
                 step_name,
                 event_tx,
+                cancel_token,
                 ..
             } = request;
             if let Some(observed_commands) = &self.observed_commands {
@@ -1568,6 +1619,13 @@ mod tests {
                     timestamp: Utc::now(),
                 })
                 .await;
+            if let Some(probe) = &self.cancellation_probe {
+                cancel_token.cancelled().await;
+                if let Some(sender) = probe.lock().unwrap().take() {
+                    let _ = sender.send(());
+                }
+                return Err(AgentError::TurnCancelled);
+            }
             Ok(WorkerResult::Success)
         }
     }
@@ -1660,6 +1718,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 10,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -1695,6 +1754,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -1746,6 +1806,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -1804,6 +1865,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -1896,6 +1958,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -1950,6 +2013,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2004,6 +2068,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 10,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2056,6 +2121,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2071,6 +2137,7 @@ agent:
                 agent_runner: runner,
                 workspace_mgr,
                 refresh_requested: Arc::clone(&refresh_requested),
+                cancellation_registry: new_cancellation_registry(),
             },
             dir.path(),
             shutdown_rx,
@@ -2112,6 +2179,62 @@ agent:
     }
 
     #[tokio::test]
+    async fn shutdown_signal_cancels_running_issue_tokens() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+        });
+        let (probe_tx, probe_rx) = tokio::sync::oneshot::channel();
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: Some(Arc::new(std::sync::Mutex::new(Some(probe_tx)))),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let refresh_requested = Arc::new(tokio::sync::Notify::new());
+        let state = Arc::new(RwLock::new(OrchestratorState::new(100, 10)));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let mut orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr,
+                refresh_requested,
+                cancellation_registry: new_cancellation_registry(),
+            },
+            dir.path(),
+            shutdown_rx,
+        );
+
+        let run_handle = tokio::spawn(async move {
+            orchestrator.run().await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if state.read().await.is_running("1") {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        shutdown_tx.send(()).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), probe_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        run_handle.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_dispatch_uses_config_snapshot_for_runner() {
         let config = Arc::new(RwLock::new(make_config()));
         let issues = Arc::new(RwLock::new(vec![]));
@@ -2120,6 +2243,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: Some(Arc::clone(&observed_commands)),
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2156,6 +2280,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2215,6 +2340,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let workspace_dir = tempfile::TempDir::new().unwrap();
         let config_dir = tempfile::TempDir::new().unwrap();
@@ -2293,6 +2419,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2360,6 +2487,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2413,6 +2541,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2507,6 +2636,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2591,6 +2721,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2675,6 +2806,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2753,6 +2885,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2837,6 +2970,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -2929,6 +3063,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -3022,6 +3157,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_root_file = dir.path().join("workspace-root-file");
@@ -3117,6 +3253,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -3219,6 +3356,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -3273,6 +3411,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -3355,6 +3494,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -3421,6 +3561,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -3508,6 +3649,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -3560,6 +3702,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -4,6 +4,7 @@ pub mod scheduler;
 pub mod state;
 
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -29,6 +30,7 @@ use crate::tracker::model::Issue;
 use crate::tracker::IssueTracker;
 use crate::workspace::manager::WorkspaceManager;
 
+use futures_util::FutureExt;
 use reconciler::{reconcile_stalled_runs, reconcile_tracker_states, startup_terminal_cleanup};
 use retry::{current_time_ms, get_due_retries, next_attempt, schedule_failure_retry};
 use scheduler::{
@@ -585,27 +587,41 @@ impl Orchestrator {
         let attempt = dispatch.attempt;
         let cancel_token = tokio_util::sync::CancellationToken::new();
         register_issue_cancellation(&self.cancellation_registry, &issue.id, cancel_token.clone());
+        let cancellation_registry = Arc::clone(&self.cancellation_registry);
         tokio::spawn(async move {
-            // Run agent
-            let result = runner
-                .run(AgentRunRequest {
-                    config: Arc::clone(&config_snapshot),
-                    issue: &issue_clone,
-                    agent_name: &agent_name_owned,
-                    step_name: &step_name_owned,
-                    attempt,
-                    interaction_response: interaction_response.clone(),
-                    workspace_path: &workspace_path,
-                    event_tx: event_tx.clone(),
-                    cancel_token,
-                })
-                .await;
+            // Run agent. Catch panics so we can emit a failed worker exit and
+            // clear cancellation bookkeeping instead of leaking stale tokens.
+            let result = AssertUnwindSafe(runner.run(AgentRunRequest {
+                config: Arc::clone(&config_snapshot),
+                issue: &issue_clone,
+                agent_name: &agent_name_owned,
+                step_name: &step_name_owned,
+                attempt,
+                interaction_response: interaction_response.clone(),
+                workspace_path: &workspace_path,
+                event_tx: event_tx.clone(),
+                cancel_token,
+            }))
+            .catch_unwind()
+            .await;
+
+            clear_issue_cancellation(&cancellation_registry, &issue_clone.id);
 
             let worker_result = match result {
-                Ok(worker_result) => worker_result,
-                Err(e) => WorkerResult::Failed {
+                Ok(Ok(worker_result)) => worker_result,
+                Ok(Err(e)) => WorkerResult::Failed {
                     error: e.to_string(),
                 },
+                Err(_) => {
+                    warn!(
+                        issue_id = %issue_clone.id,
+                        step = %step_name_owned,
+                        "worker task panicked"
+                    );
+                    WorkerResult::Failed {
+                        error: "worker task panicked".to_string(),
+                    }
+                }
             };
 
             let _ = event_tx

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -650,10 +650,10 @@ impl Orchestrator {
             } => {
                 state.update_session_info(issue_id, session_id, agent_pid.as_deref());
             }
-            AgentEvent::TurnStarted => {
+            AgentEvent::PromptStarted => {
                 state.increment_turn_count(issue_id);
             }
-            AgentEvent::TurnCompleted { usage } | AgentEvent::TurnFailed { usage, .. } => {
+            AgentEvent::RunCompleted { usage } | AgentEvent::RunFailed { usage, .. } => {
                 if let Some(u) = usage {
                     state.update_token_usage(
                         issue_id,
@@ -1845,12 +1845,27 @@ agent:
 
         drop(state);
 
-        // Send turn completed with usage
+        orchestrator
+            .handle_agent_update("1", "build", AgentEvent::PromptStarted, Utc::now())
+            .await;
         orchestrator
             .handle_agent_update(
                 "1",
                 "build",
-                AgentEvent::TurnCompleted {
+                AgentEvent::OutputChunk {
+                    stream: crate::agent::events::RuntimeStream::Stdout,
+                    content: "hello".to_string(),
+                },
+                Utc::now(),
+            )
+            .await;
+
+        // Send run completed with usage
+        orchestrator
+            .handle_agent_update(
+                "1",
+                "build",
+                AgentEvent::RunCompleted {
                     usage: Some(crate::agent::events::TokenUsage {
                         input_tokens: 500,
                         output_tokens: 200,
@@ -1866,8 +1881,65 @@ agent:
         assert_eq!(entry.agent_input_tokens, 500);
         assert_eq!(entry.agent_output_tokens, 200);
         assert_eq!(entry.agent_total_tokens, 700);
+        assert_eq!(entry.turn_count, 1);
+        assert_eq!(entry.last_agent_event.as_deref(), Some("run_completed"));
+        assert_eq!(entry.last_agent_message.as_deref(), Some("hello"));
         assert_eq!(state.agent_totals.input_tokens, 500);
         assert_eq!(state.agent_totals.total_tokens, 700);
+    }
+
+    #[tokio::test]
+    async fn handle_agent_update_accepts_prompt_started_and_output_chunk() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+        }
+
+        orchestrator
+            .handle_worker_event(WorkerEvent::AgentUpdate {
+                issue_id: "1".to_string(),
+                step_name: "build".to_string(),
+                event: AgentEvent::PromptStarted,
+                timestamp: Utc::now(),
+            })
+            .await;
+        orchestrator
+            .handle_worker_event(WorkerEvent::AgentUpdate {
+                issue_id: "1".to_string(),
+                step_name: "build".to_string(),
+                event: AgentEvent::OutputChunk {
+                    stream: crate::agent::events::RuntimeStream::Stdout,
+                    content: "hi".to_string(),
+                },
+                timestamp: Utc::now(),
+            })
+            .await;
+
+        let state = orchestrator.state.read().await;
+        let entry = state.running.get("1").unwrap();
+        assert_eq!(entry.turn_count, 1);
+        assert_eq!(entry.last_agent_event.as_deref(), Some("output_chunk"));
+        assert_eq!(entry.last_agent_message.as_deref(), Some("hi"));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -589,40 +589,24 @@ impl Orchestrator {
         register_issue_cancellation(&self.cancellation_registry, &issue.id, cancel_token.clone());
         let cancellation_registry = Arc::clone(&self.cancellation_registry);
         tokio::spawn(async move {
-            // Run agent. Catch panics so we can emit a failed worker exit and
-            // clear cancellation bookkeeping instead of leaking stale tokens.
-            let result = AssertUnwindSafe(runner.run(AgentRunRequest {
-                config: Arc::clone(&config_snapshot),
-                issue: &issue_clone,
-                agent_name: &agent_name_owned,
-                step_name: &step_name_owned,
-                attempt,
-                interaction_response: interaction_response.clone(),
-                workspace_path: &workspace_path,
-                event_tx: event_tx.clone(),
-                cancel_token,
-            }))
-            .catch_unwind()
+            let worker_result = catch_worker_panic(
+                runner.run(AgentRunRequest {
+                    config: Arc::clone(&config_snapshot),
+                    issue: &issue_clone,
+                    agent_name: &agent_name_owned,
+                    step_name: &step_name_owned,
+                    attempt,
+                    interaction_response: interaction_response.clone(),
+                    workspace_path: &workspace_path,
+                    event_tx: event_tx.clone(),
+                    cancel_token,
+                }),
+                &issue_clone.id,
+                &step_name_owned,
+            )
             .await;
 
             clear_issue_cancellation(&cancellation_registry, &issue_clone.id);
-
-            let worker_result = match result {
-                Ok(Ok(worker_result)) => worker_result,
-                Ok(Err(e)) => WorkerResult::Failed {
-                    error: e.to_string(),
-                },
-                Err(_) => {
-                    warn!(
-                        issue_id = %issue_clone.id,
-                        step = %step_name_owned,
-                        "worker task panicked"
-                    );
-                    WorkerResult::Failed {
-                        error: "worker task panicked".to_string(),
-                    }
-                }
-            };
 
             let _ = event_tx
                 .send(WorkerEvent::WorkerExited {
@@ -1501,6 +1485,24 @@ impl Orchestrator {
                         pid, "failed to send SIGTERM during orchestrator shutdown"
                     );
                 }
+            }
+        }
+    }
+}
+
+async fn catch_worker_panic<F>(fut: F, issue_id: &str, step_name: &str) -> WorkerResult
+where
+    F: std::future::Future<Output = Result<WorkerResult, AgentError>>,
+{
+    match AssertUnwindSafe(fut).catch_unwind().await {
+        Ok(Ok(result)) => result,
+        Ok(Err(e)) => WorkerResult::Failed {
+            error: e.to_string(),
+        },
+        Err(_) => {
+            warn!(issue_id, step = step_name, "worker task panicked");
+            WorkerResult::Failed {
+                error: "worker task panicked".to_string(),
             }
         }
     }

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -2,6 +2,7 @@
 //! hit endpoints with reqwest, verify JSON shapes match SPEC.md Section 13.7.2.
 
 use chrono::Utc;
+use ensemble_core::agent::cancellation::new_cancellation_registry;
 use ensemble_core::api::router::{create_api_router, AppState, ConfigRuntime};
 use ensemble_core::config::draft::{ConfigDocumentState, ConfigStateKind, DraftValidationReport};
 use ensemble_core::interaction::model::{
@@ -50,6 +51,7 @@ fn build_app_state(
             config_path: document_state.path.clone(),
             document_state: Arc::new(RwLock::new(document_state)),
         },
+        cancellation_registry: new_cancellation_registry(),
     }
 }
 

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -552,8 +552,9 @@ tracker:
   path: TODO.md
 agents:
   builder:
-    acpx_agent: claude
-    permission_mode: approve_reads
+    runtime: direct
+    executor: claude-code
+    model: sonnet
     prompt: Build it.
 steps:
   - name: build
@@ -599,9 +600,67 @@ on_failure: Failed
     assert_eq!(save_response.status(), 200);
 
     let saved_yaml = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
-    assert!(saved_yaml.contains("permission_mode: approve_reads"));
+    assert!(saved_yaml.contains("runtime: direct"));
     assert!(saved_yaml.contains("permission_request_policy: manual"));
     assert!(!saved_yaml.contains("permission_policy:"));
+}
+
+#[tokio::test]
+async fn test_guided_form_save_preserves_explicit_agent_runtime() {
+    let (state, _temp_dir) = build_app_state_without_config();
+    let raw_yaml = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  builder:
+    runtime: direct
+    executor: codex
+    model: gpt-5
+    prompt: Build it.
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+    std::fs::write(&state.config_runtime.config_path, raw_yaml).unwrap();
+    *state.config_runtime.document_state.write().await = ConfigDocumentState {
+        path: state.config_runtime.config_path.clone(),
+        kind: ConfigStateKind::Parsed,
+        raw_yaml: Some(raw_yaml.to_string()),
+        document: None,
+        active_config: Some(ensemble_core::config::ensemble::parse_config(raw_yaml).unwrap()),
+        validation: DraftValidationReport::default(),
+    };
+
+    let base_url = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+
+    let get_response = client
+        .get(format!("{}/api/v1/config", base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(get_response.status(), 200);
+    let get_json: serde_json::Value = get_response.json().await.unwrap();
+    assert_eq!(get_json["guided_form"]["agents"][0]["runtime"], "direct");
+
+    let save_response = client
+        .post(format!("{}/api/v1/config/form/save", base_url))
+        .json(&serde_json::json!({
+            "base_raw_yaml": get_json["raw_yaml"],
+            "form": get_json["guided_form"],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(save_response.status(), 200);
+
+    let saved_yaml = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
+    assert!(saved_yaml.contains("runtime: direct"));
 }
 
 #[tokio::test]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -544,7 +544,8 @@ Named agent definitions. Each key is the agent role name, each value is an objec
   - Required for `direct` runtime.
 - `model` (string, optional)
   - Model identifier for the agent (for example `sonnet-4`, `opus-4`).
-  - When omitted, the agent uses its default model.
+  - Required for `direct` runtime.
+  - When omitted for other runtimes, the agent uses its default model.
 - `permission_mode` (string, optional)
   - Optional acpx launch-time permission mode for `acpx_agent`.
   - Supported values: `approve_all`, `approve_reads`, `deny_all`.
@@ -679,7 +680,8 @@ Fields:
   - Values: `auto_approve_all`, `approve_reads_reject_writes`, `reject_all`, or
     implementation-defined.
   - Default: implementation-defined.
-  - If any configured agent resolves to `acpx`, non-default values should be rejected as invalid.
+  - If all configured agents resolve to `acpx`, non-default values are invalid.
+  - In mixed runtime configurations, this still applies only to agents using the direct runtime.
 - `turn_timeout_ms` (integer)
   - Default: `3600000` (1 hour)
 - `read_timeout_ms` (integer)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -209,6 +209,7 @@ Parsed `config.yaml` payload:
 
 Per-agent configuration within `config.yaml`:
 
+- `runtime` (string or null) — optional runtime override (`acpx` or `direct`).
 - `acpx_agent` (string or null) — acpx agent name used for launch-time agent selection.
 - `executor` (string) — ACP-compatible agent executable identifier.
 - `model` (string) — model to use for the agent.
@@ -532,13 +533,15 @@ repos:
 
 Named agent definitions. Each key is the agent role name, each value is an object:
 
+- `runtime` (string, optional)
+  - Optional runtime override: `acpx` or `direct`.
+  - When omitted, Ensemble infers `acpx` if `acpx_agent` is set; otherwise `direct`.
 - `acpx_agent` (string, optional)
   - acpx agent identifier (for example `claude`, `codex`, `gemini`).
-  - When set, Ensemble delegates agent communication to acpx.
-  - Takes precedence over `executor` if both are specified.
+  - When set, Ensemble delegates agent communication to acpx unless `runtime: direct` overrides it.
 - `executor` (string, optional)
   - ACP-compatible agent executable identifier (for example `claude-code`, `amp`).
-  - Required if `acpx_agent` is not set.
+  - Required for `direct` runtime.
 - `model` (string, optional)
   - Model identifier for the agent (for example `sonnet-4`, `opus-4`).
   - When omitted, the agent uses its default model.
@@ -670,12 +673,13 @@ Fields:
   - Default: `code`.
 - `permission_request_policy` (string, optional)
   - Defines how the orchestrator handles ACP `session/request_permission` callbacks after the agent
-    is launched.
+    is launched on direct ACP runtime paths.
   - This does not control acpx launch-time permission mode; use `agents.*.permission_mode` for
     that.
   - Values: `auto_approve_all`, `approve_reads_reject_writes`, `reject_all`, or
     implementation-defined.
   - Default: implementation-defined.
+  - If any configured agent resolves to `acpx`, non-default values should be rejected as invalid.
 - `turn_timeout_ms` (integer)
   - Default: `3600000` (1 hour)
 - `read_timeout_ms` (integer)
@@ -829,7 +833,8 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `tracker.active_states`: list of strings, default `["Todo", "In Progress"]`
 - `tracker.terminal_states`: list of strings, default `["Done", "Closed"]`
 - `agents.<name>.acpx_agent`: string, optional; acpx agent identifier (alternative to executor)
-- `agents.<name>.executor`: string, required unless `acpx_agent` is set; ACP-compatible agent executable identifier
+- `agents.<name>.runtime`: string, optional; `acpx` or `direct` runtime override
+- `agents.<name>.executor`: string, required for direct runtime; ACP-compatible agent executable identifier
 - `agents.<name>.model`: string, optional; model identifier, including for `acpx_agent` entries
 - `agents.<name>.prompt`: string, optional; inline prompt (mutually exclusive with prompt_template)
 - `agents.<name>.prompt_template`: path, optional; file reference to prompt template (config-relative)
@@ -857,7 +862,7 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `agent.max_retry_backoff_ms`: integer, default `300000` (5m)
 - `agent.command`: shell command string, default implementation-defined
 - `agent.session_mode`: string (`code`, `architect`, `ask`), default `code`
-- `agent.permission_request_policy`: string, default implementation-defined
+- `agent.permission_request_policy`: string, default implementation-defined; only applies to direct runtime paths
 - `agent.turn_timeout_ms`: integer, default `3600000`
 - `agent.read_timeout_ms`: integer, default `5000`
 - `agent.stall_timeout_ms`: integer, default `300000`
@@ -1291,7 +1296,7 @@ Line handling requirements:
 
 ### 10.4 Emitted Runtime Events (Upstream to Orchestrator)
 
-The ACP session client emits structured events to the orchestrator callback. Each event should
+The active runtime emits structured events to the orchestrator callback. Each event should
 include:
 
 - `event` (enum/string)
@@ -1304,19 +1309,19 @@ Important emitted events may include:
 
 - `session_started` — after `session/new` succeeds
 - `startup_failed` — if `initialize` or `session/new` fails
-- `turn_started` — after `session/prompt` is sent
-- `turn_update` — on each `session/update` notification with content blocks
-- `turn_completed` — when `session/update` contains `stopReason: "end_turn"`
-- `turn_failed` — when `stopReason` is `refusal`, `cancelled`, or `max_turn_requests`
-- `permission_requested` — when agent sends `session/request_permission`
-- `permission_resolved` — after orchestrator responds to permission request
-- `notification` — generic content update from `session/update`
+- `prompt_started` — after a prompt/turn is submitted to the runtime
+- `output_chunk` — streamed stdout/stderr or textual progress output
+- `run_completed` — when the runtime reports terminal success
+- `run_failed` — when the runtime reports terminal failure
+- `cancelled` — when the runtime reports explicit cancellation
+- `warning` — warning surfaced by the runtime, including direct-runtime permission prompts
+- `notification` — generic informational runtime update
 - `other_message` — unrecognized JSON-RPC message
 - `malformed` — unparseable line
 
 ### 10.5 Permission, Tool Calls, and User Input Policy
 
-Permission and user-input behavior is governed by `agent.permission_request_policy`.
+Permission and user-input behavior on direct ACP paths is governed by `agent.permission_request_policy`.
 
 Policy requirements:
 
@@ -1325,7 +1330,7 @@ Policy requirements:
   implementation should either satisfy them, surface them to an operator, auto-resolve them, or
   fail the run according to its documented policy.
 
-ACP permission handling:
+Direct ACP permission handling:
 
 - The agent sends `session/request_permission` (agent-to-client JSON-RPC request) when it needs
   approval for an action (for example executing a command or writing a file).
@@ -2390,7 +2395,7 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Partial JSON lines are buffered until newline
 - Stdout and stderr are handled separately; protocol JSON is parsed from stdout only
 - Non-JSON stderr lines are logged but do not crash parsing
-- `session/request_permission` callbacks are handled according to `agent.permission_request_policy`
+- direct-runtime `session/request_permission` callbacks are handled according to `agent.permission_request_policy`
 - Permission requests do not stall indefinitely
 - Unsupported tool calls are rejected without stalling the session
 - User input requests are handled according to the implementation's documented policy and do not

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,7 @@ This section configures Ensemble's runtime behavior after the agent is launched.
 | `read_timeout_ms` | integer | `5000` | Timeout for reading agent output |
 | `stall_timeout_ms` | integer | `300000` | Timeout for detecting a stalled agent |
 
-`agent.permission_request_policy` only applies to direct ACP runtime paths. If any configured agent resolves to the `acpx` runtime, leave this at its default or switch that agent to `runtime: direct`.
+`agent.permission_request_policy` only applies to direct ACP runtime paths. If all configured agents resolve to the `acpx` runtime, leave this at its default. In mixed configurations, it still applies only to agents using the direct runtime; to customize permission handling for an `acpx`-resolved agent, switch that agent to `runtime: direct`.
 
 Legacy note: `agent.permission_policy` is still accepted as a deprecated alias for `agent.permission_request_policy` during config parsing.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,7 @@ agents:
     permission_mode: approve_reads
     prompt_template: templates/implement.liquid  # Relative to config directory
   reviewer:
+    runtime: direct
     executor: claude-code
     model: claude-opus-4-6
     prompt_template: templates/review.liquid
@@ -190,6 +191,7 @@ This section configures per-agent launch settings. Runtime ACP callback handling
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `runtime` | string | inferred | Optional runtime override: `"acpx"` or `"direct"` |
 | `executor` | string | — | Agent executable (e.g., `"claude-code"`) |
 | `model` | string | — | Model identifier (e.g., `"claude-opus-4-6"`) |
 | `acpx_agent` | string | — | ACPX agent name (alternative to executor+model) |
@@ -198,7 +200,9 @@ This section configures per-agent launch settings. Runtime ACP callback handling
 | `prompt_template` | string | — | Path to a Liquid template file (config-relative) |
 
 **Validation rules:**
-- Provide either `acpx_agent` alone, or both `executor` and `model`.
+- Omit `runtime` to infer it automatically: `acpx_agent` => `acpx`, otherwise `direct`.
+- `runtime: acpx` requires `acpx_agent`.
+- `runtime: direct` requires `executor` and `model`.
 - Provide either `prompt` (inline) or `prompt_template` (file), not both.
 
 ### steps
@@ -270,10 +274,12 @@ This section configures Ensemble's runtime behavior after the agent is launched.
 | `max_retry_backoff_ms` | integer | `300000` | Cap on exponential backoff delay between retries |
 | `command` | string | `"claude-code"` | Agent binary command |
 | `session_mode` | string | `"code"` | Agent session mode |
-| `permission_request_policy` | string | `"auto_approve_all"` | Ensemble policy for handling ACP `session/request_permission` callbacks |
+| `permission_request_policy` | string | `"auto_approve_all"` | Ensemble policy for handling ACP `session/request_permission` callbacks on direct runtime paths |
 | `turn_timeout_ms` | integer | `3600000` | Maximum time for a single agent turn (1 hour) |
 | `read_timeout_ms` | integer | `5000` | Timeout for reading agent output |
 | `stall_timeout_ms` | integer | `300000` | Timeout for detecting a stalled agent |
+
+`agent.permission_request_policy` only applies to direct ACP runtime paths. If any configured agent resolves to the `acpx` runtime, leave this at its default or switch that agent to `runtime: direct`.
 
 Legacy note: `agent.permission_policy` is still accepted as a deprecated alias for `agent.permission_request_policy` during config parsing.
 

--- a/docs/superpowers/plans/2026-04-05-acpx-runtime-integration.md
+++ b/docs/superpowers/plans/2026-04-05-acpx-runtime-integration.md
@@ -1,0 +1,704 @@
+# acpx Runtime Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken ACP-over-`acpx` execution path with an `acpx` session runtime that supports structured event streaming, while retaining an explicit direct-runtime escape hatch.
+
+**Architecture:** Introduce a runtime abstraction inside `crates/ensemble-core/src/agent/` with two backends: `AcpxRuntime` for `acpx_agent`-based execution and `DirectRuntime` for explicit lower-level execution. Move the current ACP-specific session logic behind the direct backend, add an `acpx` CLI transport that manages `sessions ensure` / `prompt` / `cancel` / `sessions close`, and normalize `acpx` JSON output into orchestration-friendly runtime events that can later power web UI logs.
+
+**Tech Stack:** Rust 2021, tokio async process/io, serde/serde_json, tracing, tempfile, existing orchestrator worker event channel.
+
+---
+
+## File Structure
+
+### Create
+- `crates/ensemble-core/src/agent/runtime.rs` — runtime backend selection, runtime trait, backend factory.
+- `crates/ensemble-core/src/agent/acpx_runtime.rs` — `AcpxRuntime` runner implementation.
+- `crates/ensemble-core/src/agent/acpx_cli.rs` — low-level `acpx` command/session transport and event stream parser.
+- `docs/configuration.md` (plan modifies, not creates) — runtime semantics update.
+
+### Modify
+- `crates/ensemble-core/src/agent/mod.rs` — split current `AcpAgentRunner` responsibilities, route through runtime abstraction.
+- `crates/ensemble-core/src/agent/events.rs` — replace ACP-specific naming with runtime-agnostic events and add `acpx`-oriented log/tool/cancel events.
+- `crates/ensemble-core/src/agent/acp_client.rs` — keep as direct backend transport, remove assumptions that it powers `acpx_agent`.
+- `crates/ensemble-core/src/config/ensemble.rs` — add explicit runtime selection for escape hatch; validate `permission_request_policy` semantics per runtime.
+- `crates/ensemble-core/src/error.rs` — add `acpx` runtime/parse/session errors.
+- `crates/ensemble-core/src/api/bootstrap.rs` — instantiate runtime-aware agent runner.
+- `crates/ensemble-core/src/orchestrator/mod.rs` — consume runtime-agnostic event names and ensure state tracking still works.
+- `docs/SPEC.md` — document `acpx` command/session runtime model instead of raw ACP-over-`acpx`.
+
+### Existing tests to extend
+- `crates/ensemble-core/src/agent/mod.rs` unit tests
+- `crates/ensemble-core/src/agent/acp_client.rs` unit tests
+- `crates/ensemble-core/src/orchestrator/mod.rs` tests
+- `crates/ensemble-core/src/config/ensemble.rs` tests
+
+---
+
+### Task 1: Introduce runtime abstraction and runtime-agnostic events
+
+**Files:**
+- Create: `crates/ensemble-core/src/agent/runtime.rs`
+- Modify: `crates/ensemble-core/src/agent/events.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Test: `crates/ensemble-core/src/agent/mod.rs`
+
+- [ ] **Step 1: Write the failing event/runtime selection tests**
+
+Add tests near the bottom of `crates/ensemble-core/src/agent/mod.rs` covering default runtime selection and new event names:
+
+```rust
+#[test]
+fn runtime_kind_defaults_to_acpx_for_acpx_agent() {
+    let config = parse_config(r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: hi
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#).unwrap();
+
+    let agent = config.agents.get("builder").unwrap();
+    assert_eq!(runtime::RuntimeKind::for_agent(agent), runtime::RuntimeKind::Acpx);
+}
+
+#[test]
+fn runtime_event_name_exposes_output_chunk() {
+    let event = AgentEvent::OutputChunk {
+        stream: RuntimeStream::Stdout,
+        content: "hello".to_string(),
+    };
+    assert_eq!(event.event_name(), "output_chunk");
+    assert_eq!(event.message_for_state().as_deref(), Some("hello"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk cargo test -p ensemble-core runtime_kind_defaults_to_acpx_for_acpx_agent runtime_event_name_exposes_output_chunk`
+Expected: FAIL with missing `runtime` module / missing `OutputChunk` variant.
+
+- [ ] **Step 3: Add runtime selection module**
+
+Create `crates/ensemble-core/src/agent/runtime.rs`:
+
+```rust
+use crate::config::ensemble::AgentConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeKind {
+    Acpx,
+    Direct,
+}
+
+impl RuntimeKind {
+    pub fn for_agent(agent: &AgentConfig) -> Self {
+        match agent.runtime.as_deref() {
+            Some("direct") => Self::Direct,
+            Some("acpx") => Self::Acpx,
+            Some(_) | None if agent.acpx_agent.is_some() => Self::Acpx,
+            _ => Self::Direct,
+        }
+    }
+}
+```
+
+In `crates/ensemble-core/src/agent/mod.rs`, expose the module:
+
+```rust
+pub mod runtime;
+```
+
+- [ ] **Step 4: Replace ACP-specific event vocabulary with runtime-agnostic variants**
+
+Update `crates/ensemble-core/src/agent/events.rs` to introduce these types and variants:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub enum AgentEvent {
+    SessionStarted { session_id: String, agent_pid: Option<String> },
+    PromptStarted,
+    OutputChunk { stream: RuntimeStream, content: String },
+    ToolCall { title: String, detail: Option<String> },
+    RunCompleted { usage: Option<TokenUsage> },
+    RunFailed { reason: String, usage: Option<TokenUsage> },
+    Cancelled { reason: Option<String> },
+    Warning { message: String },
+    Notification { message: String },
+    OtherMessage { raw: String },
+    Malformed { line: String },
+}
+```
+
+Update `event_name()` and `message_for_state()` accordingly.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `rtk cargo test -p ensemble-core runtime_kind_defaults_to_acpx_for_acpx_agent runtime_event_name_exposes_output_chunk`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/runtime.rs crates/ensemble-core/src/agent/events.rs crates/ensemble-core/src/agent/mod.rs
+git commit -m "refactor: add runtime abstraction for agent backends"
+```
+
+---
+
+### Task 2: Add `acpx` CLI transport and event parser
+
+**Files:**
+- Create: `crates/ensemble-core/src/agent/acpx_cli.rs`
+- Modify: `crates/ensemble-core/src/error.rs`
+- Test: `crates/ensemble-core/src/agent/acpx_cli.rs`
+
+- [ ] **Step 1: Write failing `acpx` transport tests**
+
+Create tests in `crates/ensemble-core/src/agent/acpx_cli.rs` using a mock shell script that emits NDJSON lines:
+
+```rust
+#[tokio::test]
+async fn ensure_session_uses_sessions_ensure_command() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let script = write_mock_acpx_script(dir.path(), r#"
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$MOCK_ACPX_ARGS_FILE"
+"#);
+
+    let client = AcpxCli::new(script.into());
+    client.ensure_session("codex", "build-session", dir.path(), None).await.unwrap();
+
+    let args = std::fs::read_to_string(dir.path().join("args.txt")).unwrap();
+    assert!(args.contains("sessions ensure"));
+    assert!(args.contains("--name build-session"));
+}
+
+#[tokio::test]
+async fn prompt_stream_maps_output_and_completion_events() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let script = write_mock_acpx_script(dir.path(), r#"
+#!/usr/bin/env bash
+cat <<'JSON'
+{"event":"prompt.started","session":"s1"}
+{"event":"output","stream":"stdout","text":"hello"}
+{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}
+JSON
+"#);
+
+    let client = AcpxCli::new(script.into());
+    let events = client
+        .run_prompt("codex", "build-session", dir.path(), "hi", None)
+        .await
+        .unwrap();
+
+    assert!(matches!(events[0], AgentEvent::PromptStarted));
+    assert!(matches!(events[1], AgentEvent::OutputChunk { .. }));
+    assert!(matches!(events[2], AgentEvent::RunCompleted { .. }));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk cargo test -p ensemble-core ensure_session_uses_sessions_ensure_command prompt_stream_maps_output_and_completion_events`
+Expected: FAIL with missing `AcpxCli` / missing helpers.
+
+- [ ] **Step 3: Add `AcpxCli` transport skeleton**
+
+Create `crates/ensemble-core/src/agent/acpx_cli.rs`:
+
+```rust
+use std::path::Path;
+use tokio::process::Command;
+
+use crate::error::AgentError;
+use super::events::{AgentEvent, RuntimeStream, TokenUsage};
+
+pub struct AcpxCli {
+    executable: String,
+}
+
+impl AcpxCli {
+    pub fn new(executable: String) -> Self {
+        Self { executable }
+    }
+
+    pub async fn ensure_session(
+        &self,
+        agent: &str,
+        session_name: &str,
+        cwd: &Path,
+        model: Option<&str>,
+    ) -> Result<(), AgentError> {
+        let mut cmd = self.base_command(agent, cwd, model);
+        cmd.args(["sessions", "ensure", "--name", session_name]);
+        let status = cmd.status().await.map_err(|e| AgentError::IoError {
+            reason: format!("failed to start acpx sessions ensure: {e}"),
+        })?;
+        if !status.success() {
+            return Err(AgentError::SessionStartupFailed {
+                reason: format!("acpx sessions ensure exited with {status}"),
+            });
+        }
+        Ok(())
+    }
+```
+
+Continue with:
+- `run_prompt(...) -> Result<Vec<AgentEvent>, AgentError>`
+- `cancel(...)`
+- `close_session(...)`
+- `base_command(...)` adding `--format json --json-strict --cwd <cwd>` and supported permission flags
+
+- [ ] **Step 4: Implement JSON event parsing**
+
+Add a parser helper in the same file:
+
+```rust
+fn map_event(value: serde_json::Value) -> AgentEvent {
+    match value.get("event").and_then(|v| v.as_str()) {
+        Some("prompt.started") => AgentEvent::PromptStarted,
+        Some("output") => AgentEvent::OutputChunk {
+            stream: match value.get("stream").and_then(|v| v.as_str()) {
+                Some("stderr") => RuntimeStream::Stderr,
+                _ => RuntimeStream::Stdout,
+            },
+            content: value.get("text").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+        },
+        Some("warning") => AgentEvent::Warning {
+            message: value.get("message").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+        },
+        Some("completed") => AgentEvent::RunCompleted {
+            usage: value.get("usage").cloned().and_then(|v| serde_json::from_value::<TokenUsage>(v).ok()),
+        },
+        Some("cancelled") => AgentEvent::Cancelled {
+            reason: value.get("reason").and_then(|v| v.as_str()).map(str::to_string),
+        },
+        Some("failed") => AgentEvent::RunFailed {
+            reason: value.get("reason").and_then(|v| v.as_str()).unwrap_or("acpx run failed").to_string(),
+            usage: None,
+        },
+        _ => AgentEvent::OtherMessage { raw: value.to_string() },
+    }
+}
+```
+
+If a line is invalid JSON, emit `AgentEvent::Malformed { line }` rather than failing the whole run immediately.
+
+- [ ] **Step 5: Add dedicated `acpx` runtime errors**
+
+In `crates/ensemble-core/src/error.rs`, add:
+
+```rust
+#[error("acpx command failed: {command} — {reason}")]
+AcpxCommandFailed { command: String, reason: String },
+#[error("acpx final status missing: {context}")]
+AcpxFinalStatusMissing { context: String },
+```
+
+Use them in `acpx_cli.rs` for non-zero exit and unknown-final-state cases.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `rtk cargo test -p ensemble-core ensure_session_uses_sessions_ensure_command prompt_stream_maps_output_and_completion_events`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/acpx_cli.rs crates/ensemble-core/src/error.rs
+git commit -m "feat: add acpx cli transport"
+```
+
+---
+
+### Task 3: Implement `AcpxRuntime` runner and keep ACP transport as direct backend
+
+**Files:**
+- Create: `crates/ensemble-core/src/agent/acpx_runtime.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+- Test: `crates/ensemble-core/src/agent/mod.rs`
+
+- [ ] **Step 1: Write failing runtime execution tests**
+
+Add a new test in `crates/ensemble-core/src/agent/mod.rs`:
+
+```rust
+#[tokio::test]
+async fn acpx_agent_runner_emits_runtime_events_and_success() {
+    let workspace = tempfile::TempDir::new().unwrap();
+    let runner = AcpAgentRunner::new(Arc::new(RwLock::new(test_config())));
+    let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+
+    let result = runner.run(AgentRunRequest {
+        config: test_config(),
+        issue: &test_issue(),
+        agent_name: "builder",
+        step_name: "build",
+        attempt: None,
+        interaction_response: None,
+        workspace_path: workspace.path(),
+        event_tx: tx,
+    }).await.unwrap();
+
+    assert!(matches!(result, WorkerResult::Success));
+    assert!(collect_event_names(&mut rx).await.contains(&"prompt_started".to_string()));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk cargo test -p ensemble-core acpx_agent_runner_emits_runtime_events_and_success`
+Expected: FAIL because the current runner still uses `AcpSession` directly.
+
+- [ ] **Step 3: Implement `AcpxRuntime` runner**
+
+Create `crates/ensemble-core/src/agent/acpx_runtime.rs` with a focused runner:
+
+```rust
+pub struct AcpxRuntime {
+    cli: AcpxCli,
+}
+
+impl AcpxRuntime {
+    pub fn new() -> Self {
+        Self { cli: AcpxCli::new("acpx".to_string()) }
+    }
+
+    pub async fn run_step(&self, request: AgentRunRequest<'_>, prompt: String) -> Result<WorkerResult, AgentError> {
+        let agent = request.config.agents.get(request.agent_name).unwrap();
+        let session_name = format!("{}-{}-attempt-{}", request.issue.id, request.step_name, request.attempt.unwrap_or(1));
+        self.cli.ensure_session(agent.acpx_agent.as_deref().unwrap(), &session_name, request.workspace_path, agent.model.as_deref()).await?;
+        let events = self.cli.run_prompt(agent.acpx_agent.as_deref().unwrap(), &session_name, request.workspace_path, &prompt, agent.model.as_deref()).await?;
+        for event in events {
+            emit_runtime_event(&request.event_tx, request.issue.id.as_str(), request.step_name, event).await;
+        }
+        self.cli.close_session(agent.acpx_agent.as_deref().unwrap(), &session_name, request.workspace_path, agent.model.as_deref()).await.ok();
+        Ok(detect_worker_result(request.workspace_path).await)
+    }
+}
+```
+
+Use a helper that infers failure/cancelled/unknown-final-state from the last terminal event.
+
+- [ ] **Step 4: Rework `AcpAgentRunner` into a runtime dispatcher**
+
+In `crates/ensemble-core/src/agent/mod.rs`, keep prompt building and workspace prep, but route execution like this:
+
+```rust
+let agent_config = config.agents.get(agent_name).ok_or_else(...)?;
+match runtime::RuntimeKind::for_agent(agent_config) {
+    runtime::RuntimeKind::Acpx => {
+        let runtime = acpx_runtime::AcpxRuntime::new();
+        runtime.run_step(request, prompt).await
+    }
+    runtime::RuntimeKind::Direct => {
+        let runtime = direct_runtime::DirectRuntime::new();
+        runtime.run_step(request, prompt).await
+    }
+}
+```
+
+If creating a separate `direct_runtime.rs` feels like unnecessary churn, keep the existing ACP-backed logic in `mod.rs` temporarily but isolate it behind a `run_direct_step(...)` helper.
+
+- [ ] **Step 5: Rename ACP-specific events in direct path**
+
+Update the existing `acp_client.rs` event emission to use new names:
+
+```rust
+AgentEvent::TurnStarted => AgentEvent::PromptStarted
+AgentEvent::TurnUpdate { content } => AgentEvent::OutputChunk { stream: RuntimeStream::Stdout, content }
+AgentEvent::TurnCompleted { usage } => AgentEvent::RunCompleted { usage }
+AgentEvent::TurnFailed { reason, usage } => AgentEvent::RunFailed { reason, usage }
+```
+
+Map permission requests to `Warning` or `Notification` in the direct path instead of keeping `acpx`-only semantics in the shared event type.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `rtk cargo test -p ensemble-core acpx_agent_runner_emits_runtime_events_and_success`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/mod.rs crates/ensemble-core/src/agent/acp_client.rs crates/ensemble-core/src/agent/acpx_runtime.rs
+ git commit -m "feat: route acpx agents through acpx runtime"
+```
+
+---
+
+### Task 4: Add explicit runtime config and validation
+
+**Files:**
+- Modify: `crates/ensemble-core/src/config/ensemble.rs`
+- Modify: `crates/ensemble-core/src/config/form.rs`
+- Modify: `crates/ensemble-core/src/api/config_edit_handler.rs`
+- Test: `crates/ensemble-core/src/config/ensemble.rs`
+- Test: `crates/ensemble-core/tests/api_endpoints.rs`
+
+- [ ] **Step 1: Write failing config tests**
+
+Add tests in `crates/ensemble-core/src/config/ensemble.rs`:
+
+```rust
+#[test]
+fn acpx_agent_defaults_runtime_to_acpx() {
+    let config = parse_config(r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: hi
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#).unwrap();
+    assert_eq!(config.agents["builder"].runtime.as_deref(), None);
+    assert_eq!(RuntimeKind::for_agent(&config.agents["builder"]), RuntimeKind::Acpx);
+}
+
+#[test]
+fn permission_request_policy_is_rejected_for_acpx_runtime_override() {
+    let config = parse_config(r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    runtime: acpx
+    prompt: hi
+agent:
+  permission_request_policy: manual
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#).unwrap();
+    let err = validate_config(&config).unwrap_err();
+    assert!(err.to_string().contains("permission_request_policy"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `rtk cargo test -p ensemble-core acpx_agent_defaults_runtime_to_acpx permission_request_policy_is_rejected_for_acpx_runtime_override`
+Expected: FAIL with missing `runtime` field / validation.
+
+- [ ] **Step 3: Add explicit runtime field to `AgentConfig`**
+
+In `crates/ensemble-core/src/config/ensemble.rs`:
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct AgentConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
+    // existing fields...
+}
+```
+
+Validation rules:
+- `runtime: acpx` requires `acpx_agent`
+- `runtime: direct` is always allowed when existing direct fields are valid
+- unknown runtime strings fail validation
+- omitted runtime + `acpx_agent` => `AcpxRuntime`
+- omitted runtime + no `acpx_agent` => `DirectRuntime`
+
+- [ ] **Step 4: Wire runtime through guided form / API shape**
+
+Update:
+- `crates/ensemble-core/src/config/form.rs`
+- `crates/ensemble-core/src/api/config_edit_handler.rs`
+- `crates/ensemble-core/tests/api_endpoints.rs`
+
+Add `runtime?: string` to the guided agent form and preserve it only when explicitly set. Do **not** force-writing `runtime: acpx` for normal `acpx_agent` entries unless the user explicitly chose it.
+
+- [ ] **Step 5: Update permission policy validation**
+
+In `validate_config(...)`, add logic like:
+
+```rust
+let any_acpx = config.agents.values().any(|agent| RuntimeKind::for_agent(agent) == RuntimeKind::Acpx);
+if any_acpx && config.agent.permission_request_policy != default_permission_request_policy() {
+    return Err(ConfigError::ConfigWriteRejected {
+        reason: "agent.permission_request_policy is ignored for acpx runtime; remove it or use direct runtime".to_string(),
+    }.into());
+}
+```
+
+If this is too strict for mixed configs, narrow it to agents explicitly configured as direct vs acpx and document the limitation in the spec/docs task.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `rtk cargo test -p ensemble-core acpx_agent_defaults_runtime_to_acpx permission_request_policy_is_rejected_for_acpx_runtime_override`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-core/src/config/ensemble.rs crates/ensemble-core/src/config/form.rs crates/ensemble-core/src/api/config_edit_handler.rs crates/ensemble-core/tests/api_endpoints.rs
+git commit -m "feat: add runtime selection config"
+```
+
+---
+
+### Task 5: Update orchestrator/bootstrap wiring and regression coverage
+
+**Files:**
+- Modify: `crates/ensemble-core/src/api/bootstrap.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Test: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Test: `crates/ensemble-core/src/api/bootstrap.rs`
+
+- [ ] **Step 1: Write failing regression tests**
+
+Add orchestrator-facing tests ensuring new event names still update state and that `acpx_agent` workers no longer expect ACP startup messages:
+
+```rust
+#[tokio::test]
+async fn handle_agent_update_accepts_prompt_started_and_output_chunk() {
+    let orchestrator = test_orchestrator();
+    orchestrator.handle_worker_event(WorkerEvent::AgentUpdate {
+        issue_id: "1".to_string(),
+        step_name: "build".to_string(),
+        event: AgentEvent::PromptStarted,
+        timestamp: chrono::Utc::now(),
+    }).await;
+    orchestrator.handle_worker_event(WorkerEvent::AgentUpdate {
+        issue_id: "1".to_string(),
+        step_name: "build".to_string(),
+        event: AgentEvent::OutputChunk { stream: RuntimeStream::Stdout, content: "hi".to_string() },
+        timestamp: chrono::Utc::now(),
+    }).await;
+}
+```
+
+And a transport regression test in bootstrap/agent tests that asserts no `initialize` JSON is sent when `acpx_agent` is used by injecting a mock `acpx` executable and checking argv/stdin.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `rtk cargo test -p ensemble-core handle_agent_update_accepts_prompt_started_and_output_chunk`
+Expected: FAIL with missing event handling.
+
+- [ ] **Step 3: Update orchestrator worker-event handling**
+
+In `crates/ensemble-core/src/orchestrator/mod.rs`, update match arms to consume new event names:
+
+```rust
+AgentEvent::PromptStarted => { /* mark running */ }
+AgentEvent::RunCompleted { usage } | AgentEvent::RunFailed { usage, .. } => { /* token accounting */ }
+AgentEvent::OutputChunk { content, .. } => { /* recent-event/state message */ }
+AgentEvent::Cancelled { .. } => { /* state messaging */ }
+AgentEvent::Warning { message } => { /* warning tracking */ }
+```
+
+Preserve current token aggregation and timeline behavior.
+
+- [ ] **Step 4: Keep bootstrap wiring minimal**
+
+In `crates/ensemble-core/src/api/bootstrap.rs`, keep the same `Arc<dyn AgentRunner>` instantiation but verify that `AcpAgentRunner::new(...)` now means runtime-dispatcher, not ACP-over-`acpx` specifically. Update comments/tests accordingly.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `rtk cargo test -p ensemble-core handle_agent_update_accepts_prompt_started_and_output_chunk`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/orchestrator/mod.rs crates/ensemble-core/src/api/bootstrap.rs
+git commit -m "refactor: wire orchestrator to runtime-agnostic agent events"
+```
+
+---
+
+### Task 6: Update docs and run full verification
+
+**Files:**
+- Modify: `docs/SPEC.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/superpowers/specs/2026-04-05-acpx-runtime-integration-design.md` (only if implementation reveals spec wording drift)
+
+- [ ] **Step 1: Update runtime docs**
+
+In `docs/SPEC.md`, replace statements that imply raw ACP-over-`acpx` with language like:
+
+```md
+When `agents.<name>.acpx_agent` is set, Ensemble executes that step through the `acpx` command/session runtime. Ensemble does not speak ACP JSON-RPC directly to `acpx`; instead it manages `acpx` sessions and consumes structured runtime events.
+```
+
+In `docs/configuration.md`, add/update:
+- `runtime` field on agents (`acpx` / `direct`)
+- `acpx_agent` defaulting behavior
+- note that `agent.permission_request_policy` applies only to direct runtime paths
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+```bash
+rtk cargo test -p ensemble-core agent::
+rtk cargo test -p ensemble-core orchestrator::
+rtk cargo test -p ensemble-core config::
+```
+Expected: PASS.
+
+- [ ] **Step 3: Run full Rust verification**
+
+Run:
+```bash
+rtk cargo test --workspace --exclude ensemble-desktop
+rtk cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+rtk cargo fmt --all -- --check
+```
+Expected: all PASS.
+
+- [ ] **Step 4: Commit final docs/cleanup**
+
+```bash
+git add docs/SPEC.md docs/configuration.md docs/superpowers/specs/2026-04-05-acpx-runtime-integration-design.md
+git commit -m "docs: describe acpx runtime integration"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+- Runtime abstraction and dual backends: Tasks 1, 3, 4
+- `acpx` session runtime replacing ACP-over-`acpx`: Tasks 2, 3, 5
+- Event/log streaming for future web UI logs: Tasks 1, 2, 5
+- Separate session per step / fresh session per retry: Tasks 2, 3, 5
+- Direct-runtime escape hatch: Tasks 3, 4
+- Config semantics for `permission_request_policy`: Task 4
+- Docs/spec updates: Task 6
+
+### Placeholder scan
+- No TBD/TODO markers
+- Every code-changing task includes concrete file paths, code snippets, and commands
+- Regression coverage included explicitly
+
+### Type consistency
+- Runtime selector name: `RuntimeKind`
+- Backend names: `AcpxRuntime`, `DirectRuntime`
+- Shared event variants: `PromptStarted`, `OutputChunk`, `RunCompleted`, `RunFailed`, `Cancelled`, `Warning`
+

--- a/docs/superpowers/specs/2026-04-05-acpx-runtime-integration-design.md
+++ b/docs/superpowers/specs/2026-04-05-acpx-runtime-integration-design.md
@@ -1,0 +1,247 @@
+# acpx Runtime Integration Design
+
+## Goal
+
+Replace Ensemble's current broken `acpx` runtime integration with a documented `acpx` command/session runtime while preserving a direct execution escape hatch.
+
+Primary outcomes:
+- `acpx_agent` uses `acpx`'s real runtime contract rather than raw ACP JSON-RPC.
+- Ensemble supports event/log streaming suitable for future web UI live logs.
+- The system retains an explicit direct-runtime escape hatch for non-`acpx` use cases.
+
+## Problem
+
+Today Ensemble treats `acpx` like an ACP stdio server. The runtime spawns commands such as:
+
+- `acpx --agent <name> --model <model>`
+
+and then sends ACP JSON-RPC messages such as:
+
+- `initialize`
+- `session/new`
+- `session/prompt`
+
+That contract is incorrect for the installed/documented `acpx` CLI. `acpx` is a command-oriented runtime wrapper around supported agents. Its documented model is session/command based (`sessions ensure`, `prompt`, `exec`, `cancel`, `sessions close`) with structured JSON output, not raw ACP JSON-RPC over stdin/stdout.
+
+The result is startup hangs and `response timeout after 5000ms` before the first prompt is even accepted.
+
+## Design Principles
+
+1. **Make `acpx` first-class** when `acpx_agent` is configured.
+2. **Keep direct execution possible** as an explicit escape hatch.
+3. **Design for streaming now** so the web UI can later show live logs without redesigning the backend.
+4. **Prefer deterministic orchestration semantics** over conversational carry-over across retries.
+5. **Do not preserve the broken hybrid contract** where Ensemble sends ACP JSON-RPC to `acpx`.
+
+## Runtime Architecture
+
+Introduce a runtime abstraction for step execution.
+
+### Runtime kinds
+
+- **AcpxRuntime**
+  - Default when `agents.<name>.acpx_agent` is set.
+  - Uses `acpx`'s documented command/session contract.
+- **DirectRuntime**
+  - Explicitly selected lower-level execution path.
+  - Retains support for non-`acpx` execution scenarios.
+
+This abstraction replaces the current assumption that all agent execution is ACP-client-shaped.
+
+## Session Model
+
+For `AcpxRuntime`, the session lifecycle is:
+
+- **One session per issue-step attempt**
+- **Separate session per step**
+- **Fresh session per retry**
+- **No session sharing across steps**
+- **No session reuse across retries**
+
+Rationale:
+- Steps may use different agents.
+- Retries should be reproducible and isolated from prior bad state.
+- A single step attempt may still internally reuse its own session across multiple turns if Ensemble continues to support multi-turn prompting inside one attempt.
+
+## acpx Command Contract
+
+### Primary command flow
+
+For each issue-step attempt using `AcpxRuntime`:
+
+1. **Ensure session exists**
+   - `acpx ... sessions ensure ...`
+2. **Start prompt execution**
+   - `acpx ... prompt ...` with prompt body provided through stdin or file
+3. **Consume structured JSON output as an event stream**
+4. **Determine final outcome**
+   - success / reject / failure / cancelled
+5. **Handle operator cancellation if requested**
+   - `acpx ... cancel ...`
+6. **Close the session best-effort**
+   - `acpx ... sessions close ...`
+
+### Optional one-shot mode
+
+`acpx ... exec ...` may be supported as a simpler operational mode, but it is not the primary orchestration design. The primary model is session-based because it better matches long-running orchestration and future live log requirements.
+
+## Event and Log Streaming Model
+
+Ensemble should treat `acpx` JSON output as a first-class runtime event stream.
+
+Add an internal normalization layer:
+
+- **Raw acpx JSON/NDJSON events**
+- mapped into **Ensemble runtime events**
+
+### Normalized event categories
+
+At minimum, the mapping layer should support these event categories:
+
+- session started
+- prompt started
+- output chunk / log line
+- tool activity
+- warning
+- error
+- completed
+- cancelled
+- malformed event
+
+The mapping should be intentionally broader than what orchestration strictly needs today so that later web UI log rendering can reuse the same event model.
+
+## Orchestrator Integration
+
+The orchestrator should consume normalized runtime events rather than ACP-specific events.
+
+### Short-term usage
+
+In the first implementation, orchestration primarily depends on:
+- prompt/session start confirmation
+- progress/log events for observability
+- completion / cancellation / failure
+- structured final outcome
+
+### Long-term usage
+
+The same event stream should later feed:
+- web UI live step logs
+- richer issue-level event history
+- tool invocation visibility
+- operator diagnostics
+
+This avoids a second redesign when UI log streaming is implemented.
+
+## Final Outcome Resolution
+
+Final step outcome should come from structured `acpx` completion output plus existing Ensemble conventions.
+
+Resolution order:
+1. Use normalized final runtime completion/cancellation/failure events if available.
+2. Apply existing workspace/verdict conventions where they still matter (for example `.ensemble/verdict.json` and interaction files).
+3. If a final state cannot be determined reliably, fail the step explicitly.
+
+Malformed or partial intermediate log events are **non-fatal** unless they prevent determining the final outcome.
+
+## Cancellation Semantics
+
+Cancellation should be explicit.
+
+- Operator stop/cancel actions trigger runtime cancellation through `acpx ... cancel ...`
+- Ensemble should not infer cancellation solely from abrupt process termination
+- Final state should distinguish:
+  - cancelled by operator
+  - failed due to runtime/transport error
+  - failed due to agent outcome
+
+## Error Handling
+
+### Startup failures
+
+Treat these as runtime startup failures:
+- `sessions ensure` failure
+- prompt command launch failure
+- immediate invalid/missing required runtime output
+
+### Streaming degradation
+
+If streaming output is partially malformed but final status is still determinable:
+- preserve final outcome
+- record degraded logging / malformed event diagnostics
+- do not fail the step solely because some log events were malformed
+
+### Unknown final state
+
+If the event stream ends and Ensemble cannot determine the final outcome:
+- mark the step failed
+- include a clear runtime error reason
+
+### Cleanup failures
+
+Best-effort session close should not overwrite the primary step result unless cleanup failure itself is the only available signal and no prior result exists.
+
+## Configuration Behavior
+
+### Default behavior
+
+- `agents.<name>.acpx_agent` implies **AcpxRuntime** by default
+- direct runtime is only used when explicitly configured
+
+### Compatibility behavior
+
+Ensemble continues to support both runtime families, but the normal/high-level path is `acpx`.
+
+### Permission behavior
+
+Per-agent `permission_mode` continues to control launch-time `acpx` permission flags where supported by the `acpx` CLI contract.
+
+For `AcpxRuntime`, `agent.permission_request_policy` does not drive runtime permission callbacks and should be treated as unsupported/ignored for that backend. It remains meaningful only for `DirectRuntime` paths that still implement client-side permission handling.
+
+## Testing Strategy
+
+Add tests for:
+
+1. runtime selection
+   - `acpx_agent` selects `AcpxRuntime` by default
+   - explicit direct configuration selects `DirectRuntime`
+2. session lifecycle
+   - one session per issue-step attempt
+   - separate sessions per step
+   - fresh sessions per retry
+3. command contract
+   - session ensure / prompt / cancel / close invocation shape
+4. event mapping
+   - valid JSON events map into normalized runtime events
+   - malformed events are surfaced as diagnostics, not silent drops
+5. outcome resolution
+   - success / failure / cancelled / unknown final state
+6. cleanup semantics
+   - close failures are best-effort
+7. regression coverage
+   - Ensemble no longer sends ACP JSON-RPC messages to `acpx`
+
+## Migration Notes
+
+The implementation is an architectural pivot in the runtime layer, not a bugfix limited to timeout settings.
+
+The migration should:
+- preserve public config compatibility where reasonable
+- keep `acpx_agent` user intent intact
+- remove the incorrect transport assumption from the runtime internals
+
+## Non-Goals
+
+This design does not require in the first slice:
+- full web UI live log rendering
+- all possible `acpx` event types to be user-visible
+- removal of the direct execution escape hatch
+- preserving the current ACP-client implementation as the `acpx` path
+
+## Recommended Implementation Direction
+
+Implement `AcpxRuntime` as the new default runtime for `acpx_agent`, retain `DirectRuntime` as an explicit escape hatch, and build the runtime around structured streaming events from day one.
+
+This is the lowest-risk way to:
+- align Ensemble with documented `acpx` behavior,
+- preserve `acpx` as the cross-agent abstraction layer,
+- and support future web UI logs without another backend redesign.


### PR DESCRIPTION
## Summary
- replace the broken ACP-over-`acpx` path with a real acpx session/CLI runtime, including runtime selection, structured event mapping, and updated orchestrator wiring
- document the runtime design and implementation plan, and update config/spec docs for `acpx` runtime behavior and permission semantics
- harden the runtime with explicit override handling, cleanup/logging improvements, cancellation support, prompt-child cleanup, panic-safe bookkeeping, and follow-up validation/test fixes

## Included Work
- add `AcpxRuntime`, `AcpxCli`, runtime selection, and runtime-agnostic agent events
- route `acpx_agent` configs through the acpx runtime while preserving `runtime: direct` as the escape hatch
- update orchestrator handling for streamed runtime events, token accounting, and session metadata
- add cancellation registry plumbing so stop/shutdown requests can cancel acpx runs cleanly
- tighten config validation for mixed direct/acpx setups and preserve backward-compatible permission-policy handling
- add and update tests/docs covering runtime selection, acpx lifecycle behavior, cancellation, and follow-up hardening items

## Test Plan
- [x] rtk cargo test --workspace --exclude ensemble-desktop
- [x] rtk cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- [x] rtk cargo fmt --all -- --check