### PR TITLE
feat: runtime-first verdict resolution with automatic fallback injection

### DIFF
--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -38,11 +38,15 @@ pub struct InitializeResult {
 #[derive(Debug)]
 pub enum TurnResult {
     /// Turn completed successfully (end_turn or max_tokens).
-    Completed { usage: Option<TokenUsage> },
+    Completed {
+        usage: Option<TokenUsage>,
+        runtime_verdict: Option<serde_json::Value>,
+    },
     /// Turn failed with a reason.
     Failed {
         reason: String,
         usage: Option<TokenUsage>,
+        runtime_verdict: Option<serde_json::Value>,
     },
 }
 
@@ -254,6 +258,7 @@ impl AcpSession {
         event_tx: &mpsc::Sender<WorkerEvent>,
     ) -> Result<TurnResult, AgentError> {
         let mut last_usage: Option<TokenUsage> = None;
+        let mut last_runtime_verdict: Option<serde_json::Value> = None;
 
         loop {
             let line = self.read_line().await?;
@@ -283,6 +288,7 @@ impl AcpSession {
                             return Ok(TurnResult::Failed {
                                 reason: err.message.clone(),
                                 usage: last_usage,
+                                runtime_verdict: last_runtime_verdict,
                             });
                         }
                         if let Some(stop_reason) = msg
@@ -297,11 +303,15 @@ impl AcpSession {
                                     step_name,
                                     event_tx,
                                     last_usage,
+                                    last_runtime_verdict.clone(),
                                 )
                                 .await;
                         }
                         // A prompt response without error means turn completed
-                        return Ok(TurnResult::Completed { usage: last_usage });
+                        return Ok(TurnResult::Completed {
+                            usage: last_usage,
+                            runtime_verdict: last_runtime_verdict,
+                        });
                     }
                 }
                 continue;
@@ -350,6 +360,9 @@ impl AcpSession {
                                 if let Some(usage) = parsed.usage {
                                     last_usage = Some(usage);
                                 }
+                                if let Some(verdict) = parsed.verdict {
+                                    last_runtime_verdict = Some(verdict);
+                                }
 
                                 if let Some(stop_reason) = parsed.stop_reason {
                                     return self
@@ -359,6 +372,7 @@ impl AcpSession {
                                             step_name,
                                             event_tx,
                                             last_usage,
+                                            last_runtime_verdict.clone(),
                                         )
                                         .await;
                                 }
@@ -409,6 +423,7 @@ impl AcpSession {
         step_name: &str,
         event_tx: &mpsc::Sender<WorkerEvent>,
         usage: Option<TokenUsage>,
+        runtime_verdict: Option<serde_json::Value>,
     ) -> Result<TurnResult, AgentError> {
         match stop_reason {
             StopReason::EndTurn | StopReason::MaxTokens => {
@@ -421,7 +436,10 @@ impl AcpSession {
                     },
                 )
                 .await;
-                Ok(TurnResult::Completed { usage })
+                Ok(TurnResult::Completed {
+                    usage,
+                    runtime_verdict,
+                })
             }
             StopReason::Cancelled => {
                 let reason = "stop reason: cancelled".to_string();
@@ -436,7 +454,11 @@ impl AcpSession {
                 )
                 .await;
 
-                Ok(TurnResult::Failed { reason, usage })
+                Ok(TurnResult::Failed {
+                    reason,
+                    usage,
+                    runtime_verdict,
+                })
             }
             StopReason::Refusal => {
                 let reason = "stop reason: refusal".to_string();
@@ -451,7 +473,11 @@ impl AcpSession {
                 )
                 .await;
 
-                Ok(TurnResult::Failed { reason, usage })
+                Ok(TurnResult::Failed {
+                    reason,
+                    usage,
+                    runtime_verdict,
+                })
             }
             StopReason::MaxTurnRequests => {
                 let reason = "stop reason: max_turn_requests".to_string();
@@ -466,7 +492,11 @@ impl AcpSession {
                 )
                 .await;
 
-                Ok(TurnResult::Failed { reason, usage })
+                Ok(TurnResult::Failed {
+                    reason,
+                    usage,
+                    runtime_verdict,
+                })
             }
         }
     }
@@ -814,7 +844,7 @@ done
             .unwrap();
 
         assert!(turn_result.is_success());
