### PR TITLE
Fix todo_file generated ID transitions and align fallback IDs

### DIFF
--- a/crates/ensemble-core/src/config/template.rs
+++ b/crates/ensemble-core/src/config/template.rs
@@ -44,22 +44,31 @@ pub fn render_prompt_with_interaction_response(
         "labels": issue.labels,
     });
 
-    // Optional string fields: present as value or absent (nil)
-    if let Some(ref desc) = issue.description {
-        issue_obj.insert(
-            "description".into(),
-            liquid::model::Value::scalar(desc.clone()),
-        );
-    }
-    if let Some(ref bn) = issue.branch_name {
-        issue_obj.insert(
-            "branch_name".into(),
-            liquid::model::Value::scalar(bn.clone()),
-        );
-    }
-    if let Some(ref u) = issue.url {
-        issue_obj.insert("url".into(), liquid::model::Value::scalar(u.clone()));
-    }
+    // Optional fields are always present for issue.*, using nil when absent.
+    issue_obj.insert(
+        "description".into(),
+        issue
+            .description
+            .as_ref()
+            .map_or(liquid::model::Value::Nil, |desc| {
+                liquid::model::Value::scalar(desc.clone())
+            }),
+    );
+    issue_obj.insert(
+        "branch_name".into(),
+        issue
+            .branch_name
+            .as_ref()
+            .map_or(liquid::model::Value::Nil, |branch_name| {
+                liquid::model::Value::scalar(branch_name.clone())
+            }),
+    );
+    issue_obj.insert(
+        "url".into(),
+        issue.url.as_ref().map_or(liquid::model::Value::Nil, |url| {
+            liquid::model::Value::scalar(url.clone())
+        }),
+    );
 
     let mut globals = liquid::object!({
         "issue": issue_obj,
@@ -154,6 +163,15 @@ mod tests {
         let template = "{% if issue.description %}has desc{% else %}no desc{% endif %}";
         let result = render_prompt(template, &issue, None).unwrap();
         assert_eq!(result, "no desc");
+    }
+
+    #[test]
+    fn test_render_missing_description_direct_access_renders_empty() {
+        let mut issue = test_issue();
+        issue.description = None;
+        let template = "{{ issue.description }}";
+        let result = render_prompt(template, &issue, None).unwrap();
+        assert_eq!(result, "");
     }
 
     #[test]

--- a/crates/ensemble-core/src/tracker/todo_file.rs
+++ b/crates/ensemble-core/src/tracker/todo_file.rs
@@ -264,6 +264,9 @@ fn collect_issue_block(lines: &[&str], start_idx: usize) -> (Vec<String>, usize)
 
 fn locate_issue_block(lines: &[&str], id: &str) -> Option<(usize, usize, Vec<String>)> {
     let mut current_state: Option<String> = None;
+    // Generated IDs depend on `(state, position_in_state, title_slug)`, so this counter must
+    // mirror parse order for the *current file snapshot*. If list order changes between runs,
+    // generated IDs for no-bracket items may also change.
     let mut position_in_state: i32 = 0;
 
     for (idx, line) in lines.iter().enumerate() {
@@ -291,7 +294,7 @@ fn locate_issue_block(lines: &[&str], id: &str) -> Option<(usize, usize, Vec<Str
             continue;
         }
 
-        let (mut issue_block, end_idx) = collect_issue_block(lines, idx);
+        let (mut issue_lines, end_idx) = collect_issue_block(lines, idx);
         let explicit_identifier = rest.starts_with('[')
             && rest
                 .find(']')
@@ -299,14 +302,17 @@ fn locate_issue_block(lines: &[&str], id: &str) -> Option<(usize, usize, Vec<Str
                 .unwrap_or(false);
 
         if !explicit_identifier {
-            issue_block[0] = if title.is_empty() {
+            let rewritten_first_line = if title.is_empty() {
                 format!("- [{id}]")
             } else {
                 format!("- [{id}] {title}")
             };
+            if let Some(first_line) = issue_lines.first_mut() {
+                *first_line = rewritten_first_line;
+            }
         }
 
-        return Some((idx, end_idx, issue_block));
+        return Some((idx, end_idx, issue_lines));
     }
 
     None
@@ -998,5 +1004,32 @@ mod tests {
         assert_eq!(done.len(), 1);
         assert_eq!(done[0].identifier, generated_id);
         assert_eq!(done[0].state, "Done");
+    }
+
+    #[tokio::test]
+    async fn test_set_issue_state_whitespace_only_title_item() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"## Todo
+-   
+
+## In Progress
+"#;
+        let path = write_todo(dir.path(), content);
+        let tracker = TodoFileTracker::new(path.clone(), active_states());
+
+        tracker
+            .set_issue_state("todo-0", "In Progress")
+            .await
+            .unwrap();
+
+        let in_progress = tracker
+            .fetch_issues_by_states(&["In Progress".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(in_progress.len(), 1);
+        assert_eq!(in_progress[0].identifier, "todo-0");
+
+        let written = tokio::fs::read_to_string(path).await.unwrap();
+        assert!(written.contains("- [todo-0]"));
     }
 }

--- a/crates/ensemble-core/src/tracker/todo_file.rs
+++ b/crates/ensemble-core/src/tracker/todo_file.rs
@@ -236,6 +236,82 @@ fn state_matches(state: &str, states: &[String]) -> bool {
     states.iter().any(|s| s.eq_ignore_ascii_case(state))
 }
 
+fn collect_issue_block(lines: &[&str], start_idx: usize) -> (Vec<String>, usize) {
+    let mut issue_block: Vec<String> = vec![lines[start_idx].to_string()];
+    let mut end_idx = start_idx + 1;
+    while end_idx < lines.len() {
+        let line = lines[end_idx];
+        // A continuation line is either blank or starts with whitespace.
+        if line.is_empty() || line.starts_with("  ") || line.starts_with('\t') {
+            issue_block.push(line.to_string());
+            end_idx += 1;
+        } else {
+            break;
+        }
+    }
+
+    // Trim trailing blank lines from the issue block so we don't accumulate extra whitespace.
+    while issue_block
+        .last()
+        .map(|line| line.trim().is_empty())
+        .unwrap_or(false)
+    {
+        issue_block.pop();
+    }
+
+    (issue_block, end_idx)
+}
+
+fn locate_issue_block(lines: &[&str], id: &str) -> Option<(usize, usize, Vec<String>)> {
+    let mut current_state: Option<String> = None;
+    let mut position_in_state: i32 = 0;
+
+    for (idx, line) in lines.iter().enumerate() {
+        if let Some(heading) = line.strip_prefix("## ") {
+            let heading = heading.trim();
+            if !heading.is_empty() {
+                current_state = Some(heading.to_string());
+                position_in_state = 0;
+            }
+            continue;
+        }
+
+        let Some(rest) = line.strip_prefix("- ") else {
+            continue;
+        };
+        let Some(state) = current_state.as_ref() else {
+            continue;
+        };
+
+        let rest = rest.trim();
+        let (parsed_id, title) = extract_identifier_and_title(rest, state, position_in_state);
+        position_in_state += 1;
+
+        if parsed_id != id {
+            continue;
+        }
+
+        let (mut issue_block, end_idx) = collect_issue_block(lines, idx);
+        let explicit_identifier = rest.starts_with('[')
+            && rest
+                .find(']')
+                .map(|end| !rest[1..end].trim().is_empty())
+                .unwrap_or(false);
+
+        if !explicit_identifier {
+            issue_block[0] = if title.is_empty() {
+                format!("- [{id}]")
+            } else {
+                format!("- [{id}] {title}")
+            };
+        }
+
+        return Some((idx, end_idx, issue_block));
+    }
+
+    None
+}
+
 #[async_trait]
 impl IssueTracker for TodoFileTracker {
     /// Fetch candidate issues in active states for dispatch.
@@ -296,49 +372,16 @@ impl IssueTracker for TodoFileTracker {
 
         let lines: Vec<&str> = content.lines().collect();
 
-        // Identify the issue block: the `- [ID]` line plus any immediately following
-        // indented continuation lines.
-        let issue_prefix = format!("- [{id}]");
-        let issue_line_idx = lines.iter().position(|l| {
-            l.starts_with(&issue_prefix) && {
-                // Confirm the character after `]` is either end-of-line, a space, or nothing
-                // (avoids matching `[PROJ-10]` when searching for `[PROJ-1]`).
-                let after = &l[issue_prefix.len()..];
-                after.is_empty() || after.starts_with(' ')
-            }
-        });
-
-        let issue_line_idx = match issue_line_idx {
-            Some(i) => i,
+        // Identify the issue block from parsed identifiers so both bracketed IDs and
+        // generated slug IDs can be transitioned.
+        let (issue_line_idx, end_idx, issue_block) = match locate_issue_block(&lines, id) {
+            Some(result) => result,
             None => {
                 return Err(TrackerError::IoError {
                     reason: format!("issue [{id}] not found in {}", self.path.display()),
                 });
             }
         };
-
-        // Collect the full issue block (title line + indented continuation lines).
-        let mut issue_block: Vec<String> = vec![lines[issue_line_idx].to_string()];
-        let mut end_idx = issue_line_idx + 1;
-        while end_idx < lines.len() {
-            let line = lines[end_idx];
-            // A continuation line is either blank or starts with whitespace.
-            if line.is_empty() || line.starts_with("  ") || line.starts_with('\t') {
-                issue_block.push(line.to_string());
-                end_idx += 1;
-            } else {
-                break;
-            }
-        }
-
-        // Trim trailing blank lines from the issue block so we don't accumulate extra whitespace.
-        while issue_block
-            .last()
-            .map(|l| l.trim().is_empty())
-            .unwrap_or(false)
-        {
-            issue_block.pop();
-        }
 
         // Build the new file content without the issue block.
         let mut new_lines: Vec<String> = lines
@@ -894,5 +937,66 @@ mod tests {
             written.contains("## Done"),
             "expected '## Done' heading in file"
         );
+    }
+
+    #[tokio::test]
+    async fn test_set_issue_state_moves_slug_identifier_and_bracketizes_line() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"## Todo
+- Configure build toolchain
+  Verify all dependencies resolve.
+
+## In Progress
+"#;
+        let path = write_todo(dir.path(), content);
+        let tracker = TodoFileTracker::new(path.clone(), active_states());
+
+        let generated_id = "todo-0-configure-build-toolchain";
+        tracker
+            .set_issue_state(generated_id, "In Progress")
+            .await
+            .unwrap();
+
+        let all_issues = tracker
+            .fetch_issues_by_states(&["Todo".to_string(), "In Progress".to_string()])
+            .await
+            .unwrap();
+        let moved = all_issues
+            .iter()
+            .find(|issue| issue.identifier == generated_id)
+            .unwrap();
+        assert_eq!(moved.state, "In Progress");
+
+        let written = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(written.contains("- [todo-0-configure-build-toolchain] Configure build toolchain"));
+    }
+
+    #[tokio::test]
+    async fn test_set_issue_state_slug_identifier_can_transition_again() {
+        let dir = TempDir::new().unwrap();
+        let content = r#"## Todo
+- Do the thing
+
+## In Progress
+
+## Done
+"#;
+        let path = write_todo(dir.path(), content);
+        let tracker = TodoFileTracker::new(path, active_states());
+
+        let generated_id = "todo-0-do-the-thing";
+        tracker
+            .set_issue_state(generated_id, "In Progress")
+            .await
+            .unwrap();
+        tracker.set_issue_state(generated_id, "Done").await.unwrap();
+
+        let done = tracker
+            .fetch_issues_by_states(&["Done".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].identifier, generated_id);
+        assert_eq!(done[0].state, "Done");
     }
 }

--- a/crates/ensemble-core/src/tracker/todo_file.rs
+++ b/crates/ensemble-core/src/tracker/todo_file.rs
@@ -158,8 +158,7 @@ fn parse_todo_content(content: &str) -> Vec<ParsedIssue> {
 /// Extract identifier and title from a list item.
 ///
 /// If the line starts with `[IDENTIFIER]`, extracts the identifier and remaining title.
-/// Otherwise generates a stable slug from the title, incorporating the state and
-/// position to ensure uniqueness and handle non-alphanumeric-only titles.
+/// Otherwise generates a stable identifier from state + position.
 fn extract_identifier_and_title(line: &str, state: &str, position: i32) -> (String, String) {
     if line.starts_with('[') {
         if let Some(end) = line.find(']') {
@@ -170,16 +169,9 @@ fn extract_identifier_and_title(line: &str, state: &str, position: i32) -> (Stri
             }
         }
     }
-    // No bracketed identifier — generate a stable slug with position for uniqueness.
-    // The position suffix ensures duplicate titles produce distinct identifiers,
-    // and provides a fallback when the title contains no ASCII alphanumeric chars.
-    let slug = generate_slug(line);
+    // No bracketed identifier — generate a stable state+position identifier.
     let state_slug = generate_slug(state);
-    let identifier = if slug.is_empty() {
-        format!("{}-{}", state_slug, position)
-    } else {
-        format!("{}-{}-{}", state_slug, position, slug)
-    };
+    let identifier = format!("{}-{}", state_slug, position);
     (identifier, line.to_string())
 }
 
@@ -538,10 +530,10 @@ mod tests {
         let issues = parse_todo_content(content);
         assert_eq!(issues.len(), 2);
 
-        assert_eq!(issues[0].identifier, "todo-0-add-login-page");
+        assert_eq!(issues[0].identifier, "todo-0");
         assert_eq!(issues[0].title, "Add login page");
 
-        assert_eq!(issues[1].identifier, "todo-1-fix-the-checkout-bug");
+        assert_eq!(issues[1].identifier, "todo-1");
         assert_eq!(issues[1].title, "Fix the checkout bug!");
     }
 
@@ -605,8 +597,8 @@ mod tests {
         let content = "## Todo\n- [] Some title\n";
         let issues = parse_todo_content(content);
         assert_eq!(issues.len(), 1);
-        // Empty brackets -> fallback to slug with state-position prefix
-        assert_eq!(issues[0].identifier, "todo-0-some-title");
+        // Empty brackets -> fallback to state-position identifier
+        assert_eq!(issues[0].identifier, "todo-0");
         assert_eq!(issues[0].title, "[] Some title");
     }
 
@@ -622,7 +614,7 @@ mod tests {
     #[test]
     fn test_extract_without_identifier() {
         let (id, title) = extract_identifier_and_title("Add login page", "Todo", 0);
-        assert_eq!(id, "todo-0-add-login-page");
+        assert_eq!(id, "todo-0");
         assert_eq!(title, "Add login page");
     }
 
@@ -646,8 +638,8 @@ mod tests {
         let (id1, _) = extract_identifier_and_title("Fix bug", "Todo", 0);
         let (id2, _) = extract_identifier_and_title("Fix bug", "Todo", 1);
         assert_ne!(id1, id2);
-        assert_eq!(id1, "todo-0-fix-bug");
-        assert_eq!(id2, "todo-1-fix-bug");
+        assert_eq!(id1, "todo-0");
+        assert_eq!(id2, "todo-1");
     }
 
     // --- generate_slug tests ---
@@ -957,7 +949,7 @@ mod tests {
         let path = write_todo(dir.path(), content);
         let tracker = TodoFileTracker::new(path.clone(), active_states());
 
-        let generated_id = "todo-0-configure-build-toolchain";
+        let generated_id = "todo-0";
         tracker
             .set_issue_state(generated_id, "In Progress")
             .await
@@ -974,7 +966,7 @@ mod tests {
         assert_eq!(moved.state, "In Progress");
 
         let written = tokio::fs::read_to_string(&path).await.unwrap();
-        assert!(written.contains("- [todo-0-configure-build-toolchain] Configure build toolchain"));
+        assert!(written.contains("- [todo-0] Configure build toolchain"));
     }
 
     #[tokio::test]
@@ -990,7 +982,7 @@ mod tests {
         let path = write_todo(dir.path(), content);
         let tracker = TodoFileTracker::new(path, active_states());
 
-        let generated_id = "todo-0-do-the-thing";
+        let generated_id = "todo-0";
         tracker
             .set_issue_state(generated_id, "In Progress")
             .await

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -469,8 +469,11 @@ Parsing rules:
 - Level-2 headings (`## <State>`) define state sections.
 - List items under a heading are issues. The first line is the title.
 - If the title starts with `[<identifier>]`, that bracketed value is the issue identifier.
-  Otherwise, the implementation generates a stable identifier from the title (for example a
-  slugified hash).
+- Otherwise, the implementation generates a stable identifier from state + position + title slug
+  (for example `todo-0-add-login-page`).
+- Items without bracketed IDs are supported for dispatch and state transitions. When moved to a
+  new state, implementations may normalize the list line to bracket form
+  (`- [generated-id] Title`) so future transitions remain stable.
 - Indented lines after the title line (before the next list item) are the description.
 - The file is re-read on each poll tick. Implementations may also watch for file changes.
 - Issues are returned in document order within each state section.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -469,8 +469,8 @@ Parsing rules:
 - Level-2 headings (`## <State>`) define state sections.
 - List items under a heading are issues. The first line is the title.
 - If the title starts with `[<identifier>]`, that bracketed value is the issue identifier.
-- Otherwise, the implementation generates a stable identifier from state + position + title slug
-  (for example `todo-0-add-login-page`).
+- Otherwise, the implementation generates a stable identifier from state + position
+  (for example `todo-0`).
 - Items without bracketed IDs are supported for dispatch and state transitions. When moved to a
   new state, implementations may normalize the list line to bracket form
   (`- [generated-id] Title`) so future transitions remain stable.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,7 +178,7 @@ Todo file issue format:
 
 - `- [ID] Title` (explicit ID) or `- Title` (ID auto-generated) are both valid.
 - Indented lines under an item are treated as description text.
-- Auto-generated IDs follow a stable `state-position-slug` format (for example `todo-0-fix-bug`).
+- Auto-generated IDs follow a stable `state-position` format (for example `todo-0`).
 - When a no-ID item is moved between states, Ensemble may rewrite it to bracket form
   (`- [generated-id] Title`) to stabilize future state transitions.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,6 +174,14 @@ Defines where Ensemble reads and writes issues.
 
 For todo_file trackers, if `path` is not specified, it defaults to `~/ensemble/TODO.md` (the `ensemble` directory in your home folder).
 
+Todo file issue format:
+
+- `- [ID] Title` (explicit ID) or `- Title` (ID auto-generated) are both valid.
+- Indented lines under an item are treated as description text.
+- Auto-generated IDs follow a stable `state-position-slug` format (for example `todo-0-fix-bug`).
+- When a no-ID item is moved between states, Ensemble may rewrite it to bracket form
+  (`- [generated-id] Title`) to stabilize future state transitions.
+
 ### repos
 
 List of repositories for workspace setup. Paths can be absolute or relative to the config directory.


### PR DESCRIPTION
## Summary
- make Liquid issue optional fields render as nil when absent so direct issue.description access does not error in strict mode
- allow todo_file state transitions for generated IDs from plain list items and normalize moved items to bracketed IDs for stable future transitions
- align fallback generated TODO IDs to state+position (for example, todo-0) and update related tracker tests
- update SPEC/configuration docs to match the generated-ID behavior

## Test Plan
- [x] cargo test --workspace --exclude ensemble-desktop
- [x] cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- [x] cargo fmt --all -- --check
- [x] cargo test -p ensemble-core tracker::todo_file::tests:: -- --nocapture