### PR TITLE
Fix acpx argument order and retry exhaustion handling

### DIFF
--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -331,6 +331,7 @@ mod tests {
                 args_path.display()
             ),
         );
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
         let client = AcpxCli::new(script);
         client

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -25,17 +25,36 @@ impl AcpxCli {
         cwd: &Path,
         model: Option<&str>,
     ) -> Result<(), AgentError> {
-        let mut command = self.base_command(agent, cwd, model);
-        command.args(["sessions", "ensure", "--name", session_name]);
-        debug!(agent, session_name, cwd = %cwd.display(), "running acpx sessions ensure");
+        let mut command = Command::new(&self.executable);
+        command.kill_on_drop(true);
+        if let Some(model) = model {
+            command.args(["--model", model]);
+        }
+        command
+            .arg("--cwd")
+            .arg(cwd.display().to_string())
+            .args(["--format", "json", "--json-strict"])
+            .arg(agent)
+            .args(["sessions", "ensure", "--name", session_name]);
+        debug!(agent, session_name, cwd = %cwd.display(), model, "running acpx sessions ensure");
 
-        let status = command.status().await.map_err(|e| AgentError::IoError {
+        let output = command.output().await.map_err(|e| AgentError::IoError {
             reason: format!("failed to run acpx sessions ensure: {e}"),
         })?;
-        if !status.success() {
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let reason = if stderr.is_empty() && stdout.is_empty() {
+                output.status.to_string()
+            } else {
+                format!(
+                    "{}; stderr: {}; stdout: {}",
+                    output.status, stderr.trim(), stdout.trim()
+                )
+            };
             return Err(AgentError::AcpxCommandFailed {
                 command: "sessions ensure".to_string(),
-                reason: status.to_string(),
+                reason,
             });
         }
 
@@ -185,14 +204,15 @@ impl AcpxCli {
 
     fn base_command(&self, agent: &str, cwd: &Path, model: Option<&str>) -> Command {
         let mut command = Command::new(&self.executable);
-        command
-            .kill_on_drop(true)
-            .args(["--format", "json", "--json-strict", "--cwd"])
-            .arg(cwd)
-            .arg(agent);
+        command.kill_on_drop(true);
         if let Some(model) = model {
             command.args(["--model", model]);
         }
+        command
+            .arg("--cwd")
+            .arg(cwd.display().to_string())
+            .args(["--format", "json", "--json-strict"])
+            .arg(agent);
         command
     }
 }
@@ -296,6 +316,39 @@ mod tests {
         let args = std::fs::read_to_string(args_path).unwrap();
         assert!(args.contains("sessions ensure"));
         assert!(args.contains("--name build-session"));
+    }
+
+    #[tokio::test]
+    async fn ensure_session_puts_model_before_agent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let args_path = dir.path().join("args.txt");
+        let script = write_mock_acpx_script(
+            dir.path(),
+            &format!(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" > \"{}\"\n",
+                args_path.display()
+            ),
+        );
+
+        let client = AcpxCli::new(script);
+        client
+            .ensure_session(
+                "codex",
+                "build-session",
+                dir.path(),
+                Some("gpt-5.4/medium"),
+            )
+            .await
+            .unwrap();
+
+        let args = std::fs::read_to_string(args_path).unwrap();
+        let model_pos = args.find("--model").expect("--model should be present");
+        let agent_pos = args.find("codex").expect("codex agent should be present");
+        assert!(
+            model_pos < agent_pos,
+            "--model must come BEFORE agent; got: {}",
+            args
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -49,7 +49,9 @@ impl AcpxCli {
             } else {
                 format!(
                     "{}; stderr: {}; stdout: {}",
-                    output.status, stderr.trim(), stdout.trim()
+                    output.status,
+                    stderr.trim(),
+                    stdout.trim()
                 )
             };
             return Err(AgentError::AcpxCommandFailed {
@@ -332,12 +334,7 @@ mod tests {
 
         let client = AcpxCli::new(script);
         client
-            .ensure_session(
-                "codex",
-                "build-session",
-                dir.path(),
-                Some("gpt-5.4/medium"),
-            )
+            .ensure_session("codex", "build-session", dir.path(), Some("gpt-5.4/medium"))
             .await
             .unwrap();
 

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -289,6 +289,7 @@ mod tests {
         let script_path = dir.join("mock_acpx.sh");
         let mut file = std::fs::File::create(&script_path).unwrap();
         file.write_all(script_content.as_bytes()).unwrap();
+        file.sync_all().unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -331,7 +332,6 @@ mod tests {
                 args_path.display()
             ),
         );
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
         let client = AcpxCli::new(script);
         client

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -58,6 +58,9 @@ impl AcpxRuntime {
         debug!(
             issue_id = %request.issue.id,
             step = request.step_name,
+            agent_name = request.agent_name,
+            acpx_agent,
+            model = agent.model.as_deref(),
             session_name,
             "ensuring acpx session"
         );

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -819,19 +819,9 @@ impl Orchestrator {
                                 reason = %reason,
                                 "pipeline failed"
                             );
-                            // Set tracker to on_failure state
-                            if self.tracker.supports_writes() {
-                                if let Err(e) = self
-                                    .tracker
-                                    .set_issue_state(issue_id, &config.on_failure)
-                                    .await
-                                {
-                                    warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
-                                }
-                            }
                             if let Some(entry) = state.remove_running(issue_id) {
                                 state.add_runtime_seconds(&entry);
-                                schedule_failure_retry(
+                                let retry_scheduled = schedule_failure_retry(
                                     &mut state,
                                     issue_id,
                                     &entry.identifier,
@@ -840,6 +830,15 @@ impl Orchestrator {
                                     config.max_cycles,
                                     &reason,
                                 );
+                                if retry_scheduled.is_none() && self.tracker.supports_writes() {
+                                    if let Err(e) = self
+                                        .tracker
+                                        .set_issue_state(issue_id, &config.on_failure)
+                                        .await
+                                    {
+                                        warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
+                                    }
+                                }
                             }
                             state.remove_pipeline_run(issue_id);
                         }
@@ -903,25 +902,13 @@ impl Orchestrator {
                     "worker exited with failure"
                 );
 
-                // Notify pipeline of step failure
                 if let Some(run) = state.get_pipeline_run_mut(issue_id) {
                     run.step_failed(step_name, error.clone());
                 }
 
-                // Set tracker to on_failure state
-                if self.tracker.supports_writes() {
-                    if let Err(e) = self
-                        .tracker
-                        .set_issue_state(issue_id, &config.on_failure)
-                        .await
-                    {
-                        warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
-                    }
-                }
-
                 if let Some(entry) = state.remove_running(issue_id) {
                     state.add_runtime_seconds(&entry);
-                    schedule_failure_retry(
+                    let retry_scheduled = schedule_failure_retry(
                         &mut state,
                         issue_id,
                         &entry.identifier,
@@ -930,6 +917,15 @@ impl Orchestrator {
                         config.max_cycles,
                         &error,
                     );
+                    if retry_scheduled.is_none() && self.tracker.supports_writes() {
+                        if let Err(e) = self
+                            .tracker
+                            .set_issue_state(issue_id, &config.on_failure)
+                            .await
+                        {
+                            warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
+                        }
+                    }
                 }
                 state.remove_pipeline_run(issue_id);
             }


### PR DESCRIPTION
## Summary
- Fix `--model` argument order: must come **before** agent name in acpx commands (e.g., `acpx --model 'gpt-5.4/medium' codex`, not `acpx codex --model 'gpt-5.4/medium'`)
- Fix `ensure_session` to capture stderr/stdout on failure instead of just exit code
- Fix premature terminal state: issues only move to "Failed" when retries are exhausted, not on every failure
- Add debug logging for `agent_name`, `acpx_agent`, and `model` in acpx_runtime
- Add regression test for `--model` argument ordering

## Testing
- All 672 tests pass
- Manual testing with TODO.md tracker confirms `sessions ensure` now works correctly