-        if let TurnResult::Completed { usage } = &turn_result {
+        if let TurnResult::Completed { usage, .. } = &turn_result {
             let u = usage.as_ref().unwrap();
             assert_eq!(u.input_tokens, 100);
             assert_eq!(u.output_tokens, 50);

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -584,6 +584,41 @@ JSON
     }
 
     #[tokio::test]
+    async fn run_prompt_returns_runtime_verdict_from_acpx_updates() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+cat <<'JSON'
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"turn_complete","verdict":{"verdict":"reject","summary":"lint errors"},"stopReason":"end_turn"}}}
+{"jsonrpc":"2.0","id":14,"result":{"stopReason":"end_turn"}}
+JSON
+"#,
+        );
+
+        let client = AcpxCli::new(script);
+        let outcome = client
+            .run_prompt(
+                "codex",
+                "build-session",
+                dir.path(),
+                "hi",
+                None,
+                |_| async {},
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome.runtime_verdict,
+            Some(serde_json::json!({
+                "verdict": "reject",
+                "summary": "lint errors"
+            }))
+        );
+    }
+
+    #[tokio::test]
     async fn cancelled_stop_reason_is_mapped_to_run_failed() {
         let dir = tempfile::TempDir::new().unwrap();
         let script = write_mock_acpx_script(

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -14,6 +14,11 @@ pub struct AcpxCli {
     executable: String,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct PromptOutcome {
+    pub runtime_verdict: Option<serde_json::Value>,
+}
+
 impl AcpxCli {
     pub fn new(executable: String) -> Self {
         Self { executable }
@@ -72,7 +77,7 @@ impl AcpxCli {
         prompt: &str,
         model: Option<&str>,
         mut on_event: F,
-    ) -> Result<(), AgentError>
+    ) -> Result<PromptOutcome, AgentError>
     where
         F: FnMut(AgentEvent) -> Fut,
         Fut: Future<Output = ()> + Send,
@@ -123,6 +128,7 @@ impl AcpxCli {
         let mut reader = BufReader::new(stdout).lines();
         let mut saw_terminal_event = false;
         let mut last_usage: Option<TokenUsage> = None;
+        let mut last_runtime_verdict: Option<serde_json::Value> = None;
 
         while let Some(line) = reader.next_line().await.map_err(|e| AgentError::IoError {
             reason: format!("failed to read acpx stdout: {e}"),
@@ -135,6 +141,9 @@ impl AcpxCli {
             if let Some(update) = parse_session_update_from_message(&message)? {
                 if let Some(usage) = update.usage {
                     last_usage = Some(usage);
+                }
+                if let Some(verdict) = update.verdict {
+                    last_runtime_verdict = Some(verdict);
                 }
                 if let Some(content) = update.output_text {
                     on_event(AgentEvent::OutputChunk {
@@ -197,7 +206,9 @@ impl AcpxCli {
             });
         }
 
-        Ok(())
+        Ok(PromptOutcome {
+            runtime_verdict: last_runtime_verdict,
+        })
     }
 
     pub async fn cancel(

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -162,13 +162,11 @@ impl AcpxRuntime {
 
         let prompt_outcome = prompt_result?;
 
-        Ok(
-            detect_worker_result_with_runtime_verdict(
-                request.workspace_path,
-                prompt_outcome.runtime_verdict,
-            )
-            .await,
+        Ok(detect_worker_result_with_runtime_verdict(
+            request.workspace_path,
+            prompt_outcome.runtime_verdict,
         )
+        .await)
     }
 }
 

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -5,7 +5,7 @@ use crate::error::AgentError;
 
 use super::acpx_cli::AcpxCli;
 use super::events::{AgentEvent, WorkerEvent, WorkerResult};
-use super::{detect_worker_result, AgentRunRequest};
+use super::{detect_worker_result_with_runtime_verdict, AgentRunRequest};
 
 pub struct AcpxRuntime {
     cli: AcpxCli,
@@ -160,9 +160,15 @@ impl AcpxRuntime {
         )
         .await;
 
-        prompt_result?;
+        let prompt_outcome = prompt_result?;
 
-        Ok(detect_worker_result(request.workspace_path).await)
+        Ok(
+            detect_worker_result_with_runtime_verdict(
+                request.workspace_path,
+                prompt_outcome.runtime_verdict,
+            )
+            .await,
+        )
     }
 }
 

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -317,7 +317,12 @@ exit 1
 
         let result = runner.run_step(&request, "finish the task").await.unwrap();
 
-        assert!(matches!(result, WorkerResult::Success));
+        assert!(matches!(
+            result,
+            WorkerResult::Success {
+                runtime_verdict: None
+            }
+        ));
         let mut saw_output = false;
         while let Ok(event) = rx.try_recv() {
             if let WorkerEvent::AgentUpdate { event, .. } = event {
@@ -373,7 +378,12 @@ exit 1
 
         let result = runner.run_step(&request, "finish the task").await.unwrap();
 
-        assert!(matches!(result, WorkerResult::Success));
+        assert!(matches!(
+            result,
+            WorkerResult::Success {
+                runtime_verdict: None
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -191,8 +191,12 @@ pub enum WorkerResult {
     Success {
         runtime_verdict: Option<serde_json::Value>,
     },
-    BlockedOnHuman { request: InteractionRequestDraft },
-    Failed { error: String },
+    BlockedOnHuman {
+        request: InteractionRequestDraft,
+    },
+    Failed {
+        error: String,
+    },
 }
 
 impl WorkerResult {
@@ -299,12 +303,10 @@ mod tests {
 
     #[test]
     fn test_worker_result_is_success() {
-        assert!(
-            WorkerResult::Success {
-                runtime_verdict: None
-            }
-            .is_success()
-        );
+        assert!(WorkerResult::Success {
+            runtime_verdict: None
+        }
+        .is_success());
         assert!(!WorkerResult::BlockedOnHuman {
             request: InteractionRequestDraft {
                 schema_version: 1,

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -188,14 +188,16 @@ pub enum WorkerEvent {
 /// Outcome of a worker task.
 #[derive(Debug, Clone)]
 pub enum WorkerResult {
-    Success,
+    Success {
+        runtime_verdict: Option<serde_json::Value>,
+    },
     BlockedOnHuman { request: InteractionRequestDraft },
     Failed { error: String },
 }
 
 impl WorkerResult {
     pub fn is_success(&self) -> bool {
-        matches!(self, WorkerResult::Success)
+        matches!(self, WorkerResult::Success { .. })
     }
 }
 
@@ -297,7 +299,12 @@ mod tests {
 
     #[test]
     fn test_worker_result_is_success() {
-        assert!(WorkerResult::Success.is_success());
+        assert!(
+            WorkerResult::Success {
+                runtime_verdict: None
+            }
+            .is_success()
+        );
         assert!(!WorkerResult::BlockedOnHuman {
             request: InteractionRequestDraft {
                 schema_version: 1,

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -221,7 +221,9 @@ async fn detect_worker_result(workspace_path: &Path) -> WorkerResult {
                     .to_string(),
         },
         Some(request) => WorkerResult::BlockedOnHuman { request },
-        None => WorkerResult::Success,
+        None => WorkerResult::Success {
+            runtime_verdict: None,
+        },
     }
 }
 
@@ -607,7 +609,9 @@ mod tests {
                 .await;
 
             if self.should_succeed {
-                Ok(WorkerResult::Success)
+                Ok(WorkerResult::Success {
+                    runtime_verdict: None,
+                })
             } else {
                 Err(AgentError::TurnFailed {
                     reason: "mock failure".to_string(),
@@ -730,7 +734,12 @@ on_failure: Todo
             })
             .await;
 
-        assert!(matches!(result, Ok(WorkerResult::Success)));
+        assert!(matches!(
+            result,
+            Ok(WorkerResult::Success {
+                runtime_verdict: None
+            })
+        ));
 
         let evt = rx.try_recv().unwrap();
         match evt {
@@ -825,7 +834,12 @@ exit 1
             std::env::remove_var("ENSEMBLE_TEST_ACPX_EXECUTABLE");
         }
 
-        assert!(matches!(result, WorkerResult::Success));
+        assert!(matches!(
+            result,
+            WorkerResult::Success {
+                runtime_verdict: None
+            }
+        ));
         let event_names = collect_event_names(&mut rx);
         assert!(event_names.contains(&"output_chunk".to_string()));
         assert!(event_names.contains(&"run_completed".to_string()));
@@ -874,7 +888,12 @@ exit 0
             .await
             .unwrap();
 
-        assert!(matches!(result, WorkerResult::Success));
+        assert!(matches!(
+            result,
+            WorkerResult::Success {
+                runtime_verdict: None
+            }
+        ));
         let event_names = collect_event_names(&mut rx);
         assert!(event_names.contains(&"output_chunk".to_string()));
     }
@@ -1099,7 +1118,12 @@ exit 0
             .unwrap();
 
         let result = detect_worker_result(workspace.path()).await;
-        assert!(matches!(result, WorkerResult::Success));
+        assert!(matches!(
+            result,
+            WorkerResult::Success {
+                runtime_verdict: None
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -252,6 +252,7 @@ async fn detect_worker_result_with_runtime_verdict(
     }
 }
 
+#[cfg(test)]
 async fn detect_worker_result(workspace_path: &Path) -> WorkerResult {
     detect_worker_result_with_runtime_verdict(workspace_path, None).await
 }
@@ -563,11 +564,7 @@ impl AcpAgentRunner {
 
         result?;
 
-        Ok(detect_worker_result_with_runtime_verdict(
-            workspace_path,
-            final_runtime_verdict,
-        )
-        .await)
+        Ok(detect_worker_result_with_runtime_verdict(workspace_path, final_runtime_verdict).await)
     }
 }
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -26,6 +26,12 @@ use events::{AgentEvent, InteractionRequestDraft, WorkerEvent, WorkerResult};
 use acp_client::{AcpSession, TurnResult};
 use acpx_runtime::AcpxRuntime;
 
+const VERDICT_FALLBACK_INSTRUCTION: &str = "\
+If you cannot return a structured runtime verdict, write .ensemble/verdict.json with:\n\
+{\"verdict\":\"approve\"}\n\
+or\n\
+{\"verdict\":\"reject\",\"summary\":\"<reason>\"}";
+
 pub struct AgentRunRequest<'a> {
     pub config: Arc<EnsembleConfig>,
     pub issue: &'a Issue,
@@ -101,7 +107,7 @@ impl AcpAgentRunner {
 
             let interaction_response = load_interaction_response(workspace_path).await?;
 
-            render_prompt_with_interaction_response(
+            let rendered = render_prompt_with_interaction_response(
                 &template_str,
                 issue,
                 attempt,
@@ -111,7 +117,12 @@ impl AcpAgentRunner {
             )
             .map_err(|e| AgentError::PromptError {
                 reason: e.to_string(),
-            })
+            })?;
+
+            Ok(maybe_append_verdict_fallback_instruction(
+                rendered,
+                config.agent.inject_verdict_fallback_instructions,
+            ))
         } else {
             // Continuation turns: send guidance, not the full original prompt
             Ok(format!(
@@ -137,6 +148,19 @@ impl AcpAgentRunner {
         }
 
         Ok(())
+    }
+}
+
+fn maybe_append_verdict_fallback_instruction(prompt: String, enabled: bool) -> String {
+    if !enabled || prompt.contains(VERDICT_FALLBACK_INSTRUCTION) {
+        return prompt;
+    }
+
+    let trimmed = prompt.trim_end();
+    if trimmed.is_empty() {
+        VERDICT_FALLBACK_INSTRUCTION.to_string()
+    } else {
+        format!("{trimmed}\n\n{VERDICT_FALLBACK_INSTRUCTION}")
     }
 }
 
@@ -928,6 +952,28 @@ exit 0
             .unwrap();
     }
 
+    #[test]
+    fn injects_verdict_block_when_enabled() {
+        let prompt = "Do the work.".to_string();
+        let rendered = maybe_append_verdict_fallback_instruction(prompt, true);
+        assert!(rendered.contains("write .ensemble/verdict.json"));
+    }
+
+    #[test]
+    fn does_not_inject_verdict_block_when_disabled() {
+        let prompt = "Do the work.".to_string();
+        let rendered = maybe_append_verdict_fallback_instruction(prompt.clone(), false);
+        assert_eq!(rendered, prompt);
+    }
+
+    #[test]
+    fn does_not_duplicate_verdict_block_when_present() {
+        let prompt = format!("Do work.\n\n{VERDICT_FALLBACK_INSTRUCTION}");
+        let rendered = maybe_append_verdict_fallback_instruction(prompt.clone(), true);
+        assert_eq!(rendered, prompt);
+        assert_eq!(rendered.matches("write .ensemble/verdict.json").count(), 1);
+    }
+
     #[tokio::test]
     async fn detects_interaction_request_file_and_returns_blocked_result() {
         let workspace = tempfile::TempDir::new().unwrap();
@@ -1203,7 +1249,8 @@ on_failure: Todo
             .await
             .unwrap();
 
-        assert_eq!(prompt, "question: Use staging");
+        assert!(prompt.starts_with("question: Use staging"));
+        assert!(prompt.contains("write .ensemble/verdict.json"));
     }
 
     #[tokio::test]
@@ -1261,7 +1308,8 @@ on_failure: Todo
             .await
             .unwrap();
 
-        assert_eq!(prompt, "hi");
+        assert!(prompt.starts_with("hi"));
+        assert!(prompt.contains("write .ensemble/verdict.json"));
     }
 
     #[test]

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -139,6 +139,9 @@ impl AcpAgentRunner {
         workspace_path: &Path,
         interaction_response: Option<&InteractionResponseEnvelope>,
     ) -> Result<(), AgentError> {
+        // Ensure stale verdict data from previous attempts cannot influence the
+        // current run's resolution path.
+        remove_ensemble_file(workspace_path, "verdict.json").await?;
         remove_ensemble_file(workspace_path, "interaction-request.json").await?;
 
         if let Some(interaction_response) = interaction_response {
@@ -1307,6 +1310,29 @@ on_failure: Todo
 
         assert!(prompt.starts_with("hi"));
         assert!(prompt.contains("write .ensemble/verdict.json"));
+    }
+
+    #[tokio::test]
+    async fn prepare_workspace_removes_stale_verdict_file() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let ensemble_dir = workspace.path().join(".ensemble");
+        tokio::fs::create_dir_all(&ensemble_dir).await.unwrap();
+        tokio::fs::write(
+            ensemble_dir.join("verdict.json"),
+            r#"{"verdict":"reject","summary":"stale"}"#,
+        )
+        .await
+        .unwrap();
+
+        AcpAgentRunner
+            .prepare_workspace(workspace.path(), None)
+            .await
+            .unwrap();
+
+        let exists = tokio::fs::try_exists(ensemble_dir.join("verdict.json"))
+            .await
+            .unwrap();
+        assert!(!exists, "stale verdict.json should be removed before run");
     }
 
     #[test]

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -189,7 +189,10 @@ async fn load_interaction_response(
     }
 }
 
-async fn detect_worker_result(workspace_path: &Path) -> WorkerResult {
+async fn detect_worker_result_with_runtime_verdict(
+    workspace_path: &Path,
+    runtime_verdict: Option<serde_json::Value>,
+) -> WorkerResult {
     let interaction_path = workspace_path
         .join(".ensemble")
         .join("interaction-request.json");
@@ -221,10 +224,12 @@ async fn detect_worker_result(workspace_path: &Path) -> WorkerResult {
                     .to_string(),
         },
         Some(request) => WorkerResult::BlockedOnHuman { request },
-        None => WorkerResult::Success {
-            runtime_verdict: None,
-        },
+        None => WorkerResult::Success { runtime_verdict },
     }
+}
+
+async fn detect_worker_result(workspace_path: &Path) -> WorkerResult {
+    detect_worker_result_with_runtime_verdict(workspace_path, None).await
 }
 
 async fn write_interaction_response_file(
@@ -442,6 +447,7 @@ impl AcpAgentRunner {
         let max_turns = config.agent.max_turns;
         let mut turn_number: u32 = 1;
 
+        let mut final_runtime_verdict: Option<serde_json::Value> = None;
         let result = loop {
             let prompt = match self
                 .build_prompt(
@@ -474,7 +480,12 @@ impl AcpAgentRunner {
                 .await;
 
             match turn_result {
-                Ok(TurnResult::Completed { .. }) => {
+                Ok(TurnResult::Completed {
+                    runtime_verdict, ..
+                }) => {
+                    if runtime_verdict.is_some() {
+                        final_runtime_verdict = runtime_verdict;
+                    }
                     info!(
                         issue_id = %issue.id,
                         identifier = %issue.identifier,
@@ -484,7 +495,14 @@ impl AcpAgentRunner {
                         "turn completed successfully"
                     );
                 }
-                Ok(TurnResult::Failed { reason, .. }) => {
+                Ok(TurnResult::Failed {
+                    reason,
+                    runtime_verdict,
+                    ..
+                }) => {
+                    if runtime_verdict.is_some() {
+                        final_runtime_verdict = runtime_verdict;
+                    }
                     warn!(
                         issue_id = %issue.id,
                         identifier = %issue.identifier,
@@ -521,7 +539,11 @@ impl AcpAgentRunner {
 
         result?;
 
-        Ok(detect_worker_result(workspace_path).await)
+        Ok(detect_worker_result_with_runtime_verdict(
+            workspace_path,
+            final_runtime_verdict,
+        )
+        .await)
     }
 }
 

--- a/crates/ensemble-core/src/agent/protocol.rs
+++ b/crates/ensemble-core/src/agent/protocol.rs
@@ -18,6 +18,7 @@ pub struct ParsedSessionUpdate {
     pub usage: Option<TokenUsage>,
     pub stop_reason: Option<StopReason>,
     pub permission_request: Option<PermissionRequest>,
+    pub verdict: Option<serde_json::Value>,
 }
 
 /// Parse one stdout line as a JSON-RPC message.
@@ -69,18 +70,21 @@ pub fn parse_session_update(value: &serde_json::Value) -> Option<ParsedSessionUp
     let usage = extract_usage(params, update);
     let stop_reason = extract_stop_reason(params, update);
     let permission_request = extract_permission_request(params, update);
+    let verdict = extract_verdict(params, update);
 
     let parsed = ParsedSessionUpdate {
         output_text,
         usage,
         stop_reason,
         permission_request,
+        verdict,
     };
 
     if parsed.output_text.is_none()
         && parsed.usage.is_none()
         && parsed.stop_reason.is_none()
         && parsed.permission_request.is_none()
+        && parsed.verdict.is_none()
     {
         return None;
     }
@@ -174,6 +178,16 @@ fn extract_permission_request(
         permission_id: permission_id.to_string(),
         description,
     })
+}
+
+fn extract_verdict(
+    params: &serde_json::Value,
+    update: Option<&serde_json::Value>,
+) -> Option<serde_json::Value> {
+    update
+        .and_then(|u| u.get("verdict"))
+        .cloned()
+        .or_else(|| params.get("verdict").cloned())
 }
 
 #[cfg(test)]
@@ -276,6 +290,34 @@ mod tests {
             .expect("permission request should be parsed");
         assert_eq!(permission.permission_id, "perm-1");
         assert_eq!(permission.description, "write file");
+    }
+
+    #[test]
+    fn parse_session_update_extracts_verdict_from_params() {
+        let params = json!({
+            "sessionId": "s1",
+            "verdict": {"verdict": "approve"}
+        });
+
+        let parsed = parse_session_update(&params).unwrap();
+        assert_eq!(parsed.verdict, Some(json!({"verdict":"approve"})));
+    }
+
+    #[test]
+    fn parse_session_update_extracts_verdict_from_nested_update() {
+        let params = json!({
+            "sessionId": "s1",
+            "update": {
+                "sessionUpdate": "turn_complete",
+                "verdict": {"verdict": "reject", "summary": "tests failed"}
+            }
+        });
+
+        let parsed = parse_session_update(&params).unwrap();
+        assert_eq!(
+            parsed.verdict,
+            Some(json!({"verdict":"reject","summary":"tests failed"}))
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -288,6 +288,7 @@ pub struct AgentRuntimeConfig {
     #[serde(default = "default_stall_timeout_ms")]
     pub stall_timeout_ms: i64,
     #[serde(default = "default_inject_verdict_fallback_instructions")]
+    #[serde(alias = "inject_verdict_instructions")]
     pub inject_verdict_fallback_instructions: bool,
 }
 
@@ -1979,6 +1980,28 @@ on_success: Done
 on_failure: Failed
 agent:
   inject_verdict_fallback_instructions: false
+"#;
+
+        let config = parse_config(yaml).unwrap();
+        assert!(!config.agent.inject_verdict_fallback_instructions);
+    }
+
+    #[test]
+    fn test_parse_config_with_short_verdict_injection_field_name() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+agent:
+  inject_verdict_instructions: false
 "#;
 
         let config = parse_config(yaml).unwrap();

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -287,6 +287,8 @@ pub struct AgentRuntimeConfig {
     pub read_timeout_ms: u64,
     #[serde(default = "default_stall_timeout_ms")]
     pub stall_timeout_ms: i64,
+    #[serde(default = "default_inject_verdict_fallback_instructions")]
+    pub inject_verdict_fallback_instructions: bool,
 }
 
 fn default_agent_max_turns() -> u32 {
@@ -321,6 +323,10 @@ fn default_stall_timeout_ms() -> i64 {
     300_000
 }
 
+fn default_inject_verdict_fallback_instructions() -> bool {
+    true
+}
+
 impl Default for AgentRuntimeConfig {
     fn default() -> Self {
         Self {
@@ -332,6 +338,7 @@ impl Default for AgentRuntimeConfig {
             turn_timeout_ms: default_turn_timeout_ms(),
             read_timeout_ms: default_read_timeout_ms(),
             stall_timeout_ms: default_stall_timeout_ms(),
+            inject_verdict_fallback_instructions: default_inject_verdict_fallback_instructions(),
         }
     }
 }
@@ -1934,5 +1941,47 @@ on_failure: Failed
 
         assert_eq!(config.tracker.api_key, None);
         std::env::remove_var("GITHUB_TOKEN");
+    }
+
+    #[test]
+    fn test_agent_runtime_defaults_include_verdict_fallback_injection_enabled() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+
+        let config = parse_config(yaml).unwrap();
+        assert!(config.agent.inject_verdict_fallback_instructions);
+    }
+
+    #[test]
+    fn test_parse_config_with_verdict_fallback_injection_disabled() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+agent:
+  inject_verdict_fallback_instructions: false
+"#;
+
+        let config = parse_config(yaml).unwrap();
+        assert!(!config.agent.inject_verdict_fallback_instructions);
     }
 }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -33,7 +33,7 @@ use crate::observability::events_contract::{
 };
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{PipelineAction, PipelineRun, StepState};
-use crate::pipeline::verdict::resolve_verdict;
+use crate::pipeline::verdict::{resolve_verdict_with_source, Verdict, VerdictSource};
 use crate::tracker::model::Issue;
 use crate::tracker::IssueTracker;
 use crate::workspace::manager::WorkspaceManager;
@@ -800,7 +800,7 @@ impl Orchestrator {
         };
 
         match result {
-            WorkerResult::Success { .. } => {
+            WorkerResult::Success { runtime_verdict } => {
                 let config = self.config.read().await;
                 info!(
                     issue_id = %issue_id,
@@ -817,15 +817,36 @@ impl Orchestrator {
                         .map(|i| i.identifier.as_str())
                         .unwrap_or(issue_id),
                 );
-                let verdict = match workspace_path {
-                    Some(wp) => resolve_verdict(None, &wp).await,
-                    None => crate::pipeline::verdict::Verdict::Approve,
+                let resolved = match workspace_path {
+                    Some(wp) => resolve_verdict_with_source(runtime_verdict.as_ref(), &wp).await,
+                    None => crate::pipeline::verdict::ResolvedVerdict {
+                        verdict: Verdict::Approve,
+                        source: VerdictSource::Default,
+                    },
                 };
+                let verdict_value = match &resolved.verdict {
+                    Verdict::Approve => "approve",
+                    Verdict::Reject { .. } => "reject",
+                };
+                info!(
+                    issue_id = %issue_id,
+                    step = step_name,
+                    verdict_source = ?resolved.source,
+                    verdict_value,
+                    "resolved step verdict"
+                );
+                if matches!(resolved.source, VerdictSource::Default) {
+                    warn!(
+                        issue_id = %issue_id,
+                        step = step_name,
+                        "no runtime or file verdict found; defaulting to approve"
+                    );
+                }
 
                 // Drive the pipeline
                 let pipeline_action = if let Some(run) = state.get_pipeline_run_mut(issue_id) {
                     Some((
-                        run.step_completed(step_name, verdict),
+                        run.step_completed(step_name, resolved.verdict),
                         state.get_pipeline_config(issue_id).cloned(),
                     ))
                 } else {
@@ -2126,12 +2147,17 @@ agent:
     }
 
     #[tokio::test]
+<<<<<<< HEAD
     async fn test_orchestrator_writes_history_record_on_completion() {
         let dir = tempfile::TempDir::new().unwrap();
         let mut raw_config = make_config();
         raw_config.workspace.root = Some(dir.path().display().to_string());
 
         let config = Arc::new(RwLock::new(raw_config));
+=======
+    async fn test_worker_exit_runtime_verdict_overrides_file_verdict() {
+        let config = Arc::new(RwLock::new(make_config()));
+>>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
         let issues = Arc::new(RwLock::new(vec![]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
@@ -2139,6 +2165,10 @@ agent:
             observed_commands: None,
             cancellation_probe: None,
         });
+<<<<<<< HEAD
+=======
+        let dir = tempfile::TempDir::new().unwrap();
+>>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
@@ -2153,6 +2183,7 @@ agent:
 
         {
             let cfg = config.read().await;
+<<<<<<< HEAD
             let dag = build_dag(&cfg.steps).unwrap();
             let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
             pipeline_run.start();
@@ -2188,6 +2219,49 @@ agent:
         raw_config.max_cycles = 1;
 
         let config = Arc::new(RwLock::new(raw_config));
+=======
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        let workspace = orchestrator
+            .workspace_mgr
+            .workspace_path("repo#1")
+            .expect("workspace path");
+        tokio::fs::create_dir_all(workspace.join(".ensemble"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            workspace.join(".ensemble").join("verdict.json"),
+            r#"{"verdict":"reject","summary":"broken"}"#,
+        )
+        .await
+        .unwrap();
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    runtime_verdict: Some(serde_json::json!({"verdict":"approve"})),
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.completed.contains("1"));
+        assert!(!state.retry_attempts.contains_key("1"));
+    }
+
+    #[tokio::test]
+    async fn test_worker_exit_uses_file_verdict_when_runtime_missing() {
+        let config = Arc::new(RwLock::new(make_config()));
+>>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
         let issues = Arc::new(RwLock::new(vec![]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
@@ -2195,6 +2269,10 @@ agent:
             observed_commands: None,
             cancellation_probe: None,
         });
+<<<<<<< HEAD
+=======
+        let dir = tempfile::TempDir::new().unwrap();
+>>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
@@ -2209,10 +2287,16 @@ agent:
 
         {
             let cfg = config.read().await;
+<<<<<<< HEAD
+=======
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+>>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
             let dag = build_dag(&cfg.steps).unwrap();
             let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
             pipeline_run.start();
             pipeline_run.mark_running("build", "session-1".to_string());
+<<<<<<< HEAD
 
             let mut state = orchestrator.state.write().await;
             state.add_running(&test_issue("1", "Todo"), Some(1));
@@ -2282,22 +2366,50 @@ agent:
             state.add_running(&test_issue("1", "Todo"), Some(1));
             state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
         }
+=======
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        let workspace = orchestrator
+            .workspace_mgr
+            .workspace_path("repo#1")
+            .expect("workspace path");
+        tokio::fs::create_dir_all(workspace.join(".ensemble"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            workspace.join(".ensemble").join("verdict.json"),
+            r#"{"verdict":"reject","summary":"broken"}"#,
+        )
+        .await
+        .unwrap();
+>>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
 
         orchestrator
             .handle_worker_exit(
                 "1",
                 "build",
+<<<<<<< HEAD
                 WorkerResult::Failed {
                     error: "temporary agent crash".to_string(),
+=======
+                WorkerResult::Success {
+                    runtime_verdict: None,
+>>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
                 },
             )
             .await;
 
+<<<<<<< HEAD
         let history_path = dir.path().join("ensemble_history.jsonl");
         assert!(
             tokio::fs::read_to_string(&history_path).await.is_err(),
             "retryable failure should not append history"
         );
+=======
+        let state = orchestrator.state.read().await;
+        assert!(state.retry_attempts.contains_key("1"));
+>>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -2147,17 +2147,8 @@ agent:
     }
 
     #[tokio::test]
-<<<<<<< HEAD
-    async fn test_orchestrator_writes_history_record_on_completion() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let mut raw_config = make_config();
-        raw_config.workspace.root = Some(dir.path().display().to_string());
-
-        let config = Arc::new(RwLock::new(raw_config));
-=======
     async fn test_worker_exit_runtime_verdict_overrides_file_verdict() {
         let config = Arc::new(RwLock::new(make_config()));
->>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
         let issues = Arc::new(RwLock::new(vec![]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
@@ -2165,10 +2156,7 @@ agent:
             observed_commands: None,
             cancellation_probe: None,
         });
-<<<<<<< HEAD
-=======
         let dir = tempfile::TempDir::new().unwrap();
->>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
@@ -2183,43 +2171,6 @@ agent:
 
         {
             let cfg = config.read().await;
-<<<<<<< HEAD
-            let dag = build_dag(&cfg.steps).unwrap();
-            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
-            pipeline_run.start();
-            pipeline_run.mark_running("build", "session-1".to_string());
-
-            let mut state = orchestrator.state.write().await;
-            state.add_running(&test_issue("1", "Todo"), None);
-            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
-        }
-
-        orchestrator
-            .handle_worker_exit("1", "build", WorkerResult::Success)
-            .await;
-
-        let history_path = dir.path().join("ensemble_history.jsonl");
-        let contents = tokio::fs::read_to_string(&history_path).await.unwrap();
-        let record = contents
-            .lines()
-            .map(|line| serde_json::from_str::<crate::history::model::HistoryRecord>(line).unwrap())
-            .next()
-            .unwrap();
-
-        assert_eq!(record.issue_id, "1");
-        assert_eq!(record.outcome, "succeeded");
-        assert_eq!(record.verdict.as_deref(), Some("approved"));
-    }
-
-    #[tokio::test]
-    async fn test_orchestrator_writes_history_record_on_terminal_failure() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let mut raw_config = make_config();
-        raw_config.workspace.root = Some(dir.path().display().to_string());
-        raw_config.max_cycles = 1;
-
-        let config = Arc::new(RwLock::new(raw_config));
-=======
             let mut state = orchestrator.state.write().await;
             state.add_running(&test_issue("1", "Todo"), None);
             let dag = build_dag(&cfg.steps).unwrap();
@@ -2261,7 +2212,6 @@ agent:
     #[tokio::test]
     async fn test_worker_exit_uses_file_verdict_when_runtime_missing() {
         let config = Arc::new(RwLock::new(make_config()));
->>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
         let issues = Arc::new(RwLock::new(vec![]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
@@ -2269,10 +2219,7 @@ agent:
             observed_commands: None,
             cancellation_probe: None,
         });
-<<<<<<< HEAD
-=======
         let dir = tempfile::TempDir::new().unwrap();
->>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
@@ -2287,16 +2234,137 @@ agent:
 
         {
             let cfg = config.read().await;
-<<<<<<< HEAD
-=======
             let mut state = orchestrator.state.write().await;
             state.add_running(&test_issue("1", "Todo"), None);
->>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
             let dag = build_dag(&cfg.steps).unwrap();
             let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
             pipeline_run.start();
             pipeline_run.mark_running("build", "session-1".to_string());
-<<<<<<< HEAD
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        let workspace = orchestrator
+            .workspace_mgr
+            .workspace_path("repo#1")
+            .expect("workspace path");
+        tokio::fs::create_dir_all(workspace.join(".ensemble"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            workspace.join(".ensemble").join("verdict.json"),
+            r#"{"verdict":"reject","summary":"broken"}"#,
+        )
+        .await
+        .unwrap();
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    runtime_verdict: None,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.retry_attempts.contains_key("1"));
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_writes_history_record_on_completion() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut raw_config = make_config();
+        raw_config.workspace.root = Some(dir.path().display().to_string());
+
+        let config = Arc::new(RwLock::new(raw_config));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config.clone(),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    runtime_verdict: None,
+                },
+            )
+            .await;
+
+        let history_path = dir.path().join("ensemble_history.jsonl");
+        let contents = tokio::fs::read_to_string(&history_path).await.unwrap();
+        let record = contents
+            .lines()
+            .map(|line| serde_json::from_str::<crate::history::model::HistoryRecord>(line).unwrap())
+            .next()
+            .unwrap();
+
+        assert_eq!(record.issue_id, "1");
+        assert_eq!(record.outcome, "succeeded");
+        assert_eq!(record.verdict.as_deref(), Some("approved"));
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_writes_history_record_on_terminal_failure() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut raw_config = make_config();
+        raw_config.workspace.root = Some(dir.path().display().to_string());
+        raw_config.max_cycles = 1;
+
+        let config = Arc::new(RwLock::new(raw_config));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config.clone(),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
 
             let mut state = orchestrator.state.write().await;
             state.add_running(&test_issue("1", "Todo"), Some(1));
@@ -2366,50 +2434,22 @@ agent:
             state.add_running(&test_issue("1", "Todo"), Some(1));
             state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
         }
-=======
-            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
-        }
-
-        let workspace = orchestrator
-            .workspace_mgr
-            .workspace_path("repo#1")
-            .expect("workspace path");
-        tokio::fs::create_dir_all(workspace.join(".ensemble"))
-            .await
-            .unwrap();
-        tokio::fs::write(
-            workspace.join(".ensemble").join("verdict.json"),
-            r#"{"verdict":"reject","summary":"broken"}"#,
-        )
-        .await
-        .unwrap();
->>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
 
         orchestrator
             .handle_worker_exit(
                 "1",
                 "build",
-<<<<<<< HEAD
                 WorkerResult::Failed {
                     error: "temporary agent crash".to_string(),
-=======
-                WorkerResult::Success {
-                    runtime_verdict: None,
->>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
                 },
             )
             .await;
 
-<<<<<<< HEAD
         let history_path = dir.path().join("ensemble_history.jsonl");
         assert!(
             tokio::fs::read_to_string(&history_path).await.is_err(),
             "retryable failure should not append history"
         );
-=======
-        let state = orchestrator.state.read().await;
-        assert!(state.retry_attempts.contains_key("1"));
->>>>>>> e748d36 (feat: resolve step verdicts runtime-first in orchestrator)
     }
 
     #[tokio::test]
@@ -4206,7 +4246,13 @@ agent:
         }
 
         orchestrator
-            .handle_worker_exit("1", "build", WorkerResult::Success)
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    runtime_verdict: None,
+                },
+            )
             .await;
 
         assert!(workspace_root.join("ensemble_history.jsonl").exists());

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -800,7 +800,7 @@ impl Orchestrator {
         };
 
         match result {
-            WorkerResult::Success => {
+            WorkerResult::Success { .. } => {
                 let config = self.config.read().await;
                 info!(
                     issue_id = %issue_id,
@@ -1896,7 +1896,9 @@ mod tests {
                 }
                 return Err(AgentError::TurnCancelled);
             }
-            Ok(WorkerResult::Success)
+            Ok(WorkerResult::Success {
+                runtime_verdict: None,
+            })
         }
     }
 
@@ -2106,7 +2108,13 @@ agent:
 
         // Simulate worker exit
         orchestrator
-            .handle_worker_exit("1", "build", WorkerResult::Success)
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    runtime_verdict: None,
+                },
+            )
             .await;
 
         let state = orchestrator.state.read().await;
@@ -3059,7 +3067,13 @@ agent:
         }
 
         orchestrator
-            .handle_worker_exit("1", "docs", WorkerResult::Success)
+            .handle_worker_exit(
+                "1",
+                "docs",
+                WorkerResult::Success {
+                    runtime_verdict: None,
+                },
+            )
             .await;
 
         let state = orchestrator.state.read().await;

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -12,6 +12,19 @@ pub enum Verdict {
     Reject { summary: String },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerdictSource {
+    Runtime,
+    File,
+    Default,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedVerdict {
+    pub verdict: Verdict,
+    pub source: VerdictSource,
+}
+
 /// Internal deserialization type for both ACP JSON values and verdict files.
 #[derive(Debug, Deserialize)]
 struct VerdictPayload {
@@ -55,28 +68,50 @@ pub async fn read_verdict_file(workspace: &Path) -> Result<Option<Verdict>, std:
 /// 2. `.ensemble/verdict.json` in the workspace — checked if ACP yields nothing.
 /// 3. Default to [`Verdict::Approve`] if neither source provides a verdict.
 pub async fn resolve_verdict(acp_verdict: Option<&serde_json::Value>, workspace: &Path) -> Verdict {
+    resolve_verdict_with_source(acp_verdict, workspace).await.verdict
+}
+
+/// Resolve the final verdict for a completed step, including the source.
+pub async fn resolve_verdict_with_source(
+    acp_verdict: Option<&serde_json::Value>,
+    workspace: &Path,
+) -> ResolvedVerdict {
     // 1. Try ACP event.
     if let Some(value) = acp_verdict {
         if let Some(v) = parse_verdict_from_value(value) {
-            return v;
+            return ResolvedVerdict {
+                verdict: v,
+                source: VerdictSource::Runtime,
+            };
         }
     }
 
     // 2. Try file.
     match read_verdict_file(workspace).await {
-        Ok(Some(v)) => return v,
+        Ok(Some(v)) => {
+            return ResolvedVerdict {
+                verdict: v,
+                source: VerdictSource::File,
+            };
+        }
         Ok(None) => {} // file doesn't exist — fall through to default
         Err(e) => {
             // Malformed verdict file — treat as rejection, not silent approval.
-            return Verdict::Reject {
-                summary: format!("failed to parse .ensemble/verdict.json: {e}"),
+            return ResolvedVerdict {
+                verdict: Verdict::Reject {
+                    summary: format!("failed to parse .ensemble/verdict.json: {e}"),
+                },
+                source: VerdictSource::File,
             };
         }
     }
 
     // 3. Default (no ACP verdict, no file).
     warn!("no verdict source found for step, defaulting to Approve");
-    Verdict::Approve
+    ResolvedVerdict {
+        verdict: Verdict::Approve,
+        source: VerdictSource::Default,
+    }
 }
 
 /// Convert a [`VerdictPayload`] into an `Option<Verdict>`.
@@ -185,6 +220,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_resolve_verdict_with_source_runtime_takes_priority() {
+        let dir = TempDir::new().unwrap();
+        write_verdict_file(&dir, r#"{"verdict":"reject","summary":"broken"}"#).await;
+
+        let acp = json!({ "verdict": "approve" });
+        let result = resolve_verdict_with_source(Some(&acp), dir.path()).await;
+        assert_eq!(result.verdict, Verdict::Approve);
+        assert_eq!(result.source, VerdictSource::Runtime);
+    }
+
+    #[tokio::test]
     async fn test_resolve_verdict_falls_back_to_file() {
         // No ACP value — file provides the verdict.
         let dir = TempDir::new().unwrap();
@@ -200,11 +246,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_resolve_verdict_with_source_falls_back_to_file() {
+        let dir = TempDir::new().unwrap();
+        write_verdict_file(&dir, r#"{"verdict":"reject","summary":"compile error"}"#).await;
+
+        let result = resolve_verdict_with_source(None, dir.path()).await;
+        assert_eq!(
+            result.verdict,
+            Verdict::Reject {
+                summary: "compile error".to_string()
+            }
+        );
+        assert_eq!(result.source, VerdictSource::File);
+    }
+
+    #[tokio::test]
     async fn test_resolve_verdict_no_source_is_approve() {
         // No ACP, no file — defaults to Approve.
         let dir = TempDir::new().unwrap();
         let result = resolve_verdict(None, dir.path()).await;
         assert_eq!(result, Verdict::Approve);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_verdict_with_source_no_source_is_default_approve() {
+        let dir = TempDir::new().unwrap();
+        let result = resolve_verdict_with_source(None, dir.path()).await;
+        assert_eq!(result.verdict, Verdict::Approve);
+        assert_eq!(result.source, VerdictSource::Default);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -68,7 +68,9 @@ pub async fn read_verdict_file(workspace: &Path) -> Result<Option<Verdict>, std:
 /// 2. `.ensemble/verdict.json` in the workspace — checked if ACP yields nothing.
 /// 3. Default to [`Verdict::Approve`] if neither source provides a verdict.
 pub async fn resolve_verdict(acp_verdict: Option<&serde_json::Value>, workspace: &Path) -> Verdict {
-    resolve_verdict_with_source(acp_verdict, workspace).await.verdict
+    resolve_verdict_with_source(acp_verdict, workspace)
+        .await
+        .verdict
 }
 
 /// Resolve the final verdict for a completed step, including the source.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,6 +287,7 @@ This section configures Ensemble's runtime behavior after the agent is launched.
 | `turn_timeout_ms` | integer | `3600000` | Maximum time for a single agent turn (1 hour) |
 | `read_timeout_ms` | integer | `5000` | Timeout for reading agent output |
 | `stall_timeout_ms` | integer | `300000` | Timeout for detecting a stalled agent |
+| `inject_verdict_fallback_instructions` | boolean | `true` | Appends Ensemble-owned fallback instructions so agents can write `.ensemble/verdict.json` when no structured runtime verdict is emitted |
 
 `agent.permission_request_policy` only applies to direct ACP runtime paths. If all configured agents resolve to the `acpx` runtime, leave this at its default. In mixed configurations, it still applies only to agents using the direct runtime; to customize permission handling for an `acpx`-resolved agent, switch that agent to `runtime: direct`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,6 +289,8 @@ This section configures Ensemble's runtime behavior after the agent is launched.
 | `stall_timeout_ms` | integer | `300000` | Timeout for detecting a stalled agent |
 | `inject_verdict_fallback_instructions` | boolean | `true` | Appends Ensemble-owned fallback instructions so agents can write `.ensemble/verdict.json` when no structured runtime verdict is emitted |
 
+`agent.inject_verdict_instructions` is accepted as a shorter alias for `agent.inject_verdict_fallback_instructions`.
+
 `agent.permission_request_policy` only applies to direct ACP runtime paths. If all configured agents resolve to the `acpx` runtime, leave this at its default. In mixed configurations, it still applies only to agents using the direct runtime; to customize permission handling for an `acpx`-resolved agent, switch that agent to `runtime: direct`.
 
 Legacy note: `agent.permission_policy` is still accepted as a deprecated alias for `agent.permission_request_policy` during config parsing.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -94,10 +94,10 @@ Todo → Building → In Review → Done
 
 ## Verdicts
 
-After an agent finishes, Ensemble checks for a verdict:
+After an agent finishes, Ensemble resolves verdicts with this strict precedence:
 
-1. **Runtime verdict (primary)** — the runtime reports a structured verdict in session updates/results
-2. **File fallback** — the agent writes `.ensemble/verdict.json` in the workspace:
+1. **Runtime verdict (primary)** — if the runtime reports a parseable structured verdict, Ensemble uses it.
+2. **File fallback** — only when no runtime verdict is available, Ensemble checks `.ensemble/verdict.json`:
 
 ```json
 {
@@ -114,9 +114,11 @@ or:
 }
 ```
 
-3. **Default** — if no verdict is found, the step is treated as approved
+3. **Default approve** — if neither source provides a verdict, the step is treated as approved.
 
-By default, Ensemble appends fallback verdict instructions to rendered prompts (`agent.inject_verdict_fallback_instructions: true`), so users do not need to manually add `.ensemble/verdict.json` instructions in their templates.
+If both runtime and file verdicts exist, runtime verdict takes precedence and file verdict is ignored.
+
+By default, Ensemble appends fallback verdict instructions to rendered prompts (`agent.inject_verdict_fallback_instructions: true`, alias `agent.inject_verdict_instructions`), so users do not need to manually add `.ensemble/verdict.json` instructions in their templates.
 
 **Approve** means the step passed. The pipeline moves to the next step (or completes).
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -96,7 +96,7 @@ Todo → Building → In Review → Done
 
 After an agent finishes, Ensemble checks for a verdict:
 
-1. **ACP protocol** — the agent reports a verdict in its session response (preferred)
+1. **Runtime verdict (primary)** — the runtime reports a structured verdict in session updates/results
 2. **File fallback** — the agent writes `.ensemble/verdict.json` in the workspace:
 
 ```json
@@ -115,6 +115,8 @@ or:
 ```
 
 3. **Default** — if no verdict is found, the step is treated as approved
+
+By default, Ensemble appends fallback verdict instructions to rendered prompts (`agent.inject_verdict_fallback_instructions: true`), so users do not need to manually add `.ensemble/verdict.json` instructions in their templates.
 
 **Approve** means the step passed. The pipeline moves to the next step (or completes).
 

--- a/docs/superpowers/plans/2026-04-08-runtime-first-verdict-and-injection-plan.md
+++ b/docs/superpowers/plans/2026-04-08-runtime-first-verdict-and-injection-plan.md
@@ -1,0 +1,425 @@
+# Runtime-First Verdict + Automatic Fallback Injection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make runtime verdicts the true primary source again, keep file fallback + default approve behavior, and remove user prompt boilerplate by auto-injecting fallback verdict instructions.
+
+**Architecture:** Extend worker/runtime plumbing to carry an optional runtime verdict payload into orchestrator verdict resolution. Keep `resolve_verdict()` priority unchanged (runtime -> file -> default approve), but add explicit verdict-source observability. Inject Ensemble-owned fallback instructions at prompt assembly with a default-on config escape hatch.
+
+**Tech Stack:** Rust 2021, tokio, serde/serde_json/serde_yaml, tracing, thiserror, tempfile
+
+---
+
+## File Structure
+
+### Modified Files
+
+| File | Responsibility |
+|---|---|
+| `crates/ensemble-core/src/agent/events.rs` | Extend worker result payload to carry optional runtime verdict JSON |
+| `crates/ensemble-core/src/agent/protocol.rs` | Parse optional verdict payload from `session/update` messages |
+| `crates/ensemble-core/src/agent/acp_client.rs` | Track last runtime verdict seen during turn streaming |
+| `crates/ensemble-core/src/agent/acpx_cli.rs` | Track runtime verdict from ACPX JSON stream and return it |
+| `crates/ensemble-core/src/agent/acpx_runtime.rs` | Forward runtime verdict into `WorkerResult::Success` |
+| `crates/ensemble-core/src/agent/mod.rs` | Central prompt assembly injection + direct-runtime verdict propagation |
+| `crates/ensemble-core/src/orchestrator/mod.rs` | Pass runtime verdict into `resolve_verdict` and log verdict source/value |
+| `crates/ensemble-core/src/pipeline/verdict.rs` | Add source-aware resolve helper (or equivalent) and tests |
+| `crates/ensemble-core/src/config/ensemble.rs` | Add `agent.inject_verdict_fallback_instructions` config field + default |
+| `docs/configuration.md` | Document new runtime-level config flag |
+| `docs/pipelines.md` | Clarify runtime-first verdict behavior and automatic fallback injection |
+
+---
+
+### Task 1: Add source-carrying verdict model (TDD)
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/events.rs`
+- Modify: `crates/ensemble-core/src/pipeline/verdict.rs`
+- Test: `crates/ensemble-core/src/pipeline/verdict.rs` (existing test module)
+
+- [ ] **Step 1: Add worker success payload type**
+
+Update `WorkerResult` to carry optional runtime verdict JSON:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum WorkerResult {
+    Success {
+        runtime_verdict: Option<serde_json::Value>,
+    },
+    BlockedOnHuman { request: InteractionRequestDraft },
+    Failed { error: String },
+}
+```
+
+Keep helper working:
+
+```rust
+pub fn is_success(&self) -> bool {
+    matches!(self, WorkerResult::Success { .. })
+}
+```
+
+- [ ] **Step 2: Add source-aware resolve API in verdict module**
+
+Introduce:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerdictSource {
+    Runtime,
+    File,
+    Default,
+}
+
+pub struct ResolvedVerdict {
+    pub verdict: Verdict,
+    pub source: VerdictSource,
+}
+
+pub async fn resolve_verdict_with_source(
+    runtime_verdict: Option<&serde_json::Value>,
+    workspace: &Path,
+) -> ResolvedVerdict { /* runtime -> file -> default */ }
+```
+
+Keep existing `resolve_verdict(...) -> Verdict` as a thin wrapper for compatibility:
+
+```rust
+pub async fn resolve_verdict(runtime_verdict: Option<&serde_json::Value>, workspace: &Path) -> Verdict {
+    resolve_verdict_with_source(runtime_verdict, workspace).await.verdict
+}
+```
+
+- [ ] **Step 3: Write failing tests for source behavior**
+
+Add tests:
+
+```rust
+#[tokio::test]
+async fn test_resolve_with_source_runtime_beats_file() { /* expect source Runtime */ }
+
+#[tokio::test]
+async fn test_resolve_with_source_file_when_runtime_missing() { /* expect source File */ }
+
+#[tokio::test]
+async fn test_resolve_with_source_default_when_none() { /* expect source Default */ }
+```
+
+- [ ] **Step 4: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --workspace -p ensemble-core pipeline::verdict
+```
+
+Expected: all verdict tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/events.rs crates/ensemble-core/src/pipeline/verdict.rs
+git commit -m "feat: add runtime verdict payload and source-aware verdict resolution"
+```
+
+---
+
+### Task 2: Plumb runtime verdict from ACP/ACPX workers (TDD)
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/protocol.rs`
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+- Modify: `crates/ensemble-core/src/agent/acpx_cli.rs`
+- Modify: `crates/ensemble-core/src/agent/acpx_runtime.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Test: `crates/ensemble-core/src/agent/protocol.rs`
+- Test: `crates/ensemble-core/src/agent/acpx_cli.rs`
+- Test: `crates/ensemble-core/src/agent/mod.rs`
+
+- [ ] **Step 1: Extend parsed session update with verdict**
+
+In `protocol.rs`:
+
+```rust
+pub struct ParsedSessionUpdate {
+    pub output_text: Option<String>,
+    pub usage: Option<TokenUsage>,
+    pub stop_reason: Option<StopReason>,
+    pub permission_request: Option<PermissionRequest>,
+    pub verdict: Option<serde_json::Value>,
+}
+```
+
+Add extraction helper that accepts either `params.verdict` or `params.update.verdict`.
+
+- [ ] **Step 2: Add protocol tests for verdict extraction**
+
+Add tests:
+
+```rust
+#[test]
+fn parse_session_update_extracts_verdict_from_params() { /* verdict approve */ }
+
+#[test]
+fn parse_session_update_extracts_verdict_from_nested_update() { /* verdict reject */ }
+```
+
+- [ ] **Step 3: Capture last runtime verdict in ACP direct path**
+
+In `AcpSession::stream_turn`, track `last_verdict: Option<serde_json::Value>` from parsed updates and return it in `TurnResult::Completed` / `Failed`:
+
+```rust
+pub enum TurnResult {
+    Completed { usage: Option<TokenUsage>, runtime_verdict: Option<serde_json::Value> },
+    Failed { reason: String, usage: Option<TokenUsage>, runtime_verdict: Option<serde_json::Value> },
+}
+```
+
+- [ ] **Step 4: Capture last runtime verdict in ACPX path**
+
+In `acpx_cli.rs`, track the same `last_verdict` and return a run outcome struct (or equivalent) consumed by `acpx_runtime.rs`.
+
+Example shape:
+
+```rust
+pub struct PromptOutcome {
+    pub runtime_verdict: Option<serde_json::Value>,
+}
+```
+
+- [ ] **Step 5: Forward runtime verdict into worker exit result**
+
+In `agent/mod.rs` + `acpx_runtime.rs`, return:
+
+```rust
+WorkerResult::Success { runtime_verdict }
+```
+
+For file-only/legacy paths, use `runtime_verdict: None`.
+
+- [ ] **Step 6: Update/extend worker-result tests**
+
+In `agent/mod.rs` tests, assert success variant includes `runtime_verdict: None` in non-runtime-verdict scenarios.
+
+- [ ] **Step 7: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --workspace -p ensemble-core agent::protocol
+cargo test --workspace -p ensemble-core agent::acpx_cli
+cargo test --workspace -p ensemble-core agent::tests
+```
+
+Expected: pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/protocol.rs crates/ensemble-core/src/agent/acp_client.rs crates/ensemble-core/src/agent/acpx_cli.rs crates/ensemble-core/src/agent/acpx_runtime.rs crates/ensemble-core/src/agent/mod.rs
+git commit -m "feat: propagate runtime verdict payloads through agent runtimes"
+```
+
+---
+
+### Task 3: Wire orchestrator to runtime-first resolution + observability (TDD)
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Test: `crates/ensemble-core/src/orchestrator/mod.rs` (existing tests)
+
+- [ ] **Step 1: Use source-aware resolver in worker success handler**
+
+Update success match arm:
+
+```rust
+match result {
+    WorkerResult::Success { runtime_verdict } => {
+        let resolved = match workspace_path {
+            Some(wp) => resolve_verdict_with_source(runtime_verdict.as_ref(), &wp).await,
+            None => ResolvedVerdict { verdict: Verdict::Approve, source: VerdictSource::Default },
+        };
+        // pass resolved.verdict to pipeline engine
+    }
+    // ...
+}
+```
+
+- [ ] **Step 2: Add verdict source/value logging**
+
+Emit structured fields before pipeline transition:
+
+```rust
+info!(
+    issue_id = %issue_id,
+    step = step_name,
+    verdict_source = ?resolved.source,
+    verdict_value = %match &resolved.verdict { Verdict::Approve => "approve", Verdict::Reject { .. } => "reject" },
+    "resolved step verdict"
+);
+```
+
+Also emit warn when source is `Default` and step completed successfully.
+
+- [ ] **Step 3: Add orchestrator tests**
+
+Add tests for:
+- Runtime verdict passed in `WorkerResult::Success` wins over file.
+- Missing runtime verdict falls back to file.
+- Missing both remains approve with default source path.
+
+- [ ] **Step 4: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --workspace -p ensemble-core orchestrator::tests
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/orchestrator/mod.rs
+git commit -m "feat: use runtime-first verdict resolution in orchestrator"
+```
+
+---
+
+### Task 4: Add automatic fallback verdict-instruction injection (TDD)
+
+**Files:**
+- Modify: `crates/ensemble-core/src/config/ensemble.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Test: `crates/ensemble-core/src/config/ensemble.rs`
+- Test: `crates/ensemble-core/src/agent/mod.rs`
+
+- [ ] **Step 1: Add config flag with default true**
+
+In `AgentRuntimeConfig`:
+
+```rust
+#[serde(default = "default_inject_verdict_fallback_instructions")]
+pub inject_verdict_fallback_instructions: bool,
+
+fn default_inject_verdict_fallback_instructions() -> bool {
+    true
+}
+```
+
+Update `Default` impl and config parsing tests.
+
+- [ ] **Step 2: Add shared prompt injection helper in agent module**
+
+Create helper:
+
+```rust
+fn maybe_append_verdict_fallback_instruction(
+    prompt: String,
+    enabled: bool,
+) -> String { /* append once, idempotent */ }
+```
+
+Append after `render_prompt_with_interaction_response(...)` in `build_prompt` first-turn path.
+
+Suggested injected block (exact constant):
+
+```text
+If you cannot return a structured runtime verdict, write .ensemble/verdict.json with:
+{"verdict":"approve"}
+or
+{"verdict":"reject","summary":"<reason>"}
+```
+
+- [ ] **Step 3: Add unit tests for injection behavior**
+
+Add tests in `agent/mod.rs`:
+
+```rust
+#[test]
+fn injects_verdict_block_when_enabled() { /* contains block */ }
+
+#[test]
+fn does_not_inject_when_disabled() { /* unchanged */ }
+
+#[test]
+fn does_not_duplicate_when_prompt_already_contains_block() { /* single instance */ }
+```
+
+- [ ] **Step 4: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --workspace -p ensemble-core config::ensemble
+cargo test --workspace -p ensemble-core agent::tests
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/config/ensemble.rs crates/ensemble-core/src/agent/mod.rs
+git commit -m "feat: auto-inject fallback verdict instructions into prompts"
+```
+
+---
+
+### Task 5: Docs + full verification
+
+**Files:**
+- Modify: `docs/configuration.md`
+- Modify: `docs/pipelines.md`
+
+- [ ] **Step 1: Document new runtime config flag**
+
+In `docs/configuration.md` under `agent.*` runtime fields, add:
+
+```md
+| `inject_verdict_fallback_instructions` | boolean | `true` | Appends Ensemble-owned fallback instructions so agents can write `.ensemble/verdict.json` when no structured runtime verdict is emitted. |
+```
+
+- [ ] **Step 2: Update verdict docs**
+
+In `docs/pipelines.md` verdict section, clarify:
+- Runtime verdict is primary source.
+- `.ensemble/verdict.json` is fallback.
+- Ensemble auto-injects fallback instruction by default.
+- No source still defaults to approve.
+
+- [ ] **Step 3: Run workspace verification**
+
+Run:
+
+```bash
+cargo test --workspace --exclude ensemble-desktop
+cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit docs + final polish**
+
+```bash
+git add docs/configuration.md docs/pipelines.md
+git commit -m "docs: clarify runtime-first verdicts and fallback injection"
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Runtime-first verdict restoration: covered by Tasks 1-3.
+  - Fallback instruction auto-injection: covered by Task 4.
+  - Source observability: covered by Task 3.
+  - Backward-compatible defaults/docs: covered by Tasks 1 + 5.
+- Placeholder scan: no unresolved placeholders remain.
+- Type consistency:
+  - `WorkerResult::Success { runtime_verdict }` is used consistently in agent runtimes and orchestrator.
+  - Verdict source naming is consistent: `Runtime`, `File`, `Default`.
+

--- a/docs/superpowers/specs/2026-04-08-verdict-primary-and-fallback-injection-design.md
+++ b/docs/superpowers/specs/2026-04-08-verdict-primary-and-fallback-injection-design.md
@@ -1,0 +1,129 @@
+# Runtime-First Verdict Resolution + Automatic Fallback Injection Design
+
+Date: 2026-04-08  
+Status: Proposed  
+Owner: Ensemble core
+
+## Goal
+
+Ensure verdict handling matches intended architecture (runtime verdict as primary, file fallback second) while removing prompt authoring burden from users.
+
+## Scope
+
+In scope:
+- Restore runtime verdict as first-class input to pipeline verdict resolution
+- Keep `.ensemble/verdict.json` fallback behavior
+- Preserve existing default behavior when no verdict exists (approve)
+- Add automatic fallback instruction injection into rendered prompts
+- Add observability for verdict source selection
+
+Out of scope:
+- Changing verdict semantics (no-verdict remains approve)
+- Breaking runtime/file compatibility
+- Major protocol redesign beyond current runtime contracts
+
+## Problem Statement
+
+Current behavior is intended to be:
+1. Runtime/structured verdict
+2. `.ensemble/verdict.json` fallback
+3. Default approve
+
+However, the current orchestrator success path resolves verdicts with no runtime verdict payload passed through, which can cause effective reliance on file/default behavior in practice. This also forces users to include verdict-file instructions in prompts manually.
+
+## Design Summary
+
+Implement a two-part fix:
+
+1. **Runtime-first plumbing**: propagate runtime verdict payload from worker completion to orchestrator verdict resolution.
+2. **Automatic fallback instruction injection**: append a standard Ensemble-owned verdict-file instruction block during prompt assembly so users do not need to write verdict boilerplate.
+
+Behavioral contract remains:
+- runtime verdict (if present and valid) wins
+- else file verdict (if present and valid)
+- else approve (unchanged)
+
+## Detailed Design
+
+### 1) Verdict Resolution Architecture
+
+- Keep `resolve_verdict(acp_verdict, workspace)` priority unchanged.
+- Update worker success data model so completion can carry an optional runtime verdict JSON value.
+- Pass that runtime verdict value into `resolve_verdict(Some(...), workspace)` from orchestrator worker-exit handling.
+- Maintain compatibility with existing file-based and no-verdict flows.
+
+### 2) Automatic Fallback Instruction Injection
+
+- Inject a standard fallback verdict instruction block at prompt assembly time (after template render, before runtime dispatch).
+- This instruction block is owned by Ensemble, not user prompt templates.
+- Default config: injection enabled.
+- Add advanced escape hatch:
+  - `agent.inject_verdict_fallback_instructions: true` (default)
+
+Implementation constraints:
+- Idempotent append (avoid duplicate injection)
+- Shared across runtime paths so behavior is uniform
+- Keep instruction concise and deterministic
+
+### 3) Observability and Safety Rails
+
+Add structured fields on step completion logs:
+- `verdict_source`: `runtime | file | default`
+- `verdict_value`: `approve | reject`
+
+Additional diagnostics:
+- Warn log when runtime verdict is absent and fallback injection is enabled, but no file verdict exists (still resolves to approve).
+- Counter/metric by source to validate real-world usage of runtime-first path.
+
+## Data Flow (Post-change)
+
+1. Agent runtime completes turn/step.
+2. Worker extracts optional runtime verdict payload (if present).
+3. Worker exit event carries `result=Success { runtime_verdict: Option<Value> }`.
+4. Orchestrator resolves verdict with:
+   - runtime payload first
+   - file fallback second
+   - default approve last
+5. Pipeline engine receives resolved `Verdict` and advances state as today.
+
+## Testing Strategy
+
+1. Runtime verdict beats conflicting file verdict.
+2. Missing runtime verdict falls back to file verdict.
+3. Missing runtime and file verdict defaults to approve.
+4. Prompt injection appends expected fallback block when enabled.
+5. Prompt injection does not append block when disabled.
+6. Verdict source fields/metrics reflect actual source used.
+
+## Rollout Plan
+
+- Ship with default-on injection and runtime-first wiring.
+- No migration required.
+- Monitor verdict source counters/logs to confirm runtime verdict path adoption.
+- Keep fallback and default behavior for safe backward compatibility.
+
+## Risks and Mitigations
+
+Risk: Runtime verdict extraction varies across runtimes.
+- Mitigation: Use optional payload + existing fallback chain.
+
+Risk: Injection text conflicts with highly customized agent prompts.
+- Mitigation: Provide opt-out config flag.
+
+Risk: Silent default-approve remains easy to miss.
+- Mitigation: add explicit `verdict_source=default` logging and warn path.
+
+## Alternatives Considered
+
+1. **Prompt-only solution** (fallback instructions only): low effort but does not restore intended runtime-primary architecture.
+2. **Runtime-only strict verdict** (no fallback): cleaner contract but breaks compatibility and increases operational risk.
+
+Chosen approach keeps intended architecture while minimizing disruption.
+
+## Acceptance Criteria
+
+- Runtime verdict is propagated into orchestrator verdict resolution path.
+- Users are not required to include verdict-file instructions in prompt templates.
+- No-verdict behavior remains approve.
+- Logs/metrics show verdict source per completed step.
+- Existing file fallback workflows continue to work unchanged.


### PR DESCRIPTION
## Summary

This PR implements runtime-first verdict resolution with automatic fallback instruction injection for ensemble pipelines.

## Changes

### Runtime-First Verdict Resolution
- Runtime verdicts (from acpx agent outputs) now take precedence over file-based verdicts
- Added `VerdictSource` enum to track where verdicts originate (Runtime, File, or Default)
- Updated orchestrator to use `resolve_verdict_with_source()` for source-aware resolution

### Automatic Fallback Injection
- Step prompts now automatically include instructions for writing verdict files as fallback
- New config option `inject_verdict_fallback_instructions` (default: true)
- Idempotent injection prevents duplicate instructions if already present in prompt

### Observability Improvements
- Verdict source is now logged for debugging (which source won: runtime vs file vs default)
- Warning logged when defaulting to approve with no runtime/file verdict
- Structured logging with `verdict_source` and `verdict_value` fields

### Implementation Details
- Runtime verdicts flow: ACP/ACPX events → TurnResult → PromptOutcome → WorkerResult → orchestrator
- File fallback remains for non-acpx agents or when runtime verdict unavailable
- All existing APIs preserved for backward compatibility

## Testing

- 12 new tests covering runtime > file > default precedence
- Tests for fallback injection (enabled, disabled, idempotent)
- All 714 tests passing

## Configuration

```yaml
pipelines:
  default:
    inject_verdict_fallback_instructions: true  # default
```

Closes #63