### PR TITLE
Persist execution-ordered issue timeline with inline retries

### DIFF
--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -169,6 +169,8 @@ async fn prepare_orchestrator_runtime(
             workspace_mgr,
             refresh_requested: Arc::clone(&app_state.refresh_requested),
             cancellation_registry: Arc::clone(&app_state.cancellation_registry),
+            event_bus: app_state.event_bus.clone(),
+            workspace_root: PathBuf::from(&app_state.workspace_root),
         },
         &config_dir,
         shutdown_rx,

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -176,6 +176,7 @@ mod tests {
         RunningEntry {
             issue_id: "NODE_123".to_string(),
             identifier: "my-repo#42".to_string(),
+            run_id: Some("run-1".to_string()),
             issue: test_issue(),
             session_id: Some("session-abc".to_string()),
             agent_pid: Some("12345".to_string()),

--- a/crates/ensemble-core/src/api/mod.rs
+++ b/crates/ensemble-core/src/api/mod.rs
@@ -9,6 +9,7 @@ pub mod history_handler;
 pub mod interactions;
 pub mod openapi;
 pub mod router;
+pub mod timeline_handler;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 pub mod ws;

--- a/crates/ensemble-core/src/api/mod.rs
+++ b/crates/ensemble-core/src/api/mod.rs
@@ -9,7 +9,7 @@ pub mod history_handler;
 pub mod interactions;
 pub mod openapi;
 pub mod router;
-pub mod timeline_handler;
 #[cfg(test)]
 pub(crate) mod test_helpers;
+pub mod timeline_handler;
 pub mod ws;

--- a/crates/ensemble-core/src/api/openapi.rs
+++ b/crates/ensemble-core/src/api/openapi.rs
@@ -12,6 +12,7 @@ use utoipa::OpenApi;
         crate::api::handlers::get_issue_detail,
         crate::api::handlers::post_refresh,
         crate::api::history_handler::get_history,
+        crate::api::timeline_handler::get_timeline,
         crate::api::config_handler::get_config,
         crate::api::config_edit_handler::validate_yaml,
         crate::api::config_edit_handler::save_yaml,
@@ -119,6 +120,9 @@ use utoipa::OpenApi;
         crate::history::model::HistoryRecord,
         crate::history::model::TokenTotals,
         crate::history::reader::HistoryResponse,
+        // Timeline types
+        crate::timeline::model::TimelineEventRecord,
+        crate::timeline::reader::TimelineResponse,
         // Conversation types
         crate::api::conversation::ConversationResponse,
         crate::api::conversation::ConversationMessage,

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -2,7 +2,7 @@ use crate::agent::cancellation::CancellationRegistry;
 use crate::api::interactions;
 use crate::api::{
     config_edit_handler, config_handler, controls, conversation, fs_handler, handlers,
-    history_handler, ws,
+    history_handler, timeline_handler, ws,
 };
 use crate::config::draft::ConfigDocumentState;
 use crate::observability::events::EventBus;
@@ -136,6 +136,7 @@ pub fn create_api_router(state: AppState) -> Router {
             "/{identifier}/conversation/{index}",
             get(conversation::get_conversation_message),
         )
+        .route("/{identifier}/timeline", get(timeline_handler::get_timeline))
         .route("/{identifier}/stop", post(controls::post_stop))
         .route("/{identifier}/retry", post(controls::post_retry))
         .route(

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -136,7 +136,10 @@ pub fn create_api_router(state: AppState) -> Router {
             "/{identifier}/conversation/{index}",
             get(conversation::get_conversation_message),
         )
-        .route("/{identifier}/timeline", get(timeline_handler::get_timeline))
+        .route(
+            "/{identifier}/timeline",
+            get(timeline_handler::get_timeline),
+        )
         .route("/{identifier}/stop", post(controls::post_stop))
         .route("/{identifier}/retry", post(controls::post_retry))
         .route(

--- a/crates/ensemble-core/src/api/timeline_handler.rs
+++ b/crates/ensemble-core/src/api/timeline_handler.rs
@@ -1,0 +1,120 @@
+use crate::api::router::AppState;
+use crate::timeline::reader::{read_timeline, TimelineQuery, TimelineResponse};
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use std::path::PathBuf;
+
+fn timeline_path(workspace_root: &str, run_id: &str) -> PathBuf {
+    PathBuf::from(workspace_root)
+        .join(".ensemble")
+        .join("runs")
+        .join(run_id)
+        .join("events.jsonl")
+}
+
+/// GET /api/v1/{identifier}/timeline
+///
+/// Returns paginated timeline events for a run.
+#[utoipa::path(
+    get,
+    path = "/api/v1/{identifier}/timeline",
+    operation_id = "getTimeline",
+    params(
+        ("identifier" = String, Path, description = "Issue identifier"),
+        TimelineQuery,
+    ),
+    responses(
+        (status = 200, description = "Timeline events", body = TimelineResponse),
+        (status = 500, description = "Read error", body = crate::api::handlers::ApiError)
+    ),
+    tag = "history"
+)]
+pub async fn get_timeline(
+    State(state): State<AppState>,
+    Path(_identifier): Path<String>,
+    Query(query): Query<TimelineQuery>,
+) -> impl IntoResponse {
+    let path = timeline_path(&state.workspace_root, &query.run_id);
+    match read_timeline(&path, &query).await {
+        Ok(response) => (StatusCode::OK, axum::Json(response)).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            crate::api::handlers::api_error(
+                "timeline_read_error",
+                format!("failed to read timeline: {}", e),
+            ),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
+    use crate::timeline::model::TimelineEventRecord;
+    use crate::timeline::writer::TimelineWriter;
+    use chrono::Utc;
+
+    fn build_app_state(workspace_root: String) -> AppState {
+        let mut app_state = app_state_with_document_state(parsed_document_state());
+        app_state.workspace_root = workspace_root;
+        app_state
+    }
+
+    fn sample_event(run_id: &str, sequence: u64) -> TimelineEventRecord {
+        TimelineEventRecord {
+            run_id: run_id.to_string(),
+            issue_identifier: "repo#1".to_string(),
+            sequence,
+            timestamp: Utc::now(),
+            event_type: "step_started".to_string(),
+            step_name: Some("build".to_string()),
+            attempt: 1,
+            detail: "started build".to_string(),
+            verdict: None,
+            tool_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn get_timeline_returns_empty_when_file_missing() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let state = build_app_state(temp_dir.path().to_string_lossy().to_string());
+        let response = get_timeline(
+            State(state),
+            Path("repo#1".to_string()),
+            Query(TimelineQuery {
+                run_id: "run-missing".to_string(),
+                cursor: None,
+                limit: None,
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn get_timeline_returns_paginated_events_for_run_id() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let state = build_app_state(temp_dir.path().to_string_lossy().to_string());
+        let writer = TimelineWriter::new(temp_dir.path().to_path_buf());
+        writer.append("run-abc", &sample_event("run-abc", 1)).await.unwrap();
+        writer.append("run-abc", &sample_event("run-abc", 2)).await.unwrap();
+
+        let response = get_timeline(
+            State(state),
+            Path("repo#1".to_string()),
+            Query(TimelineQuery {
+                run_id: "run-abc".to_string(),
+                cursor: Some(0),
+                limit: Some(1),
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/crates/ensemble-core/src/api/timeline_handler.rs
+++ b/crates/ensemble-core/src/api/timeline_handler.rs
@@ -101,8 +101,14 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let state = build_app_state(temp_dir.path().to_string_lossy().to_string());
         let writer = TimelineWriter::new(temp_dir.path().to_path_buf());
-        writer.append("run-abc", &sample_event("run-abc", 1)).await.unwrap();
-        writer.append("run-abc", &sample_event("run-abc", 2)).await.unwrap();
+        writer
+            .append("run-abc", &sample_event("run-abc", 1))
+            .await
+            .unwrap();
+        writer
+            .append("run-abc", &sample_event("run-abc", 2))
+            .await
+            .unwrap();
 
         let response = get_timeline(
             State(state),

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -8,5 +8,6 @@ pub mod observability;
 pub mod orchestrator;
 pub mod pipeline;
 pub mod tracker;
+pub mod timeline;
 pub mod ui;
 pub mod workspace;

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -7,7 +7,7 @@ pub mod interaction;
 pub mod observability;
 pub mod orchestrator;
 pub mod pipeline;
-pub mod tracker;
 pub mod timeline;
+pub mod tracker;
 pub mod ui;
 pub mod workspace;

--- a/crates/ensemble-core/src/observability/events.rs
+++ b/crates/ensemble-core/src/observability/events.rs
@@ -330,4 +330,92 @@ mod tests {
         assert_eq!(record.attempt, 2);
         assert_eq!(record.event_type, "retry_scheduled");
     }
+
+    #[test]
+    fn all_pipeline_events_map_to_timeline_record() {
+        let ts = Utc::now();
+
+        let session_started = PipelineEvent::SessionStarted {
+            issue_identifier: "repo#1".into(),
+            timestamp: ts,
+            detail: "session started".into(),
+        };
+        let session_record = session_started.to_timeline_record("run-1", 1);
+        assert_eq!(session_record.event_type, "session_started");
+        assert_eq!(session_record.run_id, "run-1");
+        assert_eq!(session_record.sequence, 1);
+
+        let step_started = PipelineEvent::StepStarted {
+            issue_identifier: "repo#1".into(),
+            timestamp: ts,
+            step_name: "build".into(),
+            agent_name: "agent-1".into(),
+            detail: "step started".into(),
+        };
+        let step_record = step_started.to_timeline_record("run-1", 2);
+        assert_eq!(step_record.event_type, "step_started");
+        assert_eq!(step_record.step_name, Some("build".into()));
+
+        let step_completed = PipelineEvent::StepCompleted {
+            issue_identifier: "repo#1".into(),
+            timestamp: ts,
+            step_name: "build".into(),
+            detail: "step completed".into(),
+            verdict: Some("approved".into()),
+        };
+        let completed_record = step_completed.to_timeline_record("run-1", 3);
+        assert_eq!(completed_record.event_type, "step_completed");
+        assert_eq!(completed_record.verdict, Some("approved".into()));
+
+        let turn_completed = PipelineEvent::TurnCompleted {
+            issue_identifier: "repo#1".into(),
+            timestamp: ts,
+            turn: 2,
+            detail: "turn completed".into(),
+            conversation_index: Some(1),
+            tokens_delta: TokensDelta {
+                input: 100,
+                output: 200,
+            },
+        };
+        let turn_record = turn_completed.to_timeline_record("run-1", 4);
+        assert_eq!(turn_record.event_type, "turn_completed");
+
+        let tool_call = PipelineEvent::ToolCall {
+            issue_identifier: "repo#1".into(),
+            timestamp: ts,
+            tool_name: "bash".into(),
+            detail: "ls".into(),
+        };
+        let tool_record = tool_call.to_timeline_record("run-1", 5);
+        assert_eq!(tool_record.event_type, "tool_call");
+        assert_eq!(tool_record.tool_name, Some("bash".into()));
+
+        let error_event = PipelineEvent::Error {
+            issue_identifier: "repo#1".into(),
+            timestamp: ts,
+            detail: "something failed".into(),
+        };
+        let error_record = error_event.to_timeline_record("run-1", 6);
+        assert_eq!(error_record.event_type, "error");
+
+        let complete = PipelineEvent::Complete {
+            issue_identifier: "repo#1".into(),
+            timestamp: ts,
+            outcome: "succeeded".into(),
+        };
+        let complete_record = complete.to_timeline_record("run-1", 7);
+        assert_eq!(complete_record.event_type, "complete");
+        assert_eq!(complete_record.detail, "succeeded");
+
+        let retry = PipelineEvent::RetryScheduled {
+            issue_identifier: "repo#1".into(),
+            timestamp: ts,
+            attempt: 3,
+            detail: "retrying".into(),
+        };
+        let retry_record = retry.to_timeline_record("run-1", 8);
+        assert_eq!(retry_record.event_type, "retry_scheduled");
+        assert_eq!(retry_record.attempt, 3);
+    }
 }

--- a/crates/ensemble-core/src/observability/events.rs
+++ b/crates/ensemble-core/src/observability/events.rs
@@ -1,3 +1,4 @@
+use crate::timeline::model::TimelineEventRecord;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::sync::broadcast;
@@ -106,6 +107,146 @@ impl PipelineEvent {
             | Self::Complete { timestamp, .. } => *timestamp,
         }
     }
+
+    pub fn to_timeline_record(&self, run_id: &str, sequence: u64) -> TimelineEventRecord {
+        match self {
+            Self::SessionStarted {
+                issue_identifier,
+                timestamp,
+                detail,
+            } => TimelineEventRecord {
+                run_id: run_id.to_string(),
+                issue_identifier: issue_identifier.clone(),
+                sequence,
+                timestamp: *timestamp,
+                event_type: "session_started".to_string(),
+                step_name: None,
+                attempt: 1,
+                detail: detail.clone(),
+                verdict: None,
+                tool_name: None,
+            },
+            Self::StepStarted {
+                issue_identifier,
+                timestamp,
+                step_name,
+                detail,
+                ..
+            } => TimelineEventRecord {
+                run_id: run_id.to_string(),
+                issue_identifier: issue_identifier.clone(),
+                sequence,
+                timestamp: *timestamp,
+                event_type: "step_started".to_string(),
+                step_name: Some(step_name.clone()),
+                attempt: 1,
+                detail: detail.clone(),
+                verdict: None,
+                tool_name: None,
+            },
+            Self::StepCompleted {
+                issue_identifier,
+                timestamp,
+                step_name,
+                detail,
+                verdict,
+            } => TimelineEventRecord {
+                run_id: run_id.to_string(),
+                issue_identifier: issue_identifier.clone(),
+                sequence,
+                timestamp: *timestamp,
+                event_type: "step_completed".to_string(),
+                step_name: Some(step_name.clone()),
+                attempt: 1,
+                detail: detail.clone(),
+                verdict: verdict.clone(),
+                tool_name: None,
+            },
+            Self::TurnCompleted {
+                issue_identifier,
+                timestamp,
+                detail,
+                ..
+            } => TimelineEventRecord {
+                run_id: run_id.to_string(),
+                issue_identifier: issue_identifier.clone(),
+                sequence,
+                timestamp: *timestamp,
+                event_type: "turn_completed".to_string(),
+                step_name: None,
+                attempt: 1,
+                detail: detail.clone(),
+                verdict: None,
+                tool_name: None,
+            },
+            Self::ToolCall {
+                issue_identifier,
+                timestamp,
+                tool_name,
+                detail,
+            } => TimelineEventRecord {
+                run_id: run_id.to_string(),
+                issue_identifier: issue_identifier.clone(),
+                sequence,
+                timestamp: *timestamp,
+                event_type: "tool_call".to_string(),
+                step_name: None,
+                attempt: 1,
+                detail: detail.clone(),
+                verdict: None,
+                tool_name: Some(tool_name.clone()),
+            },
+            Self::Error {
+                issue_identifier,
+                timestamp,
+                detail,
+            } => TimelineEventRecord {
+                run_id: run_id.to_string(),
+                issue_identifier: issue_identifier.clone(),
+                sequence,
+                timestamp: *timestamp,
+                event_type: "error".to_string(),
+                step_name: None,
+                attempt: 1,
+                detail: detail.clone(),
+                verdict: None,
+                tool_name: None,
+            },
+            Self::RetryScheduled {
+                issue_identifier,
+                timestamp,
+                detail,
+                attempt,
+            } => TimelineEventRecord {
+                run_id: run_id.to_string(),
+                issue_identifier: issue_identifier.clone(),
+                sequence,
+                timestamp: *timestamp,
+                event_type: "retry_scheduled".to_string(),
+                step_name: None,
+                attempt: *attempt,
+                detail: detail.clone(),
+                verdict: None,
+                tool_name: None,
+            },
+            Self::Complete {
+                issue_identifier,
+                timestamp,
+                outcome,
+            } => TimelineEventRecord {
+                run_id: run_id.to_string(),
+                issue_identifier: issue_identifier.clone(),
+                sequence,
+                timestamp: *timestamp,
+                event_type: "complete".to_string(),
+                step_name: None,
+                attempt: 1,
+                detail: outcome.clone(),
+                verdict: Some(outcome.clone()),
+                tool_name: None,
+            },
+        }
+    }
 }
 
 const EVENT_BUS_CAPACITY: usize = 1024;
@@ -172,5 +313,21 @@ mod tests {
             detail: "ls".into(),
         };
         assert_eq!(event.issue_identifier(), "MT-99");
+    }
+
+    #[test]
+    fn pipeline_event_maps_to_timeline_record_with_run_and_sequence() {
+        let event = PipelineEvent::RetryScheduled {
+            issue_identifier: "repo#1".into(),
+            timestamp: Utc::now(),
+            attempt: 2,
+            detail: "retry".into(),
+        };
+
+        let record = event.to_timeline_record("run-1", 7);
+        assert_eq!(record.run_id, "run-1");
+        assert_eq!(record.sequence, 7);
+        assert_eq!(record.attempt, 2);
+        assert_eq!(record.event_type, "retry_scheduled");
     }
 }

--- a/crates/ensemble-core/src/observability/redaction.rs
+++ b/crates/ensemble-core/src/observability/redaction.rs
@@ -24,6 +24,14 @@ pub fn redact_kv(input: &str) -> String {
             return format!("{prefix}{REDACTED}");
         }
     }
+
+    if input.starts_with("Authorization: Bearer ") {
+        return "Authorization: Bearer [REDACTED]".to_string();
+    }
+    if input.starts_with("Bearer ") {
+        return "Bearer [REDACTED]".to_string();
+    }
+
     input.to_string()
 }
 
@@ -95,5 +103,14 @@ mod tests {
         assert!(out.contains(r#""authorization":"[REDACTED]""#));
         assert!(out.contains(r#""api_key":"[REDACTED]""#));
         assert!(out.contains(r#""keep":"ok""#));
+    }
+
+    #[test]
+    fn redact_bearer_token_header() {
+        assert_eq!(
+            redact_kv("Authorization: Bearer abc123xyz"),
+            "Authorization: Bearer [REDACTED]"
+        );
+        assert_eq!(redact_kv("Bearer abc123xyz"), "Bearer [REDACTED]");
     }
 }

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -151,6 +151,7 @@ pub struct AttemptInfo {
 /// Running session detail for issue detail.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct RunningDetail {
+    pub run_id: Option<String>,
     pub session_id: Option<String>,
     pub step_name: Option<String>,
     pub turn_count: u32,
@@ -303,6 +304,7 @@ pub fn build_issue_snapshot(
             })
         });
         RunningDetail {
+            run_id: entry.run_id.clone(),
             session_id: entry.session_id.clone(),
             step_name,
             turn_count: entry.turn_count,
@@ -457,6 +459,7 @@ mod tests {
         RunningEntry {
             issue_id: "NODE_123".to_string(),
             identifier: "my-repo#42".to_string(),
+            run_id: Some("run-1".to_string()),
             issue: test_issue(),
             session_id: Some("session-abc".to_string()),
             agent_pid: Some("12345".to_string()),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -26,6 +26,7 @@ use crate::error::{AgentError, EnsembleError};
 use crate::history::model::{HistoryRecord, TokenTotals};
 use crate::history::writer::HistoryWriter;
 use crate::interaction::{InteractionStatus, InteractionStore};
+use crate::observability::events::{EventBus, PipelineEvent};
 use crate::observability::events_contract::{
     elapsed_ms, ISSUE_DISPATCH_COMPLETED, ISSUE_DISPATCH_STARTED, ORCH_TICK_FINISHED,
     ORCH_TICK_STARTED, STEP_STARTED, TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED,
@@ -34,6 +35,7 @@ use crate::observability::events_contract::{
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{PipelineAction, PipelineRun, StepState};
 use crate::pipeline::verdict::{resolve_verdict_with_source, Verdict, VerdictSource};
+use crate::timeline::writer::TimelineWriter;
 use crate::tracker::model::Issue;
 use crate::tracker::IssueTracker;
 use crate::workspace::finalize::FinalizeMode;
@@ -85,6 +87,8 @@ pub struct Orchestrator {
     refresh_requested: Arc<tokio::sync::Notify>,
     cancellation_registry: CancellationRegistry,
     history_write_lock: Arc<tokio::sync::Mutex<()>>,
+    event_bus: EventBus,
+    timeline_writer: TimelineWriter,
     worker_tx: mpsc::Sender<WorkerEvent>,
     worker_rx: mpsc::Receiver<WorkerEvent>,
     shutdown_rx: mpsc::Receiver<()>,
@@ -101,6 +105,8 @@ pub struct OrchestratorRuntimeParts {
     pub workspace_mgr: WorkspaceManager,
     pub refresh_requested: Arc<tokio::sync::Notify>,
     pub cancellation_registry: CancellationRegistry,
+    pub event_bus: EventBus,
+    pub workspace_root: std::path::PathBuf,
 }
 
 impl Orchestrator {
@@ -124,6 +130,8 @@ impl Orchestrator {
                 workspace_mgr,
                 refresh_requested,
                 cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                workspace_root: config_dir.to_path_buf(),
             },
             config_dir,
             shutdown_rx,
@@ -148,6 +156,8 @@ impl Orchestrator {
             refresh_requested: parts.refresh_requested,
             cancellation_registry: parts.cancellation_registry,
             history_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+            event_bus: parts.event_bus,
+            timeline_writer: TimelineWriter::new(parts.workspace_root),
             worker_tx,
             worker_rx,
             shutdown_rx,
@@ -671,18 +681,36 @@ impl Orchestrator {
         }
 
         // Mark step as running in pipeline
-        {
+        let (run_id, sequence, attempt_num) = {
             let mut state = self.state.write().await;
-            if let Some(run) = state.get_pipeline_run_mut(&issue.id) {
-                run.mark_running(
-                    dispatch.step_name,
-                    format!(
-                        "{}-{}-{}",
-                        issue.id, dispatch.step_name, dispatch.agent_name
-                    ),
-                );
+            let run_context = Self::run_context_for_issue(&mut state, &issue.id);
+            {
+                if let Some(run) = state.get_pipeline_run_mut(&issue.id) {
+                    run.mark_running(
+                        dispatch.step_name,
+                        format!(
+                            "{}-{}-{}",
+                            issue.id, dispatch.step_name, dispatch.agent_name
+                        ),
+                    );
+                }
             }
-        }
+            run_context
+        };
+
+        self.publish_pipeline_event(
+            run_id,
+            sequence,
+            Some(attempt_num),
+            PipelineEvent::StepStarted {
+                issue_identifier: issue.identifier.clone(),
+                timestamp: Utc::now(),
+                step_name: dispatch.step_name.to_string(),
+                agent_name: dispatch.agent_name.to_string(),
+                detail: format!("step started (attempt {})", attempt_num),
+            },
+        )
+        .await;
 
         // Spawn worker task
         let issue_clone = issue.clone();
@@ -756,11 +784,18 @@ impl Orchestrator {
     async fn handle_agent_update(
         &self,
         issue_id: &str,
-        _step_name: &str,
+        step_name: &str,
         event: AgentEvent,
         timestamp: chrono::DateTime<Utc>,
     ) {
         let mut state = self.state.write().await;
+        let issue_identifier = state
+            .running
+            .get(issue_id)
+            .map(|entry| entry.identifier.clone())
+            .unwrap_or_else(|| issue_id.to_string());
+        let (run_id, sequence, attempt_num) = Self::run_context_for_issue(&mut state, issue_id);
+        let mut pipeline_event: Option<PipelineEvent> = None;
 
         // Handle special cases
         match &event {
@@ -769,19 +804,66 @@ impl Orchestrator {
                 agent_pid,
             } => {
                 state.update_session_info(issue_id, session_id, agent_pid.as_deref());
+                pipeline_event = Some(PipelineEvent::SessionStarted {
+                    issue_identifier: issue_identifier.clone(),
+                    timestamp,
+                    detail: format!("session started: {}", session_id),
+                });
             }
             AgentEvent::PromptStarted => {
                 state.increment_turn_count(issue_id);
             }
-            AgentEvent::RunCompleted { usage } | AgentEvent::RunFailed { usage, .. } => {
-                if let Some(u) = usage {
-                    state.update_token_usage(
-                        issue_id,
-                        u.input_tokens,
-                        u.output_tokens,
-                        u.total_tokens,
-                    );
-                }
+            AgentEvent::RunCompleted { usage: Some(u) } => {
+                state.update_token_usage(issue_id, u.input_tokens, u.output_tokens, u.total_tokens);
+            }
+            AgentEvent::RunCompleted { usage: None } => {}
+            AgentEvent::TurnCompleted { usage } => {
+                pipeline_event = Some(PipelineEvent::TurnCompleted {
+                    issue_identifier: issue_identifier.clone(),
+                    timestamp,
+                    turn: state
+                        .running
+                        .get(issue_id)
+                        .map(|e| e.turn_count)
+                        .unwrap_or(0),
+                    detail: "turn completed".to_string(),
+                    conversation_index: None,
+                    tokens_delta: crate::observability::events::TokensDelta {
+                        input: usage.as_ref().map(|u| u.input_tokens).unwrap_or(0),
+                        output: usage.as_ref().map(|u| u.output_tokens).unwrap_or(0),
+                    },
+                });
+            }
+            AgentEvent::RunFailed {
+                reason,
+                usage: Some(u),
+                ..
+            } => {
+                state.update_token_usage(issue_id, u.input_tokens, u.output_tokens, u.total_tokens);
+                pipeline_event = Some(PipelineEvent::Error {
+                    issue_identifier: issue_identifier.clone(),
+                    timestamp,
+                    detail: reason.clone(),
+                });
+            }
+            AgentEvent::RunFailed {
+                reason,
+                usage: None,
+                ..
+            } => {
+                pipeline_event = Some(PipelineEvent::Error {
+                    issue_identifier: issue_identifier.clone(),
+                    timestamp,
+                    detail: reason.clone(),
+                });
+            }
+            AgentEvent::OutputChunk { content, .. } => {
+                pipeline_event = Some(PipelineEvent::ToolCall {
+                    issue_identifier: issue_identifier.clone(),
+                    timestamp,
+                    tool_name: step_name.to_string(),
+                    detail: content.chars().take(120).collect(),
+                });
             }
             _ => {}
         }
@@ -793,6 +875,15 @@ impl Orchestrator {
             event.message_for_state().as_deref(),
             timestamp,
         );
+        drop(state);
+
+        if let Some(mut event) = pipeline_event {
+            if let PipelineEvent::TurnCompleted { detail, .. } = &mut event {
+                *detail = format!("turn completed (attempt {})", attempt_num);
+            }
+            self.publish_pipeline_event(run_id, sequence, Some(attempt_num), event)
+                .await;
+        }
     }
 
     /// Handle a worker exit. Integrates with PipelineRun to drive step DAG.
@@ -2228,6 +2319,49 @@ impl Orchestrator {
             }
         }
     }
+
+    async fn publish_pipeline_event(
+        &self,
+        run_id: Option<String>,
+        sequence: Option<u64>,
+        attempt: Option<u32>,
+        event: PipelineEvent,
+    ) {
+        if let (Some(run_id), Some(sequence)) = (run_id, sequence) {
+            let mut record = event.to_timeline_record(&run_id, sequence);
+            if let Some(attempt) = attempt {
+                record.attempt = attempt;
+            }
+            if let Err(error) = self.timeline_writer.append(&run_id, &record).await {
+                warn!(
+                    event = "timeline_persist_failed",
+                    run_id = %run_id,
+                    error = %error,
+                    "failed to persist timeline event"
+                );
+            }
+        }
+        self.event_bus.publish(event);
+    }
+
+    fn run_context_for_issue(
+        state: &mut OrchestratorState,
+        issue_id: &str,
+    ) -> (Option<String>, Option<u64>, u32) {
+        let run_id = state
+            .running
+            .get(issue_id)
+            .and_then(|entry| entry.run_id.clone());
+        let sequence = run_id
+            .as_ref()
+            .map(|run_id| state.next_timeline_sequence(run_id));
+        let attempt = state
+            .running
+            .get(issue_id)
+            .and_then(|entry| entry.retry_attempt)
+            .unwrap_or(1);
+        (run_id, sequence, attempt)
+    }
 }
 
 async fn catch_worker_panic<F>(fut: F, issue_id: &str, step_name: &str) -> WorkerResult
@@ -3265,6 +3399,8 @@ agent:
                 workspace_mgr,
                 refresh_requested: Arc::clone(&refresh_requested),
                 cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                workspace_root: dir.path().to_path_buf(),
             },
             dir.path(),
             shutdown_rx,
@@ -3332,6 +3468,8 @@ agent:
                 workspace_mgr,
                 refresh_requested,
                 cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                workspace_root: dir.path().to_path_buf(),
             },
             dir.path(),
             shutdown_rx,

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -89,6 +90,19 @@ pub struct OrchestratorState {
     pub active_states_lower: Vec<String>,
     /// Cached lowercase terminal states for efficient dispatch checking.
     pub terminal_states_lower: Vec<String>,
+    /// Per-run sequence counters for persisted timeline events.
+    pub timeline_sequences: HashMap<String, u64>,
+    /// Stable run IDs per issue across retries within the same orchestration cycle.
+    pub issue_run_ids: HashMap<String, String>,
+}
+
+static ORCH_RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn new_issue_run_id() -> String {
+    format!(
+        "run-{}",
+        ORCH_RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
 }
 
 impl OrchestratorState {
@@ -111,6 +125,8 @@ impl OrchestratorState {
             last_tick_at: None,
             active_states_lower: Vec::new(),
             terminal_states_lower: Vec::new(),
+            timeline_sequences: HashMap::new(),
+            issue_run_ids: HashMap::new(),
         }
     }
 
@@ -132,9 +148,15 @@ impl OrchestratorState {
 
     /// Add a running entry for a dispatched issue.
     pub fn add_running(&mut self, issue: &Issue, attempt: Option<u32>) {
+        let run_id = self
+            .issue_run_ids
+            .entry(issue.id.clone())
+            .or_insert_with(new_issue_run_id)
+            .clone();
         let entry = RunningEntry {
             issue_id: issue.id.clone(),
             identifier: issue.identifier.clone(),
+            run_id: Some(run_id),
             issue: issue.clone(),
             session_id: None,
             agent_pid: None,
@@ -160,6 +182,15 @@ impl OrchestratorState {
     /// Remove a running entry and return it. Returns None if not found.
     pub fn remove_running(&mut self, issue_id: &str) -> Option<RunningEntry> {
         self.running.remove(issue_id)
+    }
+
+    pub fn next_timeline_sequence(&mut self, run_id: &str) -> u64 {
+        let entry = self
+            .timeline_sequences
+            .entry(run_id.to_string())
+            .or_insert(0);
+        *entry += 1;
+        *entry
     }
 
     /// Add an issue ID to the claimed set.
@@ -233,6 +264,9 @@ impl OrchestratorState {
         self.resume_requested.remove(issue_id);
         self.pipeline_configs.remove(issue_id);
         self.finalize.remove(issue_id);
+        if let Some(run_id) = self.issue_run_ids.remove(issue_id) {
+            self.timeline_sequences.remove(&run_id);
+        }
     }
 
     pub fn set_finalize_state(&mut self, issue_id: &str, finalize: IssueFinalizeState) {
@@ -638,5 +672,41 @@ mod tests {
         state.add_running(&test_issue("1", "Todo"), Some(2));
         assert!(!state.retry_attempts.contains_key("1"));
         assert!(state.is_running("1"));
+    }
+
+    #[test]
+    fn test_run_id_and_sequence_are_stable_across_retries_until_release() {
+        let mut state = OrchestratorState::new(30000, 10);
+        let issue = test_issue("1", "Todo");
+
+        state.add_running(&issue, Some(1));
+        let first_run_id = state
+            .running
+            .get("1")
+            .and_then(|entry| entry.run_id.clone())
+            .expect("run_id should be assigned");
+        assert_eq!(state.next_timeline_sequence(&first_run_id), 1);
+
+        let _ = state.remove_running("1");
+        state.add_retry(RetryEntry {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 2,
+            due_at_ms: 5000,
+            error: Some("retry".to_string()),
+        });
+        state.add_running(&issue, Some(2));
+
+        let second_run_id = state
+            .running
+            .get("1")
+            .and_then(|entry| entry.run_id.clone())
+            .expect("run_id should be reused");
+        assert_eq!(second_run_id, first_run_id);
+        assert_eq!(state.next_timeline_sequence(&second_run_id), 2);
+
+        state.release_claim("1");
+        assert!(state.issue_run_ids.get("1").is_none());
+        assert!(state.timeline_sequences.get(&second_run_id).is_none());
     }
 }

--- a/crates/ensemble-core/src/timeline/mod.rs
+++ b/crates/ensemble-core/src/timeline/mod.rs
@@ -1,0 +1,3 @@
+pub mod model;
+pub mod reader;
+pub mod writer;

--- a/crates/ensemble-core/src/timeline/model.rs
+++ b/crates/ensemble-core/src/timeline/model.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+pub struct TimelineEventRecord {
+    pub run_id: String,
+    pub issue_identifier: String,
+    pub sequence: u64,
+    pub timestamp: DateTime<Utc>,
+    pub event_type: String,
+    pub step_name: Option<String>,
+    pub attempt: u32,
+    pub detail: String,
+    pub verdict: Option<String>,
+    pub tool_name: Option<String>,
+}

--- a/crates/ensemble-core/src/timeline/reader.rs
+++ b/crates/ensemble-core/src/timeline/reader.rs
@@ -1,0 +1,140 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::model::TimelineEventRecord;
+
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct TimelineQuery {
+    pub run_id: String,
+    pub cursor: Option<usize>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct TimelineResponse {
+    pub events: Vec<TimelineEventRecord>,
+    pub total: usize,
+    pub next_cursor: Option<usize>,
+}
+
+pub async fn read_timeline(
+    path: &Path,
+    query: &TimelineQuery,
+) -> Result<TimelineResponse, std::io::Error> {
+    let contents = match tokio::fs::read_to_string(path).await {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(TimelineResponse {
+                events: vec![],
+                total: 0,
+                next_cursor: None,
+            });
+        }
+        Err(error) => return Err(error),
+    };
+
+    let mut events: Vec<TimelineEventRecord> = contents
+        .lines()
+        .filter_map(|line| serde_json::from_str::<TimelineEventRecord>(line).ok())
+        .filter(|event| event.run_id == query.run_id)
+        .collect();
+    events.sort_by_key(|event| event.sequence);
+
+    let total = events.len();
+    let cursor = query.cursor.unwrap_or(0);
+    let limit = query.limit.unwrap_or(50).min(200);
+    let page: Vec<TimelineEventRecord> = events.into_iter().skip(cursor).take(limit).collect();
+    let next_cursor = if cursor + page.len() < total {
+        Some(cursor + page.len())
+    } else {
+        None
+    };
+
+    Ok(TimelineResponse {
+        events: page,
+        total,
+        next_cursor,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use tempfile::NamedTempFile;
+
+    fn sample_event(run_id: &str, sequence: u64) -> TimelineEventRecord {
+        TimelineEventRecord {
+            run_id: run_id.to_string(),
+            issue_identifier: "repo#1".to_string(),
+            sequence,
+            timestamp: Utc::now(),
+            event_type: "step_started".to_string(),
+            step_name: Some("build".to_string()),
+            attempt: 1,
+            detail: "started build".to_string(),
+            verdict: None,
+            tool_name: None,
+        }
+    }
+
+    async fn write_events(path: &Path, events: &[TimelineEventRecord]) {
+        let mut body = String::new();
+        for event in events {
+            body.push_str(&serde_json::to_string(event).unwrap());
+            body.push('\n');
+        }
+        tokio::fs::write(path, body).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn read_timeline_returns_paginated_events_in_sequence_order() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        write_events(
+            &path,
+            &[sample_event("run-1", 2), sample_event("run-1", 1)],
+        )
+        .await;
+
+        let response = read_timeline(
+            &path,
+            &TimelineQuery {
+                run_id: "run-1".to_string(),
+                cursor: Some(0),
+                limit: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.events.len(), 1);
+        assert_eq!(response.events[0].sequence, 1);
+        assert_eq!(response.next_cursor, Some(1));
+    }
+
+    #[tokio::test]
+    async fn read_timeline_skips_malformed_lines() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        let valid = serde_json::to_string(&sample_event("run-1", 1)).unwrap();
+        tokio::fs::write(&path, format!("{{bad\n{}\n", valid))
+            .await
+            .unwrap();
+
+        let response = read_timeline(
+            &path,
+            &TimelineQuery {
+                run_id: "run-1".to_string(),
+                cursor: Some(0),
+                limit: Some(50),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.events.len(), 1);
+        assert_eq!(response.events[0].sequence, 1);
+    }
+}

--- a/crates/ensemble-core/src/timeline/reader.rs
+++ b/crates/ensemble-core/src/timeline/reader.rs
@@ -92,11 +92,7 @@ mod tests {
     async fn read_timeline_returns_paginated_events_in_sequence_order() {
         let tmp = NamedTempFile::new().unwrap();
         let path = tmp.path().to_path_buf();
-        write_events(
-            &path,
-            &[sample_event("run-1", 2), sample_event("run-1", 1)],
-        )
-        .await;
+        write_events(&path, &[sample_event("run-1", 2), sample_event("run-1", 1)]).await;
 
         let response = read_timeline(
             &path,

--- a/crates/ensemble-core/src/timeline/writer.rs
+++ b/crates/ensemble-core/src/timeline/writer.rs
@@ -1,0 +1,88 @@
+use std::path::{Path, PathBuf};
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+
+use super::model::TimelineEventRecord;
+
+#[derive(Debug, Clone)]
+pub struct TimelineWriter {
+    workspace_root: PathBuf,
+}
+
+impl TimelineWriter {
+    pub fn new(workspace_root: PathBuf) -> Self {
+        Self { workspace_root }
+    }
+
+    pub fn events_path(&self, run_id: &str) -> PathBuf {
+        self.workspace_root
+            .join(".ensemble")
+            .join("runs")
+            .join(run_id)
+            .join("events.jsonl")
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+
+    pub async fn append(
+        &self,
+        run_id: &str,
+        record: &TimelineEventRecord,
+    ) -> Result<(), std::io::Error> {
+        let path = self.events_path(run_id);
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let mut line = serde_json::to_string(record)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        line.push('\n');
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        file.write_all(line.as_bytes()).await?;
+        file.flush().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn sample_event(run_id: &str, sequence: u64) -> TimelineEventRecord {
+        TimelineEventRecord {
+            run_id: run_id.to_string(),
+            issue_identifier: "repo#1".to_string(),
+            sequence,
+            timestamp: Utc::now(),
+            event_type: "step_started".to_string(),
+            step_name: Some("build".to_string()),
+            attempt: 1,
+            detail: "started build".to_string(),
+            verdict: None,
+            tool_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn append_creates_run_events_file_and_writes_jsonl_line() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TimelineWriter::new(temp_dir.path().to_path_buf());
+        let record = sample_event("run-1", 1);
+
+        writer.append("run-1", &record).await.unwrap();
+
+        let contents = tokio::fs::read_to_string(writer.events_path("run-1"))
+            .await
+            .unwrap();
+        assert_eq!(contents.lines().count(), 1);
+    }
+}

--- a/crates/ensemble-core/src/timeline/writer.rs
+++ b/crates/ensemble-core/src/timeline/writer.rs
@@ -84,5 +84,38 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(contents.lines().count(), 1);
+
+        let parsed: TimelineEventRecord =
+            serde_json::from_str(contents.lines().next().unwrap()).unwrap();
+        assert_eq!(parsed.run_id, "run-1");
+        assert_eq!(parsed.sequence, 1);
+        assert_eq!(parsed.event_type, "step_started");
+        assert_eq!(parsed.step_name, Some("build".to_string()));
+    }
+
+    #[tokio::test]
+    async fn append_writes_valid_jsonl_lines() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TimelineWriter::new(temp_dir.path().to_path_buf());
+
+        writer
+            .append("run-1", &sample_event("run-1", 1))
+            .await
+            .unwrap();
+        writer
+            .append("run-1", &sample_event("run-1", 2))
+            .await
+            .unwrap();
+
+        let contents = tokio::fs::read_to_string(writer.events_path("run-1"))
+            .await
+            .unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let first: TimelineEventRecord = serde_json::from_str(lines[0]).unwrap();
+        let second: TimelineEventRecord = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(first.sequence, 1);
+        assert_eq!(second.sequence, 2);
     }
 }

--- a/crates/ensemble-core/src/tracker/model.rs
+++ b/crates/ensemble-core/src/tracker/model.rs
@@ -50,6 +50,7 @@ pub struct BlockerRef {
 pub struct RunningEntry {
     pub issue_id: String,
     pub identifier: String,
+    pub run_id: Option<String>,
     pub issue: Issue,
     pub session_id: Option<String>,
     pub agent_pid: Option<String>,

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -94,6 +94,7 @@ fn build_populated_app_state() -> (AppState, TempDir) {
         last_reported_output_tokens: 800,
         last_reported_total_tokens: 2000,
         turn_count: 7,
+        run_id: Some("run-1".to_string()),
         retry_attempt: None,
         started_at: Utc::now(),
     };

--- a/crates/ensemble-ui/src-ui/src/components/EventTimeline.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/EventTimeline.tsx
@@ -1,5 +1,6 @@
 import type { WsEventData } from "@/ws-types";
 import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
 
 interface EventTimelineProps {
   events: WsEventData[];
@@ -60,8 +61,16 @@ export default function EventTimeline({ events, live, onViewConversation }: Even
                       </span>
                     </div>
                     <div className="min-w-0 flex-1">
-                      <div className="text-sm">
+                      <div className="text-sm flex items-center gap-2 flex-wrap">
                         <span className="font-medium">{event.type}</span>
+                        {event.stepName && (
+                          <span className="text-xs text-muted-foreground">step: {event.stepName}</span>
+                        )}
+                        {(event.attempt ?? 1) > 1 && (
+                          <Badge variant="secondary" className="bg-amber-100 text-amber-900 border-amber-300">
+                            Retry • Attempt {event.attempt}
+                          </Badge>
+                        )}
                         <span className="ml-2 text-muted-foreground text-xs">{formatTime(event.timestamp)}</span>
                       </div>
                       <p className="mt-0.5 text-sm text-muted-foreground">{event.detail}</p>

--- a/crates/ensemble-ui/src-ui/src/hooks.ts
+++ b/crates/ensemble-ui/src-ui/src/hooks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useGetState, getGetStateQueryKey } from "./generated/api/state/state";
 import { useGetIssueDetail } from "./generated/api/issues/issues";
 import { getGetIssueDetailQueryKey } from "./generated/api/issues/issues";
@@ -39,6 +39,7 @@ import type {
   GuidedConfigForm,
   InteractionRequest,
 } from "./generated/models";
+import { customFetch } from "./fetch-client";
 
 /**
  * The generated orval hooks wrap responses in { data, status, headers }.
@@ -93,6 +94,42 @@ export function useIssueDetailQuery(identifier: string) {
       refetchInterval: 2000,
       enabled: identifier.length > 0,
       select: (resp) => resp.data as IssueDetailSnapshot,
+    },
+  });
+}
+
+export interface TimelineEventRecord {
+  run_id: string;
+  issue_identifier: string;
+  sequence: number;
+  timestamp: string;
+  event_type: string;
+  step_name?: string | null;
+  attempt: number;
+  detail: string;
+  verdict?: string | null;
+  tool_name?: string | null;
+}
+
+export interface TimelineResponse {
+  events: TimelineEventRecord[];
+  total: number;
+  next_cursor?: number | null;
+}
+
+export function useTimelineQuery(identifier: string, runId?: string, limit = 200) {
+  return useQuery({
+    queryKey: ["timeline", identifier, runId, limit],
+    enabled: identifier.length > 0 && (runId?.length ?? 0) > 0,
+    queryFn: async (): Promise<TimelineResponse> => {
+      const params = new URLSearchParams({
+        run_id: runId ?? "",
+        limit: String(limit),
+      });
+      const response = await customFetch<{ data: TimelineResponse }>(
+        `/api/v1/${encodeURIComponent(identifier)}/timeline?${params.toString()}`,
+      );
+      return response.data;
     },
   });
 }

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import {
@@ -9,11 +9,12 @@ import {
   useRespondToInteractionMutation,
   useCancelInteractionMutation,
   useResumeIssueMutation,
+  useTimelineQuery,
 } from "@/hooks";
 import { connectWs } from "@/ws";
 import type { WsStatus } from "@/ws";
 import type { WsEventData, WsPipelineEvent } from "@/ws-types";
-import { isCompletionEvent, normalizePipelineEvent } from "@/ws-events";
+import { isCompletionEvent, normalizePipelineEvent, timelineRecordToEventData } from "@/ws-events";
 import { addNotification, requestPermissionIfNeeded } from "@/notifications";
 import type { InteractionResponseBody } from "@/generated/models";
 import { Button } from "@/components/ui/button";
@@ -53,12 +54,39 @@ export default function IssueDetail() {
   const cancelMutation = useCancelInteractionMutation(identifier);
   const resumeMutation = useResumeIssueMutation(identifier);
 
-  const [events, setEvents] = useState<WsEventData[]>([]);
+  const [liveEvents, setLiveEvents] = useState<WsEventData[]>([]);
   const [wsStatus, setWsStatus] = useState<WsStatus>("disconnected");
   const [showStopConfirm, setShowStopConfirm] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState<number | undefined>();
 
   const isLiveRun = data?.running != null;
+  const runId = (data?.running as { run_id?: string } | undefined)?.run_id;
+  const timelineQuery = useTimelineQuery(identifier, runId);
+  const persistedEvents = useMemo(
+    () => (timelineQuery.data?.events ?? []).map(timelineRecordToEventData),
+    [timelineQuery.data?.events],
+  );
+
+  const events = useMemo(() => {
+    const merged = [...persistedEvents, ...liveEvents];
+    const seen = new Set<string>();
+    const deduped: WsEventData[] = [];
+    for (const event of merged) {
+      const key =
+        event.runId && event.sequence != null
+          ? `${event.runId}:${event.sequence}`
+          : `${event.type}:${event.timestamp}:${event.detail}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      deduped.push(event);
+    }
+    return deduped.sort((a, b) => {
+      if (a.runId && b.runId && a.runId === b.runId && a.sequence != null && b.sequence != null) {
+        return a.sequence - b.sequence;
+      }
+      return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+    });
+  }, [liveEvents, persistedEvents]);
 
   useEffect(() => {
     requestPermissionIfNeeded();
@@ -67,10 +95,10 @@ export default function IssueDetail() {
       enabled: isLiveRun,
       onMessage: (msg) => {
         if (msg.type === "snapshot") {
-          setEvents([]);
+          setLiveEvents([]);
         } else if (msg.type === "event") {
           const event = normalizePipelineEvent(msg.data);
-          setEvents((prev) => [event, ...prev]);
+          setLiveEvents((prev) => [...prev, event]);
           triggerNotification(msg.data, identifier);
 
           if (isCompletionEvent(msg.data)) {
@@ -188,6 +216,11 @@ export default function IssueDetail() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <section>
           <h2 className="text-lg font-semibold mb-3">Event Timeline</h2>
+          {timelineQuery.isError && (
+            <p className="mb-2 text-sm text-amber-700">
+              Couldn&apos;t load saved timeline history; showing live events only.
+            </p>
+          )}
           <Card className="p-4 max-h-[600px] overflow-y-auto">
             <EventTimeline events={events} live={isLiveRun} onViewConversation={(idx) => setHighlightIndex(idx)} />
           </Card>

--- a/crates/ensemble-ui/src-ui/src/ws-events.ts
+++ b/crates/ensemble-ui/src-ui/src/ws-events.ts
@@ -1,8 +1,13 @@
 import type { IssueDetailSnapshot } from "./generated/models";
+import type { TimelineEventRecord } from "./hooks";
 
 export interface WsPipelineEvent {
   event_type: string;
   timestamp: string;
+  run_id?: string;
+  sequence?: number;
+  step_name?: string;
+  attempt?: number;
   detail?: string;
   outcome?: string;
   conversation_index?: number;
@@ -23,6 +28,10 @@ export interface WsEventData {
   type: string;
   timestamp: string;
   detail: string;
+  runId?: string;
+  sequence?: number;
+  stepName?: string;
+  attempt?: number;
   conversationIndex?: number;
 }
 
@@ -35,12 +44,38 @@ export function normalizePipelineEvent(event: WsPipelineEvent): WsEventData {
     };
   }
 
+  const inferredAttempt =
+    typeof event.detail === "string"
+      ? Number(event.detail.match(/attempt\s+(\d+)/i)?.[1] ?? NaN)
+      : NaN;
+
   return {
     type: event.event_type,
     timestamp: event.timestamp,
     detail: event.detail ?? event.event_type,
+    runId: typeof event.run_id === "string" ? event.run_id : undefined,
+    sequence: typeof event.sequence === "number" ? event.sequence : undefined,
+    stepName: typeof event.step_name === "string" ? event.step_name : undefined,
+    attempt:
+      typeof event.attempt === "number"
+        ? event.attempt
+        : Number.isFinite(inferredAttempt)
+          ? inferredAttempt
+          : undefined,
     conversationIndex:
       typeof event.conversation_index === "number" ? event.conversation_index : undefined,
+  };
+}
+
+export function timelineRecordToEventData(event: TimelineEventRecord): WsEventData {
+  return {
+    type: event.event_type,
+    timestamp: event.timestamp,
+    detail: event.detail,
+    runId: event.run_id,
+    sequence: event.sequence,
+    stepName: event.step_name ?? undefined,
+    attempt: event.attempt,
   };
 }
 

--- a/docs/superpowers/plans/2026-04-08-agent-timeline-web-ui-plan.md
+++ b/docs/superpowers/plans/2026-04-08-agent-timeline-web-ui-plan.md
@@ -1,0 +1,302 @@
+# Agent Timeline Web UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist per-run timeline events and render a merged historical+live timeline in the web UI with retries shown inline and visually distinct.
+
+**Architecture:** Add a timeline persistence/read layer in `ensemble-core`, wire persistence into event publication, expose a new timeline API endpoint, and update the Issue Detail timeline to merge paged history with WebSocket events by `(run_id, sequence)`. Keep writes best-effort so runtime behavior is unaffected by log IO failures.
+
+**Tech Stack:** Rust (`tokio`, `serde`, `axum`, `utoipa`), TypeScript/React (`tanstack-query`, existing WS helpers), JSONL storage.
+
+---
+
+## File Structure
+
+- Create: `crates/ensemble-core/src/timeline/model.rs` — normalized persisted timeline event types.
+- Create: `crates/ensemble-core/src/timeline/writer.rs` — append-only JSONL writer for per-run event logs.
+- Create: `crates/ensemble-core/src/timeline/reader.rs` — paginated read API for timeline JSONL.
+- Create: `crates/ensemble-core/src/api/timeline_handler.rs` — HTTP endpoint for timeline history.
+- Modify: `crates/ensemble-core/src/timeline/mod.rs` (new module export from `lib.rs` if missing).
+- Modify: `crates/ensemble-core/src/lib.rs` — export `timeline` module.
+- Modify: `crates/ensemble-core/src/observability/events.rs` — add persisted timeline envelope helpers (run_id, sequence mapping).
+- Modify: `crates/ensemble-core/src/api/router.rs` — register `/api/v1/{identifier}/timeline` route.
+- Modify: `crates/ensemble-core/src/api/openapi.rs` — add timeline handler and schemas.
+- Modify: `crates/ensemble-core/src/observability/snapshot.rs` — include `run_id` in issue running detail (for UI API query).
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs` — route event emission through shared publish+persist path.
+- Modify: `crates/ensemble-core/src/orchestrator/state.rs` — store per-run sequence counters in orchestrator state.
+- Modify: `crates/ensemble-ui/src-ui/src/generated/api/issues/issues.ts` (via orval) — issue detail type includes `run_id`.
+- Modify: `crates/ensemble-ui/src-ui/src/generated/api/timeline/timeline.ts` (via orval) — timeline endpoint hooks.
+- Modify: `crates/ensemble-ui/src-ui/src/generated/models` (via orval) — timeline models.
+- Modify: `crates/ensemble-ui/src-ui/src/hooks.ts` — expose `useTimelineQuery`.
+- Modify: `crates/ensemble-ui/src-ui/src/ws-types.ts` and `src/ws-events.ts` — include `run_id` + `sequence` normalization.
+- Modify: `crates/ensemble-ui/src-ui/src/components/EventTimeline.tsx` — show retry badge/accent and attempt metadata.
+- Modify: `crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx` — load persisted timeline first, merge/de-dupe with WS stream.
+- Tests:
+  - `crates/ensemble-core/src/timeline/writer.rs` (unit tests)
+  - `crates/ensemble-core/src/timeline/reader.rs` (unit tests)
+  - `crates/ensemble-core/src/api/timeline_handler.rs` (API tests)
+  - `crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx` (or closest existing page test)
+  - `crates/ensemble-ui/src-ui/src/components/EventTimeline.test.tsx` (if missing, create)
+
+---
+
+### Task 1: Add timeline domain model + storage primitives
+
+**Files:**
+- Create: `crates/ensemble-core/src/timeline/model.rs`
+- Create: `crates/ensemble-core/src/timeline/writer.rs`
+- Create: `crates/ensemble-core/src/timeline/reader.rs`
+- Create: `crates/ensemble-core/src/timeline/mod.rs`
+- Modify: `crates/ensemble-core/src/lib.rs`
+- Test: `crates/ensemble-core/src/timeline/writer.rs`, `crates/ensemble-core/src/timeline/reader.rs`
+
+- [ ] **Step 1: Write failing unit tests for writer + reader**
+```rust
+#[tokio::test]
+async fn append_creates_run_events_file_and_writes_jsonl_line() {
+    let writer = TimelineWriter::new(tempdir.path().to_path_buf());
+    writer.append(&sample_event("run-1", 1)).await.unwrap();
+    let contents = tokio::fs::read_to_string(events_path(tempdir.path(), "run-1")).await.unwrap();
+    assert_eq!(contents.lines().count(), 1);
+}
+
+#[tokio::test]
+async fn read_timeline_returns_paginated_events_in_sequence_order() {
+    write_events(vec![sample_event("run-1", 2), sample_event("run-1", 1)]).await;
+    let response = read_timeline(&path, &TimelineQuery { run_id: "run-1".into(), cursor: Some(0), limit: Some(1) }).await.unwrap();
+    assert_eq!(response.events[0].sequence, 1);
+    assert_eq!(response.next_cursor, Some(1));
+}
+
+#[tokio::test]
+async fn read_timeline_skips_malformed_lines() {
+    tokio::fs::write(&path, "{\"bad\":\n{\"run_id\":\"run-1\",\"issue_identifier\":\"repo#1\",\"sequence\":1,\"timestamp\":\"2026-04-08T10:00:00Z\",\"event_type\":\"step_started\",\"step_name\":\"build\",\"attempt\":1,\"detail\":\"start\"}\n").await.unwrap();
+    let response = read_timeline(&path, &query).await.unwrap();
+    assert_eq!(response.events.len(), 1);
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+Run: `cargo test -p ensemble-core timeline::writer timeline::reader`
+Expected: FAIL (missing module/types/functions)
+
+- [ ] **Step 3: Implement `TimelineEventRecord`, writer, and reader**
+```rust
+pub struct TimelineEventRecord {
+    pub run_id: String,
+    pub issue_identifier: String,
+    pub sequence: u64,
+    pub timestamp: DateTime<Utc>,
+    pub event_type: String,
+    pub step_name: Option<String>,
+    pub attempt: u32,
+    pub detail: String,
+    pub verdict: Option<String>,
+    pub tool_name: Option<String>,
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+Run: `cargo test -p ensemble-core timeline::writer timeline::reader`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+git add crates/ensemble-core/src/timeline crates/ensemble-core/src/lib.rs
+git commit -m "Add timeline JSONL model, writer, and reader"
+```
+
+### Task 2: Expose timeline history API
+
+**Files:**
+- Create: `crates/ensemble-core/src/api/timeline_handler.rs`
+- Modify: `crates/ensemble-core/src/api/mod.rs`
+- Modify: `crates/ensemble-core/src/api/router.rs`
+- Modify: `crates/ensemble-core/src/api/openapi.rs`
+- Test: `crates/ensemble-core/src/api/timeline_handler.rs`
+
+- [ ] **Step 1: Write failing API handler tests**
+```rust
+#[tokio::test]
+async fn get_timeline_returns_empty_when_file_missing() {
+    let (status, Json(body)) = get_timeline(State(state), Path("repo#1".into()), Query(query)).await.into_parts();
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.events.is_empty());
+}
+
+#[tokio::test]
+async fn get_timeline_returns_paginated_events_for_run_id() {
+    write_timeline_lines(&state, "run-abc", vec![1, 2, 3]).await;
+    let response = get_timeline(State(state), Path("repo#1".into()), Query(query_with_limit_2)).await.into_response();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+Run: `cargo test -p ensemble-core timeline_handler`
+Expected: FAIL (missing route/handler)
+
+- [ ] **Step 3: Implement endpoint + routing + schema registration**
+```rust
+// GET /api/v1/{identifier}/timeline?run_id=run-abc&cursor=0&limit=50
+pub async fn get_timeline(
+    State(state): State<AppState>,
+    Path(identifier): Path<String>,
+    Query(query): Query<TimelineQuery>,
+) -> impl IntoResponse {
+    match read_timeline(&timeline_path(&state.workspace_root, &identifier, &query.run_id), &query).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, api_error("timeline_read_error", format!("failed to read timeline: {error}"))).into_response(),
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+Run: `cargo test -p ensemble-core timeline_handler`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+git add crates/ensemble-core/src/api/timeline_handler.rs crates/ensemble-core/src/api/mod.rs crates/ensemble-core/src/api/router.rs crates/ensemble-core/src/api/openapi.rs
+git commit -m "Add timeline history API endpoint"
+```
+
+### Task 3: Persist pipeline events with run_id + sequence
+
+**Files:**
+- Modify: `crates/ensemble-core/src/observability/events.rs`
+- Modify: orchestrator event emission callsites in `crates/ensemble-core/src/orchestrator/` (where pipeline events are produced)
+- Modify: `crates/ensemble-core/src/observability/snapshot.rs` (include `run_id` in `RunningDetail`)
+- Test: `crates/ensemble-core/src/orchestrator/mod.rs` tests and `crates/ensemble-core/src/observability/events.rs` tests
+
+- [ ] **Step 1: Add failing test for event-to-timeline mapping**
+```rust
+#[test]
+fn pipeline_event_maps_to_timeline_record_with_run_and_sequence() {
+    let event = PipelineEvent::RetryScheduled { issue_identifier: "repo#1".into(), timestamp: Utc::now(), attempt: 2, detail: "retry".into() };
+    let record = TimelineEventRecord::from_pipeline_event("run-1", 7, &event).unwrap();
+    assert_eq!(record.run_id, "run-1");
+    assert_eq!(record.sequence, 7);
+    assert_eq!(record.attempt, 2);
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+Run: `cargo test -p ensemble-core observability::events`
+Expected: FAIL (missing mapping/run_id/sequence fields)
+
+- [ ] **Step 3: Implement mapping + persistence hook (best effort)**
+```rust
+if let Some(record) = TimelineEventRecord::from_pipeline_event(event, run_id, sequence) {
+    if let Err(err) = timeline_writer.append(&record).await {
+        warn!(event = "timeline_persist_failed", %run_id, error = %err);
+    }
+}
+event_bus.publish(event);
+```
+
+- [ ] **Step 4: Expose run_id in issue detail snapshot for UI query**
+```rust
+pub struct RunningDetail {
+    pub run_id: Option<String>,
+    pub session_id: Option<String>,
+    pub step_name: Option<String>,
+    pub turn_count: u32,
+    pub state: String,
+    pub started_at: DateTime<Utc>,
+    pub last_event: Option<String>,
+    pub last_message: Option<String>,
+    pub last_event_at: Option<DateTime<Utc>>,
+    pub tokens: TokenSnapshot,
+}
+```
+
+- [ ] **Step 5: Run focused tests**
+Run: `cargo test -p ensemble-core observability::events orchestrator`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+```bash
+git add crates/ensemble-core/src/observability/events.rs crates/ensemble-core/src/observability/snapshot.rs crates/ensemble-core/src/orchestrator
+git commit -m "Persist pipeline events to per-run timeline logs"
+```
+
+### Task 4: Integrate timeline history in web UI and merge with WS
+
+**Files:**
+- Modify: `crates/ensemble-ui/src-ui/src/hooks.ts`
+- Modify: `crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx`
+- Modify: `crates/ensemble-ui/src-ui/src/ws-types.ts`
+- Modify: `crates/ensemble-ui/src-ui/src/ws-events.ts`
+- Regenerate: `crates/ensemble-ui/src-ui/src/generated/api/timeline/timeline.ts`, `crates/ensemble-ui/src-ui/src/generated/api/issues/issues.ts`, `crates/ensemble-ui/src-ui/src/generated/models/index.ts` (orval)
+- Test: `crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx`
+
+- [ ] **Step 1: Add failing UI test for merged timeline**
+```tsx
+it("merges persisted timeline with live ws and dedupes by run_id+sequence", async () => {
+  // assert single list in execution order
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+Run: `cd crates/ensemble-ui/src-ui && pnpm test IssueDetail`
+Expected: FAIL (no history hook/merge logic)
+
+- [ ] **Step 3: Add timeline query + merge/de-dupe logic in IssueDetail**
+```ts
+const key = `${event.run_id}:${event.sequence}`;
+const merged = [...history, ...live].filter(uniqueKey).sort(bySequenceThenTimestamp);
+```
+
+- [ ] **Step 4: Run UI tests**
+Run: `cd crates/ensemble-ui/src-ui && pnpm test IssueDetail`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+git add crates/ensemble-ui/src-ui/src/hooks.ts crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx crates/ensemble-ui/src-ui/src/ws-types.ts crates/ensemble-ui/src-ui/src/ws-events.ts crates/ensemble-ui/src-ui/src/generated
+git commit -m "Merge persisted and live timeline events in issue detail"
+```
+
+### Task 5: Distinct retry visuals and final verification
+
+**Files:**
+- Modify: `crates/ensemble-ui/src-ui/src/components/EventTimeline.tsx`
+- Create/Modify: `crates/ensemble-ui/src-ui/src/components/EventTimeline.test.tsx`
+
+- [ ] **Step 1: Add failing visual behavior test**
+```tsx
+it("renders retry events with a distinct retry badge and accent styling", () => {
+  // expects "Retry" and "Attempt 2" badge class
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+Run: `cd crates/ensemble-ui/src-ui && pnpm test EventTimeline`
+Expected: FAIL (badge/accent missing)
+
+- [ ] **Step 3: Implement retry-specific badge + accent styling**
+```tsx
+{event.attempt > 1 && <Badge variant="secondary">Retry • Attempt {event.attempt}</Badge>}
+```
+
+- [ ] **Step 4: Run frontend verification**
+Run: `cd crates/ensemble-ui/src-ui && pnpm test && pnpm run build`
+Expected: PASS
+
+- [ ] **Step 5: Run backend verification**
+Run: `cargo test --workspace --exclude ensemble-desktop`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+```bash
+git add crates/ensemble-ui/src-ui/src/components/EventTimeline.tsx crates/ensemble-ui/src-ui/src/components/EventTimeline.test.tsx
+git commit -m "Render retries as distinct timeline badges"
+```
+
+## Final Validation Checklist
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
+- [ ] `cargo test --workspace --exclude ensemble-desktop`
+- [ ] `cd crates/ensemble-ui/src-ui && pnpm test && pnpm run build`

--- a/docs/superpowers/specs/2026-04-08-agent-timeline-web-ui-design.md
+++ b/docs/superpowers/specs/2026-04-08-agent-timeline-web-ui-design.md
@@ -118,6 +118,10 @@ Each row shows:
 
 Retries are inline events in the same list.
 
+Retry rows must be visually distinct from first-attempt rows:
+- show a prominent retry badge (e.g. `Retry` + `Attempt N`)
+- apply retry-specific accent styling so operators can scan for churn quickly
+
 ### Empty/error states
 
 - No events yet: show empty state message

--- a/docs/superpowers/specs/2026-04-08-agent-timeline-web-ui-design.md
+++ b/docs/superpowers/specs/2026-04-08-agent-timeline-web-ui-design.md
@@ -1,0 +1,164 @@
+# Agent Timeline Web UI Design
+
+Date: 2026-04-08
+Status: Proposed
+Owner: Ensemble core + UI
+
+## Goal
+
+Make the Issue Detail timeline work for both live and historical runs by persisting pipeline events and rendering a single execution-ordered event stream in the web UI.
+
+## Scope
+
+In scope:
+- Persist timeline events per run
+- Read API for historical timeline events
+- UI merge of persisted history + live WebSocket events
+- Execution-order timeline rendering where retries appear inline
+- Tests for writer/reader/API/UI merge behavior
+
+Out of scope:
+- Raw stdout/stderr log viewing
+- SSE streaming support
+- Database-backed event storage
+- Advanced filtering/search UX
+
+## Problem Statement
+
+Today timeline events are emitted on the in-memory event bus and streamed over WebSocket, but not persisted. This means:
+- active runs can be viewed live
+- completed runs lose timeline detail
+- retries/step history cannot be replayed reliably in the UI
+
+## Design Summary
+
+Use per-run append-only JSONL event persistence, then combine:
+1. persisted timeline events from a REST endpoint
+2. live WebSocket events for the active run
+
+Render one chronological timeline in execution order. Retries are normal timeline rows (not grouped behind selectors).
+
+## Persistence Model
+
+### Storage path
+
+Store timeline events under:
+- `<workspace_root>/.ensemble/runs/<run_id>/events.jsonl`
+
+This keeps events scoped to a single run, avoids global-file growth concerns, and supports parallel/multi-step execution.
+
+### Event envelope
+
+Persist a normalized timeline event record with:
+- `run_id: String`
+- `issue_identifier: String`
+- `sequence: u64` (monotonic per run)
+- `timestamp: DateTime<Utc>`
+- `event_type: String` (or enum serialization)
+- `step_name: Option<String>`
+- `attempt: u32` (default 1)
+- `detail: String`
+- optional event-specific fields (e.g. `verdict`, `tool_name`, token deltas)
+
+### Ordering contract
+
+Primary ordering key: `sequence`.
+Fallback ordering key: `timestamp`.
+
+Retries are represented by later events with higher `sequence` and incremented `attempt`.
+
+## Backend Write Path
+
+- Add a timeline writer module in `ensemble-core` for JSONL append.
+- Hook persistence into the existing pipeline event publication path.
+- For each emitted pipeline event:
+  - map to normalized timeline event
+  - append to per-run `events.jsonl`
+  - publish live event as today
+
+### Failure behavior
+
+Persistence failures are non-fatal:
+- log warning/error with run + issue context
+- continue orchestrator execution
+
+## Read API
+
+Add timeline history endpoint:
+- `GET /api/v1/{identifier}/timeline?run_id=<id>&cursor=<n>&limit=<n>`
+
+Response:
+- `events: TimelineEvent[]`
+- `total: usize`
+- `next_cursor: Option<usize>`
+
+Reader behavior:
+- missing file => empty list
+- malformed lines => skip line (best-effort)
+- stable pagination semantics aligned with existing history/conversation patterns
+
+## UI Behavior (Issue Detail)
+
+### Data flow
+
+1. Load persisted events for current run via timeline endpoint
+2. Open WebSocket stream for live events
+3. Normalize to shared UI event type
+4. De-duplicate by `(run_id, sequence)`
+5. Render one combined ordered list
+
+### Rendering
+
+Each row shows:
+- event type/status style
+- timestamp
+- step name when present
+- attempt badge (e.g. `Attempt 2`)
+- detail text
+
+Retries are inline events in the same list.
+
+### Empty/error states
+
+- No events yet: show empty state message
+- Timeline history read failure: show non-blocking error banner and continue live stream where possible
+
+## Why Not SSE
+
+SSE is not required for this design:
+- live updates already use WebSocket
+- historical replay comes from REST timeline endpoint
+
+Adding SSE now would duplicate transport complexity without solving a current gap.
+
+## Testing Strategy
+
+### Core tests
+
+- Writer appends valid JSONL records and creates parent directories
+- Reader returns ordered pages with cursor/limit behavior
+- Reader skips malformed lines without failing whole request
+
+### API tests
+
+- Missing timeline file returns empty response
+- Valid timeline file returns ordered events
+- Pagination and cursor behavior
+
+### UI tests
+
+- Merges persisted + live events
+- De-duplicates by `(run_id, sequence)`
+- Renders retries inline in execution order
+
+## Rollout Plan
+
+1. Implement core timeline event model + writer
+2. Wire persistence into event emission path
+3. Add timeline reader + API endpoint
+4. Update UI timeline data flow and rendering
+5. Add/adjust tests for core/API/UI
+
+## Recommendation
+
+Adopt per-run JSONL timeline persistence now. It is the smallest change that enables reliable historical timeline replay while preserving existing live WebSocket behavior.


### PR DESCRIPTION
## Summary
- persist pipeline events per run to JSONL and expose them via a timeline API
- wire orchestrator event publication to persist + broadcast with run/sequence ordering
- merge persisted timeline + live websocket events in Issue Detail and render retries inline with a distinct badge
- include design + implementation docs for the timeline work

## Testing
- cargo test --workspace --exclude ensemble-desktop
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check
- cd crates/ensemble-ui/src-ui && pnpm test
- cd crates/ensemble-ui/src-ui && pnpm run build