### PR TITLE
Refactor ACP/ACPX parsing to shared JSON-RPC path

### DIFF
--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -256,6 +256,8 @@ impl AcpSession {
         loop {
             let line = self.read_line().await?;
 
+            // Keep direct deserialization here so malformed JSON can emit
+            // `AgentEvent::Malformed` with the raw original line content.
             let msg: JsonRpcMessage = match serde_json::from_str(&line) {
                 Ok(m) => m,
                 Err(_) => {
@@ -429,15 +431,38 @@ impl AcpSession {
                 .await;
                 Ok(TurnResult::Completed { usage })
             }
-            StopReason::Cancelled | StopReason::Refusal | StopReason::MaxTurnRequests => {
-                let reason = match stop_reason {
-                    StopReason::Cancelled => "stop reason: cancelled",
-                    StopReason::Refusal => "stop reason: refusal",
-                    StopReason::MaxTurnRequests => "stop reason: max_turn_requests",
-                    _ => "stop reason: unknown",
-                }
-                .to_string();
+            StopReason::Cancelled => {
+                let reason = "stop reason: cancelled".to_string();
+                Self::emit_event(
+                    event_tx,
+                    issue_id,
+                    step_name,
+                    AgentEvent::RunFailed {
+                        reason: reason.clone(),
+                        usage: usage.clone(),
+                    },
+                )
+                .await;
 
+                Ok(TurnResult::Failed { reason, usage })
+            }
+            StopReason::Refusal => {
+                let reason = "stop reason: refusal".to_string();
+                Self::emit_event(
+                    event_tx,
+                    issue_id,
+                    step_name,
+                    AgentEvent::RunFailed {
+                        reason: reason.clone(),
+                        usage: usage.clone(),
+                    },
+                )
+                .await;
+
+                Ok(TurnResult::Failed { reason, usage })
+            }
+            StopReason::MaxTurnRequests => {
+                let reason = "stop reason: max_turn_requests".to_string();
                 Self::emit_event(
                     event_tx,
                     issue_id,

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -372,16 +372,6 @@ impl AcpSession {
                                         },
                                     )
                                     .await;
-                                } else {
-                                    Self::emit_event(
-                                        event_tx,
-                                        issue_id,
-                                        step_name,
-                                        AgentEvent::Notification {
-                                            message: line.chars().take(200).collect(),
-                                        },
-                                    )
-                                    .await;
                                 }
                             } else {
                                 Self::emit_event(
@@ -892,6 +882,72 @@ done
             }
         }
         assert!(saw_output);
+
+        session.kill().await;
+    }
+
+    #[tokio::test]
+    async fn run_turn_usage_only_update_does_not_emit_notification() {
+        let dir = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+
+        let script = r#"#!/bin/bash
+while IFS= read -r line; do
+    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
+    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
+
+    if [ "$method" = "initialize" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
+    elif [ "$method" = "session/new" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"usage-only-session\"}}"
+    elif [ "$method" = "session/prompt" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"usage-only-session\",\"update\":{\"sessionUpdate\":\"usage_update\",\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}}}"
+        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"usage-only-session\",\"stopReason\":\"end_turn\"}}"
+    fi
+done
+"#;
+        let script_path = write_mock_agent_script(dir.path(), script);
+
+        let mut session = AcpSession::spawn(&script_path, workspace.path())
+            .await
+            .unwrap();
+        session.initialize(15000).await.unwrap();
+        let session_id = session
+            .start_session(
+                workspace.path().to_str().unwrap(),
+                serde_json::json!({}),
+                15000,
+            )
+            .await
+            .unwrap();
+
+        let (tx, mut rx) = mpsc::channel(100);
+        let result = session
+            .run_turn(
+                &session_id,
+                "Do work",
+                30000,
+                "auto_approve_all",
+                "issue-usage-only",
+                "build",
+                &tx,
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(result, TurnResult::Completed { .. }));
+
+        let mut saw_notification = false;
+        while let Ok(evt) = rx.try_recv() {
+            if let WorkerEvent::AgentUpdate {
+                event: AgentEvent::Notification { .. },
+                ..
+            } = evt
+            {
+                saw_notification = true;
+            }
+        }
+        assert!(!saw_notification);
 
         session.kill().await;
     }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -13,6 +13,7 @@ use crate::error::AgentError;
 use super::events::{
     AgentEvent, JsonRpcMessage, RuntimeStream, StopReason, TokenUsage, WorkerEvent,
 };
+use super::protocol;
 
 /// ACP session managing a subprocess and stdio JSON-RPC 2.0 protocol.
 pub struct AcpSession {
@@ -280,6 +281,21 @@ impl AcpSession {
                                 usage: last_usage,
                             });
                         }
+                        if let Some(stop_reason) = msg
+                            .result
+                            .as_ref()
+                            .and_then(protocol::parse_stop_reason_from_result)
+                        {
+                            return self
+                                .map_stop_reason_to_turn_result(
+                                    stop_reason,
+                                    issue_id,
+                                    step_name,
+                                    event_tx,
+                                    last_usage,
+                                )
+                                .await;
+                        }
                         // A prompt response without error means turn completed
                         return Ok(TurnResult::Completed { usage: last_usage });
                     }
@@ -326,80 +342,45 @@ impl AcpSession {
                 match method.as_str() {
                     "session/update" => {
                         if let Some(ref params) = msg.params {
-                            // Extract usage if present
-                            if let Some(usage_val) = params.get("usage") {
-                                if let Ok(usage) =
-                                    serde_json::from_value::<TokenUsage>(usage_val.clone())
-                                {
+                            if let Some(parsed) = protocol::parse_session_update(params) {
+                                if let Some(usage) = parsed.usage {
                                     last_usage = Some(usage);
                                 }
-                            }
 
-                            // Check for stopReason
-                            if let Some(stop_str) =
-                                params.get("stopReason").and_then(|v| v.as_str())
-                            {
-                                if let Some(stop_reason) = StopReason::from_str_loose(stop_str) {
-                                    if stop_reason.is_success() {
-                                        Self::emit_event(
-                                            event_tx,
+                                if let Some(stop_reason) = parsed.stop_reason {
+                                    return self
+                                        .map_stop_reason_to_turn_result(
+                                            stop_reason,
                                             issue_id,
                                             step_name,
-                                            AgentEvent::RunCompleted {
-                                                usage: last_usage.clone(),
-                                            },
-                                        )
-                                        .await;
-                                        return Ok(TurnResult::Completed { usage: last_usage });
-                                    } else if stop_reason == StopReason::MaxTokens {
-                                        // max_tokens is a potential continuation, treat as success
-                                        Self::emit_event(
                                             event_tx,
-                                            issue_id,
-                                            step_name,
-                                            AgentEvent::RunCompleted {
-                                                usage: last_usage.clone(),
-                                            },
+                                            last_usage,
                                         )
                                         .await;
-                                        return Ok(TurnResult::Completed { usage: last_usage });
-                                    } else {
-                                        let reason = format!("stop reason: {stop_str}");
-                                        Self::emit_event(
-                                            event_tx,
-                                            issue_id,
-                                            step_name,
-                                            AgentEvent::RunFailed {
-                                                reason: reason.clone(),
-                                                usage: last_usage.clone(),
-                                            },
-                                        )
-                                        .await;
-                                        return Ok(TurnResult::Failed {
-                                            reason,
-                                            usage: last_usage,
-                                        });
-                                    }
                                 }
-                            }
 
-                            // Extract content for update event
-                            let content = params
-                                .get("content")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string();
-                            if !content.is_empty() {
-                                Self::emit_event(
-                                    event_tx,
-                                    issue_id,
-                                    step_name,
-                                    AgentEvent::OutputChunk {
-                                        stream: RuntimeStream::Stdout,
-                                        content,
-                                    },
-                                )
-                                .await;
+                                if let Some(content) = parsed.output_text {
+                                    Self::emit_event(
+                                        event_tx,
+                                        issue_id,
+                                        step_name,
+                                        AgentEvent::OutputChunk {
+                                            stream: RuntimeStream::Stdout,
+                                            content,
+                                        },
+                                    )
+                                    .await;
+                                } else {
+                                    Self::emit_event(
+                                        event_tx,
+                                        issue_id,
+                                        step_name,
+                                        AgentEvent::Notification {
+                                            message: line.chars().take(200).collect(),
+                                        },
+                                    )
+                                    .await;
+                                }
                             } else {
                                 Self::emit_event(
                                     event_tx,
@@ -423,6 +404,52 @@ impl AcpSession {
                         .await;
                     }
                 }
+            }
+        }
+    }
+
+    async fn map_stop_reason_to_turn_result(
+        &self,
+        stop_reason: StopReason,
+        issue_id: &str,
+        step_name: &str,
+        event_tx: &mpsc::Sender<WorkerEvent>,
+        usage: Option<TokenUsage>,
+    ) -> Result<TurnResult, AgentError> {
+        match stop_reason {
+            StopReason::EndTurn | StopReason::MaxTokens => {
+                Self::emit_event(
+                    event_tx,
+                    issue_id,
+                    step_name,
+                    AgentEvent::RunCompleted {
+                        usage: usage.clone(),
+                    },
+                )
+                .await;
+                Ok(TurnResult::Completed { usage })
+            }
+            StopReason::Cancelled | StopReason::Refusal | StopReason::MaxTurnRequests => {
+                let reason = match stop_reason {
+                    StopReason::Cancelled => "stop reason: cancelled",
+                    StopReason::Refusal => "stop reason: refusal",
+                    StopReason::MaxTurnRequests => "stop reason: max_turn_requests",
+                    _ => "stop reason: unknown",
+                }
+                .to_string();
+
+                Self::emit_event(
+                    event_tx,
+                    issue_id,
+                    step_name,
+                    AgentEvent::RunFailed {
+                        reason: reason.clone(),
+                        usage: usage.clone(),
+                    },
+                )
+                .await;
+
+                Ok(TurnResult::Failed { reason, usage })
             }
         }
     }
@@ -772,6 +799,74 @@ done
         }
         // Should have: PromptStarted, OutputChunk or Notification, RunCompleted
         assert!(events.len() >= 2);
+
+        session.kill().await;
+    }
+
+    #[tokio::test]
+    async fn run_turn_handles_nested_session_update_content() {
+        let dir = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+
+        let script = r#"#!/bin/bash
+while IFS= read -r line; do
+    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
+    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
+
+    if [ "$method" = "initialize" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
+    elif [ "$method" = "session/new" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"nested-session\"}}"
+    elif [ "$method" = "session/prompt" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"nested-session\",\"update\":{\"sessionUpdate\":\"agent_message_chunk\",\"content\":{\"type\":\"text\",\"text\":\"hello nested\"}}}}"
+        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"nested-session\",\"update\":{\"sessionUpdate\":\"turn_complete\",\"stopReason\":\"end_turn\",\"usage\":{\"input_tokens\":3,\"output_tokens\":4,\"total_tokens\":7}}}}"
+    fi
+done
+"#;
+        let script_path = write_mock_agent_script(dir.path(), script);
+
+        let mut session = AcpSession::spawn(&script_path, workspace.path())
+            .await
+            .unwrap();
+        session.initialize(15000).await.unwrap();
+        let session_id = session
+            .start_session(
+                workspace.path().to_str().unwrap(),
+                serde_json::json!({}),
+                15000,
+            )
+            .await
+            .unwrap();
+
+        let (tx, mut rx) = mpsc::channel(100);
+        let result = session
+            .run_turn(
+                &session_id,
+                "Do work",
+                30000,
+                "auto_approve_all",
+                "issue-nested",
+                "build",
+                &tx,
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(result, TurnResult::Completed { .. }));
+
+        let mut saw_output = false;
+        while let Ok(evt) = rx.try_recv() {
+            if let WorkerEvent::AgentUpdate {
+                event: AgentEvent::OutputChunk { content, .. },
+                ..
+            } = evt
+            {
+                if content == "hello nested" {
+                    saw_output = true;
+                }
+            }
+        }
+        assert!(saw_output);
 
         session.kill().await;
     }

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -274,11 +274,10 @@ fn parse_session_update_from_message(
         return Ok(None);
     }
 
-    let value = serde_json::to_value(message).map_err(|e| AgentError::ResponseError {
-        reason: format!("failed to encode JSON-RPC message: {e}"),
-    })?;
-
-    Ok(protocol::parse_session_update(&value))
+    Ok(message
+        .params
+        .as_ref()
+        .and_then(protocol::parse_session_update))
 }
 
 fn map_stop_reason(stop_reason: StopReason, usage: Option<TokenUsage>) -> AgentEvent {

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -7,7 +7,8 @@ use tracing::debug;
 
 use crate::error::AgentError;
 
-use super::events::{AgentEvent, RuntimeStream, TokenUsage};
+use super::events::{AgentEvent, RuntimeStream, StopReason, TokenUsage};
+use super::protocol;
 
 pub struct AcpxCli {
     executable: String,
@@ -121,25 +122,67 @@ impl AcpxCli {
 
         let mut reader = BufReader::new(stdout).lines();
         let mut saw_terminal_event = false;
+        let mut last_usage: Option<TokenUsage> = None;
 
         while let Some(line) = reader.next_line().await.map_err(|e| AgentError::IoError {
             reason: format!("failed to read acpx stdout: {e}"),
         })? {
-            match serde_json::from_str::<serde_json::Value>(&line) {
-                Ok(value) => {
-                    let event = map_event(value);
-                    if matches!(
-                        event,
-                        AgentEvent::RunCompleted { .. }
-                            | AgentEvent::RunFailed { .. }
-                            | AgentEvent::Cancelled { .. }
-                    ) {
-                        saw_terminal_event = true;
-                    }
-                    on_event(event).await;
+            let message =
+                protocol::parse_jsonrpc(&line).ok_or_else(|| AgentError::ResponseError {
+                    reason: format!("invalid JSON-RPC message from acpx: {line}"),
+                })?;
+
+            if let Some(update) = parse_session_update_from_message(&message)? {
+                if let Some(usage) = update.usage {
+                    last_usage = Some(usage);
                 }
-                Err(_) => on_event(AgentEvent::Malformed { line }).await,
+                if let Some(content) = update.output_text {
+                    on_event(AgentEvent::OutputChunk {
+                        stream: RuntimeStream::Stdout,
+                        content,
+                    })
+                    .await;
+                }
+                if let Some(permission) = update.permission_request {
+                    on_event(AgentEvent::Warning {
+                        message: format!(
+                            "permission requested ({}): {}",
+                            permission.permission_id, permission.description
+                        ),
+                    })
+                    .await;
+                }
+                if let Some(stop_reason) = update.stop_reason {
+                    saw_terminal_event = true;
+                    on_event(map_stop_reason(stop_reason, last_usage.clone())).await;
+                }
+                continue;
             }
+
+            if let Some(stop_reason) = message
+                .result
+                .as_ref()
+                .and_then(protocol::parse_stop_reason_from_result)
+            {
+                saw_terminal_event = true;
+                on_event(map_stop_reason(stop_reason, last_usage.clone())).await;
+                continue;
+            }
+
+            if let Some(error) = message.error.as_ref() {
+                saw_terminal_event = true;
+                on_event(AgentEvent::RunFailed {
+                    reason: error.message.clone(),
+                    usage: last_usage.clone(),
+                })
+                .await;
+                continue;
+            }
+
+            on_event(AgentEvent::OtherMessage {
+                raw: serde_json::to_string(&message).unwrap_or_else(|_| String::from("{}")),
+            })
+            .await;
         }
 
         let status = child.wait().await.map_err(|e| AgentError::IoError {
@@ -224,52 +267,33 @@ async fn cleanup_prompt_child(child: &mut tokio::process::Child) {
     let _ = child.wait().await;
 }
 
-fn map_event(value: serde_json::Value) -> AgentEvent {
-    match value.get("event").and_then(|v| v.as_str()) {
-        Some("prompt.started") => AgentEvent::PromptStarted,
-        Some("output") => AgentEvent::OutputChunk {
-            stream: match value.get("stream").and_then(|v| v.as_str()) {
-                Some("stderr") => RuntimeStream::Stderr,
-                _ => RuntimeStream::Stdout,
-            },
-            content: value
-                .get("text")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string(),
+fn parse_session_update_from_message(
+    message: &super::events::JsonRpcMessage,
+) -> Result<Option<protocol::ParsedSessionUpdate>, AgentError> {
+    if message.method.as_deref() != Some("session/update") {
+        return Ok(None);
+    }
+
+    let value = serde_json::to_value(message).map_err(|e| AgentError::ResponseError {
+        reason: format!("failed to encode JSON-RPC message: {e}"),
+    })?;
+
+    Ok(protocol::parse_session_update(&value))
+}
+
+fn map_stop_reason(stop_reason: StopReason, usage: Option<TokenUsage>) -> AgentEvent {
+    match stop_reason {
+        StopReason::EndTurn | StopReason::MaxTokens => AgentEvent::RunCompleted { usage },
+        StopReason::Cancelled => AgentEvent::Cancelled {
+            reason: Some("stop reason: cancelled".to_string()),
         },
-        Some("completed") => AgentEvent::RunCompleted {
-            usage: value
-                .get("usage")
-                .cloned()
-                .and_then(|usage| serde_json::from_value::<TokenUsage>(usage).ok()),
+        StopReason::Refusal => AgentEvent::RunFailed {
+            reason: "stop reason: refusal".to_string(),
+            usage,
         },
-        Some("failed") => AgentEvent::RunFailed {
-            reason: value
-                .get("reason")
-                .and_then(|v| v.as_str())
-                .unwrap_or("acpx run failed")
-                .to_string(),
-            usage: value
-                .get("usage")
-                .cloned()
-                .and_then(|usage| serde_json::from_value::<TokenUsage>(usage).ok()),
-        },
-        Some("cancelled") => AgentEvent::Cancelled {
-            reason: value
-                .get("reason")
-                .and_then(|v| v.as_str())
-                .map(str::to_string),
-        },
-        Some("warning") => AgentEvent::Warning {
-            message: value
-                .get("message")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string(),
-        },
-        _ => AgentEvent::OtherMessage {
-            raw: value.to_string(),
+        StopReason::MaxTurnRequests => AgentEvent::RunFailed {
+            reason: "stop reason: max_turn_requests".to_string(),
+            usage,
         },
     }
 }
@@ -356,9 +380,8 @@ mod tests {
             dir.path(),
             r#"#!/usr/bin/env bash
 cat <<'JSON'
-{"event":"prompt.started","session":"s1"}
-{"event":"output","stream":"stdout","text":"hello"}
-{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"},"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}}
+{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}
 JSON
 "#,
         );
@@ -376,9 +399,8 @@ JSON
             .unwrap();
         let events = events.lock().unwrap();
 
-        assert!(matches!(events[0], AgentEvent::PromptStarted));
-        assert!(matches!(events[1], AgentEvent::OutputChunk { .. }));
-        assert!(matches!(events[2], AgentEvent::RunCompleted { .. }));
+        assert!(matches!(events[0], AgentEvent::OutputChunk { .. }));
+        assert!(matches!(events[1], AgentEvent::RunCompleted { .. }));
     }
 
     #[tokio::test]
@@ -412,6 +434,34 @@ JSON
     }
 
     #[tokio::test]
+    async fn prompt_stream_rejects_non_jsonrpc_lines() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+cat <<'JSON'
+{"event":"completed"}
+JSON
+"#,
+        );
+
+        let client = AcpxCli::new(script);
+        let error = client
+            .run_prompt(
+                "codex",
+                "build-session",
+                dir.path(),
+                "hi",
+                None,
+                |_| async {},
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, AgentError::ResponseError { .. }));
+    }
+
+    #[tokio::test]
     async fn prompt_stream_emits_output_before_process_exit() {
         let dir = tempfile::TempDir::new().unwrap();
         let release_path = dir.path().join("release.flag");
@@ -419,12 +469,11 @@ JSON
             dir.path(),
             &format!(
                 r#"#!/bin/bash
-printf '%s\n' '{{"event":"prompt.started","session":"s1"}}'
-printf '%s\n' '{{"event":"output","stream":"stdout","text":"hello"}}'
+printf '%s\n' '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"hello"}}}}}}}}'
 while [ ! -f "{}" ]; do
   /bin/sleep 0.05
 done
-printf '%s\n' '{{"event":"completed","usage":{{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}}'
+printf '%s\n' '{{"jsonrpc":"2.0","id":11,"result":{{"stopReason":"end_turn"}}}}'
 "#,
                 release_path.display()
             ),
@@ -440,7 +489,7 @@ printf '%s\n' '{{"event":"completed","usage":{{"input_tokens":1,"output_tokens":
         });
         tokio::pin!(run);
 
-        let saw_output = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        let saw_output = tokio::time::timeout(std::time::Duration::from_secs(3), async {
             loop {
                 tokio::select! {
                     result = &mut run => panic!("prompt exited before streaming output: {result:?}"),
@@ -469,8 +518,7 @@ printf '%s\n' '{{"event":"completed","usage":{{"input_tokens":1,"output_tokens":
             dir.path(),
             r#"#!/usr/bin/env bash
 cat <<'JSON'
-{"event":"prompt.started","session":"s1"}
-{"event":"output","stream":"stdout","text":"hello"}
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}
 JSON
 "#,
         );
@@ -498,7 +546,8 @@ JSON
             dir.path(),
             r#"#!/usr/bin/env bash
 cat <<'JSON'
-{"event":"failed","reason":"boom","usage":{"input_tokens":4,"output_tokens":5,"total_tokens":9}}
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"usage_update","usage":{"input_tokens":4,"output_tokens":5,"total_tokens":9}}}}
+{"jsonrpc":"2.0","id":12,"result":{"stopReason":"refusal"}}
 JSON
 "#,
         );
@@ -525,7 +574,7 @@ JSON
                     output_tokens: 5,
                     total_tokens: 9
                 })
-            } if reason == "boom"
+            } if reason == "stop reason: refusal"
         ));
     }
 

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -382,6 +382,36 @@ JSON
     }
 
     #[tokio::test]
+    async fn prompt_stream_maps_jsonrpc_updates_and_stop_reason() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+cat <<'JSON'
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}
+{"jsonrpc":"2.0","id":7,"result":{"stopReason":"end_turn"}}
+JSON
+"#,
+        );
+
+        let client = AcpxCli::new(script);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None, |event| {
+                let events = Arc::clone(&events);
+                async move {
+                    events.lock().unwrap().push(event);
+                }
+            })
+            .await
+            .unwrap();
+        let events = events.lock().unwrap();
+
+        assert!(matches!(events[0], AgentEvent::OutputChunk { .. }));
+        assert!(matches!(events[1], AgentEvent::RunCompleted { .. }));
+    }
+
+    #[tokio::test]
     async fn prompt_stream_emits_output_before_process_exit() {
         let dir = tempfile::TempDir::new().unwrap();
         let release_path = dir.path().join("release.flag");

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -179,10 +179,7 @@ impl AcpxCli {
                 continue;
             }
 
-            on_event(AgentEvent::OtherMessage {
-                raw: serde_json::to_string(&message).unwrap_or_else(|_| String::from("{}")),
-            })
-            .await;
+            on_event(AgentEvent::OtherMessage { raw: line }).await;
         }
 
         let status = child.wait().await.map_err(|e| AgentError::IoError {
@@ -283,8 +280,9 @@ fn parse_session_update_from_message(
 fn map_stop_reason(stop_reason: StopReason, usage: Option<TokenUsage>) -> AgentEvent {
     match stop_reason {
         StopReason::EndTurn | StopReason::MaxTokens => AgentEvent::RunCompleted { usage },
-        StopReason::Cancelled => AgentEvent::Cancelled {
-            reason: Some("stop reason: cancelled".to_string()),
+        StopReason::Cancelled => AgentEvent::RunFailed {
+            reason: "stop reason: cancelled".to_string(),
+            usage,
         },
         StopReason::Refusal => AgentEvent::RunFailed {
             reason: "stop reason: refusal".to_string(),
@@ -574,6 +572,37 @@ JSON
                     total_tokens: 9
                 })
             } if reason == "stop reason: refusal"
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancelled_stop_reason_is_mapped_to_run_failed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+cat <<'JSON'
+{"jsonrpc":"2.0","id":13,"result":{"stopReason":"cancelled"}}
+JSON
+"#,
+        );
+
+        let client = AcpxCli::new(script);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        client
+            .run_prompt("codex", "build-session", dir.path(), "hi", None, |event| {
+                let events = Arc::clone(&events);
+                async move {
+                    events.lock().unwrap().push(event);
+                }
+            })
+            .await
+            .unwrap();
+        let events = events.lock().unwrap();
+
+        assert!(matches!(
+            &events[0],
+            AgentEvent::RunFailed { reason, .. } if reason == "stop reason: cancelled"
         ));
     }
 

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -287,9 +287,8 @@ case "$*" in
   ;;
   *" prompt --session "*)
   printf '%s\n' \
-    '{"event":"prompt.started","session":"s1"}' \
-    '{"event":"output","stream":"stdout","text":"hello"}' \
-    '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
+    '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}' \
+    '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
   exit 0
   ;;
   *" sessions close "*)
@@ -319,12 +318,10 @@ exit 1
         let result = runner.run_step(&request, "finish the task").await.unwrap();
 
         assert!(matches!(result, WorkerResult::Success));
-        let mut saw_prompt_started = false;
         let mut saw_output = false;
         while let Ok(event) = rx.try_recv() {
             if let WorkerEvent::AgentUpdate { event, .. } = event {
                 match event {
-                    AgentEvent::PromptStarted => saw_prompt_started = true,
                     AgentEvent::OutputChunk {
                         stream: RuntimeStream::Stdout,
                         content,
@@ -333,7 +330,6 @@ exit 1
                 }
             }
         }
-        assert!(saw_prompt_started);
         assert!(saw_output);
     }
 
@@ -348,7 +344,7 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
-    printf '%s\n' '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
     exit 0
     ;;
   *" sessions close "*)
