### PR TITLE
Move worktrees into workspace and harden cleanup

### DIFF
--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -276,7 +276,6 @@ fn map_event(value: serde_json::Value) -> AgentEvent {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
     use std::path::Path;
     use std::sync::{Arc, Mutex};
 

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -287,9 +287,7 @@ mod tests {
 
     fn write_mock_acpx_script(dir: &Path, script_content: &str) -> String {
         let script_path = dir.join("mock_acpx.sh");
-        let mut file = std::fs::File::create(&script_path).unwrap();
-        file.write_all(script_content.as_bytes()).unwrap();
-        file.sync_all().unwrap();
+        std::fs::write(&script_path, script_content).unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -78,6 +78,8 @@ pub enum WorktreeError {
     RollbackFailed { reason: String },
     #[error("invalid repo path: {path}")]
     InvalidRepoPath { path: String },
+    #[error("cleanup failed for {repo}: {error}")]
+    CleanupFailed { repo: String, error: String },
 }
 
 #[derive(Debug, Error)]

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -23,11 +23,20 @@ pub struct WorktreeInfo {
 pub struct WorktreeCoordinator {
     repos: HashMap<String, RepoConfig>,
     base_date: String,
+    worktree_root: PathBuf,
 }
 
 impl WorktreeCoordinator {
-    pub fn new(repos: HashMap<String, RepoConfig>, base_date: String) -> Self {
-        Self { repos, base_date }
+    pub fn new(
+        repos: HashMap<String, RepoConfig>,
+        base_date: String,
+        worktree_root: PathBuf,
+    ) -> Self {
+        Self {
+            repos,
+            base_date,
+            worktree_root,
+        }
     }
 
     /// Prepare worktrees for all configured repos for the given issue.
@@ -54,7 +63,7 @@ impl WorktreeCoordinator {
                 });
             }
 
-            let worktree_path = repo_path.join(".worktrees").join(&branch);
+            let worktree_path = self.worktree_root.join(repo_name).join(&branch);
             let worktree_path_str = worktree_path.to_string_lossy().to_string();
             let repo_path_str = &repo_config.path;
 
@@ -180,17 +189,33 @@ impl WorktreeCoordinator {
 
         info!(issue_id, branch, "cleaning up worktrees");
 
+        let mut errors = Vec::new();
+
         for (repo_name, repo_config) in &self.repos {
-            let repo_path = Path::new(&repo_config.path);
-            let worktree_path = repo_path.join(".worktrees").join(&branch);
+            let worktree_path = self.worktree_root.join(repo_name).join(&branch);
             let worktree_path_str = worktree_path.to_string_lossy().to_string();
 
             if let Err(e) = remove_worktree(&repo_config.path, &worktree_path_str, &branch).await {
-                warn!(repo = repo_name, error = %e, "failed to cleanup worktree (continuing)");
+                match e {
+                    WorktreeError::NotFound { .. } => {
+                        warn!(repo = repo_name, "worktree already absent during cleanup");
+                    }
+                    other => {
+                        warn!(repo = repo_name, error = %other, "failed to cleanup worktree");
+                        errors.push(WorktreeError::CleanupFailed {
+                            repo: repo_name.clone(),
+                            error: other.to_string(),
+                        });
+                    }
+                }
             }
         }
 
-        Ok(())
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.into_iter().next().unwrap())
+        }
     }
 
     /// List expected worktree paths for an issue without creating them.
@@ -198,9 +223,8 @@ impl WorktreeCoordinator {
         let branch = self.format_branch_name(issue_id);
         let mut paths = HashMap::new();
 
-        for (repo_name, repo_config) in &self.repos {
-            let repo_path = Path::new(&repo_config.path);
-            let worktree_path = repo_path.join(".worktrees").join(&branch);
+        for repo_name in self.repos.keys() {
+            let worktree_path = self.worktree_root.join(repo_name).join(&branch);
             paths.insert(repo_name.clone(), worktree_path);
         }
 
@@ -241,7 +265,11 @@ mod tests {
     #[test]
     fn test_format_branch_name() {
         let repos = HashMap::new();
-        let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+        let coordinator = WorktreeCoordinator::new(
+            repos,
+            "2026-03-30".to_string(),
+            PathBuf::from("/tmp/worktrees"),
+        );
 
         let branch = coordinator.format_branch_name("my-repo#42");
         assert_eq!(branch, "ensemble-2026-03-30-my-repo-42");

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -1,8 +1,8 @@
 use crate::config::ensemble::RepoConfig;
 use crate::error::WorktreeError;
 use crate::workspace::worktree::{
-    attach_worktree, branch_exists, create_worktree, pull_worktree, remove_orphaned_worktree,
-    remove_worktree, sanitize_branch_name, worktree_exists,
+    attach_worktree, branch_exists, create_worktree, delete_branch_if_exists, pull_worktree,
+    remove_orphaned_worktree, remove_worktree, sanitize_branch_name, worktree_exists,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -189,7 +189,7 @@ impl WorktreeCoordinator {
 
         info!(issue_id, branch, "cleaning up worktrees");
 
-        let mut errors = Vec::new();
+        let mut errors: Vec<(String, String)> = Vec::new();
 
         for (repo_name, repo_config) in &self.repos {
             let worktree_path = self.worktree_root.join(repo_name).join(&branch);
@@ -199,13 +199,15 @@ impl WorktreeCoordinator {
                 match e {
                     WorktreeError::NotFound { .. } => {
                         warn!(repo = repo_name, "worktree already absent during cleanup");
+                        if let Err(orphan_error) =
+                            delete_branch_if_exists(&repo_config.path, &branch).await
+                        {
+                            errors.push((repo_name.clone(), orphan_error.to_string()));
+                        }
                     }
                     other => {
                         warn!(repo = repo_name, error = %other, "failed to cleanup worktree");
-                        errors.push(WorktreeError::CleanupFailed {
-                            repo: repo_name.clone(),
-                            error: other.to_string(),
-                        });
+                        errors.push((repo_name.clone(), other.to_string()));
                     }
                 }
             }
@@ -214,7 +216,16 @@ impl WorktreeCoordinator {
         if errors.is_empty() {
             Ok(())
         } else {
-            Err(errors.into_iter().next().unwrap())
+            errors.sort_by(|a, b| a.0.cmp(&b.0));
+            let error = errors
+                .into_iter()
+                .map(|(repo, error)| format!("{repo}: {error}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            Err(WorktreeError::CleanupFailed {
+                repo: "multiple repos".to_string(),
+                error,
+            })
         }
     }
 

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -4,6 +4,21 @@ use crate::tracker::model::sanitize_workspace_key;
 use crate::workspace::coordinator::{WorktreeCoordinator, WorktreeInfo};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use tokio::fs;
+use tracing::{info, warn};
+
+const WORKSPACE_METADATA_FILE: &str = ".ensemble-workspace.json";
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct WorkspaceMetadata {
+    branch_date: String,
+}
+
+/// Manage per-issue workspace directories.
+pub struct WorkspaceManager {
+    root: PathBuf,
+    repos: HashMap<String, RepoConfig>,
+}
 
 /// Result of preparing a workspace for an issue.
 pub struct WorkspaceResult {
@@ -15,12 +30,6 @@ pub struct WorkspaceResult {
     pub workspace_key: String,
     /// True if the directory was newly created (not reused).
     pub created_now: bool,
-}
-
-/// Manage per-issue workspace directories.
-pub struct WorkspaceManager {
-    root: PathBuf,
-    worktree_coordinator: Option<WorktreeCoordinator>,
 }
 
 impl WorkspaceManager {
@@ -39,23 +48,25 @@ impl WorkspaceManager {
                 .join(root)
         };
 
-        let worktree_coordinator = repos.filter(|r| !r.is_empty()).map(|repo_list| {
-            let mut repos_map = HashMap::new();
-            for (index, repo) in repo_list.into_iter().enumerate() {
-                let name = Path::new(&repo.path)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| format!("repo-{index}"));
-                repos_map.insert(name, repo);
-            }
-            let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-            WorktreeCoordinator::new(repos_map, today)
-        });
+        let repos_map = repos
+            .filter(|r| !r.is_empty())
+            .map(|repo_list| {
+                let mut repos_map = HashMap::new();
+                for (index, repo) in repo_list.into_iter().enumerate() {
+                    let name = Path::new(&repo.path)
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!("repo-{index}"));
+                    repos_map.insert(name, repo);
+                }
+                repos_map
+            })
+            .unwrap_or_default();
 
         Ok(Self {
             root,
-            worktree_coordinator,
+            repos: repos_map,
         })
     }
 
@@ -68,6 +79,37 @@ impl WorkspaceManager {
     /// Returns None if the identifier cannot be sanitized.
     pub fn workspace_path(&self, identifier: &str) -> Option<PathBuf> {
         sanitize_workspace_key(identifier).map(|key| self.root.join(key))
+    }
+
+    fn metadata_path(base_path: &Path) -> PathBuf {
+        base_path.join(WORKSPACE_METADATA_FILE)
+    }
+
+    async fn load_branch_date(&self, base_path: &Path) -> Option<String> {
+        let metadata_path = Self::metadata_path(base_path);
+        if metadata_path.exists() {
+            let content = fs::read_to_string(&metadata_path).await.ok()?;
+            let metadata: WorkspaceMetadata = serde_json::from_str(&content).ok()?;
+            Some(metadata.branch_date)
+        } else {
+            None
+        }
+    }
+
+    async fn save_branch_date(&self, base_path: &Path, date: &str) -> Result<(), WorkspaceError> {
+        let metadata = WorkspaceMetadata {
+            branch_date: date.to_string(),
+        };
+        let content =
+            serde_json::to_string(&metadata).map_err(|e| WorkspaceError::CreationFailed {
+                reason: format!("failed to serialize workspace metadata: {e}"),
+            })?;
+        let metadata_path = Self::metadata_path(base_path);
+        fs::write(&metadata_path, content)
+            .await
+            .map_err(|e| WorkspaceError::CreationFailed {
+                reason: format!("failed to write workspace metadata: {e}"),
+            })
     }
 
     /// Prepare (create or reuse) a workspace for the given issue identifier.
@@ -101,8 +143,25 @@ impl WorkspaceManager {
             true
         };
 
-        // Prepare worktrees if coordinator is configured
-        let worktrees = if let Some(coordinator) = &self.worktree_coordinator {
+        // Prepare worktrees if repos configured
+        let worktrees = if !self.repos.is_empty() {
+            let branch_date = if base_created {
+                let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+                self.save_branch_date(&base_path, &today).await?;
+                today
+            } else {
+                match self.load_branch_date(&base_path).await {
+                    Some(date) => date,
+                    None => {
+                        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+                        self.save_branch_date(&base_path, &today).await?;
+                        today
+                    }
+                }
+            };
+            let coordinator =
+                WorktreeCoordinator::new(self.repos.clone(), branch_date, base_path.clone());
+            info!(workspace = %base_path.display(), "preparing worktrees inside workspace");
             coordinator
                 .prepare_worktrees(identifier)
                 .await
@@ -133,8 +192,21 @@ impl WorkspaceManager {
 
         self.validate_path_inside_root(&base_path)?;
 
-        // Clean up worktrees first
-        if let Some(coordinator) = &self.worktree_coordinator {
+        // Clean up worktrees first - use persisted branch date to avoid date drift
+        if !self.repos.is_empty() {
+            let branch_date = match self.load_branch_date(&base_path).await {
+                Some(date) => date,
+                None => {
+                    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+                    if base_path.exists() {
+                        self.save_branch_date(&base_path, &today).await?;
+                    }
+                    today
+                }
+            };
+            let coordinator =
+                WorktreeCoordinator::new(self.repos.clone(), branch_date, base_path.clone());
+            warn!(workspace = %base_path.display(), "cleaning up worktrees");
             coordinator
                 .cleanup_worktrees(identifier)
                 .await
@@ -189,7 +261,42 @@ impl WorkspaceManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ensemble::RepoConfig;
     use tempfile::TempDir;
+
+    fn setup_repo(name: &str) -> (TempDir, RepoConfig) {
+        let dir = TempDir::new().unwrap();
+
+        std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(&dir)
+            .output()
+            .unwrap();
+
+        std::fs::write(dir.path().join("README.md"), format!("# {name}")).unwrap();
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(&dir)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(&dir)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .output()
+            .unwrap();
+
+        let config = RepoConfig {
+            path: dir.path().to_string_lossy().to_string(),
+            branch: "main".to_string(),
+            git_remote: "origin".to_string(),
+        };
+
+        (dir, config)
+    }
 
     fn setup() -> (TempDir, WorkspaceManager) {
         let dir = TempDir::new().unwrap();
@@ -286,5 +393,84 @@ mod tests {
     async fn test_workspace_root_accessor() {
         let (dir, mgr) = setup();
         assert_eq!(mgr.root(), dir.path());
+    }
+
+    #[tokio::test]
+    async fn test_branch_date_persisted_and_loaded() {
+        let dir = TempDir::new().unwrap();
+        let mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+
+        let test_path = dir.path().join("test-workspace");
+        std::fs::create_dir_all(&test_path).unwrap();
+
+        mgr.save_branch_date(&test_path, "2024-06-15")
+            .await
+            .unwrap();
+
+        let loaded = mgr.load_branch_date(&test_path).await;
+        assert_eq!(loaded, Some("2024-06-15".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_remove_workspace_uses_persisted_branch_date() {
+        let dir = TempDir::new().unwrap();
+
+        let test_path = dir.path().join("test_issue");
+        std::fs::create_dir_all(&test_path).unwrap();
+
+        let metadata_path = test_path.join(".ensemble-workspace.json");
+        std::fs::write(&metadata_path, r#"{"branch_date":"2020-01-01"}"#).unwrap();
+
+        let repos = vec![RepoConfig {
+            path: "/nonexistent/path".to_string(),
+            branch: "main".to_string(),
+            git_remote: "origin".to_string(),
+        }];
+        let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
+
+        let result = mgr.remove_workspace("test-issue").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_remove_workspace_blocks_on_cleanup_failure() {
+        let dir = TempDir::new().unwrap();
+        let repos = vec![RepoConfig {
+            path: "/nonexistent/path".to_string(),
+            branch: "main".to_string(),
+            git_remote: "origin".to_string(),
+        }];
+        let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
+
+        let ws_path = dir.path().join("cleanup-test");
+        std::fs::create_dir_all(&ws_path).unwrap();
+        let metadata_path = ws_path.join(".ensemble-workspace.json");
+        std::fs::write(&metadata_path, r#"{"branch_date":"2020-01-01"}"#).unwrap();
+
+        let remove_result = mgr.remove_workspace("cleanup-test").await;
+        assert!(remove_result.is_err());
+
+        assert!(
+            ws_path.exists(),
+            "workspace should not be deleted when cleanup fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prepare_persists_branch_date_for_legacy_workspace() {
+        let root = TempDir::new().unwrap();
+        let (_repo_dir, repo) = setup_repo("repo1");
+        let mgr = WorkspaceManager::new(root.path(), Some(vec![repo])).unwrap();
+
+        let identifier = "legacy#42";
+        let workspace_key = sanitize_workspace_key(identifier).unwrap();
+        let base_path = root.path().join(workspace_key);
+        std::fs::create_dir_all(&base_path).unwrap();
+
+        assert!(!WorkspaceManager::metadata_path(&base_path).exists());
+
+        let result = mgr.prepare_workspace(identifier).await;
+        assert!(result.is_ok());
+        assert!(WorkspaceManager::metadata_path(&base_path).exists());
     }
 }

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -87,13 +87,35 @@ impl WorkspaceManager {
 
     async fn load_branch_date(&self, base_path: &Path) -> Option<String> {
         let metadata_path = Self::metadata_path(base_path);
-        if metadata_path.exists() {
-            let content = fs::read_to_string(&metadata_path).await.ok()?;
-            let metadata: WorkspaceMetadata = serde_json::from_str(&content).ok()?;
-            Some(metadata.branch_date)
-        } else {
-            None
+        if !metadata_path.exists() {
+            return None;
         }
+
+        let content = match fs::read_to_string(&metadata_path).await {
+            Ok(content) => content,
+            Err(error) => {
+                warn!(
+                    path = %metadata_path.display(),
+                    error = %error,
+                    "failed to read workspace metadata; ignoring persisted branch date"
+                );
+                return None;
+            }
+        };
+
+        let metadata: WorkspaceMetadata = match serde_json::from_str(&content) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                warn!(
+                    path = %metadata_path.display(),
+                    error = %error,
+                    "failed to parse workspace metadata; ignoring persisted branch date"
+                );
+                return None;
+            }
+        };
+
+        Some(metadata.branch_date)
     }
 
     async fn save_branch_date(&self, base_path: &Path, date: &str) -> Result<(), WorkspaceError> {
@@ -415,7 +437,9 @@ mod tests {
     async fn test_remove_workspace_uses_persisted_branch_date() {
         let dir = TempDir::new().unwrap();
 
-        let test_path = dir.path().join("test_issue");
+        let identifier = "test-issue";
+        let workspace_key = sanitize_workspace_key(identifier).unwrap();
+        let test_path = dir.path().join(&workspace_key);
         std::fs::create_dir_all(&test_path).unwrap();
 
         let metadata_path = test_path.join(".ensemble-workspace.json");
@@ -428,8 +452,9 @@ mod tests {
         }];
         let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
 
-        let result = mgr.remove_workspace("test-issue").await;
+        let result = mgr.remove_workspace(identifier).await;
         assert!(result.is_err());
+        assert!(test_path.exists());
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -284,24 +284,38 @@ impl WorkspaceManager {
 mod tests {
     use super::*;
     use crate::config::ensemble::RepoConfig;
+    use std::path::Path;
     use tempfile::TempDir;
+
+    fn git_binary_for_tests() -> &'static str {
+        for candidate in [
+            "/usr/bin/git",
+            "/usr/local/bin/git",
+            "/opt/homebrew/bin/git",
+        ] {
+            if Path::new(candidate).is_file() {
+                return candidate;
+            }
+        }
+        "git"
+    }
 
     fn setup_repo(name: &str) -> (TempDir, RepoConfig) {
         let dir = TempDir::new().unwrap();
 
-        std::process::Command::new("git")
+        std::process::Command::new(git_binary_for_tests())
             .args(["init", "-b", "main"])
             .current_dir(&dir)
             .output()
             .unwrap();
 
         std::fs::write(dir.path().join("README.md"), format!("# {name}")).unwrap();
-        std::process::Command::new("git")
+        std::process::Command::new(git_binary_for_tests())
             .args(["add", "."])
             .current_dir(&dir)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        std::process::Command::new(git_binary_for_tests())
             .args(["commit", "-m", "initial"])
             .current_dir(&dir)
             .env("GIT_AUTHOR_NAME", "Test")

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -227,6 +227,25 @@ pub async fn branch_exists(repo_path: &str, branch: &str) -> Result<bool, Worktr
     Ok(output.status.success())
 }
 
+/// Delete a local branch if it exists.
+pub async fn delete_branch_if_exists(repo_path: &str, branch: &str) -> Result<(), WorktreeError> {
+    if !branch_exists(repo_path, branch).await? {
+        return Ok(());
+    }
+
+    let branch_args = ["branch", "-D", branch];
+    let command = git_command_label(&branch_args);
+    let error_command = command.clone();
+    ensure_git_success(run_git(repo_path, &branch_args, command).await?, |stderr| {
+        WorktreeError::GitCommandFailed {
+            command: error_command,
+            reason: stderr,
+        }
+    })?;
+
+    Ok(())
+}
+
 /// Remove an orphaned worktree directory that is not registered in git.
 ///
 /// This handles the case where the directory exists but `git worktree list`
@@ -299,21 +318,8 @@ pub async fn remove_worktree(
 
     debug!(worktree_path = %worktree_path, "Worktree removed successfully");
 
-    let branch_args = ["branch", "-D", branch];
-    let branch_output = run_git(repo_path, &branch_args, git_command_label(&branch_args)).await;
-
-    match branch_output {
-        Ok(output) => {
-            if output.status.success() {
-                debug!(branch = %branch, "Branch deleted successfully");
-            } else {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                warn!(stderr = %stderr, branch = %branch, "Failed to delete branch");
-            }
-        }
-        Err(e) => {
-            warn!(error = %e, branch = %branch, "Failed to spawn branch delete command");
-        }
+    if let Err(e) = delete_branch_if_exists(repo_path, branch).await {
+        warn!(error = %e, branch = %branch, "Failed to delete branch");
     }
 
     Ok(())

--- a/crates/ensemble-core/tests/coordinator_tests.rs
+++ b/crates/ensemble-core/tests/coordinator_tests.rs
@@ -6,14 +6,12 @@ use tempfile::TempDir;
 fn setup_repo(name: &str) -> (TempDir, RepoConfig) {
     let dir = TempDir::new().unwrap();
 
-    // Initialize git repo
     std::process::Command::new("git")
         .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();
 
-    // Create initial commit
     std::fs::write(dir.path().join("README.md"), format!("# {}", name)).unwrap();
     std::process::Command::new("git")
         .args(["add", "."])
@@ -41,6 +39,7 @@ fn setup_repo(name: &str) -> (TempDir, RepoConfig) {
 
 #[tokio::test]
 async fn test_prepare_worktrees_creates_all() {
+    let worktree_root = TempDir::new().unwrap();
     let (_repo1_dir, repo1_config) = setup_repo("repo1");
     let (_repo2_dir, repo2_config) = setup_repo("repo2");
 
@@ -49,7 +48,11 @@ async fn test_prepare_worktrees_creates_all() {
         ("api".to_string(), repo2_config),
     ]);
 
-    let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+    let coordinator = WorktreeCoordinator::new(
+        repos,
+        "2026-03-30".to_string(),
+        worktree_root.path().to_path_buf(),
+    );
 
     let result = coordinator.prepare_worktrees("my-issue-42").await;
 
@@ -60,7 +63,6 @@ async fn test_prepare_worktrees_creates_all() {
     assert!(worktrees.contains_key("frontend"));
     assert!(worktrees.contains_key("api"));
 
-    // Verify directories exist
     let frontend_path = &worktrees["frontend"].path;
     let api_path = &worktrees["api"].path;
 
@@ -72,17 +74,20 @@ async fn test_prepare_worktrees_creates_all() {
 
 #[tokio::test]
 async fn test_prepare_worktrees_reuses_existing() {
+    let worktree_root = TempDir::new().unwrap();
     let (_repo1_dir, repo1_config) = setup_repo("repo1");
 
     let repos = HashMap::from([("frontend".to_string(), repo1_config)]);
 
-    let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+    let coordinator = WorktreeCoordinator::new(
+        repos,
+        "2026-03-30".to_string(),
+        worktree_root.path().to_path_buf(),
+    );
 
-    // First call creates
     let result1 = coordinator.prepare_worktrees("my-issue-42").await.unwrap();
     assert!(result1["frontend"].created_now);
 
-    // Second call reuses
     let result2 = coordinator.prepare_worktrees("my-issue-42").await.unwrap();
     assert!(!result2["frontend"].created_now);
     assert_eq!(result1["frontend"].path, result2["frontend"].path);
@@ -90,20 +95,61 @@ async fn test_prepare_worktrees_reuses_existing() {
 
 #[tokio::test]
 async fn test_cleanup_worktrees() {
+    let worktree_root = TempDir::new().unwrap();
     let (_repo1_dir, repo1_config) = setup_repo("repo1");
 
     let repos = HashMap::from([("frontend".to_string(), repo1_config)]);
 
-    let coordinator = WorktreeCoordinator::new(repos, "2026-03-30".to_string());
+    let coordinator = WorktreeCoordinator::new(
+        repos,
+        "2026-03-30".to_string(),
+        worktree_root.path().to_path_buf(),
+    );
 
-    // Create worktree
     let worktrees = coordinator.prepare_worktrees("my-issue-42").await.unwrap();
     let path = worktrees["frontend"].path.clone();
     assert!(path.exists());
 
-    // Cleanup
     coordinator.cleanup_worktrees("my-issue-42").await.unwrap();
 
-    // Verify removed
     assert!(!path.exists());
+}
+
+#[tokio::test]
+async fn test_cleanup_worktrees_is_idempotent_when_missing() {
+    let worktree_root = TempDir::new().unwrap();
+    let (_repo1_dir, repo1_config) = setup_repo("repo1");
+
+    let repos = HashMap::from([("frontend".to_string(), repo1_config)]);
+
+    let coordinator = WorktreeCoordinator::new(
+        repos,
+        "2026-03-30".to_string(),
+        worktree_root.path().to_path_buf(),
+    );
+
+    let result = coordinator.cleanup_worktrees("my-issue-42").await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_cleanup_worktrees_propagates_failure() {
+    let worktree_root = TempDir::new().unwrap();
+    let repos = HashMap::from([(
+        "frontend".to_string(),
+        RepoConfig {
+            path: "/nonexistent/path/to/repo".to_string(),
+            branch: "main".to_string(),
+            git_remote: "origin".to_string(),
+        },
+    )]);
+
+    let coordinator = WorktreeCoordinator::new(
+        repos,
+        "2026-03-30".to_string(),
+        worktree_root.path().to_path_buf(),
+    );
+
+    let result = coordinator.cleanup_worktrees("my-issue-42").await;
+    assert!(result.is_err());
 }

--- a/docs/superpowers/plans/2024-04-07-worktrees-inside-workspace.md
+++ b/docs/superpowers/plans/2024-04-07-worktrees-inside-workspace.md
@@ -1,0 +1,391 @@
+# Worktrees Inside Workspace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move git worktrees from `<repo>/.worktrees/<branch>/` to `<workspace.root>/<issue>/<repo>/<branch>/`, placing them inside the per-issue workspace directory.
+
+**Architecture:** Add `worktree_root` parameter to `WorktreeCoordinator`, compute worktree paths as `<worktree_root>/<repo_name>/<branch>` instead of `<repo>/.worktrees/<branch>`. `WorkspaceManager` passes workspace directory as worktree root.
+
+**Tech Stack:** Rust, async/await, tokio, tempfile(testing)
+
+---
+
+## File Structure
+
+**Modified files:**
+- `crates/ensemble-core/src/workspace/coordinator.rs` - Add worktree_root field, change path calculation
+- `crates/ensemble-core/src/workspace/manager.rs` - Pass workspace path as worktree root
+
+**Unchanged files:**
+- `crates/ensemble-core/src/workspace/worktree.rs` - Pure git operations, no changes
+- `crates/ensemble-core/src/workspace/mod.rs` - Re-exports only
+
+---
+
+### Task 1: Add worktree_root to WorktreeCoordinator
+
+**Files:**
+- Modify: `crates/ensemble-core/src/workspace/coordinator.rs`
+
+- [ ] **Step 1: Write failing test for new constructor signature**
+
+Create test that passes worktree_root:
+
+```rust
+#[test]
+fn test_coordinator_uses_worktree_root() {
+    let mut repos = HashMap::new();
+    repos.insert(
+        "myproject".to_string(),
+        RepoConfig {
+            path: "/path/to/project".to_string(),
+            branch: "main".to_string(),
+            git_remote: "origin".to_string(),
+        },
+    );
+    let worktree_root = PathBuf::from("/tmp/workspaces/PROJ-42");
+    let coordinator = WorktreeCoordinator::new(repos, "2024-04-07".to_string(), worktree_root);
+    
+    let paths = coordinator.list_worktree_paths("PROJ-42");
+    assert_eq!(
+        paths.get("myproject"),
+        Some(&PathBuf::from("/tmp/workspaces/PROJ-42/myproject"))
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --package ensemble-core test_coordinator_uses_worktree_root 2>&1`
+
+Expected: Compilation error - `WorktreeCoordinator::new` takes wrong number of arguments
+
+- [ ] **Step 3: Add worktree_root field to struct**
+
+```rust
+pub struct WorktreeCoordinator {
+    repos: HashMap<String, RepoConfig>,
+    base_date: String,
+    worktree_root: PathBuf,  // NEW
+}
+```
+
+- [ ] **Step 4: Update constructor signature**
+
+```rust
+impl WorktreeCoordinator {
+    pub fn new(
+        repos: HashMap<String, RepoConfig>,
+        base_date: String,
+        worktree_root: PathBuf,  // NEW
+    ) -> Self {
+        Self {
+            repos,
+            base_date,
+            worktree_root,
+        }
+    }
+```
+
+- [ ] **Step 5: Update list_worktree_paths to use worktree_root**
+
+```rust
+pub fn list_worktree_paths(&self, issue_id: &str) -> HashMap<String, PathBuf> {
+    let branch = self.format_branch_name(issue_id);
+    let mut paths = HashMap::new();
+
+    for (repo_name, _repo_config) in &self.repos {
+        let worktree_path = self.worktree_root.join(repo_name).join(&branch);
+        paths.insert(repo_name.clone(), worktree_path);
+    }
+
+    paths
+}
+```
+
+- [ ] **Step 6: Update prepare_worktrees path calculation**
+
+In `prepare_worktrees`, change:
+```rust
+// OLD:
+let worktree_path = repo_path.join(".worktrees").join(&branch);
+
+// NEW:
+let worktree_path = self.worktree_root.join(repo_name).join(&branch);
+```
+
+- [ ] **Step 7: Update cleanup_worktrees path calculation**
+
+In `cleanup_worktrees`, change:
+```rust
+// OLD:
+let worktree_path = repo_path.join(".worktrees").join(&branch);
+
+// NEW:
+let worktree_path = self.worktree_root.join(repo_name).join(&branch);
+```
+
+- [ ] **Step 8: Run tests to verify compilation and basic tests pass**
+
+Run: `cargo test --package ensemble-core -- coordinator::tests 2>&1`
+
+Expected: All coordinator tests pass
+
+- [ ] **Step 9: Commit changes tocoordinator**
+
+```bash
+git add crates/ensemble-core/src/workspace/coordinator.rs
+git commit -m "feat(workspace): add worktree_root parameter to WorktreeCoordinator
+
+- Add worktree_root field to WorktreeCoordinator struct
+- Change worktree path calculation from <repo>/.worktrees/ to <worktree_root>/<repo>/
+- Update constructor and path methods to use worktree_root"
+```
+
+---
+
+### Task 2: Update WorkspaceManager to pass workspace path
+
+**Files:**
+- Modify: `crates/ensemble-core/src/workspace/manager.rs`
+
+- [ ] **Step 1: Write failing test for workspace-internal worktrees**
+
+```rust
+#[tokio::test]
+async fn test_worktrees_inside_workspace() {
+    let repo_dir = tempfile::TempDir::new().unwrap();
+    init_git_repo(&repo_dir).await;
+    
+    let workspace_root = tempfile::TempDir::new().unwrap();
+    let repos = vec![RepoConfig {
+        path: repo_dir.path().display().to_string(),
+        branch: "main".to_string(),
+        git_remote: "origin".to_string(),
+    }];
+    
+    let mgr = WorkspaceManager::new(workspace_root.path(), Some(repos)).unwrap();
+    let result = mgr.prepare_workspace("TEST-1").await.unwrap();
+    
+    // Worktree should be inside workspace
+    let expected_worktree = result.base_path.join("repo");  // repo name from basename
+    assert!(expected_worktree.exists());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails or shows current behavior**
+
+Run: `cargo test --package ensemble-core test_worktrees_inside_workspace 2>&1`
+
+Expected: Test fails because worktrees are created in `<repo>/.worktrees/` not inside workspace
+
+- [ ] **Step 3: Update WorkspaceManager to store repos HashMap instead of coordinator**
+
+The key insight: `WorktreeCoordinator` needs the specific workspace directory (`root/workspace_key/`), not just the root. This is only known when `prepare_workspace` is called.
+
+Change `WorkspaceManager` to store `repos` HashMap instead of `WorktreeCoordinator`:
+
+```rust
+pub struct WorkspaceManager {
+    root: PathBuf,
+    repos: HashMap<String, RepoConfig>,  // Changed from WorktreeCoordinator
+}
+
+impl WorkspaceManager {
+    pub fn new(root: &Path, repos: Option<Vec<RepoConfig>>) -> Result<Self, WorkspaceError> {
+        // ... root normalization ...
+        
+        let repos_map = repos
+            .filter(|r| !r.is_empty())
+            .map(|repo_list| {
+                let mut map = HashMap::new();
+                for (index, repo) in repo_list.into_iter().enumerate() {
+                    let name = Path::new(&repo.path)
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!("repo-{index}"));
+                    map.insert(name, repo);
+                }
+                map
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            root,
+            repos: repos_map,
+        })
+    }
+```
+
+- [ ] **Step 4: Create coordinator in prepare_workspace**
+
+In `prepare_workspace`, create coordinator with workspace-specific path:
+
+```rust
+pub async fn prepare_workspace(
+    &self,
+    identifier: &str,
+) -> Result<WorkspaceResult, WorkspaceError> {
+    let workspace_key =
+        sanitize_workspace_key(identifier).ok_or_else(|| WorkspaceError::CreationFailed {
+            reason: format!("unsafe workspace key from identifier: {identifier:?}"),
+        })?;
+    let base_path = self.root.join(&workspace_key);
+
+    // ... create directory ...
+
+    // Prepare worktrees if repos configured
+    let worktrees = if !self.repos.is_empty() {
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        let coordinator = WorktreeCoordinator::new(
+            self.repos.clone(),
+            today,
+            base_path.clone(),// Worktrees go inside this workspace
+        );
+        coordinator
+            .prepare_worktrees(identifier)
+            .await
+            .map_err(|e| WorkspaceError::CreationFailed {
+                reason: format!("worktree preparation failed: {e}"),
+            })?
+    } else {
+        HashMap::new()
+    };
+
+    // ... rest of method ...
+}
+```
+
+- [ ] **Step 5: Update remove_workspace similarly**
+
+In `remove_workspace`:
+
+```rust
+pub async fn remove_workspace(&self, identifier: &str) -> Result<(), WorkspaceError> {
+    // ... sanitize and validate ...
+
+    // Clean up worktrees first
+    if !self.repos.is_empty() {
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        let workspace_key = sanitize_workspace_key(identifier).ok_or_else(|| {
+            WorkspaceError::CreationFailed {
+                reason: format!("unsafe workspace key: {identifier:?}"),
+            }
+        })?;
+        let base_path = self.root.join(&workspace_key);
+        
+        let coordinator = WorktreeCoordinator::new(
+            self.repos.clone(),
+            today,
+            base_path,
+        );
+        coordinator
+            .cleanup_worktrees(identifier)
+            .await
+            .map_err(|e| WorkspaceError::CreationFailed {
+                reason: format!("worktree cleanup failed: {e}"),
+            })?;
+    }
+
+    // Remove base workspace
+    // ...existing code ...
+}
+```
+
+- [ ] **Step 6: Run manager tests**
+
+Run: `cargo test --package ensemble-core --workspace::manager::tests 2>&1`
+
+Expected: Tests pass (may need fixture updates for new behavior)
+
+- [ ] **Step 7: Run coordinator tests**
+
+Run: `cargo test --package ensemble-core --workspace::coordinator::tests 2>&1`
+
+Expected: Tests pass
+
+- [ ] **Step 8: Run all workspace tests**
+
+Run: `cargo test --package ensemble-core --workspace: 2>&1`
+
+Expected: All workspace tests pass
+
+- [ ] **Step 9: Commit manager changes**
+
+```bash
+git add crates/ensemble-core/src/workspace/manager.rs
+git commit -m "feat(workspace): create worktrees inside workspace directory
+
+- Move WorktreeCoordinator creation to prepare_workspace
+- Pass workspace-specific path as worktree_root
+- Worktrees now live at <workspace>/<repo>/<branch>"
+```
+
+---
+
+### Task 3: Update integration tests
+
+**Files:**
+- Modify: `crates/ensemble-core/tests/workflow_to_workspace.rs` (if exists)
+
+- [ ] **Step 1: Check for integration tests**
+
+Run: `find crates -name "*.rs" -path "*/tests/*" | head -20`
+
+- [ ] **Step 2: Update any integration tests that check worktree paths**
+
+If tests check for `.worktrees/` paths, update to expect workspace-internal paths.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cargo test --workspace --exclude ensemble-desktop 2>&1`
+
+Expected: All tests pass
+
+---
+
+### Task 4: Final verification
+
+- [ ] **Step 1: Run clippy**
+
+Run: `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings 2>&1`
+
+Expected: No warnings
+
+- [ ] **Step 2: Run format check**
+
+Run: `cargo fmt --all -- --check 2>&1`
+
+Expected: No errors
+
+- [ ] **Step 3: Commit final verification**
+
+```bash
+git commit --allow-empty -m "chore: verify worktrees-inside-workspace implementation"
+```
+
+---
+
+## Testing Checklist
+
+After implementation:
+
+- [ ] Worktree created inside workspace directory (`<workspace>/<repo>/`)
+- [ ] Multiple repos create multiple subdirectories (`<workspace>/frontend/`, `<workspace>/backend/`)
+- [ ] Workspace cleanup removes worktrees
+- [ ] Retry reuses existing worktrees
+- [ ] Git operations still work (worktrees properly linked)
+- [ ] Branch names sanitized correctly
+- [ ] Coordinator path calculation uses worktree_root
+
+---
+
+## Files Modified Summary
+
+1. `coordinator.rs` - Add worktree_root field, update path calculations
+2. `manager.rs` - Move coordinator creation to prepare_workspace, pass workspace path
+
+## Backward Compatibility Note
+
+No migration path provided. Existing `.worktrees/` directories in repos should be manually cleaned if desired.

--- a/docs/superpowers/specs/2024-04-07-worktrees-inside-workspace-design.md
+++ b/docs/superpowers/specs/2024-04-07-worktrees-inside-workspace-design.md
@@ -1,0 +1,156 @@
+# Worktrees Inside Workspace Design
+
+**Date**: 2024-04-07
+**Status**: Approved
+
+## Problem
+
+Git worktrees are currently placed inside repositories at `<repo>/.worktrees/<branch>/`. This causes several issues:
+
+1. Dirties the repository with `.worktrees/` directories
+2. Requires manual `.gitignore` configuration
+3. Accumulates across issues until manually cleaned
+4. Mixes ensemble-managed files with user's repository
+
+## Solution
+
+Move worktrees inside the per-issue workspace directory, yielding:
+
+```
+<workspace.root>/<issue-id>/
+├── .ensemble/
+│   └── verdict.json
+├── myproject/          ← worktree for myproject repo
+│   ├── .git           ← gitfile pointing to repo
+│   └── src/...
+└── other-repo/         ← worktree for other-repo (if configured)
+```
+
+## Design
+
+### Conceptual Model
+
+- **Workspace**: Per-issue directory where agent runs
+- **Worktree**: Git worktree (linked checkout) inside the workspace
+- One workspace per issue, shared across all pipeline steps
+- Worktrees for all configured repos go inside that workspace
+
+### Implementation
+
+#### 1. WorktreeCoordinator Changes
+
+**File**: `crates/ensemble-core/src/workspace/coordinator.rs`
+
+**Current**:
+```rust
+pub struct WorktreeCoordinator {
+    repos: HashMap<String, RepoConfig>,
+    base_date: String,
+}
+```
+
+**New**:
+```rust
+pub struct WorktreeCoordinator {
+    repos: HashMap<String, RepoConfig>,
+    base_date: String,
+    worktree_root: PathBuf,  // Parent directory for worktrees
+}
+```
+
+**Constructor**: Accept `worktree_root` parameter (workspace path)
+
+**Worktree path calculation**:
+- Current: `<repo_path>/.worktrees/<branch>`
+- New: `<worktree_root>/<repo_name>/<branch>`
+
+#### 2. WorkspaceManager Changes
+
+**File**: `crates/ensemble-core/src/workspace/manager.rs`
+
+In `prepare_workspace`, after creating the workspace directory:
+
+1. Create `WorktreeCoordinator` with `worktree_root = base_path.clone()`
+2. Worktrees created under `base_path/<repo_name>/<branch>/`
+
+**Removed**: Hardcoded `.worktrees` directory name in coordinator
+
+#### 3. Config Schema
+
+No changes required. The `workspace.root` config already defines where workspaces live, and worktrees go inside automatically.
+
+```yaml
+workspace:
+  root: /tmp/ensemble_workspaces  # Worktrees go inside as ./<repo>/
+```
+
+#### 4. Cleanup
+
+When removing a workspace via `remove_workspace`:
+1. Coordinator calls `cleanup_worktrees` (removes worktrees from git, deletes branches)
+2. Workspace directory is removed (including worktree directories)
+
+Git cleanup remains the same - `git worktree remove --force` unregisters the worktree from git.
+
+### Path Examples
+
+**Before** (current):
+```
+/tmp/ensemble_workspaces/PROJ-42/              ← workspace
+~/projects/myproject/.worktrees/ensemble-2024-04-07-PROJ-42/  ← worktree
+```
+
+**After** (proposed):
+```
+/tmp/ensemble_workspaces/PROJ-42/              ← workspace
+/tmp/ensemble_workspaces/PROJ-42/myproject/    ← worktree inside workspace
+```
+
+### Multi-Repo Example
+
+Config:
+```yaml
+repos:
+  - path: /home/user/frontend
+    branch: main
+  - path: /home/user/backend
+    branch: develop
+```
+
+Result:
+```
+PROJ-42/
+├── frontend/      ← worktree for frontend repo
+└── backend/       ← worktree for backend repo
+```
+
+### Edge Cases
+
+1. **Workspace reuse on retry**: Worktrees already exist, pull latest base branch
+2. **Empty repos config**: No worktrees created, workspace is just a directory
+3. **Concurrent issues**: Each issue has its own workspace with its own worktrees
+
+## Files to Modify
+
+1. `crates/ensemble-core/src/workspace/coordinator.rs`
+   - Add `worktree_root: PathBuf` field
+   - Update constructor to accept worktree root
+   - Change path calculation from `<repo>/.worktrees/` to `<worktree_root>/<repo_name>/`
+
+2. `crates/ensemble-core/src/workspace/manager.rs`
+   - Pass `base_path` as worktree root to coordinator
+   - Coordinator created inside `prepare_workspace` after workspace exists
+
+3. `crates/ensemble-core/src/workspace/worktree.rs`
+   - No changes (pure git operations)
+
+4. `crates/ensemble-core/src/workspace/mod.rs`
+   - No changes (re-exports)
+
+## Testing
+
+1. Worktree created inside workspace directory
+2. Multiple repos create multiple subdirectories
+3. Workspace cleanup removes worktrees
+4. Retry reuses existing worktrees
+5. Git operations still work (worktrees properly linked)


### PR DESCRIPTION
## Summary
- move `WorktreeCoordinator` worktree paths from `<repo>/.worktrees/...` to `<workspace>/<repo>/<branch>` by introducing a `worktree_root`
- persist per-workspace branch date metadata (`.ensemble-workspace.json`) and reuse it during prepare/remove to avoid date-based cleanup drift
- make cleanup behavior safer by treating already-missing worktrees as idempotent while still surfacing real cleanup failures; add regression coverage for idempotency and legacy metadata persistence

## Testing
- cargo test -p ensemble-core --test coordinator_tests
- cargo test -p ensemble-core workspace::manager::tests
- cargo fmt --all -- --check