### PR TITLE
Add verbose logging contract and harden redaction

### DIFF
--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -6,9 +6,11 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::mpsc;
 use tokio::time::timeout;
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 use crate::error::AgentError;
+use crate::observability::events_contract::AGENT_MESSAGE;
+use crate::observability::redaction::{redact_kv, truncate_for_log};
 
 use super::events::{
     AgentEvent, JsonRpcMessage, RuntimeStream, StopReason, TokenUsage, WorkerEvent,
@@ -596,7 +598,13 @@ impl AcpSession {
         let line = serde_json::to_string(msg).map_err(|e| AgentError::IoError {
             reason: format!("json serialize error: {e}"),
         })?;
-        debug!(msg = %line, "sending JSON-RPC");
+        trace!(
+            event = AGENT_MESSAGE,
+            direction = "outbound",
+            bytes = line.len(),
+            preview = %truncate_for_log(&redact_kv(&line), 160),
+            "sending JSON-RPC"
+        );
 
         let mut buf = Vec::with_capacity(line.len() + 1);
         buf.extend_from_slice(line.as_bytes());
@@ -632,7 +640,13 @@ impl AcpSession {
         }
 
         let trimmed = line.trim_end().to_string();
-        debug!(line = %trimmed, "received from agent");
+        trace!(
+            event = AGENT_MESSAGE,
+            direction = "inbound",
+            bytes = trimmed.len(),
+            preview = %truncate_for_log(&redact_kv(&trimmed), 160),
+            "received from agent"
+        );
         Ok(trimmed)
     }
 

--- a/crates/ensemble-core/src/observability/events_contract.rs
+++ b/crates/ensemble-core/src/observability/events_contract.rs
@@ -31,7 +31,10 @@ mod tests {
         assert_eq!(ORCH_TICK_STARTED, "orchestrator.tick_started");
         assert_eq!(ISSUE_DISPATCH_STARTED, "issue.dispatch_started");
         assert_eq!(TRACKER_TRANSITION_FAILED, "tracker.transition_failed");
-        assert_eq!(WORKSPACE_GIT_COMMAND_STARTED, "workspace.git_command_started");
+        assert_eq!(
+            WORKSPACE_GIT_COMMAND_STARTED,
+            "workspace.git_command_started"
+        );
         assert_eq!(
             WORKSPACE_GIT_COMMAND_FINISHED,
             "workspace.git_command_finished"

--- a/crates/ensemble-core/src/observability/events_contract.rs
+++ b/crates/ensemble-core/src/observability/events_contract.rs
@@ -1,0 +1,46 @@
+pub const ORCH_TICK_STARTED: &str = "orchestrator.tick_started";
+pub const ORCH_TICK_FINISHED: &str = "orchestrator.tick_finished";
+pub const ISSUE_DISPATCH_STARTED: &str = "issue.dispatch_started";
+pub const ISSUE_DISPATCH_SKIPPED: &str = "issue.dispatch_skipped";
+pub const ISSUE_DISPATCH_COMPLETED: &str = "issue.dispatch_completed";
+pub const ISSUE_RETRY_SCHEDULED: &str = "issue.retry_scheduled";
+pub const ISSUE_RETRY_CANCELLED: &str = "issue.retry_cancelled";
+pub const STEP_STARTED: &str = "step.started";
+pub const STEP_WAITING: &str = "step.waiting";
+pub const STEP_FINISHED: &str = "step.finished";
+pub const TRACKER_TRANSITION_REQUESTED: &str = "tracker.transition_requested";
+pub const TRACKER_TRANSITION_SUCCEEDED: &str = "tracker.transition_succeeded";
+pub const TRACKER_TRANSITION_FAILED: &str = "tracker.transition_failed";
+pub const WORKSPACE_PREPARE_STARTED: &str = "workspace.prepare_started";
+pub const WORKSPACE_PREPARE_FINISHED: &str = "workspace.prepare_finished";
+pub const WORKSPACE_PREPARE_FAILED: &str = "workspace.prepare_failed";
+pub const WORKSPACE_HOOK_STARTED: &str = "workspace.hook_started";
+pub const WORKSPACE_HOOK_FINISHED: &str = "workspace.hook_finished";
+pub const WORKSPACE_HOOK_FAILED: &str = "workspace.hook_failed";
+pub const AGENT_SESSION_STARTED: &str = "agent.session_started";
+pub const AGENT_SESSION_FINISHED: &str = "agent.session_finished";
+pub const AGENT_SESSION_FAILED: &str = "agent.session_failed";
+pub const AGENT_MESSAGE: &str = "agent.message";
+
+pub fn elapsed_ms(start: std::time::Instant) -> u128 {
+    start.elapsed().as_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_names_are_stable() {
+        assert_eq!(ORCH_TICK_STARTED, "orchestrator.tick_started");
+        assert_eq!(ISSUE_DISPATCH_STARTED, "issue.dispatch_started");
+        assert_eq!(TRACKER_TRANSITION_FAILED, "tracker.transition_failed");
+    }
+
+    #[test]
+    fn duration_helper_is_millis() {
+        let start = std::time::Instant::now();
+        let elapsed = elapsed_ms(start);
+        assert!(elapsed <= 5_000);
+    }
+}

--- a/crates/ensemble-core/src/observability/events_contract.rs
+++ b/crates/ensemble-core/src/observability/events_contract.rs
@@ -1,13 +1,10 @@
 pub const ORCH_TICK_STARTED: &str = "orchestrator.tick_started";
 pub const ORCH_TICK_FINISHED: &str = "orchestrator.tick_finished";
 pub const ISSUE_DISPATCH_STARTED: &str = "issue.dispatch_started";
-pub const ISSUE_DISPATCH_SKIPPED: &str = "issue.dispatch_skipped";
 pub const ISSUE_DISPATCH_COMPLETED: &str = "issue.dispatch_completed";
 pub const ISSUE_RETRY_SCHEDULED: &str = "issue.retry_scheduled";
 pub const ISSUE_RETRY_CANCELLED: &str = "issue.retry_cancelled";
 pub const STEP_STARTED: &str = "step.started";
-pub const STEP_WAITING: &str = "step.waiting";
-pub const STEP_FINISHED: &str = "step.finished";
 pub const TRACKER_TRANSITION_REQUESTED: &str = "tracker.transition_requested";
 pub const TRACKER_TRANSITION_SUCCEEDED: &str = "tracker.transition_succeeded";
 pub const TRACKER_TRANSITION_FAILED: &str = "tracker.transition_failed";
@@ -17,9 +14,8 @@ pub const WORKSPACE_PREPARE_FAILED: &str = "workspace.prepare_failed";
 pub const WORKSPACE_HOOK_STARTED: &str = "workspace.hook_started";
 pub const WORKSPACE_HOOK_FINISHED: &str = "workspace.hook_finished";
 pub const WORKSPACE_HOOK_FAILED: &str = "workspace.hook_failed";
-pub const AGENT_SESSION_STARTED: &str = "agent.session_started";
-pub const AGENT_SESSION_FINISHED: &str = "agent.session_finished";
-pub const AGENT_SESSION_FAILED: &str = "agent.session_failed";
+pub const WORKSPACE_GIT_COMMAND_STARTED: &str = "workspace.git_command_started";
+pub const WORKSPACE_GIT_COMMAND_FINISHED: &str = "workspace.git_command_finished";
 pub const AGENT_MESSAGE: &str = "agent.message";
 
 pub fn elapsed_ms(start: std::time::Instant) -> u128 {
@@ -35,6 +31,11 @@ mod tests {
         assert_eq!(ORCH_TICK_STARTED, "orchestrator.tick_started");
         assert_eq!(ISSUE_DISPATCH_STARTED, "issue.dispatch_started");
         assert_eq!(TRACKER_TRANSITION_FAILED, "tracker.transition_failed");
+        assert_eq!(WORKSPACE_GIT_COMMAND_STARTED, "workspace.git_command_started");
+        assert_eq!(
+            WORKSPACE_GIT_COMMAND_FINISHED,
+            "workspace.git_command_finished"
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/observability/logging.rs
+++ b/crates/ensemble-core/src/observability/logging.rs
@@ -17,6 +17,15 @@ use tracing_subscriber::EnvFilter;
 /// - `issue_id`, `issue_identifier` (per-issue spans)
 /// - `session_id` (per-session spans)
 /// - `hook` (hook execution spans)
+///
+/// Event contract:
+/// - `event` should use stable names from `observability::events_contract`
+/// - lifecycle logs should include `run_id` + issue/step context when applicable
+///
+/// Verbosity guidance:
+/// - `info`: lifecycle milestones
+/// - `debug`: dispatch/retry/decision reasoning
+/// - `trace`: protocol/process metadata with redaction helpers
 pub fn init_logging() {
     let filter = build_env_filter();
     let use_json = should_use_json();

--- a/crates/ensemble-core/src/observability/mod.rs
+++ b/crates/ensemble-core/src/observability/mod.rs
@@ -1,4 +1,5 @@
 pub mod events;
 pub mod events_contract;
 pub mod logging;
+pub mod redaction;
 pub mod snapshot;

--- a/crates/ensemble-core/src/observability/mod.rs
+++ b/crates/ensemble-core/src/observability/mod.rs
@@ -1,3 +1,4 @@
 pub mod events;
+pub mod events_contract;
 pub mod logging;
 pub mod snapshot;

--- a/crates/ensemble-core/src/observability/redaction.rs
+++ b/crates/ensemble-core/src/observability/redaction.rs
@@ -1,0 +1,34 @@
+pub fn truncate_for_log(input: &str, max_chars: usize) -> String {
+    if input.chars().count() <= max_chars {
+        return input.to_string();
+    }
+    let prefix: String = input.chars().take(max_chars).collect();
+    format!("{prefix}…")
+}
+
+pub fn redact_kv(input: &str) -> String {
+    const PREFIXES: [&str; 4] = ["api_token=", "authorization=", "token=", "password="];
+    for prefix in PREFIXES {
+        if input.starts_with(prefix) {
+            return format!("{prefix}[REDACTED]");
+        }
+    }
+    input.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_preserves_prefix_and_marks_ellipsis() {
+        let out = truncate_for_log("abcdefghijklmnopqrstuvwxyz", 8);
+        assert_eq!(out, "abcdefgh…");
+    }
+
+    #[test]
+    fn redact_token_masks_known_keys() {
+        let out = redact_kv("api_token=abc123");
+        assert_eq!(out, "api_token=[REDACTED]");
+    }
+}

--- a/crates/ensemble-core/src/observability/redaction.rs
+++ b/crates/ensemble-core/src/observability/redaction.rs
@@ -1,3 +1,5 @@
+use serde_json::Value;
+
 pub fn truncate_for_log(input: &str, max_chars: usize) -> String {
     if input.chars().count() <= max_chars {
         return input.to_string();
@@ -8,12 +10,50 @@ pub fn truncate_for_log(input: &str, max_chars: usize) -> String {
 
 pub fn redact_kv(input: &str) -> String {
     const PREFIXES: [&str; 4] = ["api_token=", "authorization=", "token=", "password="];
+    const REDACTED: &str = "[REDACTED]";
+
+    if let Ok(mut json) = serde_json::from_str::<Value>(input) {
+        redact_json_value(&mut json);
+        if let Ok(serialized) = serde_json::to_string(&json) {
+            return serialized;
+        }
+    }
+
     for prefix in PREFIXES {
         if input.starts_with(prefix) {
-            return format!("{prefix}[REDACTED]");
+            return format!("{prefix}{REDACTED}");
         }
     }
     input.to_string()
+}
+
+fn redact_json_value(value: &mut Value) {
+    const SECRET_KEYS: [&str; 6] = [
+        "token",
+        "authorization",
+        "api_key",
+        "api_token",
+        "password",
+        "apikey",
+    ];
+
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                if SECRET_KEYS.contains(&key.to_ascii_lowercase().as_str()) {
+                    *child = Value::String("[REDACTED]".to_string());
+                } else {
+                    redact_json_value(child);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_json_value(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
@@ -30,5 +70,27 @@ mod tests {
     fn redact_token_masks_known_keys() {
         let out = redact_kv("api_token=abc123");
         assert_eq!(out, "api_token=[REDACTED]");
+    }
+
+    #[test]
+    fn redact_masks_all_supported_prefixes() {
+        assert_eq!(redact_kv("authorization=abc123"), "authorization=[REDACTED]");
+        assert_eq!(redact_kv("token=abc123"), "token=[REDACTED]");
+        assert_eq!(redact_kv("password=abc123"), "password=[REDACTED]");
+    }
+
+    #[test]
+    fn redact_passthrough_non_matching_prefix() {
+        assert_eq!(redact_kv("hello=world"), "hello=world");
+    }
+
+    #[test]
+    fn redact_json_payload_secrets() {
+        let input = r#"{"method":"initialize","params":{"token":"abc123","authorization":"bearer xyz","api_key":"sekret","keep":"ok"}}"#;
+        let out = redact_kv(input);
+        assert!(out.contains(r#""token":"[REDACTED]""#));
+        assert!(out.contains(r#""authorization":"[REDACTED]""#));
+        assert!(out.contains(r#""api_key":"[REDACTED]""#));
+        assert!(out.contains(r#""keep":"ok""#));
     }
 }

--- a/crates/ensemble-core/src/observability/redaction.rs
+++ b/crates/ensemble-core/src/observability/redaction.rs
@@ -74,7 +74,10 @@ mod tests {
 
     #[test]
     fn redact_masks_all_supported_prefixes() {
-        assert_eq!(redact_kv("authorization=abc123"), "authorization=[REDACTED]");
+        assert_eq!(
+            redact_kv("authorization=abc123"),
+            "authorization=[REDACTED]"
+        );
         assert_eq!(redact_kv("token=abc123"), "token=[REDACTED]");
         assert_eq!(redact_kv("password=abc123"), "password=[REDACTED]");
     }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -21,7 +21,8 @@ use crate::agent::cancellation::{
 };
 use crate::observability::events_contract::{
     elapsed_ms, ISSUE_DISPATCH_COMPLETED, ISSUE_DISPATCH_STARTED, ORCH_TICK_FINISHED,
-    ORCH_TICK_STARTED,
+    ORCH_TICK_STARTED, STEP_STARTED, TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED,
+    TRACKER_TRANSITION_SUCCEEDED,
 };
 use crate::agent::events::{AgentEvent, InteractionRequestDraft, WorkerEvent, WorkerResult};
 use crate::agent::{AgentRunRequest, AgentRunner, InteractionResponseEnvelope};
@@ -575,6 +576,7 @@ impl Orchestrator {
         dispatch: StepDispatchContext<'_>,
     ) -> Result<(), EnsembleError> {
         info!(
+            event = STEP_STARTED,
             issue_id = %issue.id,
             identifier = %issue.identifier,
             step = dispatch.step_name,
@@ -585,13 +587,33 @@ impl Orchestrator {
         // Set tracker state if specified by the step
         if let Some(state_name) = dispatch.tracker_state {
             if self.tracker.supports_writes() {
-                if let Err(e) = self.tracker.set_issue_state(&issue.id, state_name).await {
-                    warn!(
-                        issue_id = %issue.id,
-                        state = state_name,
-                        error = %e,
-                        "failed to set tracker state for step dispatch"
-                    );
+                info!(
+                    event = TRACKER_TRANSITION_REQUESTED,
+                    issue_id = %issue.id,
+                    step = dispatch.step_name,
+                    tracker_state_to = state_name,
+                    "requesting tracker state transition"
+                );
+                match self.tracker.set_issue_state(&issue.id, state_name).await {
+                    Ok(()) => {
+                        info!(
+                            event = TRACKER_TRANSITION_SUCCEEDED,
+                            issue_id = %issue.id,
+                            step = dispatch.step_name,
+                            tracker_state_to = state_name,
+                            "tracker state transition succeeded"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            event = TRACKER_TRANSITION_FAILED,
+                            issue_id = %issue.id,
+                            step = dispatch.step_name,
+                            tracker_state_to = state_name,
+                            error = %e,
+                            "failed to set tracker state for step dispatch"
+                        );
+                    }
                 }
             }
         }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -19,16 +19,16 @@ use crate::agent::cancellation::{
     cancel_all, clear_issue_cancellation, new_cancellation_registry, register_issue_cancellation,
     CancellationRegistry,
 };
-use crate::observability::events_contract::{
-    elapsed_ms, ISSUE_DISPATCH_COMPLETED, ISSUE_DISPATCH_STARTED, ORCH_TICK_FINISHED,
-    ORCH_TICK_STARTED, STEP_STARTED, TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED,
-    TRACKER_TRANSITION_SUCCEEDED,
-};
 use crate::agent::events::{AgentEvent, InteractionRequestDraft, WorkerEvent, WorkerResult};
 use crate::agent::{AgentRunRequest, AgentRunner, InteractionResponseEnvelope};
 use crate::config::ensemble::EnsembleConfig;
 use crate::error::{AgentError, EnsembleError};
 use crate::interaction::{InteractionStatus, InteractionStore};
+use crate::observability::events_contract::{
+    elapsed_ms, ISSUE_DISPATCH_COMPLETED, ISSUE_DISPATCH_STARTED, ORCH_TICK_FINISHED,
+    ORCH_TICK_STARTED, STEP_STARTED, TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED,
+    TRACKER_TRANSITION_SUCCEEDED,
+};
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{PipelineAction, PipelineRun};
 use crate::pipeline::verdict::resolve_verdict;

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -19,6 +19,10 @@ use crate::agent::cancellation::{
     cancel_all, clear_issue_cancellation, new_cancellation_registry, register_issue_cancellation,
     CancellationRegistry,
 };
+use crate::observability::events_contract::{
+    elapsed_ms, ISSUE_DISPATCH_COMPLETED, ISSUE_DISPATCH_STARTED, ORCH_TICK_FINISHED,
+    ORCH_TICK_STARTED,
+};
 use crate::agent::events::{AgentEvent, InteractionRequestDraft, WorkerEvent, WorkerResult};
 use crate::agent::{AgentRunRequest, AgentRunner, InteractionResponseEnvelope};
 use crate::config::ensemble::EnsembleConfig;
@@ -238,6 +242,9 @@ impl Orchestrator {
 
     /// Handle a poll tick: reconcile, validate, fetch, dispatch.
     async fn handle_tick(&self) {
+        let tick_started_at = std::time::Instant::now();
+        info!(event = ORCH_TICK_STARTED, "orchestrator tick started");
+
         // Initialize state lists lazily (for tests that don't call run())
         {
             let state = self.state.read().await;
@@ -371,6 +378,11 @@ impl Orchestrator {
             Ok(issues) => issues,
             Err(e) => {
                 warn!(error = %e, "failed to fetch candidate issues, skipping dispatch");
+                info!(
+                    event = ORCH_TICK_FINISHED,
+                    duration_ms = elapsed_ms(tick_started_at),
+                    "orchestrator tick finished with fetch error"
+                );
                 return;
             }
         };
@@ -428,6 +440,12 @@ impl Orchestrator {
                 self.dispatch_issue(issue, None).await;
             }
         }
+
+        info!(
+            event = ORCH_TICK_FINISHED,
+            duration_ms = elapsed_ms(tick_started_at),
+            "orchestrator tick finished"
+        );
     }
 
     /// Dispatch a single issue: build DAG, create PipelineRun, dispatch initial steps.
@@ -448,9 +466,10 @@ impl Orchestrator {
         let action = pipeline_run.start();
 
         info!(
+            event = ISSUE_DISPATCH_STARTED,
             issue_id = %issue.id,
             identifier = %issue.identifier,
-            attempt = ?attempt,
+            cycle = cycle,
             "dispatching issue with pipeline"
         );
 
@@ -510,6 +529,14 @@ impl Orchestrator {
                     .await;
             }
         }
+
+        info!(
+            event = ISSUE_DISPATCH_COMPLETED,
+            issue_id = %issue.id,
+            identifier = %issue.identifier,
+            cycle = cycle,
+            "issue dispatch setup completed"
+        );
     }
 
     async fn prepare_step_workspace(

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6,6 +6,7 @@ pub mod state;
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -70,6 +71,8 @@ pub struct Orchestrator {
     worker_rx: mpsc::Receiver<WorkerEvent>,
     shutdown_rx: mpsc::Receiver<()>,
 }
+
+static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 pub struct OrchestratorRuntimeParts {
     pub state: Arc<RwLock<OrchestratorState>>,
@@ -143,6 +146,10 @@ impl Orchestrator {
 
     /// Run the orchestrator main loop.
     pub async fn run(&mut self) {
+        let run_id = new_run_id();
+        let run_span = tracing::info_span!("ensemble_run", run_id = %run_id, mode = "orchestrator");
+        let _run_guard = run_span.enter();
+
         // Initialize state from config
         {
             let config = self.config.read().await;
@@ -1504,6 +1511,12 @@ where
     }
 }
 
+fn new_run_id() -> String {
+    let millis = Utc::now().timestamp_millis();
+    let seq = RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("run-{millis}-{seq}")
+}
+
 fn build_interaction_request(
     issue: &Issue,
     context: InteractionRequestContext,
@@ -1729,6 +1742,13 @@ agent:
   session_mode: code
 "#;
         parse_config(yaml).unwrap()
+    }
+
+    #[test]
+    fn run_id_has_expected_prefix() {
+        let run_id = new_run_id();
+        assert!(run_id.starts_with("run-"));
+        assert!(run_id.len() > 8);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -109,6 +109,8 @@ pub fn next_attempt(current: Option<u32>) -> u32 {
 }
 
 fn normalize_reason(reason: &str) -> &str {
+    // Returns either the original borrowed input or a static fallback.
+    // Callers must treat the result as borrowed data and avoid assuming ownership.
     if reason.trim().is_empty() {
         "unknown"
     } else {

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -1,5 +1,6 @@
 use tracing::{info, warn};
 
+use crate::observability::events_contract::{ISSUE_RETRY_CANCELLED, ISSUE_RETRY_SCHEDULED};
 use crate::tracker::model::RetryEntry;
 
 use super::state::OrchestratorState;
@@ -39,8 +40,10 @@ pub fn schedule_continuation_retry(
     };
 
     info!(
+        event = ISSUE_RETRY_SCHEDULED,
         issue_id = issue_id,
         identifier = identifier,
+        reason = "continuation",
         delay_ms = CONTINUATION_RETRY_DELAY_MS,
         "scheduling continuation retry"
     );
@@ -63,11 +66,12 @@ pub fn schedule_failure_retry(
 ) -> Option<u64> {
     if attempt >= max_cycles {
         warn!(
+            event = ISSUE_RETRY_CANCELLED,
             issue_id = issue_id,
             identifier = identifier,
             attempt = attempt,
             max_cycles = max_cycles,
-            error = error,
+            reason = normalize_reason(error),
             "max retry cycles reached, not scheduling further retries"
         );
         return None;
@@ -85,11 +89,12 @@ pub fn schedule_failure_retry(
     };
 
     info!(
+        event = ISSUE_RETRY_SCHEDULED,
         issue_id = issue_id,
         identifier = identifier,
         attempt = attempt,
         delay_ms = delay,
-        error = error,
+        reason = normalize_reason(error),
         "scheduling failure retry"
     );
 
@@ -101,6 +106,14 @@ pub fn schedule_failure_retry(
 /// If the entry had a retry_attempt, increment it; otherwise start at 1.
 pub fn next_attempt(current: Option<u32>) -> u32 {
     current.map(|a| a + 1).unwrap_or(1)
+}
+
+fn normalize_reason(reason: &str) -> &str {
+    if reason.trim().is_empty() {
+        "unknown"
+    } else {
+        reason
+    }
 }
 
 /// Get the current time in milliseconds (monotonic-ish for retry scheduling).
@@ -138,6 +151,12 @@ pub fn next_retry_time(state: &OrchestratorState) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retry_reason_is_non_empty() {
+        let reason = normalize_reason("");
+        assert_eq!(reason, "unknown");
+    }
 
     #[test]
     fn test_calculate_backoff_attempt_1() {

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -4,11 +4,11 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
+use super::model::Issue;
+use super::{IssueTracker, TrackerError};
 use crate::observability::events_contract::{
     TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED, TRACKER_TRANSITION_SUCCEEDED,
 };
-use super::model::Issue;
-use super::{IssueTracker, TrackerError};
 
 // --- GraphQL query constants ---
 
@@ -1035,7 +1035,10 @@ impl IssueTracker for GithubTracker {
                 "fieldId": field_id,
                 "optionId": option_id,
             });
-            if let Err(error) = self.graphql(UPDATE_PROJECT_ITEM_FIELD_MUTATION, variables).await {
+            if let Err(error) = self
+                .graphql(UPDATE_PROJECT_ITEM_FIELD_MUTATION, variables)
+                .await
+            {
                 warn!(
                     event = TRACKER_TRANSITION_FAILED,
                     issue_id = id,

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -6,9 +6,6 @@ use tracing::{debug, info, warn};
 
 use super::model::Issue;
 use super::{IssueTracker, TrackerError};
-use crate::observability::events_contract::{
-    TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED, TRACKER_TRANSITION_SUCCEEDED,
-};
 
 // --- GraphQL query constants ---
 
@@ -992,13 +989,6 @@ impl IssueTracker for GithubTracker {
     }
 
     async fn set_issue_state(&self, id: &str, state: &str) -> Result<(), TrackerError> {
-        info!(
-            event = TRACKER_TRANSITION_REQUESTED,
-            issue_id = id,
-            tracker_state_to = state,
-            "github tracker state transition requested"
-        );
-
         if self.project_number.is_some() {
             // Ensure project metadata is discovered (populates project_node_id,
             // status_field_id, and status_option_ids).
@@ -1035,29 +1025,11 @@ impl IssueTracker for GithubTracker {
                 "fieldId": field_id,
                 "optionId": option_id,
             });
-            if let Err(error) = self
-                .graphql(UPDATE_PROJECT_ITEM_FIELD_MUTATION, variables)
-                .await
-            {
-                warn!(
-                    event = TRACKER_TRANSITION_FAILED,
-                    issue_id = id,
-                    tracker_state_to = state,
-                    error = %error,
-                    "github tracker state transition failed"
-                );
-                return Err(error);
-            }
-            info!(
-                event = TRACKER_TRANSITION_SUCCEEDED,
-                issue_id = id,
-                tracker_state_to = state,
-                "github tracker state transition succeeded"
-            );
+            self.graphql(UPDATE_PROJECT_ITEM_FIELD_MUTATION, variables)
+                .await?;
             Ok(())
         } else {
             tracing::warn!(
-                event = TRACKER_TRANSITION_FAILED,
                 issue_id = id,
                 target_state = state,
                 "set_issue_state in repo mode: label-based state transitions not yet implemented"

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -4,6 +4,9 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
+use crate::observability::events_contract::{
+    TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED, TRACKER_TRANSITION_SUCCEEDED,
+};
 use super::model::Issue;
 use super::{IssueTracker, TrackerError};
 
@@ -989,6 +992,13 @@ impl IssueTracker for GithubTracker {
     }
 
     async fn set_issue_state(&self, id: &str, state: &str) -> Result<(), TrackerError> {
+        info!(
+            event = TRACKER_TRANSITION_REQUESTED,
+            issue_id = id,
+            tracker_state_to = state,
+            "github tracker state transition requested"
+        );
+
         if self.project_number.is_some() {
             // Ensure project metadata is discovered (populates project_node_id,
             // status_field_id, and status_option_ids).
@@ -1025,11 +1035,26 @@ impl IssueTracker for GithubTracker {
                 "fieldId": field_id,
                 "optionId": option_id,
             });
-            self.graphql(UPDATE_PROJECT_ITEM_FIELD_MUTATION, variables)
-                .await?;
+            if let Err(error) = self.graphql(UPDATE_PROJECT_ITEM_FIELD_MUTATION, variables).await {
+                warn!(
+                    event = TRACKER_TRANSITION_FAILED,
+                    issue_id = id,
+                    tracker_state_to = state,
+                    error = %error,
+                    "github tracker state transition failed"
+                );
+                return Err(error);
+            }
+            info!(
+                event = TRACKER_TRANSITION_SUCCEEDED,
+                issue_id = id,
+                tracker_state_to = state,
+                "github tracker state transition succeeded"
+            );
             Ok(())
         } else {
             tracing::warn!(
+                event = TRACKER_TRANSITION_FAILED,
                 issue_id = id,
                 target_state = state,
                 "set_issue_state in repo mode: label-based state transitions not yet implemented"

--- a/crates/ensemble-core/src/workspace/hooks.rs
+++ b/crates/ensemble-core/src/workspace/hooks.rs
@@ -59,7 +59,6 @@ pub async fn run_hook(
                     event = WORKSPACE_HOOK_FINISHED,
                     hook = hook_name,
                     duration_ms = elapsed_ms(started_at),
-                    detail = %format_hook_log(hook_name, elapsed_ms(started_at), "ok"),
                     "hook completed successfully"
                 );
                 Ok(())
@@ -79,7 +78,6 @@ pub async fn run_hook(
                     event = WORKSPACE_HOOK_FAILED,
                     hook = hook_name,
                     duration_ms = elapsed_ms(started_at),
-                    detail = %format_hook_log(hook_name, elapsed_ms(started_at), "failed"),
                     %reason,
                     "hook failed"
                 );
@@ -118,10 +116,6 @@ pub async fn run_hook(
             })
         }
     }
-}
-
-fn format_hook_log(hook_name: &str, duration_ms: u128, outcome: &str) -> String {
-    format!("hook={hook_name} duration_ms={duration_ms} outcome={outcome}")
 }
 
 fn preferred_shell() -> &'static str {
@@ -199,13 +193,6 @@ mod tests {
 
     fn setup() -> TempDir {
         TempDir::new().unwrap()
-    }
-
-    #[test]
-    fn hook_log_includes_duration_and_outcome() {
-        let line = format_hook_log("after_run", 42, "ok");
-        assert!(line.contains("duration_ms=42"));
-        assert!(line.contains("outcome=ok"));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/workspace/hooks.rs
+++ b/crates/ensemble-core/src/workspace/hooks.rs
@@ -59,6 +59,7 @@ pub async fn run_hook(
                     event = WORKSPACE_HOOK_FINISHED,
                     hook = hook_name,
                     duration_ms = elapsed_ms(started_at),
+                    detail = %format_hook_log(hook_name, elapsed_ms(started_at), "ok"),
                     "hook completed successfully"
                 );
                 Ok(())
@@ -78,6 +79,7 @@ pub async fn run_hook(
                     event = WORKSPACE_HOOK_FAILED,
                     hook = hook_name,
                     duration_ms = elapsed_ms(started_at),
+                    detail = %format_hook_log(hook_name, elapsed_ms(started_at), "failed"),
                     %reason,
                     "hook failed"
                 );

--- a/crates/ensemble-core/src/workspace/hooks.rs
+++ b/crates/ensemble-core/src/workspace/hooks.rs
@@ -1,4 +1,7 @@
 use crate::error::WorkspaceError;
+use crate::observability::events_contract::{
+    elapsed_ms, WORKSPACE_HOOK_FAILED, WORKSPACE_HOOK_FINISHED, WORKSPACE_HOOK_STARTED,
+};
 use std::path::Path;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -22,7 +25,13 @@ pub async fn run_hook(
     workspace_path: &Path,
     timeout_ms: u64,
 ) -> Result<(), WorkspaceError> {
-    info!(hook = hook_name, cwd = %workspace_path.display(), "running hook");
+    let started_at = std::time::Instant::now();
+    info!(
+        event = WORKSPACE_HOOK_STARTED,
+        hook = hook_name,
+        cwd = %workspace_path.display(),
+        "running hook"
+    );
 
     let duration = Duration::from_millis(timeout_ms);
 
@@ -46,7 +55,12 @@ pub async fn run_hook(
     match timeout(duration, child).await {
         Ok(Ok(output)) => {
             if output.status.success() {
-                info!(hook = hook_name, "hook completed successfully");
+                info!(
+                    event = WORKSPACE_HOOK_FINISHED,
+                    hook = hook_name,
+                    duration_ms = elapsed_ms(started_at),
+                    "hook completed successfully"
+                );
                 Ok(())
             } else {
                 let stderr = String::from_utf8_lossy(&output.stderr);
@@ -60,7 +74,13 @@ pub async fn run_hook(
                     }
                     format!("exit code: {} — {}", output.status, truncated)
                 };
-                warn!(hook = hook_name, %reason, "hook failed");
+                warn!(
+                    event = WORKSPACE_HOOK_FAILED,
+                    hook = hook_name,
+                    duration_ms = elapsed_ms(started_at),
+                    %reason,
+                    "hook failed"
+                );
                 Err(WorkspaceError::HookFailed {
                     hook: hook_name.to_string(),
                     reason,
@@ -69,7 +89,13 @@ pub async fn run_hook(
         }
         Ok(Err(e)) => {
             let reason = format!("failed to execute: {e}");
-            warn!(hook = hook_name, %reason, "hook execution error");
+            warn!(
+                event = WORKSPACE_HOOK_FAILED,
+                hook = hook_name,
+                duration_ms = elapsed_ms(started_at),
+                %reason,
+                "hook execution error"
+            );
             Err(WorkspaceError::HookFailed {
                 hook: hook_name.to_string(),
                 reason,
@@ -78,8 +104,11 @@ pub async fn run_hook(
         Err(_) => {
             // Child future is dropped here, which triggers kill_on_drop
             warn!(
+                event = WORKSPACE_HOOK_FAILED,
                 hook = hook_name,
-                timeout_ms, "hook timed out, process killed"
+                timeout_ms,
+                duration_ms = elapsed_ms(started_at),
+                "hook timed out, process killed"
             );
             Err(WorkspaceError::HookTimedOut {
                 hook: hook_name.to_string(),
@@ -87,6 +116,10 @@ pub async fn run_hook(
             })
         }
     }
+}
+
+fn format_hook_log(hook_name: &str, duration_ms: u128, outcome: &str) -> String {
+    format!("hook={hook_name} duration_ms={duration_ms} outcome={outcome}")
 }
 
 fn preferred_shell() -> &'static str {
@@ -164,6 +197,13 @@ mod tests {
 
     fn setup() -> TempDir {
         TempDir::new().unwrap()
+    }
+
+    #[test]
+    fn hook_log_includes_duration_and_outcome() {
+        let line = format_hook_log("after_run", 42, "ok");
+        assert!(line.contains("duration_ms=42"));
+        assert!(line.contains("outcome=ok"));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -1,5 +1,8 @@
 use crate::config::ensemble::RepoConfig;
 use crate::error::WorkspaceError;
+use crate::observability::events_contract::{
+    elapsed_ms, WORKSPACE_PREPARE_FAILED, WORKSPACE_PREPARE_FINISHED, WORKSPACE_PREPARE_STARTED,
+};
 use crate::tracker::model::sanitize_workspace_key;
 use crate::workspace::coordinator::{WorktreeCoordinator, WorktreeInfo};
 use std::collections::HashMap;
@@ -139,6 +142,12 @@ impl WorkspaceManager {
         &self,
         identifier: &str,
     ) -> Result<WorkspaceResult, WorkspaceError> {
+        let prepare_started_at = std::time::Instant::now();
+        info!(
+            event = WORKSPACE_PREPARE_STARTED,
+            issue_identifier = identifier,
+            "preparing workspace"
+        );
         let workspace_key =
             sanitize_workspace_key(identifier).ok_or_else(|| WorkspaceError::CreationFailed {
                 reason: format!("unsafe workspace key from identifier: {identifier:?}"),
@@ -184,24 +193,43 @@ impl WorkspaceManager {
             let coordinator =
                 WorktreeCoordinator::new(self.repos.clone(), branch_date, base_path.clone());
             info!(workspace = %base_path.display(), "preparing worktrees inside workspace");
-            coordinator
-                .prepare_worktrees(identifier)
-                .await
-                .map_err(|e| WorkspaceError::CreationFailed {
-                    reason: format!("worktree preparation failed: {e}"),
-                })?
+            match coordinator.prepare_worktrees(identifier).await {
+                Ok(worktrees) => worktrees,
+                Err(e) => {
+                    warn!(
+                        event = WORKSPACE_PREPARE_FAILED,
+                        issue_identifier = identifier,
+                        duration_ms = elapsed_ms(prepare_started_at),
+                        error = %e,
+                        "workspace preparation failed"
+                    );
+                    return Err(WorkspaceError::CreationFailed {
+                        reason: format!("worktree preparation failed: {e}"),
+                    });
+                }
+            }
         } else {
             HashMap::new()
         };
 
         let created_now = base_created || worktrees.values().any(|w| w.created_now);
 
-        Ok(WorkspaceResult {
+        let result = WorkspaceResult {
             base_path,
             worktrees,
             workspace_key,
             created_now,
-        })
+        };
+
+        info!(
+            event = WORKSPACE_PREPARE_FINISHED,
+            issue_identifier = identifier,
+            duration_ms = elapsed_ms(prepare_started_at),
+            created_now = result.created_now,
+            "workspace prepared"
+        );
+
+        Ok(result)
     }
 
     /// Remove a workspace directory and its worktrees for the given issue identifier.

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -1,4 +1,7 @@
 use crate::error::WorktreeError;
+use crate::observability::events_contract::{
+    WORKSPACE_GIT_COMMAND_FINISHED, WORKSPACE_GIT_COMMAND_STARTED,
+};
 use crate::observability::redaction::truncate_for_log;
 use std::path::Path;
 use std::sync::OnceLock;
@@ -43,7 +46,7 @@ async fn run_git(
 ) -> Result<std::process::Output, WorktreeError> {
     let command = command_label.into();
     trace!(
-        event = "workspace.git_command_started",
+        event = WORKSPACE_GIT_COMMAND_STARTED,
         repo_path = repo_path,
         command = %command,
         "starting git command"
@@ -63,7 +66,7 @@ async fn run_git(
         })?;
 
     trace!(
-        event = "workspace.git_command_finished",
+        event = WORKSPACE_GIT_COMMAND_FINISHED,
         repo_path = repo_path,
         command = %command,
         success = output.status.success(),

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -1,8 +1,9 @@
 use crate::error::WorktreeError;
+use crate::observability::redaction::truncate_for_log;
 use std::path::Path;
 use std::sync::OnceLock;
 use tokio::process::Command;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 static GIT_BINARY: OnceLock<&'static str> = OnceLock::new();
 
@@ -41,7 +42,14 @@ async fn run_git(
     command_label: impl Into<String>,
 ) -> Result<std::process::Output, WorktreeError> {
     let command = command_label.into();
-    Command::new(git_binary())
+    trace!(
+        event = "workspace.git_command_started",
+        repo_path = repo_path,
+        command = %command,
+        "starting git command"
+    );
+
+    let output = Command::new(git_binary())
         .args(args)
         .current_dir(repo_path)
         .output()
@@ -49,10 +57,22 @@ async fn run_git(
         .map_err(|error| {
             error!(error = %error, command = %command, "Failed to spawn git command");
             WorktreeError::GitCommandFailed {
-                command,
+                command: command.clone(),
                 reason: error.to_string(),
             }
-        })
+        })?;
+
+    trace!(
+        event = "workspace.git_command_finished",
+        repo_path = repo_path,
+        command = %command,
+        success = output.status.success(),
+        exit_code = output.status.code(),
+        stderr_preview = %truncate_for_log(&String::from_utf8_lossy(&output.stderr), 200),
+        "finished git command"
+    );
+
+    Ok(output)
 }
 
 fn git_binary() -> &'static str {

--- a/docs/superpowers/plans/2026-04-08-verbose-logging-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-08-verbose-logging-implementation-plan.md
@@ -1,0 +1,444 @@
+# Verbose Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement correlation-first, level-aware logging in Ensemble so operators can trace issue execution end-to-end and selectively enable deep debug output.
+
+**Architecture:** Add a small observability contract layer in `ensemble-core` (event names + helper emitters + redaction utilities), propagate `run_id` through orchestrator spans, then migrate high-value orchestration/workspace/tracker/agent callsites to standardized events. Keep `info` concise, add reasoning at `debug`, and gate protocol/process internals to `trace`.
+
+**Tech Stack:** Rust 2021, `tracing`, `tracing-subscriber`, `tokio`, existing `ensemble-core` orchestrator/pipeline/workspace/agent modules.
+
+---
+
+## File Structure (planned)
+
+- Create: `crates/ensemble-core/src/observability/events_contract.rs`
+  - Stable event name constants + helper functions for required fields.
+- Create: `crates/ensemble-core/src/observability/redaction.rs`
+  - Truncation/redaction helpers for trace logging.
+- Modify: `crates/ensemble-core/src/observability/mod.rs`
+  - Export new observability modules.
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+  - Root run span, `run_id`, standardized lifecycle events.
+- Modify: `crates/ensemble-core/src/orchestrator/retry.rs`
+  - Standard retry schedule/cancel event fields.
+- Modify: `crates/ensemble-core/src/workspace/manager.rs`
+  - Workspace prepare events and durations.
+- Modify: `crates/ensemble-core/src/workspace/hooks.rs`
+  - Hook start/finish/failure with duration + redacted command context.
+- Modify: `crates/ensemble-core/src/tracker/github.rs`
+  - Transition requested/succeeded/failed events.
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+  - Trace-level ACP metadata logging with redaction.
+- Modify: `crates/ensemble-core/src/observability/logging.rs`
+  - Add module-level docs referencing event contract and levels.
+- Test: `crates/ensemble-core/src/observability/events_contract.rs` (unit tests inline)
+- Test: `crates/ensemble-core/src/observability/redaction.rs` (unit tests inline)
+
+---
+
+### Task 1: Add observability contract module (event names + helper emitters)
+
+**Files:**
+- Create: `crates/ensemble-core/src/observability/events_contract.rs`
+- Modify: `crates/ensemble-core/src/observability/mod.rs`
+- Test: `crates/ensemble-core/src/observability/events_contract.rs`
+
+- [ ] **Step 1: Write failing tests for event constants and helper field formatting**
+
+```rust
+#[test]
+fn event_names_are_stable() {
+    assert_eq!(ORCH_TICK_STARTED, "orchestrator.tick_started");
+    assert_eq!(ISSUE_DISPATCH_STARTED, "issue.dispatch_started");
+    assert_eq!(TRACKER_TRANSITION_FAILED, "tracker.transition_failed");
+}
+
+#[test]
+fn duration_helper_is_millis() {
+    let start = std::time::Instant::now();
+    let elapsed = elapsed_ms(start);
+    assert!(elapsed <= 5_000);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (module missing)**
+
+Run: `rtk cargo test -p ensemble-core observability::events_contract::tests::event_names_are_stable`
+Expected: FAIL with unresolved module/path errors.
+
+- [ ] **Step 3: Add minimal implementation module and exports**
+
+```rust
+// crates/ensemble-core/src/observability/events_contract.rs
+pub const ORCH_TICK_STARTED: &str = "orchestrator.tick_started";
+pub const ORCH_TICK_FINISHED: &str = "orchestrator.tick_finished";
+pub const ISSUE_DISPATCH_STARTED: &str = "issue.dispatch_started";
+pub const ISSUE_DISPATCH_SKIPPED: &str = "issue.dispatch_skipped";
+pub const ISSUE_DISPATCH_COMPLETED: &str = "issue.dispatch_completed";
+pub const STEP_STARTED: &str = "step.started";
+pub const STEP_WAITING: &str = "step.waiting";
+pub const STEP_FINISHED: &str = "step.finished";
+pub const TRACKER_TRANSITION_REQUESTED: &str = "tracker.transition_requested";
+pub const TRACKER_TRANSITION_SUCCEEDED: &str = "tracker.transition_succeeded";
+pub const TRACKER_TRANSITION_FAILED: &str = "tracker.transition_failed";
+
+pub fn elapsed_ms(start: std::time::Instant) -> u128 {
+    start.elapsed().as_millis()
+}
+```
+
+```rust
+// crates/ensemble-core/src/observability/mod.rs
+pub mod events_contract;
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `rtk cargo test -p ensemble-core observability::events_contract`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add crates/ensemble-core/src/observability/events_contract.rs crates/ensemble-core/src/observability/mod.rs
+rtk git commit -m "Add observability event contract module"
+```
+
+---
+
+### Task 2: Add `run_id` generation and root orchestrator span
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Test: `crates/ensemble-core/src/orchestrator/mod.rs` (inline tests if applicable)
+
+- [ ] **Step 1: Write failing test for run_id format helper**
+
+```rust
+#[test]
+fn run_id_has_expected_prefix() {
+    let run_id = new_run_id();
+    assert!(run_id.starts_with("run-"));
+    assert!(run_id.len() > 8);
+}
+```
+
+- [ ] **Step 2: Run test to confirm fail**
+
+Run: `rtk cargo test -p ensemble-core orchestrator::tests::run_id_has_expected_prefix`
+Expected: FAIL (helper not found).
+
+- [ ] **Step 3: Implement helper and root span in `run()`**
+
+```rust
+fn new_run_id() -> String {
+    format!("run-{}", uuid::Uuid::new_v4())
+}
+
+pub async fn run(&mut self) {
+    let run_id = new_run_id();
+    let run_span = tracing::info_span!("ensemble_run", run_id = %run_id, mode = "run");
+    let _guard = run_span.enter();
+
+    tracing::info!(event = crate::observability::events_contract::ORCH_TICK_STARTED, "orchestrator starting");
+    // existing run body continues...
+}
+```
+
+- [ ] **Step 4: Run targeted tests**
+
+Run: `rtk cargo test -p ensemble-core orchestrator::tests::run_id_has_expected_prefix`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add crates/ensemble-core/src/orchestrator/mod.rs
+rtk git commit -m "Add run_id and root run span for orchestrator"
+```
+
+---
+
+### Task 3: Standardize orchestrator lifecycle events (dispatch/tick/retry)
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/retry.rs`
+- Test: `crates/ensemble-core/src/orchestrator/retry.rs` (existing tests + new asserts)
+
+- [ ] **Step 1: Write failing test for retry event reason normalization**
+
+```rust
+#[test]
+fn retry_reason_is_non_empty() {
+    let reason = normalize_reason("");
+    assert_eq!(reason, "unknown");
+}
+```
+
+- [ ] **Step 2: Run test to verify fail**
+
+Run: `rtk cargo test -p ensemble-core orchestrator::retry::tests::retry_reason_is_non_empty`
+Expected: FAIL.
+
+- [ ] **Step 3: Add standardized event logs around ticks/dispatch/retry**
+
+```rust
+let tick_started = std::time::Instant::now();
+tracing::info!(event = ORCH_TICK_STARTED, "tick started");
+
+// existing handle_tick body
+
+tracing::info!(
+    event = ORCH_TICK_FINISHED,
+    duration_ms = crate::observability::events_contract::elapsed_ms(tick_started),
+    "tick finished"
+);
+```
+
+```rust
+tracing::info!(
+    event = ISSUE_DISPATCH_STARTED,
+    issue_id = %issue.id,
+    issue_identifier = %issue.identifier,
+    cycle = cycle,
+    "dispatching issue"
+);
+```
+
+```rust
+tracing::debug!(
+    event = "issue.retry_scheduled",
+    issue_id = %issue_id,
+    reason = %normalize_reason(reason),
+    backoff_ms = delay_ms,
+    "retry scheduled"
+);
+```
+
+- [ ] **Step 4: Run orchestrator-focused tests**
+
+Run: `rtk cargo test -p ensemble-core orchestrator::retry`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add crates/ensemble-core/src/orchestrator/mod.rs crates/ensemble-core/src/orchestrator/retry.rs
+rtk git commit -m "Standardize orchestrator tick dispatch and retry events"
+```
+
+---
+
+### Task 4: Instrument pipeline/workspace/tracker transitions with required fields
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Modify: `crates/ensemble-core/src/workspace/manager.rs`
+- Modify: `crates/ensemble-core/src/workspace/hooks.rs`
+- Modify: `crates/ensemble-core/src/tracker/github.rs`
+
+- [ ] **Step 1: Add failing tests for redaction-safe hook/tracker logging metadata**
+
+```rust
+#[test]
+fn hook_log_includes_duration_and_outcome() {
+    let line = format_hook_log("after_run", 42, "ok");
+    assert!(line.contains("duration_ms=42"));
+    assert!(line.contains("outcome=ok"));
+}
+```
+
+- [ ] **Step 2: Run targeted test to verify fail**
+
+Run: `rtk cargo test -p ensemble-core workspace::hooks::tests::hook_log_includes_duration_and_outcome`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement lifecycle events for step/workspace/tracker**
+
+```rust
+tracing::info!(
+    event = STEP_STARTED,
+    issue_id = %issue.id,
+    issue_identifier = %issue.identifier,
+    step = %ctx.step_name,
+    agent = %ctx.agent_name,
+    "step started"
+);
+```
+
+```rust
+let started = std::time::Instant::now();
+tracing::info!(event = "workspace.prepare_started", issue_identifier = %identifier, "workspace prepare started");
+// existing prepare logic
+tracing::info!(event = "workspace.prepare_finished", duration_ms = elapsed_ms(started), issue_identifier = %identifier, "workspace prepare finished");
+```
+
+```rust
+tracing::info!(
+    event = TRACKER_TRANSITION_REQUESTED,
+    issue_id = %issue.id,
+    tracker_state_from = %from,
+    tracker_state_to = %to,
+    "tracker transition requested"
+);
+```
+
+- [ ] **Step 4: Run focused module tests**
+
+Run: `rtk cargo test -p ensemble-core workspace::hooks tracker::github`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add crates/ensemble-core/src/orchestrator/mod.rs crates/ensemble-core/src/workspace/manager.rs crates/ensemble-core/src/workspace/hooks.rs crates/ensemble-core/src/tracker/github.rs
+rtk git commit -m "Add standardized step workspace and tracker transition events"
+```
+
+---
+
+### Task 5: Add redaction helpers + trace-level ACP/generic command metadata logging
+
+**Files:**
+- Create: `crates/ensemble-core/src/observability/redaction.rs`
+- Modify: `crates/ensemble-core/src/observability/mod.rs`
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+- Modify: `crates/ensemble-core/src/workspace/worktree.rs`
+- Test: `crates/ensemble-core/src/observability/redaction.rs`
+
+- [ ] **Step 1: Write failing tests for truncation and secret masking helpers**
+
+```rust
+#[test]
+fn truncate_preserves_prefix_and_marks_ellipsis() {
+    let out = truncate_for_log("abcdefghijklmnopqrstuvwxyz", 8);
+    assert_eq!(out, "abcdefgh…");
+}
+
+#[test]
+fn redact_token_masks_known_keys() {
+    let out = redact_kv("api_token=abc123");
+    assert_eq!(out, "api_token=[REDACTED]");
+}
+```
+
+- [ ] **Step 2: Run tests to verify fail**
+
+Run: `rtk cargo test -p ensemble-core observability::redaction`
+Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement helpers and integrate in trace callsites**
+
+```rust
+pub fn truncate_for_log(input: &str, max: usize) -> String {
+    if input.chars().count() <= max {
+        return input.to_string();
+    }
+    let prefix: String = input.chars().take(max).collect();
+    format!("{}…", prefix)
+}
+
+pub fn redact_kv(input: &str) -> String {
+    input
+        .replace("api_token=", "api_token=[REDACTED]")
+        .replace("authorization=", "authorization=[REDACTED]")
+}
+```
+
+```rust
+tracing::trace!(
+    event = "agent.message",
+    direction = "outbound",
+    bytes = payload.len(),
+    preview = %crate::observability::redaction::truncate_for_log(&payload, 120),
+    "acp outbound metadata"
+);
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `rtk cargo test -p ensemble-core observability::redaction agent::acp_client`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add crates/ensemble-core/src/observability/redaction.rs crates/ensemble-core/src/observability/mod.rs crates/ensemble-core/src/agent/acp_client.rs crates/ensemble-core/src/workspace/worktree.rs
+rtk git commit -m "Add redaction helpers and trace-level ACP command metadata logs"
+```
+
+---
+
+### Task 6: Documentation and verification pass
+
+**Files:**
+- Modify: `crates/ensemble-core/src/observability/logging.rs`
+- Modify: `docs/SPEC.md` (observability section only, if needed)
+
+- [ ] **Step 1: Add docs describing event contract and level semantics**
+
+```rust
+/// Logging levels:
+/// - info: lifecycle milestones
+/// - debug: decision reasons
+/// - trace: protocol/process metadata with redaction
+///
+/// Contract fields: event, run_id, issue_id/issue_identifier, cycle, step, agent, duration_ms.
+```
+
+- [ ] **Step 2: Run full Rust validation suite**
+
+Run: `rtk cargo test --workspace --exclude ensemble-desktop`
+Expected: PASS.
+
+Run: `rtk cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
+Expected: PASS.
+
+Run: `rtk cargo fmt --all -- --check`
+Expected: PASS.
+
+- [ ] **Step 3: Manual behavior check commands**
+
+Run:
+```bash
+ENSEMBLE_LOG=info rtk cargo run -p ensemble-cli -- run --config-dir <path>
+```
+Expected: concise lifecycle events with `event` names.
+
+Run:
+```bash
+ENSEMBLE_LOG=debug rtk cargo run -p ensemble-cli -- run --config-dir <path>
+```
+Expected: includes skip/retry/DAG decision reasons.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add crates/ensemble-core/src/observability/logging.rs docs/SPEC.md
+rtk git commit -m "Document structured verbose logging contract and verification runbook"
+```
+
+---
+
+## Spec Coverage Check
+
+- Correlation-first contract: Covered by Task 1, Task 2, Task 3.
+- Required event naming taxonomy: Covered by Task 1 and adopted across Tasks 3–5.
+- Level strategy (`info`/`debug`/`trace`): Covered by Tasks 3, 5, and 6 docs.
+- Redaction/truncation guardrails: Covered by Task 5.
+- Validation and operator runbook checks: Covered by Task 6.
+
+No uncovered spec requirements remain.
+
+## Placeholder Scan
+
+- No TODO/TBD placeholders remain.
+- Every task includes concrete file paths, commands, expected outcomes, and commit steps.
+
+## Type/Name Consistency Check
+
+- Event constants referenced from a single module: `observability::events_contract`.
+- Redaction helper names are consistent (`truncate_for_log`, `redact_kv`).
+- `run_id` terminology is consistent across all tasks.

--- a/docs/superpowers/specs/2026-04-08-verbose-logging-design.md
+++ b/docs/superpowers/specs/2026-04-08-verbose-logging-design.md
@@ -1,0 +1,202 @@
+# Verbose Logging Design for Ensemble
+
+Date: 2026-04-08
+Status: Proposed
+Owner: Ensemble core
+
+## Goal
+
+Improve Ensemble debugging by making logs easier to correlate end-to-end while allowing operators to opt into deeper verbosity (`debug`/`trace`) without overwhelming normal `info` runs.
+
+## Scope
+
+In scope:
+- Logging taxonomy (stable event names)
+- Correlation field contract
+- Span strategy across orchestrator/pipeline/agent/workspace
+- Level-based verbosity strategy (`info` vs `debug` vs `trace`)
+- Redaction/truncation rules for sensitive/high-volume payloads
+- Validation approach (tests + runbook checks)
+
+Out of scope:
+- Metrics backend changes
+- New log shipping infrastructure
+- UI log viewer changes
+
+## Problem Statement
+
+Ensemble already emits many `tracing` logs, but debugging complex failures is still costly because:
+- Event naming is not fully standardized
+- Correlation fields are inconsistent between modules
+- High-signal lifecycle events are mixed with ad-hoc detail
+- Deep internals are available in some places but not with consistent guardrails
+
+## Design Summary
+
+Use a combined strategy:
+1. **Correlation-first logging contract**: every lifecycle event uses stable `event` names and consistent context fields.
+2. **Tiered verbosity**: keep `info` concise for normal operations; add decision-level `debug`; reserve protocol/command internals for `trace` with redaction.
+
+This yields predictable, query-friendly logs for routine debugging and deeper diagnostics when needed.
+
+## Logging Contract
+
+### 1) Event taxonomy
+
+Define stable `event` names for key flows.
+
+Orchestrator:
+- `orchestrator.tick_started`
+- `orchestrator.tick_finished`
+- `issue.dispatch_started`
+- `issue.dispatch_skipped`
+- `issue.dispatch_completed`
+- `issue.retry_scheduled`
+- `issue.retry_cancelled`
+
+Pipeline:
+- `step.started`
+- `step.waiting`
+- `step.finished`
+
+Tracker:
+- `tracker.transition_requested`
+- `tracker.transition_succeeded`
+- `tracker.transition_failed`
+
+Workspace:
+- `workspace.prepare_started`
+- `workspace.prepare_finished`
+- `workspace.prepare_failed`
+- `workspace.hook_started`
+- `workspace.hook_finished`
+- `workspace.hook_failed`
+
+Agent:
+- `agent.session_started`
+- `agent.session_finished`
+- `agent.session_failed`
+- `agent.message` (debug/trace only)
+
+### 2) Required structured fields
+
+Required on all lifecycle logs where applicable:
+- `event`
+- `run_id`
+- `issue_id`
+- `issue_identifier`
+- `cycle` (or attempt index)
+- `step`
+- `agent`
+- `duration_ms` (for start/finish pairs)
+- `reason` (for skip/failure decisions)
+
+Optional contextual fields:
+- `workspace_path`
+- `branch`
+- `tracker_state_from`, `tracker_state_to`
+- `command` (workspace/git/acpx boundary logs)
+- `exit_code`
+
+## Span Architecture
+
+Use nested spans to avoid repeated field wiring and improve automatic context propagation:
+
+1. **Run root span**
+   - Fields: `run_id`, `mode` (`run`/`web`/`desktop`)
+2. **Issue span**
+   - Fields: `issue_id`, `issue_identifier`, `cycle`
+3. **Step span**
+   - Fields: `step`, `agent`
+4. **Workspace span** (optional)
+   - Fields: `workspace_path`, `branch`
+
+All logs emitted inside a span inherit parent context, keeping events compact and queryable.
+
+## Verbosity Levels
+
+### `info` (default operator mode)
+Log only lifecycle milestones and major outcomes:
+- Dispatch start/skip/complete
+- Step start/finish
+- Tracker transition request/result
+- Workspace prepare/hook failures and key milestones
+- Agent session start/finish/failure
+
+### `debug`
+Add decision traces and richer context:
+- Why an issue was skipped/dispatched/retried
+- DAG readiness checks (`waiting` causes)
+- Retry backoff calculations
+- Tracker adapter request intent metadata (not full payloads)
+
+### `trace`
+Add deep protocol/process internals:
+- ACP boundary envelope metadata (type/count/size)
+- Git/worktree command boundaries and summarized stderr
+- Hook command timing and exit details
+
+## Redaction and Data Hygiene
+
+Never log by default:
+- Prompt bodies
+- Secrets/tokens
+- Raw credentials
+- Full ACP payload content containing user/code content
+
+Allowed in debug/trace:
+- Metadata only (message type, byte length, counts)
+- Truncated stderr/stdout summaries when needed
+
+Redaction rules should be centralized and reused to prevent drift.
+
+## Implementation Phases
+
+### Phase 1: Foundation
+- Document taxonomy + required fields in core observability module docs.
+- Add helper functions/macros for standard events and start/finish timing.
+- Generate and attach `run_id` at orchestrator startup.
+
+### Phase 2: High-value instrumentation
+- Instrument orchestrator dispatch/retry/skip reasoning.
+- Instrument pipeline transitions with durations.
+- Instrument tracker transition request/result pairs.
+- Instrument workspace prepare + hooks with durations and outcomes.
+
+### Phase 3: Deep-debug expansion
+- Add trace-level ACP boundary metadata logs.
+- Add trace-level git/worktree/hook command boundary logs with truncation.
+
+## Error Handling Considerations
+
+- Logging helper failures must never fail runtime behavior.
+- If helper formatting fails, fallback logs should preserve core fields (`event`, `run_id`, `issue_id`).
+- Invalid log env configuration continues current behavior (warn and fallback to default filter).
+
+## Testing Strategy
+
+1. Unit tests for helper functions/macros:
+   - Correct event names
+   - Required field presence
+   - Duration emission for start/finish pairs
+2. Integration-level smoke checks:
+   - `ENSEMBLE_LOG=info` produces concise lifecycle logs
+   - `ENSEMBLE_LOG=debug` adds decision detail without secrets
+3. Manual runbook verification:
+   - Trace a single issue end-to-end by `run_id + issue_id`
+   - Confirm predictable searchability by `event`
+
+## Rollout / Compatibility
+
+- Backward-compatible with existing `ENSEMBLE_LOG` and `RUST_LOG` usage.
+- Incremental migration: legacy logs can coexist until modules are converted.
+- No tracker contract changes required.
+
+## Open Questions
+
+- Should `trace` ACP metadata be gated behind a dedicated opt-in env var in addition to level?
+- Should we emit a canonical `correlation_id` alias in addition to `run_id` for external log pipelines?
+
+## Recommendation
+
+Adopt this design as the logging baseline, then execute Phase 1 and Phase 2 first for immediate debugging gains. Phase 3 follows once redaction helpers are finalized.


### PR DESCRIPTION
## Summary
- add a shared observability event contract and propagate structured lifecycle events through orchestrator/workspace/tracker/agent paths
- add run-level correlation (`run_id`) plus trace-level ACP/git command metadata logging with truncation/redaction helpers
- address review feedback by adding JSON-aware secret redaction tests/behavior, removing duplicate tracker transition request logging, and aligning git event constants

## Test Plan
- [x] `rtk cargo test --workspace --exclude ensemble-desktop`
- [x] `rtk cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- [x] `rtk cargo fmt --all -- --check`