@@ -446,7 +442,7 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
-    printf '%s\n' '{{"event":"completed","usage":{{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}}'
+    printf '%s\n' '{{"jsonrpc":"2.0","id":3,"result":{{"stopReason":"end_turn"}}}}'
     exit 0
     ;;
   *" sessions close "*)
@@ -493,11 +489,11 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
-    printf '%s\n' '{{"event":"prompt.started","session":"s1"}}'
+    printf '%s\n' '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"running"}}}}}}}}'
     while [ ! -f "{0}/cancelled.flag" ]; do
       /bin/sleep 0.05
     done
-    printf '%s\n' '{{"event":"cancelled","reason":"stop requested"}}'
+    printf '%s\n' '{{"jsonrpc":"2.0","id":4,"result":{{"stopReason":"cancelled"}}}}'
     exit 0
     ;;
   *" cancel --session "*)

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -3,6 +3,7 @@ pub mod acpx_cli;
 pub mod acpx_runtime;
 pub mod cancellation;
 pub mod events;
+pub mod protocol;
 pub mod runtime;
 
 use std::path::Path;
@@ -786,9 +787,8 @@ case "$*" in
     ;;
   *"prompt --session"*)
     printf '%s\n' \
-      '{"event":"prompt.started","session":"s1"}' \
-      '{"event":"output","stream":"stdout","text":"hello"}' \
-      '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
+      '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}' \
+      '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
     exit 0
     ;;
   *"sessions close"*)
@@ -827,7 +827,6 @@ exit 1
 
         assert!(matches!(result, WorkerResult::Success));
         let event_names = collect_event_names(&mut rx);
-        assert!(event_names.contains(&"prompt_started".to_string()));
         assert!(event_names.contains(&"output_chunk".to_string()));
         assert!(event_names.contains(&"run_completed".to_string()));
     }
@@ -843,9 +842,8 @@ exit 1
 case "$*" in
   *"prompt --session"*)
     printf '%s\n' \
-      '{"event":"prompt.started","session":"s1"}' \
-      '{"event":"output","stream":"stdout","text":"hello"}' \
-      '{"event":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}'
+      '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}' \
+      '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
     exit 0
     ;;
 esac

--- a/crates/ensemble-core/src/agent/protocol.rs
+++ b/crates/ensemble-core/src/agent/protocol.rs
@@ -24,7 +24,29 @@ pub struct ParsedSessionUpdate {
 ///
 /// Returns `None` when the line is not valid JSON-RPC JSON.
 pub fn parse_jsonrpc(line: &str) -> Option<JsonRpcMessage> {
-    serde_json::from_str::<JsonRpcMessage>(line).ok()
+    let message = serde_json::from_str::<JsonRpcMessage>(line).ok()?;
+    let is_jsonrpc_2 = message.jsonrpc == "2.0";
+    if !is_jsonrpc_2 {
+        return None;
+    }
+
+    let has_method = message.method.is_some();
+    let has_id = message.id.is_some();
+    let has_result = message.result.is_some();
+    let has_error = message.error.is_some();
+
+    if has_method {
+        if has_result || has_error {
+            return None;
+        }
+        return Some(message);
+    }
+
+    if has_id && (has_result ^ has_error) {
+        return Some(message);
+    }
+
+    None
 }
 
 /// Parse a `session/update` payload into normalized fields.
@@ -48,12 +70,22 @@ pub fn parse_session_update(value: &serde_json::Value) -> Option<ParsedSessionUp
     let stop_reason = extract_stop_reason(params, update);
     let permission_request = extract_permission_request(params, update);
 
-    Some(ParsedSessionUpdate {
+    let parsed = ParsedSessionUpdate {
         output_text,
         usage,
         stop_reason,
         permission_request,
-    })
+    };
+
+    if parsed.output_text.is_none()
+        && parsed.usage.is_none()
+        && parsed.stop_reason.is_none()
+        && parsed.permission_request.is_none()
+    {
+        return None;
+    }
+
+    Some(parsed)
 }
 
 pub fn parse_stop_reason_from_result(value: &serde_json::Value) -> Option<StopReason> {
@@ -186,6 +218,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_jsonrpc_invalid_envelope_returns_none() {
+        let invalid = r#"{"jsonrpc":"2.0","params":{"foo":"bar"}}"#;
+        assert!(parse_jsonrpc(invalid).is_none());
+    }
+
+    #[test]
     fn parse_session_update_supports_flat_content() {
         let params = json!({
             "sessionId": "s1",
@@ -247,8 +285,19 @@ mod tests {
             "content": ""
         });
 
-        let parsed = parse_session_update(&params).unwrap();
-        assert_eq!(parsed.output_text, None);
+        assert!(parse_session_update(&params).is_none());
+    }
+
+    #[test]
+    fn parse_session_update_returns_none_for_unrecognized_update() {
+        let params = json!({
+            "sessionId": "s1",
+            "update": {
+                "sessionUpdate": "noop"
+            }
+        });
+
+        assert!(parse_session_update(&params).is_none());
     }
 
     #[test]

--- a/crates/ensemble-core/src/agent/protocol.rs
+++ b/crates/ensemble-core/src/agent/protocol.rs
@@ -1,0 +1,168 @@
+use crate::agent::events::{JsonRpcMessage, StopReason, TokenUsage};
+
+#[derive(Debug, Clone)]
+pub struct PermissionRequest {
+    pub permission_id: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedSessionUpdate {
+    pub output_text: Option<String>,
+    pub usage: Option<TokenUsage>,
+    pub stop_reason: Option<StopReason>,
+    pub permission_request: Option<PermissionRequest>,
+}
+
+pub fn parse_jsonrpc(line: &str) -> Option<JsonRpcMessage> {
+    serde_json::from_str::<JsonRpcMessage>(line).ok()
+}
+
+pub fn parse_session_update(value: &serde_json::Value) -> Option<ParsedSessionUpdate> {
+    let params = if let Some(method) = value.get("method").and_then(|v| v.as_str()) {
+        if method != "session/update" {
+            return None;
+        }
+        value.get("params")?
+    } else {
+        value
+    };
+
+    let update = params.get("update");
+    let output_text = extract_output_text(params, update);
+    let usage = extract_usage(params, update);
+    let stop_reason = extract_stop_reason(params, update);
+    let permission_request = extract_permission_request(params, update);
+
+    Some(ParsedSessionUpdate {
+        output_text,
+        usage,
+        stop_reason,
+        permission_request,
+    })
+}
+
+pub fn parse_stop_reason_from_result(value: &serde_json::Value) -> Option<StopReason> {
+    let result = value.get("result").unwrap_or(value);
+    let raw = result.get("stopReason").and_then(|v| v.as_str())?;
+    StopReason::from_str_loose(raw)
+}
+
+fn extract_output_text(
+    params: &serde_json::Value,
+    update: Option<&serde_json::Value>,
+) -> Option<String> {
+    if let Some(text) = update.and_then(|u| u.get("content")).and_then(content_text) {
+        return Some(text);
+    }
+
+    if let Some(text) = params.get("content").and_then(content_text) {
+        return Some(text);
+    }
+
+    None
+}
+
+fn content_text(value: &serde_json::Value) -> Option<String> {
+    if let Some(text) = value.as_str() {
+        return Some(text.to_string());
+    }
+    value
+        .get("text")
+        .and_then(|v| v.as_str())
+        .map(ToString::to_string)
+}
+
+fn extract_usage(
+    params: &serde_json::Value,
+    update: Option<&serde_json::Value>,
+) -> Option<TokenUsage> {
+    if let Some(usage) = update
+        .and_then(|u| u.get("usage"))
+        .cloned()
+        .and_then(|v| serde_json::from_value::<TokenUsage>(v).ok())
+    {
+        return Some(usage);
+    }
+
+    params
+        .get("usage")
+        .cloned()
+        .and_then(|v| serde_json::from_value::<TokenUsage>(v).ok())
+}
+
+fn extract_stop_reason(
+    params: &serde_json::Value,
+    update: Option<&serde_json::Value>,
+) -> Option<StopReason> {
+    if let Some(raw) = update
+        .and_then(|u| u.get("stopReason"))
+        .and_then(|v| v.as_str())
+    {
+        return StopReason::from_str_loose(raw);
+    }
+
+    params
+        .get("stopReason")
+        .and_then(|v| v.as_str())
+        .and_then(StopReason::from_str_loose)
+}
+
+fn extract_permission_request(
+    params: &serde_json::Value,
+    update: Option<&serde_json::Value>,
+) -> Option<PermissionRequest> {
+    let source = update.unwrap_or(params);
+    let permission_id = source
+        .get("permissionId")
+        .and_then(|v| v.as_str())
+        .or_else(|| params.get("permissionId").and_then(|v| v.as_str()))?;
+    let description = source
+        .get("description")
+        .and_then(|v| v.as_str())
+        .or_else(|| params.get("description").and_then(|v| v.as_str()))
+        .unwrap_or_default()
+        .to_string();
+
+    Some(PermissionRequest {
+        permission_id: permission_id.to_string(),
+        description,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parse_agent_message_chunk_from_nested_update() {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "s1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "hello"}
+                }
+            }
+        });
+
+        let parsed = parse_session_update(&line).unwrap();
+        assert_eq!(parsed.output_text.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn parse_stop_reason_from_prompt_response_result() {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "result": {"stopReason": "end_turn"}
+        });
+
+        let stop = parse_stop_reason_from_result(&line).unwrap();
+        assert_eq!(stop, StopReason::EndTurn);
+    }
+}

--- a/crates/ensemble-core/src/agent/protocol.rs
+++ b/crates/ensemble-core/src/agent/protocol.rs
@@ -1,11 +1,17 @@
 use crate::agent::events::{JsonRpcMessage, StopReason, TokenUsage};
 
+/// Permission request details surfaced in session updates.
 #[derive(Debug, Clone)]
 pub struct PermissionRequest {
     pub permission_id: String,
     pub description: String,
 }
 
+/// Normalized data extracted from ACP `session/update` payloads.
+///
+/// `permission_request` is currently consumed by the acpx runtime path when
+/// mapping runtime warnings, but the shared parser keeps this field available
+/// for any runtime that needs it.
 #[derive(Debug, Clone)]
 pub struct ParsedSessionUpdate {
     pub output_text: Option<String>,
@@ -14,10 +20,18 @@ pub struct ParsedSessionUpdate {
     pub permission_request: Option<PermissionRequest>,
 }
 
+/// Parse one stdout line as a JSON-RPC message.
+///
+/// Returns `None` when the line is not valid JSON-RPC JSON.
 pub fn parse_jsonrpc(line: &str) -> Option<JsonRpcMessage> {
     serde_json::from_str::<JsonRpcMessage>(line).ok()
 }
 
+/// Parse a `session/update` payload into normalized fields.
+///
+/// Accepts either:
+/// - a full JSON-RPC notification object (`method = session/update`), or
+/// - a direct `params` object from that notification.
 pub fn parse_session_update(value: &serde_json::Value) -> Option<ParsedSessionUpdate> {
     let params = if let Some(method) = value.get("method").and_then(|v| v.as_str()) {
         if method != "session/update" {
@@ -53,11 +67,11 @@ fn extract_output_text(
     update: Option<&serde_json::Value>,
 ) -> Option<String> {
     if let Some(text) = update.and_then(|u| u.get("content")).and_then(content_text) {
-        return Some(text);
+        return Some(text).filter(|s| !s.is_empty());
     }
 
     if let Some(text) = params.get("content").and_then(content_text) {
-        return Some(text);
+        return Some(text).filter(|s| !s.is_empty());
     }
 
     None
@@ -164,5 +178,96 @@ mod tests {
 
         let stop = parse_stop_reason_from_result(&line).unwrap();
         assert_eq!(stop, StopReason::EndTurn);
+    }
+
+    #[test]
+    fn parse_jsonrpc_invalid_input_returns_none() {
+        assert!(parse_jsonrpc("not-json").is_none());
+    }
+
+    #[test]
+    fn parse_session_update_supports_flat_content() {
+        let params = json!({
+            "sessionId": "s1",
+            "content": "flat text",
+            "stopReason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        });
+
+        let parsed = parse_session_update(&params).unwrap();
+        assert_eq!(parsed.output_text.as_deref(), Some("flat text"));
+        assert_eq!(parsed.stop_reason, Some(StopReason::EndTurn));
+        let usage = parsed.usage.expect("usage should be parsed");
+        assert_eq!(usage.input_tokens, 1);
+        assert_eq!(usage.output_tokens, 2);
+        assert_eq!(usage.total_tokens, 3);
+    }
+
+    #[test]
+    fn parse_session_update_prefers_nested_usage_over_flat_usage() {
+        let params = json!({
+            "sessionId": "s1",
+            "usage": {"input_tokens": 9, "output_tokens": 9, "total_tokens": 18},
+            "update": {
+                "sessionUpdate": "usage_update",
+                "usage": {"input_tokens": 4, "output_tokens": 5, "total_tokens": 9}
+            }
+        });
+
+        let parsed = parse_session_update(&params).unwrap();
+        let usage = parsed.usage.expect("usage should be parsed");
+        assert_eq!(usage.input_tokens, 4);
+        assert_eq!(usage.output_tokens, 5);
+        assert_eq!(usage.total_tokens, 9);
+    }
+
+    #[test]
+    fn parse_session_update_extracts_permission_request() {
+        let params = json!({
+            "sessionId": "s1",
+            "update": {
+                "sessionUpdate": "permission_request",
+                "permissionId": "perm-1",
+                "description": "write file"
+            }
+        });
+
+        let parsed = parse_session_update(&params).unwrap();
+        let permission = parsed
+            .permission_request
+            .expect("permission request should be parsed");
+        assert_eq!(permission.permission_id, "perm-1");
+        assert_eq!(permission.description, "write file");
+    }
+
+    #[test]
+    fn parse_session_update_ignores_empty_content() {
+        let params = json!({
+            "sessionId": "s1",
+            "content": ""
+        });
+
+        let parsed = parse_session_update(&params).unwrap();
+        assert_eq!(parsed.output_text, None);
+    }
+
+    #[test]
+    fn parse_session_update_supports_content_object_and_string() {
+        let object_params = json!({
+            "sessionId": "s1",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "obj text"}
+            }
+        });
+        let string_params = json!({
+            "sessionId": "s1",
+            "content": "str text"
+        });
+
+        let object_parsed = parse_session_update(&object_params).unwrap();
+        let string_parsed = parse_session_update(&string_params).unwrap();
+        assert_eq!(object_parsed.output_text.as_deref(), Some("obj text"));
+        assert_eq!(string_parsed.output_text.as_deref(), Some("str text"));
     }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -542,6 +542,8 @@ Named agent definitions. Each key is the agent role name, each value is an objec
 - `acpx_agent` (string, optional)
   - acpx agent identifier (for example `claude`, `codex`, `gemini`).
   - When set, Ensemble delegates agent communication to acpx unless `runtime: direct` overrides it.
+  - acpx runtime parsing is JSON-RPC-only: stdout protocol lines must be valid JSON-RPC messages.
+    Non-JSON-RPC stdout lines are treated as runtime protocol errors.
 - `executor` (string, optional)
   - ACP-compatible agent executable identifier (for example `claude-code`, `amp`).
   - Required for `direct` runtime.
@@ -1295,6 +1297,8 @@ Line handling requirements:
 - Read protocol messages from stdout only.
 - Buffer partial stdout lines until newline arrives.
 - Attempt JSON parse on complete stdout lines.
+- For `acpx` runtime, accept JSON-RPC 2.0 protocol envelopes only. Reject non-JSON-RPC stdout
+  lines as protocol errors.
 - Stderr is not part of the protocol stream:
   - ignore it or log it as diagnostics
   - do not attempt protocol JSON parsing on stderr

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,6 +210,7 @@ This section configures per-agent launch settings. Runtime ACP callback handling
 **Validation rules:**
 - Omit `runtime` to infer it automatically: `acpx_agent` => `acpx`, otherwise `direct`.
 - `runtime: acpx` requires `acpx_agent`.
+- `runtime: acpx` expects JSON-RPC protocol output on stdout; non-JSON-RPC stdout lines are treated as runtime errors.
 - `runtime: direct` requires `executor` and `model`.
 - Provide either `prompt` (inline) or `prompt_template` (file), not both.
 

--- a/docs/superpowers/plans/2026-04-07-acpx-shared-jsonrpc-parsing.md
+++ b/docs/superpowers/plans/2026-04-07-acpx-shared-jsonrpc-parsing.md
@@ -1,0 +1,245 @@
+# ACPX Shared JSON-RPC Parsing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify ACP/ACPX message parsing so both direct ACP sessions and the `acpx` CLI runtime correctly handle JSON-RPC `session/update` envelopes and terminal `stopReason` responses.
+
+**Architecture:** Introduce a shared ACP protocol parsing module in `ensemble-core` that normalizes JSON-RPC lines into runtime-friendly signals (output chunks, usage deltas, stop reasons, permission requests). Refactor both `acp_client.rs` and `acpx_cli.rs` to use the same helpers instead of maintaining divergent message-shape assumptions. Keep flat legacy `{"event": ...}` mapping as fallback in `acpx_cli` only for backward compatibility.
+
+**Tech Stack:** Rust 2021, tokio async process I/O, serde/serde_json, thiserror, tracing, cargo test.
+
+---
+
+### Task 1: Add shared ACP protocol parser module
+
+**Files:**
+- Create: `crates/ensemble-core/src/agent/protocol.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Test: `crates/ensemble-core/src/agent/protocol.rs` (unit tests in `#[cfg(test)]`)
+
+- [ ] **Step 1: Write failing tests for nested ACP update extraction**
+
+```rust
+#[test]
+fn parse_agent_message_chunk_from_nested_update() {
+    let line = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "sessionId": "s1",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "hello"}
+            }
+        }
+    });
+
+    let parsed = parse_session_update(&line).unwrap();
+    assert_eq!(parsed.output_text.as_deref(), Some("hello"));
+}
+
+#[test]
+fn parse_stop_reason_from_prompt_response_result() {
+    let line = json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "result": {"stopReason": "end_turn"}
+    });
+
+    let stop = parse_stop_reason_from_result(&line).unwrap();
+    assert_eq!(stop, StopReason::EndTurn);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk cargo test -p ensemble-core parse_agent_message_chunk_from_nested_update -- --exact`
+Expected: FAIL with unresolved parser functions / module not found.
+
+- [ ] **Step 3: Implement `protocol.rs` minimal parser API**
+
+```rust
+pub struct ParsedSessionUpdate {
+    pub output_text: Option<String>,
+    pub usage: Option<TokenUsage>,
+    pub stop_reason: Option<StopReason>,
+    pub permission_request: Option<PermissionRequest>,
+}
+
+pub fn parse_jsonrpc(line: &str) -> Option<JsonRpcMessage> { /* serde_json::from_str */ }
+pub fn parse_session_update(value: &serde_json::Value) -> Option<ParsedSessionUpdate> { /* flat + nested */ }
+pub fn parse_stop_reason_from_result(value: &serde_json::Value) -> Option<StopReason> { /* result.stopReason */ }
+```
+
+- [ ] **Step 4: Export parser module from `agent/mod.rs`**
+
+```rust
+pub mod protocol;
+```
+
+- [ ] **Step 5: Run parser tests to green**
+
+Run: `rtk cargo test -p ensemble-core parse_agent_message_chunk_from_nested_update parse_stop_reason_from_prompt_response_result`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/protocol.rs crates/ensemble-core/src/agent/mod.rs
+git commit -m "feat(agent): add shared ACP JSON-RPC protocol parser"
+```
+
+### Task 2: Refactor `acpx_cli` to use shared parser for JSON-RPC streams
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/acpx_cli.rs`
+- Test: `crates/ensemble-core/src/agent/acpx_cli.rs`
+
+- [ ] **Step 1: Write failing test for ACPX JSON-RPC stream**
+
+```rust
+#[tokio::test]
+async fn prompt_stream_maps_jsonrpc_updates_and_stop_reason() {
+    // script emits session/update(agent_message_chunk) then id/result(stopReason=end_turn)
+    // expect OutputChunk then RunCompleted
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails on current mapper**
+
+Run: `rtk cargo test -p ensemble-core prompt_stream_maps_jsonrpc_updates_and_stop_reason -- --exact`
+Expected: FAIL with `AcpxFinalStatusMissing` (no flat terminal event seen).
+
+- [ ] **Step 3: Replace `map_event`-only path with shared parser-first logic**
+
+```rust
+while let Some(line) = reader.next_line().await? {
+    if let Some(msg) = protocol::parse_jsonrpc(&line) {
+        handle_jsonrpc_message(&msg, &mut saw_terminal_event, &mut on_event).await;
+        continue;
+    }
+
+    // fallback compatibility for legacy flat {"event": ...}
+    match serde_json::from_str::<serde_json::Value>(&line) {
+        Ok(value) => { /* old map_event path */ }
+        Err(_) => on_event(AgentEvent::Malformed { line }).await,
+    }
+}
+```
+
+- [ ] **Step 4: Add stop-reason mapping from JSON-RPC response result**
+
+```rust
+match stop_reason {
+    StopReason::EndTurn | StopReason::MaxTokens => AgentEvent::RunCompleted { usage: None },
+    StopReason::Cancelled => AgentEvent::Cancelled { reason: Some("stop reason: cancelled".into()) },
+    other => AgentEvent::RunFailed { reason: format!("stop reason: {}", other.as_str()), usage: None },
+}
+```
+
+- [ ] **Step 5: Keep legacy flat-event compatibility tests green**
+
+Run: `rtk cargo test -p ensemble-core prompt_stream_maps_output_and_completion_events prompt_stream_maps_jsonrpc_updates_and_stop_reason`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/acpx_cli.rs
+git commit -m "fix(acpx): parse JSON-RPC prompt streams via shared protocol parser"
+```
+
+### Task 3: Refactor `acp_client` to consume shared parser
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+- Test: `crates/ensemble-core/src/agent/acp_client.rs`
+
+- [ ] **Step 1: Write failing regression test for nested `params.update` content**
+
+```rust
+#[tokio::test]
+async fn run_turn_handles_nested_session_update_content() {
+    // fake ACP output with params.update.sessionUpdate=agent_message_chunk
+    // expect OutputChunk event and successful turn completion
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails pre-refactor**
+
+Run: `rtk cargo test -p ensemble-core run_turn_handles_nested_session_update_content -- --exact`
+Expected: FAIL because current `stream_turn` only checks `params.content` / `params.stopReason` flat fields.
+
+- [ ] **Step 3: Swap ad-hoc field lookups for shared parser output**
+
+```rust
+if let Some(parsed) = protocol::parse_session_update(params) {
+    if let Some(usage) = parsed.usage { last_usage = Some(usage); }
+    if let Some(text) = parsed.output_text { emit OutputChunk(text); }
+    if let Some(stop) = parsed.stop_reason { return map_stop_reason(stop, last_usage.clone()); }
+}
+```
+
+- [ ] **Step 4: Preserve permission request flow and unknown-message behavior**
+
+```rust
+// keep existing request/response handling for session/request_permission
+// keep AgentEvent::OtherMessage fallback for unsupported notifications
+```
+
+- [ ] **Step 5: Run targeted ACP client tests**
+
+Run: `rtk cargo test -p ensemble-core run_turn_handles_nested_session_update_content`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/acp_client.rs
+git commit -m "refactor(agent): share ACP message parsing in direct runtime"
+```
+
+### Task 4: End-to-end runtime regression tests and verification
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/acpx_runtime.rs` (tests only if needed)
+- Modify: `crates/ensemble-core/src/agent/mod.rs` (tests only if needed)
+- Optional docs update: `docs/pipelines.md` (if runtime event wording changed)
+
+- [ ] **Step 1: Add/adjust runtime integration test fixtures to JSON-RPC shape**
+
+```rust
+// Replace flat {"event":"..."} fixture in at least one runtime integration test
+// with session/update + result.stopReason payloads.
+```
+
+- [ ] **Step 2: Run focused integration tests**
+
+Run:
+- `rtk cargo test -p ensemble-core acpx_runtime_emits_runtime_events_and_success -- --exact`
+- `rtk cargo test -p ensemble-core acpx_agent_runner_emits_runtime_events_and_success -- --exact`
+
+Expected: PASS
+
+- [ ] **Step 3: Run crate-level validation**
+
+Run:
+- `rtk cargo test -p ensemble-core`
+- `rtk cargo clippy -p ensemble-core -- -D warnings`
+- `rtk cargo fmt --all -- --check`
+
+Expected: all PASS with no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/acpx_runtime.rs crates/ensemble-core/src/agent/mod.rs docs/pipelines.md
+git commit -m "test(agent): add JSON-RPC regressions for acpx/direct runtimes"
+```
+
+## Self-Review Checklist
+
+- Spec coverage: includes shared parsing module, acpx runtime path, direct ACP path, and regression verification.
+- Placeholder scan: no TBD/TODO placeholders in actionable steps; each task contains file paths and commands.
+- Type consistency: shared parser outputs (`ParsedSessionUpdate`, `StopReason`, `TokenUsage`) are reused across both runtimes.
+

--- a/docs/superpowers/plans/2026-04-07-acpx-shared-jsonrpc-parsing.md
+++ b/docs/superpowers/plans/2026-04-07-acpx-shared-jsonrpc-parsing.md
@@ -4,7 +4,7 @@
 
 **Goal:** Unify ACP/ACPX message parsing so both direct ACP sessions and the `acpx` CLI runtime correctly handle JSON-RPC `session/update` envelopes and terminal `stopReason` responses.
 
-**Architecture:** Introduce a shared ACP protocol parsing module in `ensemble-core` that normalizes JSON-RPC lines into runtime-friendly signals (output chunks, usage deltas, stop reasons, permission requests). Refactor both `acp_client.rs` and `acpx_cli.rs` to use the same helpers instead of maintaining divergent message-shape assumptions. Keep flat legacy `{"event": ...}` mapping as fallback in `acpx_cli` only for backward compatibility.
+**Architecture:** Introduce a shared ACP protocol parsing module in `ensemble-core` that normalizes JSON-RPC lines into runtime-friendly signals (output chunks, usage deltas, stop reasons, permission requests). Refactor both `acp_client.rs` and `acpx_cli.rs` to use the same helpers instead of maintaining divergent message-shape assumptions. Remove flat legacy `{"event": ...}` parsing from `acpx_cli` so ACP/ACPX transport handling is JSON-RPC-only.
 
 **Tech Stack:** Rust 2021, tokio async process I/O, serde/serde_json, thiserror, tracing, cargo test.
 
@@ -110,19 +110,17 @@ async fn prompt_stream_maps_jsonrpc_updates_and_stop_reason() {
 Run: `rtk cargo test -p ensemble-core prompt_stream_maps_jsonrpc_updates_and_stop_reason -- --exact`
 Expected: FAIL with `AcpxFinalStatusMissing` (no flat terminal event seen).
 
-- [ ] **Step 3: Replace `map_event`-only path with shared parser-first logic**
+- [ ] **Step 3: Replace `map_event` path with strict JSON-RPC parsing**
 
 ```rust
 while let Some(line) = reader.next_line().await? {
-    if let Some(msg) = protocol::parse_jsonrpc(&line) {
-        handle_jsonrpc_message(&msg, &mut saw_terminal_event, &mut on_event).await;
-        continue;
-    }
-
-    // fallback compatibility for legacy flat {"event": ...}
-    match serde_json::from_str::<serde_json::Value>(&line) {
-        Ok(value) => { /* old map_event path */ }
-        Err(_) => on_event(AgentEvent::Malformed { line }).await,
+    match protocol::parse_jsonrpc(&line) {
+        Some(msg) => handle_jsonrpc_message(&msg, &mut saw_terminal_event, &mut on_event).await,
+        None => {
+            return Err(AgentError::ResponseError {
+                reason: format!("invalid JSON-RPC message from acpx: {line}"),
+            });
+        }
     }
 }
 ```
@@ -137,9 +135,9 @@ match stop_reason {
 }
 ```
 
-- [ ] **Step 5: Keep legacy flat-event compatibility tests green**
+- [ ] **Step 5: Remove flat-event parser tests; keep JSON-RPC tests green**
 
-Run: `rtk cargo test -p ensemble-core prompt_stream_maps_output_and_completion_events prompt_stream_maps_jsonrpc_updates_and_stop_reason`
+Run: `rtk cargo test -p ensemble-core prompt_stream_maps_jsonrpc_updates_and_stop_reason`
 Expected: PASS
 
 - [ ] **Step 6: Commit**
@@ -206,11 +204,11 @@ git commit -m "refactor(agent): share ACP message parsing in direct runtime"
 - Modify: `crates/ensemble-core/src/agent/mod.rs` (tests only if needed)
 - Optional docs update: `docs/pipelines.md` (if runtime event wording changed)
 
-- [ ] **Step 1: Add/adjust runtime integration test fixtures to JSON-RPC shape**
+- [ ] **Step 1: Convert runtime integration fixtures to JSON-RPC shape only**
 
 ```rust
-// Replace flat {"event":"..."} fixture in at least one runtime integration test
-// with session/update + result.stopReason payloads.
+// Replace flat {"event":"..."} fixtures with session/update + result.stopReason payloads.
+// Ensure no runtime tests depend on flat event parsing.
 ```
 
 - [ ] **Step 2: Run focused integration tests**
@@ -242,4 +240,3 @@ git commit -m "test(agent): add JSON-RPC regressions for acpx/direct runtimes"
 - Spec coverage: includes shared parsing module, acpx runtime path, direct ACP path, and regression verification.
 - Placeholder scan: no TBD/TODO placeholders in actionable steps; each task contains file paths and commands.
 - Type consistency: shared parser outputs (`ParsedSessionUpdate`, `StopReason`, `TokenUsage`) are reused across both runtimes.
-


### PR DESCRIPTION
## Summary
- add a shared ACP protocol parser module and use it from both direct ACP and acpx runtime paths
- remove flat acpx event parsing and make acpx stdout parsing JSON-RPC-only
- fix follow-up review items: ignore empty output chunks, avoid JSON re-serialization in acpx CLI parsing, and tighten stop-reason mapping
- expand parser/unit/runtime test coverage and update docs for JSON-RPC-only acpx behavior

## Testing
- cargo test -p ensemble-core
- cargo clippy -p ensemble-core -- -D warnings
- cargo fmt --all -- --check