### PR TITLE
feat: add generic step approval gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 .superpowers/
 .DS_Store
+.worktrees/
 node_modules/
 crates/ensemble-ui/src-ui/dist/
 crates/ensemble-ui/src-ui/src/generated/

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -324,7 +324,8 @@ exit 1
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None
+                runtime_verdict: None,
+                ..
             }
         ));
         let mut saw_output = false;
@@ -386,7 +387,8 @@ exit 1
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None
+                runtime_verdict: None,
+                ..
             }
         ));
     }

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -190,6 +190,7 @@ pub enum WorkerEvent {
 pub enum WorkerResult {
     Success {
         runtime_verdict: Option<serde_json::Value>,
+        approval_request: Option<StepApprovalRequestDraft>,
     },
     BlockedOnHuman {
         request: InteractionRequestDraft,
@@ -217,6 +218,16 @@ pub struct InteractionRequestDraft {
     pub options: Vec<String>,
     #[serde(default)]
     pub artifacts: Vec<String>,
+}
+
+/// Draft approval request emitted by an agent in `.ensemble/approval-request.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StepApprovalRequestDraft {
+    pub schema_version: u32,
+    pub title: String,
+    pub body: String,
+    #[serde(default)]
+    pub state: Option<String>,
 }
 
 /// JSON-RPC 2.0 message types for ACP protocol parsing.
@@ -304,7 +315,8 @@ mod tests {
     #[test]
     fn test_worker_result_is_success() {
         assert!(WorkerResult::Success {
-            runtime_verdict: None
+            runtime_verdict: None,
+            approval_request: None,
         }
         .is_success());
         assert!(!WorkerResult::BlockedOnHuman {
@@ -338,6 +350,18 @@ mod tests {
 
         assert_eq!(draft.options, Vec::<String>::new());
         assert_eq!(draft.artifacts, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_step_approval_request_draft_deserializes_state_default() {
+        let draft: StepApprovalRequestDraft = serde_json::from_value(serde_json::json!({
+            "schema_version": 1,
+            "title": "Approve plan",
+            "body": "Please review."
+        }))
+        .unwrap();
+
+        assert_eq!(draft.state, None);
     }
 
     #[test]

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -21,7 +21,9 @@ use crate::error::AgentError;
 use crate::interaction::InteractionResponse;
 use crate::tracker::model::Issue;
 use crate::workspace::hooks::{run_hook, run_hook_best_effort};
-use events::{AgentEvent, InteractionRequestDraft, WorkerEvent, WorkerResult};
+use events::{
+    AgentEvent, InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult,
+};
 
 use acp_client::{AcpSession, TurnResult};
 use acpx_runtime::AcpxRuntime;
@@ -139,10 +141,11 @@ impl AcpAgentRunner {
         workspace_path: &Path,
         interaction_response: Option<&InteractionResponseEnvelope>,
     ) -> Result<(), AgentError> {
-        // Ensure stale verdict data from previous attempts cannot influence the
-        // current run's resolution path.
+        // Ensure stale verdict and request artifacts from previous attempts
+        // cannot influence the current run's resolution path.
         remove_ensemble_file(workspace_path, "verdict.json").await?;
         remove_ensemble_file(workspace_path, "interaction-request.json").await?;
+        remove_ensemble_file(workspace_path, "approval-request.json").await?;
 
         if let Some(interaction_response) = interaction_response {
             write_interaction_response_file(workspace_path, interaction_response).await?;
@@ -223,6 +226,9 @@ async fn detect_worker_result_with_runtime_verdict(
     let interaction_path = workspace_path
         .join(".ensemble")
         .join("interaction-request.json");
+    let approval_path = workspace_path
+        .join(".ensemble")
+        .join("approval-request.json");
 
     let interaction_request = match tokio::fs::read_to_string(&interaction_path).await {
         Ok(contents) => match serde_json::from_str::<InteractionRequestDraft>(&contents) {
@@ -241,17 +247,41 @@ async fn detect_worker_result_with_runtime_verdict(
         }
     };
 
+    let approval_request = match tokio::fs::read_to_string(&approval_path).await {
+        Ok(contents) => match serde_json::from_str::<StepApprovalRequestDraft>(&contents) {
+            Ok(request) => Some(request),
+            Err(error) => {
+                return WorkerResult::Failed {
+                    error: format!("failed to parse .ensemble/approval-request.json: {error}"),
+                }
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return WorkerResult::Failed {
+                error: format!("failed to read .ensemble/approval-request.json: {error}"),
+            }
+        }
+    };
+
     let verdict_path = workspace_path.join(".ensemble").join("verdict.json");
     let verdict_exists = tokio::fs::try_exists(&verdict_path).await.unwrap_or(false);
 
     match interaction_request {
+        Some(_) if approval_request.is_some() => WorkerResult::Failed {
+            error: "agent produced both .ensemble/interaction-request.json and .ensemble/approval-request.json"
+                .to_string(),
+        },
         Some(_) if verdict_exists => WorkerResult::Failed {
             error:
                 "agent produced both .ensemble/interaction-request.json and .ensemble/verdict.json"
                     .to_string(),
         },
         Some(request) => WorkerResult::BlockedOnHuman { request },
-        None => WorkerResult::Success { runtime_verdict },
+        None => WorkerResult::Success {
+            runtime_verdict,
+            approval_request,
+        },
     }
 }
 
@@ -657,6 +687,7 @@ mod tests {
             if self.should_succeed {
                 Ok(WorkerResult::Success {
                     runtime_verdict: None,
+                    approval_request: None,
                 })
             } else {
                 Err(AgentError::TurnFailed {
@@ -783,7 +814,8 @@ on_failure: Todo
         assert!(matches!(
             result,
             Ok(WorkerResult::Success {
-                runtime_verdict: None
+                runtime_verdict: None,
+                ..
             })
         ));
 
@@ -883,7 +915,8 @@ exit 1
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None
+                runtime_verdict: None,
+                ..
             }
         ));
         let event_names = collect_event_names(&mut rx);
@@ -937,7 +970,8 @@ exit 0
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None
+                runtime_verdict: None,
+                ..
             }
         ));
         let event_names = collect_event_names(&mut rx);
@@ -1026,6 +1060,79 @@ exit 0
             result,
             WorkerResult::Failed { error }
                 if error.contains("both .ensemble/interaction-request.json and .ensemble/verdict.json")
+        ));
+    }
+
+    #[tokio::test]
+    async fn detect_worker_result_reads_post_step_approval_request() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        write_workspace_file(
+            &workspace,
+            "approval-request.json",
+            &serde_json::to_string_pretty(&StepApprovalRequestDraft {
+                schema_version: 1,
+                title: "Approve plan".to_string(),
+                body: "The step completed successfully. Please review the plan.".to_string(),
+                state: Some("Plan Review".to_string()),
+            })
+            .unwrap(),
+        )
+        .await;
+
+        let result = detect_worker_result(workspace.path()).await;
+
+        assert!(matches!(
+            result,
+            WorkerResult::Success {
+                approval_request: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn detect_worker_result_rejects_both_interaction_and_post_step_approval() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        write_workspace_file(
+            &workspace,
+            "interaction-request.json",
+            r#"{
+  "schema_version": 1,
+  "kind": "question",
+  "blocking": true,
+  "title": "Need input",
+  "body": "Which environment?"
+}"#,
+        )
+        .await;
+        write_workspace_file(
+            &workspace,
+            "approval-request.json",
+            r#"{
+  "schema_version": 1,
+  "title": "Approve plan",
+  "body": "Please review.",
+  "state": "Plan Review"
+}"#,
+        )
+        .await;
+
+        let result = detect_worker_result(workspace.path()).await;
+
+        assert!(matches!(result, WorkerResult::Failed { .. }));
+    }
+
+    #[tokio::test]
+    async fn detect_worker_result_fails_on_invalid_post_step_approval_json() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        write_workspace_file(&workspace, "approval-request.json", "not json").await;
+
+        let result = detect_worker_result(workspace.path()).await;
+
+        assert!(matches!(
+            result,
+            WorkerResult::Failed { error }
+                if error.contains("failed to parse .ensemble/approval-request.json")
         ));
     }
 
@@ -1189,7 +1296,38 @@ exit 0
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None
+                runtime_verdict: None,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn prepare_workspace_removes_stale_post_step_approval_request_before_run() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        write_workspace_file(
+            &workspace,
+            "approval-request.json",
+            r#"{
+  "schema_version": 1,
+  "title": "Stale approval",
+  "body": "Should not leak",
+  "state": "Plan Review"
+}"#,
+        )
+        .await;
+
+        AcpAgentRunner
+            .prepare_workspace(workspace.path(), None)
+            .await
+            .unwrap();
+
+        let result = detect_worker_result(workspace.path()).await;
+        assert!(matches!(
+            result,
+            WorkerResult::Success {
+                approval_request: None,
+                ..
             }
         ));
     }

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -662,6 +662,10 @@ fn setup_defaults_from_active_config(config: &EnsembleConfig) -> serde_json::Val
                 "agent_role": step.agent,
                 "depends": step.depends.clone().unwrap_or_default(),
                 "tracker_state": step.tracker_state,
+                "approval": step.approval.as_ref().map(|approval| serde_json::json!({
+                    "mode": approval.mode,
+                    "state": approval.state,
+                })),
             })
         })
         .collect();
@@ -1118,6 +1122,56 @@ on_failure: Failed
         assert_eq!(response.defaults["agents"][0]["role"], "builder");
         assert_eq!(response.defaults["agents"][0]["acpx_agent"], "codex");
         assert_eq!(response.defaults["steps"][0]["name"], "build");
+    }
+
+    #[tokio::test]
+    async fn test_get_setup_defaults_includes_step_approval_in_response() {
+        let (state, _temp_dir) = test_app_state();
+        *state.config_runtime.document_state.write().await = ConfigDocumentState {
+            path: state.config_runtime.config_path.clone(),
+            kind: ConfigStateKind::Parsed,
+            raw_yaml: None,
+            document: None,
+            active_config: Some(
+                crate::config::ensemble::parse_config(
+                    r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+agents:
+  planner:
+    acpx_agent: claude
+    prompt: Plan.
+steps:
+  - name: plan
+    agent: planner
+    tracker_state: Planning
+    approval:
+      mode: when_requested_by_agent
+      state: Plan Review
+on_success: Done
+on_failure: Failed
+"#,
+                )
+                .unwrap(),
+            ),
+            validation: DraftValidationReport::default(),
+        };
+
+        let (status, Json(response)) = get_setup_defaults(axum::extract::State(state)).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            response.defaults["steps"][0]["approval"],
+            serde_json::json!({
+                "mode": "when_requested_by_agent",
+                "state": "Plan Review"
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -125,6 +125,8 @@ pub struct ResumeResponse {
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct IssueInputRequest {
     pub response: String,
+    /// Required for approval_gate/manual_decision interactions; use
+    /// approve/reject or complete/pending. Omit for brainstorm-style prompts.
     pub outcome: Option<String>,
 }
 
@@ -860,8 +862,12 @@ pub async fn post_issue_input(
 
 fn parse_approval_outcome(outcome: Option<&str>) -> Result<bool, String> {
     match outcome {
-        None | Some("approve") | Some("approved") => Ok(true),
+        Some("approve") | Some("approved") => Ok(true),
         Some("reject") | Some("rejected") => Ok(false),
+        None => Err(
+            "approval outcome is required; expected one of: approve, approved, reject, rejected"
+                .to_string(),
+        ),
         Some(other) => Err(format!(
             "unsupported approval outcome '{other}'; expected one of: approve, approved, reject, rejected"
         )),
@@ -870,8 +876,12 @@ fn parse_approval_outcome(outcome: Option<&str>) -> Result<bool, String> {
 
 fn parse_manual_decision_outcome(outcome: Option<&str>) -> Result<bool, String> {
     match outcome {
-        None | Some("complete") | Some("completed") => Ok(true),
+        Some("complete") | Some("completed") => Ok(true),
         Some("pending") | Some("incomplete") => Ok(false),
+        None => Err(
+            "manual decision outcome is required; expected one of: complete, completed, pending, incomplete"
+                .to_string(),
+        ),
         Some(other) => Err(format!(
             "unsupported manual decision outcome '{other}'; expected one of: complete, completed, pending, incomplete"
         )),
@@ -885,8 +895,10 @@ mod tests {
     use crate::api::router::AppState;
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
     use crate::config::ensemble::StepConfig;
+    use crate::interaction::{InteractionRequest, InteractionResumeStrategy};
     use crate::orchestrator::state::{
         FinalizeStatus, IssueFinalizeState, OrchestratorState, RepoFinalizeState,
+        WaitingOnHumanEntry,
     };
     use crate::pipeline::dag::build_dag;
     use crate::pipeline::engine::PipelineRun;
@@ -982,6 +994,7 @@ mod tests {
             agent: "build".to_string(),
             depends: None,
             tracker_state: None,
+            approval: None,
         }])
         .unwrap();
 
@@ -991,6 +1004,138 @@ mod tests {
     async fn response_json(response: axum::response::Response) -> serde_json::Value {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         serde_json::from_slice(&body).unwrap()
+    }
+
+    async fn build_app_state_with_waiting_approval_gate() -> AppState {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.yaml");
+        tokio::fs::write(&config_path, "tracker:\n  kind: todo_file\n")
+            .await
+            .unwrap();
+        let config_dir = temp_dir.path().to_path_buf();
+        std::mem::forget(temp_dir);
+
+        let mut state = OrchestratorState::new(30000, 10);
+        state.add_claimed("NODE_123");
+        state.add_waiting_on_human(WaitingOnHumanEntry {
+            issue_id: "NODE_123".to_string(),
+            identifier: "my-repo#42".to_string(),
+            interaction_request_id: "approval-1".to_string(),
+            step_name: "build".to_string(),
+            kind: InteractionKind::ApprovalGate,
+            prompt: "Please review the build output".to_string(),
+            agent_name: "build".to_string(),
+            retry_attempt: Some(1),
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: chrono::Utc::now(),
+        });
+
+        let mut app_state = app_state_with_document_state(parsed_document_state());
+        app_state.orchestrator_state = Arc::new(RwLock::new(state));
+        app_state.config_runtime.config_path = config_path.clone();
+
+        InteractionStore::new(config_dir)
+            .create(InteractionRequest {
+                id: "approval-1".to_string(),
+                schema_version: 1,
+                issue_id: "NODE_123".to_string(),
+                issue_identifier: "my-repo#42".to_string(),
+                pipeline_cycle: 1,
+                completed_steps: vec![],
+                step_name: "build".to_string(),
+                agent_name: "build".to_string(),
+                step_depends: vec![],
+                step_tracker_state: None,
+                kind: InteractionKind::ApprovalGate,
+                status: InteractionStatus::Open,
+                blocking: true,
+                awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::AdvanceAfterStep,
+                title: "Approve build".to_string(),
+                body: "Please review the build output".to_string(),
+                options: vec!["approve".to_string(), "reject".to_string()],
+                artifacts: vec![],
+                response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: chrono::Utc::now(),
+                resolved_at: None,
+            })
+            .await
+            .unwrap();
+
+        app_state
+    }
+
+    async fn build_app_state_with_waiting_manual_decision() -> AppState {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.yaml");
+        tokio::fs::write(&config_path, "tracker:\n  kind: todo_file\n")
+            .await
+            .unwrap();
+        let config_dir = temp_dir.path().to_path_buf();
+        std::mem::forget(temp_dir);
+
+        let mut state = OrchestratorState::new(30000, 10);
+        state.add_claimed("NODE_123");
+        state.add_waiting_on_human(WaitingOnHumanEntry {
+            issue_id: "NODE_123".to_string(),
+            identifier: "my-repo#42".to_string(),
+            interaction_request_id: "decision-1".to_string(),
+            step_name: "build".to_string(),
+            kind: InteractionKind::ManualDecision,
+            prompt: "Should we proceed?".to_string(),
+            agent_name: "build".to_string(),
+            retry_attempt: Some(1),
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: chrono::Utc::now(),
+        });
+
+        let mut app_state = app_state_with_document_state(parsed_document_state());
+        app_state.orchestrator_state = Arc::new(RwLock::new(state));
+        app_state.config_runtime.config_path = config_path.clone();
+
+        InteractionStore::new(config_dir)
+            .create(InteractionRequest {
+                id: "decision-1".to_string(),
+                schema_version: 1,
+                issue_id: "NODE_123".to_string(),
+                issue_identifier: "my-repo#42".to_string(),
+                pipeline_cycle: 1,
+                completed_steps: vec![],
+                step_name: "build".to_string(),
+                agent_name: "build".to_string(),
+                step_depends: vec![],
+                step_tracker_state: None,
+                kind: InteractionKind::ManualDecision,
+                status: InteractionStatus::Open,
+                blocking: true,
+                awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
+                title: "Need decision".to_string(),
+                body: "Should we proceed?".to_string(),
+                options: vec!["complete".to_string(), "pending".to_string()],
+                artifacts: vec![],
+                response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: chrono::Utc::now(),
+                resolved_at: None,
+            })
+            .await
+            .unwrap();
+
+        app_state
     }
 
     fn build_app_state_with_running_pid(agent_pid: Option<&str>) -> AppState {
@@ -1258,5 +1403,100 @@ mod tests {
         let response = post_retry(State(state), Path("my-repo#42".to_string())).await;
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_issue_input_accepts_approval_outcome_for_post_step_gate() {
+        let state = build_app_state_with_waiting_approval_gate().await;
+
+        let response = post_issue_input(
+            State(state.clone()),
+            Path("my-repo#42".to_string()),
+            Json(IssueInputRequest {
+                response: "looks good".to_string(),
+                outcome: Some("approve".to_string()),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["submitted"], true);
+
+        let store = interaction_store(&state);
+        let interaction = store
+            .get("approval-1")
+            .await
+            .unwrap()
+            .expect("interaction should be persisted");
+        assert_eq!(interaction.status, InteractionStatus::Resolved);
+        assert_eq!(
+            interaction.response,
+            Some(InteractionResponse::Approval {
+                response_schema_version: 1,
+                approved: true,
+                reason: Some("looks good".to_string()),
+            })
+        );
+
+        let lock = state.orchestrator_state.read().await;
+        assert!(lock.is_resume_requested("NODE_123"));
+    }
+
+    #[tokio::test]
+    async fn test_issue_input_rejects_missing_outcome_for_approval_gate() {
+        let state = build_app_state_with_waiting_approval_gate().await;
+
+        let response = post_issue_input(
+            State(state.clone()),
+            Path("my-repo#42".to_string()),
+            Json(IssueInputRequest {
+                response: "looks good".to_string(),
+                outcome: None,
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "invalid_input_outcome");
+
+        let store = interaction_store(&state);
+        let interaction = store
+            .get("approval-1")
+            .await
+            .unwrap()
+            .expect("interaction should still exist");
+        assert_eq!(interaction.status, InteractionStatus::Open);
+    }
+
+    #[tokio::test]
+    async fn test_issue_input_rejects_missing_outcome_for_manual_decision() {
+        let state = build_app_state_with_waiting_manual_decision().await;
+
+        let response = post_issue_input(
+            State(state.clone()),
+            Path("my-repo#42".to_string()),
+            Json(IssueInputRequest {
+                response: "still thinking".to_string(),
+                outcome: None,
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "invalid_input_outcome");
+
+        let store = interaction_store(&state);
+        let interaction = store
+            .get("decision-1")
+            .await
+            .unwrap()
+            .expect("interaction should still exist");
+        assert_eq!(interaction.status, InteractionStatus::Open);
     }
 }

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -1006,14 +1006,13 @@ mod tests {
         serde_json::from_slice(&body).unwrap()
     }
 
-    async fn build_app_state_with_waiting_approval_gate() -> AppState {
+    async fn build_app_state_with_waiting_approval_gate() -> (AppState, tempfile::TempDir) {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let config_path = temp_dir.path().join("config.yaml");
         tokio::fs::write(&config_path, "tracker:\n  kind: todo_file\n")
             .await
             .unwrap();
         let config_dir = temp_dir.path().to_path_buf();
-        std::mem::forget(temp_dir);
 
         let mut state = OrchestratorState::new(30000, 10);
         state.add_claimed("NODE_123");
@@ -1069,17 +1068,16 @@ mod tests {
             .await
             .unwrap();
 
-        app_state
+        (app_state, temp_dir)
     }
 
-    async fn build_app_state_with_waiting_manual_decision() -> AppState {
+    async fn build_app_state_with_waiting_manual_decision() -> (AppState, tempfile::TempDir) {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let config_path = temp_dir.path().join("config.yaml");
         tokio::fs::write(&config_path, "tracker:\n  kind: todo_file\n")
             .await
             .unwrap();
         let config_dir = temp_dir.path().to_path_buf();
-        std::mem::forget(temp_dir);
 
         let mut state = OrchestratorState::new(30000, 10);
         state.add_claimed("NODE_123");
@@ -1135,7 +1133,7 @@ mod tests {
             .await
             .unwrap();
 
-        app_state
+        (app_state, temp_dir)
     }
 
     fn build_app_state_with_running_pid(agent_pid: Option<&str>) -> AppState {
@@ -1407,7 +1405,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_issue_input_accepts_approval_outcome_for_post_step_gate() {
-        let state = build_app_state_with_waiting_approval_gate().await;
+        let (state, _temp_dir) = build_app_state_with_waiting_approval_gate().await;
 
         let response = post_issue_input(
             State(state.clone()),
@@ -1446,7 +1444,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_issue_input_rejects_missing_outcome_for_approval_gate() {
-        let state = build_app_state_with_waiting_approval_gate().await;
+        let (state, _temp_dir) = build_app_state_with_waiting_approval_gate().await;
 
         let response = post_issue_input(
             State(state.clone()),
@@ -1474,7 +1472,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_issue_input_rejects_missing_outcome_for_manual_decision() {
-        let state = build_app_state_with_waiting_manual_decision().await;
+        let (state, _temp_dir) = build_app_state_with_waiting_manual_decision().await;
 
         let response = post_issue_input(
             State(state.clone()),

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -284,6 +284,22 @@ pub struct AgentConfig {
     pub reasoning_level: Option<String>,
 }
 
+/// Approval gate metadata for a pipeline step.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct StepApprovalConfig {
+    pub mode: StepApprovalMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+/// Approval mode for a pipeline step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StepApprovalMode {
+    Always,
+    WhenRequestedByAgent,
+}
+
 /// A single step in the pipeline DAG.
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct StepConfig {
@@ -293,6 +309,8 @@ pub struct StepConfig {
     /// previous step). `Some(vec![])` means "no dependencies" (explicit root).
     pub depends: Option<Vec<String>>,
     pub tracker_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval: Option<StepApprovalConfig>,
 }
 
 /// Concurrency limits for the pipeline orchestrator.
@@ -930,6 +948,53 @@ on_failure: Failed
         assert_eq!(config.steps[0].agent, "build");
         assert_eq!(config.on_success, "Done");
         assert_eq!(config.on_failure, "Failed");
+    }
+
+    #[test]
+    fn parses_step_approval_config_from_yaml() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  plan:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: "Plan the work."
+steps:
+  - name: plan
+    agent: plan
+    tracker_state: Planning
+    approval:
+      mode: when_requested_by_agent
+      state: Plan Review
+on_success: Done
+on_failure: Failed
+"#;
+        let config = parse_config(yaml).unwrap();
+        let approval = config.steps[0].approval.as_ref().unwrap();
+        assert_eq!(approval.mode, StepApprovalMode::WhenRequestedByAgent);
+        assert_eq!(approval.state.as_deref(), Some("Plan Review"));
+    }
+
+    #[test]
+    fn defaults_step_approval_to_none() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  plan:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: "Plan the work."
+steps:
+  - name: plan
+    agent: plan
+    tracker_state: Planning
+on_success: Done
+on_failure: Failed
+"#;
+        let config = parse_config(yaml).unwrap();
+        assert!(config.steps[0].approval.is_none());
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -799,6 +799,7 @@ fn build_setup_dag(steps: &[SetupStep]) -> Result<crate::pipeline::dag::StepDag,
             // Setup steps treat an empty list as an explicit root, not an implicit sequential dep.
             depends: Some(step.depends.clone()),
             tracker_state: step.tracker_state.clone(),
+            approval: None,
         })
         .collect();
 

--- a/crates/ensemble-core/src/interaction/mod.rs
+++ b/crates/ensemble-core/src/interaction/mod.rs
@@ -3,5 +3,8 @@ pub mod model;
 pub mod store;
 
 pub use error::InteractionError;
-pub use model::{InteractionKind, InteractionRequest, InteractionResponse, InteractionStatus};
+pub use model::{
+    InteractionKind, InteractionRequest, InteractionResponse, InteractionResumeStrategy,
+    InteractionStatus,
+};
 pub use store::InteractionStore;

--- a/crates/ensemble-core/src/interaction/model.rs
+++ b/crates/ensemble-core/src/interaction/model.rs
@@ -21,6 +21,13 @@ pub enum InteractionStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractionResumeStrategy {
+    RerunStep,
+    AdvanceAfterStep,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum InteractionResponse {
     Question {
@@ -61,15 +68,29 @@ pub struct InteractionRequest {
     pub blocking: bool,
     #[serde(default = "default_awaiting_resume")]
     pub awaiting_resume: bool,
+    #[serde(default = "default_resume_strategy")]
+    pub resume_strategy: InteractionResumeStrategy,
     pub title: String,
     pub body: String,
     pub options: Vec<String>,
     pub artifacts: Vec<String>,
     pub response: Option<InteractionResponse>,
+    #[serde(default)]
+    pub waiting_started_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub agent_input_tokens: u64,
+    #[serde(default)]
+    pub agent_output_tokens: u64,
+    #[serde(default)]
+    pub agent_total_tokens: u64,
     pub requested_at: DateTime<Utc>,
     pub resolved_at: Option<DateTime<Utc>>,
 }
 
 fn default_awaiting_resume() -> bool {
     true
+}
+
+fn default_resume_strategy() -> InteractionResumeStrategy {
+    InteractionResumeStrategy::RerunStep
 }

--- a/crates/ensemble-core/src/interaction/store.rs
+++ b/crates/ensemble-core/src/interaction/store.rs
@@ -325,7 +325,8 @@ mod tests {
     use super::InteractionStore;
     use crate::interaction::error::InteractionError;
     use crate::interaction::model::{
-        InteractionKind, InteractionRequest, InteractionResponse, InteractionStatus,
+        InteractionKind, InteractionRequest, InteractionResponse, InteractionResumeStrategy,
+        InteractionStatus,
     };
     use chrono::Utc;
     use std::sync::Arc;
@@ -352,11 +353,16 @@ mod tests {
             status: InteractionStatus::Open,
             blocking: true,
             awaiting_resume: true,
+            resume_strategy: InteractionResumeStrategy::RerunStep,
             title: "Need clarification".to_string(),
             body: "Pick the target environment".to_string(),
             options: vec!["staging".to_string(), "production".to_string()],
             artifacts: vec!["docs/spec.md".to_string()],
             response: None,
+            waiting_started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
             resolved_at: None,
         }

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -553,6 +553,10 @@ mod tests {
             prompt: "Need input".to_string(),
             agent_name: "builder".to_string(),
             retry_attempt: None,
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
         state
@@ -790,6 +794,10 @@ mod tests {
             prompt: "Need input".to_string(),
             agent_name: "builder".to_string(),
             retry_attempt: Some(3),
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
 

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -19,13 +19,18 @@ use crate::agent::cancellation::{
     cancel_all, clear_issue_cancellation, new_cancellation_registry, register_issue_cancellation,
     CancellationRegistry,
 };
-use crate::agent::events::{AgentEvent, InteractionRequestDraft, WorkerEvent, WorkerResult};
+use crate::agent::events::{
+    AgentEvent, InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult,
+};
 use crate::agent::{AgentRunRequest, AgentRunner, InteractionResponseEnvelope};
 use crate::config::ensemble::EnsembleConfig;
 use crate::error::{AgentError, EnsembleError};
 use crate::history::model::{HistoryRecord, TokenTotals};
 use crate::history::writer::HistoryWriter;
-use crate::interaction::{InteractionKind, InteractionStatus, InteractionStore};
+use crate::interaction::{
+    InteractionKind, InteractionResponse, InteractionResumeStrategy, InteractionStatus,
+    InteractionStore,
+};
 use crate::observability::events::{EventBus, PipelineEvent};
 use crate::observability::events_contract::{
     elapsed_ms, ISSUE_DISPATCH_COMPLETED, ISSUE_DISPATCH_STARTED, ORCH_TICK_FINISHED,
@@ -885,7 +890,10 @@ impl Orchestrator {
         };
 
         match result {
-            WorkerResult::Success { runtime_verdict } => {
+            WorkerResult::Success {
+                runtime_verdict,
+                approval_request,
+            } => {
                 let config = self.config.read().await;
                 info!(
                     issue_id = %issue_id,
@@ -931,7 +939,7 @@ impl Orchestrator {
                 // Drive the pipeline
                 let pipeline_action = if let Some(run) = state.get_pipeline_run_mut(issue_id) {
                     Some((
-                        run.step_completed(step_name, resolved.verdict),
+                        run.step_completed(step_name, resolved.verdict, approval_request.is_some()),
                         state.get_pipeline_config(issue_id).cloned(),
                     ))
                 } else {
@@ -1125,6 +1133,47 @@ impl Orchestrator {
                             }
                         }
                         PipelineAction::BlockedOnHuman { .. } => {}
+                        PipelineAction::AwaitingApproval {
+                            step,
+                            approval_state,
+                        } => {
+                            drop(state);
+                            if let Err(error) = self
+                                .handle_post_step_approval(
+                                    issue_id,
+                                    &step,
+                                    approval_state,
+                                    approval_request.as_ref(),
+                                    issue_snapshot.as_ref(),
+                                )
+                                .await
+                            {
+                                warn!(
+                                    issue_id = %issue_id,
+                                    step = %step,
+                                    error = %error,
+                                    "failed to create post-step approval checkpoint"
+                                );
+
+                                let mut state = self.state.write().await;
+                                if let Some(run) = state.get_pipeline_run_mut(issue_id) {
+                                    run.step_failed(&step, error.to_string());
+                                }
+                                if let Some(entry) = state.remove_running(issue_id) {
+                                    state.add_runtime_seconds(&entry);
+                                    schedule_failure_retry(
+                                        &mut state,
+                                        issue_id,
+                                        &entry.identifier,
+                                        next_attempt(entry.retry_attempt),
+                                        config.agent.max_retry_backoff_ms,
+                                        config.max_cycles,
+                                        &error.to_string(),
+                                    );
+                                }
+                                state.remove_pipeline_run(issue_id);
+                            }
+                        }
                         PipelineAction::Waiting => {
                             let issue_waiting_on_human = state.is_waiting_on_human(issue_id);
                             let has_running_steps = state
@@ -1290,7 +1339,33 @@ impl Orchestrator {
             }
         };
 
-        let interaction = build_interaction_request(issue, interaction_context, request.clone());
+        let (waiting_started_at, waiting_input_tokens, waiting_output_tokens, waiting_total_tokens) = {
+            let state = self.state.read().await;
+            let running_entry = state.running.get(issue_id);
+            (
+                running_entry.map(|entry| entry.started_at),
+                running_entry
+                    .map(|entry| entry.agent_input_tokens)
+                    .unwrap_or(0),
+                running_entry
+                    .map(|entry| entry.agent_output_tokens)
+                    .unwrap_or(0),
+                running_entry
+                    .map(|entry| entry.agent_total_tokens)
+                    .unwrap_or(0),
+            )
+        };
+
+        let mut interaction = build_interaction_request(
+            issue,
+            interaction_context,
+            request.clone(),
+            InteractionResumeStrategy::RerunStep,
+        );
+        interaction.waiting_started_at = waiting_started_at;
+        interaction.agent_input_tokens = waiting_input_tokens;
+        interaction.agent_output_tokens = waiting_output_tokens;
+        interaction.agent_total_tokens = waiting_total_tokens;
         self.interaction_store.create(interaction.clone()).await?;
 
         let mut state = self.state.write().await;
@@ -1306,7 +1381,6 @@ impl Orchestrator {
             .running
             .get(issue_id)
             .and_then(|entry| entry.retry_attempt);
-
         if !has_running_steps {
             if let Some(entry) = state.remove_running(issue_id) {
                 state.add_runtime_seconds(&entry);
@@ -1321,6 +1395,178 @@ impl Orchestrator {
             prompt: interaction.body.clone(),
             agent_name: interaction.agent_name.clone(),
             retry_attempt,
+            started_at: waiting_started_at,
+            agent_input_tokens: waiting_input_tokens,
+            agent_output_tokens: waiting_output_tokens,
+            agent_total_tokens: waiting_total_tokens,
+            requested_at: interaction.requested_at,
+        });
+        drop(state);
+
+        self.publish_pipeline_event(
+            run_id,
+            sequence,
+            attempt,
+            PipelineEvent::InputRequested {
+                issue_identifier: issue.identifier.clone(),
+                timestamp: Utc::now(),
+                step_name: step_name.to_string(),
+                kind: interaction_kind_name(&interaction.kind).to_string(),
+                detail: interaction.title.clone(),
+            },
+        )
+        .await;
+
+        Ok(())
+    }
+
+    async fn handle_post_step_approval(
+        &self,
+        issue_id: &str,
+        step_name: &str,
+        approval_state: Option<String>,
+        approval_request: Option<&StepApprovalRequestDraft>,
+        issue_snapshot: Option<&Issue>,
+    ) -> Result<(), EnsembleError> {
+        let issue = issue_snapshot.ok_or_else(|| AgentError::PromptError {
+            reason: format!("missing running issue snapshot for approval-gated issue {issue_id}"),
+        })?;
+
+        let interaction_context = {
+            let state = self.state.read().await;
+            let config =
+                state
+                    .get_pipeline_config(issue_id)
+                    .ok_or_else(|| AgentError::PromptError {
+                        reason: format!("missing pipeline config for blocked issue {issue_id}"),
+                    })?;
+            let step = config
+                .steps
+                .iter()
+                .find(|step| step.name == step_name)
+                .ok_or_else(|| AgentError::PromptError {
+                    reason: format!("approval-gated step '{step_name}' no longer exists"),
+                })?;
+            let run = state
+                .get_pipeline_run(issue_id)
+                .ok_or_else(|| AgentError::PromptError {
+                    reason: format!("missing pipeline run for blocked issue {issue_id}"),
+                })?;
+            let completed_steps = config
+                .steps
+                .iter()
+                .filter(|candidate| {
+                    matches!(
+                        run.step_states.get(&candidate.name),
+                        Some(crate::pipeline::engine::StepState::Passed)
+                    )
+                })
+                .map(|candidate| candidate.name.clone())
+                .collect();
+            InteractionRequestContext {
+                step_name: step_name.to_string(),
+                agent_name: step.agent.clone(),
+                pipeline_cycle: run.cycle,
+                completed_steps,
+                step_depends: step.depends.clone().unwrap_or_default(),
+                step_tracker_state: step.tracker_state.clone(),
+            }
+        };
+
+        let request = approval_request
+            .cloned()
+            .unwrap_or_else(|| StepApprovalRequestDraft {
+                schema_version: 1,
+                title: format!("Approve step '{step_name}'"),
+                body: format!(
+                    "Step '{step_name}' completed successfully. Approve it to continue the pipeline."
+                ),
+                state: None,
+            });
+        let mirror_state = request.state.clone().or(approval_state);
+        let (waiting_started_at, waiting_input_tokens, waiting_output_tokens, waiting_total_tokens) = {
+            let state = self.state.read().await;
+            let running_entry = state.running.get(issue_id);
+            (
+                running_entry.map(|entry| entry.started_at),
+                running_entry
+                    .map(|entry| entry.agent_input_tokens)
+                    .unwrap_or(0),
+                running_entry
+                    .map(|entry| entry.agent_output_tokens)
+                    .unwrap_or(0),
+                running_entry
+                    .map(|entry| entry.agent_total_tokens)
+                    .unwrap_or(0),
+            )
+        };
+
+        let mut interaction = build_interaction_request(
+            issue,
+            interaction_context,
+            InteractionRequestDraft {
+                schema_version: request.schema_version,
+                kind: InteractionKind::ApprovalGate,
+                blocking: true,
+                title: request.title,
+                body: request.body,
+                options: vec!["approve".to_string(), "reject".to_string()],
+                artifacts: vec![],
+            },
+            InteractionResumeStrategy::AdvanceAfterStep,
+        );
+        interaction.waiting_started_at = waiting_started_at;
+        interaction.agent_input_tokens = waiting_input_tokens;
+        interaction.agent_output_tokens = waiting_output_tokens;
+        interaction.agent_total_tokens = waiting_total_tokens;
+        self.interaction_store.create(interaction.clone()).await?;
+
+        if let Some(state_name) = mirror_state {
+            if self.tracker.supports_writes() {
+                if let Err(error) = self.tracker.set_issue_state(issue_id, &state_name).await {
+                    warn!(
+                        issue_id = %issue_id,
+                        step = %step_name,
+                        tracker_state_to = %state_name,
+                        error = %error,
+                        "failed to set tracker state for approval checkpoint"
+                    );
+                }
+            }
+        }
+
+        let mut state = self.state.write().await;
+        let (run_id, sequence, attempt) = Self::run_context_for_issue(&mut state, issue_id);
+        if let Some(run) = state.get_pipeline_run_mut(issue_id) {
+            run.bind_approval_interaction(step_name, interaction.id.clone());
+        }
+        let has_running_steps = state
+            .get_pipeline_run(issue_id)
+            .is_some_and(Self::pipeline_has_running_steps);
+
+        let retry_attempt = state
+            .running
+            .get(issue_id)
+            .and_then(|entry| entry.retry_attempt);
+        if !has_running_steps {
+            if let Some(entry) = state.remove_running(issue_id) {
+                state.add_runtime_seconds(&entry);
+            }
+        }
+
+        state.add_waiting_on_human(WaitingOnHumanEntry {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            interaction_request_id: interaction.id.clone(),
+            step_name: step_name.to_string(),
+            kind: interaction.kind.clone(),
+            prompt: interaction.body.clone(),
+            agent_name: interaction.agent_name.clone(),
+            retry_attempt,
+            started_at: waiting_started_at,
+            agent_input_tokens: waiting_input_tokens,
+            agent_output_tokens: waiting_output_tokens,
+            agent_total_tokens: waiting_total_tokens,
             requested_at: interaction.requested_at,
         });
         drop(state);
@@ -1353,7 +1599,9 @@ impl Orchestrator {
 
         let mut state = self.state.write().await;
         for interaction in interactions {
-            if state.is_running(&interaction.issue_id) {
+            if state.is_running(&interaction.issue_id)
+                || state.is_waiting_on_human(&interaction.issue_id)
+            {
                 continue;
             }
 
@@ -1366,6 +1614,10 @@ impl Orchestrator {
                 prompt: interaction.body.clone(),
                 agent_name: interaction.agent_name.clone(),
                 retry_attempt: Some(interaction.pipeline_cycle.max(1)),
+                started_at: interaction.waiting_started_at,
+                agent_input_tokens: interaction.agent_input_tokens,
+                agent_output_tokens: interaction.agent_output_tokens,
+                agent_total_tokens: interaction.agent_total_tokens,
                 requested_at: interaction.requested_at,
             });
         }
@@ -1875,6 +2127,49 @@ impl Orchestrator {
         }
     }
 
+    fn build_history_record_from_waiting(
+        &self,
+        issue_id: &str,
+        outcome: &str,
+        last_error: Option<String>,
+        waiting_entry: &WaitingOnHumanEntry,
+        run: &PipelineRun,
+        completed_at: chrono::DateTime<Utc>,
+    ) -> HistoryRecord {
+        let steps_traversed = run.traversed_steps_in_order();
+        let started_at = waiting_entry
+            .started_at
+            .unwrap_or(waiting_entry.requested_at);
+        let duration_seconds = completed_at
+            .signed_duration_since(started_at)
+            .num_seconds()
+            .max(0) as u64;
+        let workspace_path = self
+            .workspace_mgr
+            .workspace_path(&waiting_entry.identifier)
+            .map(|path| path.display().to_string())
+            .unwrap_or_default();
+
+        HistoryRecord {
+            issue_identifier: waiting_entry.identifier.clone(),
+            issue_id: issue_id.to_string(),
+            outcome: outcome.to_string(),
+            steps_traversed,
+            attempts: waiting_entry.retry_attempt.unwrap_or(1),
+            tokens: TokenTotals {
+                input_tokens: waiting_entry.agent_input_tokens,
+                output_tokens: waiting_entry.agent_output_tokens,
+                total_tokens: waiting_entry.agent_total_tokens,
+            },
+            duration_seconds,
+            started_at,
+            completed_at,
+            last_error,
+            verdict: Self::history_verdict(run),
+            workspace_path,
+        }
+    }
+
     fn history_verdict(run: &PipelineRun) -> Option<String> {
         if run
             .step_states
@@ -1946,7 +2241,19 @@ impl Orchestrator {
                 crate::pipeline::engine::StepState::Passed,
             );
         }
-        pipeline_run.step_blocked_on_human(&interaction.step_name, interaction.id.clone());
+        match interaction.resume_strategy {
+            InteractionResumeStrategy::RerunStep => {
+                pipeline_run.step_blocked_on_human(&interaction.step_name, interaction.id.clone());
+            }
+            InteractionResumeStrategy::AdvanceAfterStep => {
+                pipeline_run.step_states.insert(
+                    interaction.step_name.clone(),
+                    crate::pipeline::engine::StepState::AwaitingApproval {
+                        interaction_request_id: Some(interaction.id.clone()),
+                    },
+                );
+            }
+        }
 
         let mut state = self.state.write().await;
         state.insert_pipeline_run(&issue.id, pipeline_run, config_snapshot);
@@ -1960,6 +2267,10 @@ impl Orchestrator {
                 prompt: interaction.body.clone(),
                 agent_name: interaction.agent_name.clone(),
                 retry_attempt: Some(interaction.pipeline_cycle.max(1)),
+                started_at: interaction.waiting_started_at,
+                agent_input_tokens: interaction.agent_input_tokens,
+                agent_output_tokens: interaction.agent_output_tokens,
+                agent_total_tokens: interaction.agent_total_tokens,
                 requested_at: interaction.requested_at,
             });
         }
@@ -2076,7 +2387,18 @@ impl Orchestrator {
                     .find_map(|(step_name, step_state)| match step_state {
                         crate::pipeline::engine::StepState::BlockedOnHuman {
                             interaction_request_id,
-                        } => Some((step_name.clone(), interaction_request_id.clone())),
+                        } if interaction.resume_strategy
+                            == InteractionResumeStrategy::RerunStep =>
+                        {
+                            Some((step_name.clone(), interaction_request_id.clone()))
+                        }
+                        crate::pipeline::engine::StepState::AwaitingApproval {
+                            interaction_request_id: Some(interaction_request_id),
+                        } if interaction.resume_strategy
+                            == InteractionResumeStrategy::AdvanceAfterStep =>
+                        {
+                            Some((step_name.clone(), interaction_request_id.clone()))
+                        }
                         _ => None,
                     })
                     .ok_or_else(|| AgentError::PromptError {
@@ -2137,66 +2459,292 @@ impl Orchestrator {
             }
         }
 
-        let response = interaction
-            .response
-            .clone()
-            .ok_or_else(|| AgentError::PromptError {
-                reason: format!(
-                    "resolved interaction '{}' is missing a response",
-                    interaction.id
-                ),
-            })?;
-        let resolved_at = interaction
-            .resolved_at
-            .ok_or_else(|| AgentError::PromptError {
-                reason: format!(
-                    "resolved interaction '{}' is missing resolved_at",
-                    interaction.id
-                ),
-            })?;
-        let interaction_response = InteractionResponseEnvelope::new(
-            interaction.schema_version,
-            interaction.id.clone(),
-            interaction.kind.clone(),
-            response,
-            resolved_at,
-        );
+        match interaction.resume_strategy {
+            InteractionResumeStrategy::RerunStep => {
+                let response =
+                    interaction
+                        .response
+                        .clone()
+                        .ok_or_else(|| AgentError::PromptError {
+                            reason: format!(
+                                "resolved interaction '{}' is missing a response",
+                                interaction.id
+                            ),
+                        })?;
+                let resolved_at =
+                    interaction
+                        .resolved_at
+                        .ok_or_else(|| AgentError::PromptError {
+                            reason: format!(
+                                "resolved interaction '{}' is missing resolved_at",
+                                interaction.id
+                            ),
+                        })?;
+                let interaction_response = InteractionResponseEnvelope::new(
+                    interaction.schema_version,
+                    interaction.id.clone(),
+                    interaction.kind.clone(),
+                    response,
+                    resolved_at,
+                );
 
-        let attempt = {
-            let mut state = self.state.write().await;
-            let attempt = state
-                .get_pipeline_run(&issue.id)
-                .map(|run| run.cycle)
-                .unwrap_or(interaction.pipeline_cycle.max(1));
-            state.add_running(issue, Some(attempt));
-            attempt
-        };
+                let attempt = {
+                    let mut state = self.state.write().await;
+                    let attempt = state
+                        .get_pipeline_run(&issue.id)
+                        .map(|run| run.cycle)
+                        .unwrap_or(interaction.pipeline_cycle.max(1));
+                    state.add_running(issue, Some(attempt));
+                    attempt
+                };
 
-        let workspace_path = match self.prepare_step_workspace(issue, &current_config).await {
-            Ok(path) => path,
-            Err(error) => {
-                let mut state = self.state.write().await;
-                state.remove_running(&issue.id);
-                return Err(AgentError::PromptError {
-                    reason: format!("workspace error: {error}"),
-                }
-                .into());
+                let workspace_path = match self.prepare_step_workspace(issue, &current_config).await
+                {
+                    Ok(path) => path,
+                    Err(error) => {
+                        let mut state = self.state.write().await;
+                        state.remove_running(&issue.id);
+                        return Err(AgentError::PromptError {
+                            reason: format!("workspace error: {error}"),
+                        }
+                        .into());
+                    }
+                };
+
+                self.dispatch_step(
+                    issue,
+                    Arc::clone(&current_config),
+                    StepDispatchContext {
+                        step_name: &current_step.name,
+                        agent_name: &current_step.agent,
+                        tracker_state: current_step.tracker_state.as_deref(),
+                        attempt: Some(attempt),
+                        interaction_response: Some(interaction_response),
+                        workspace_path,
+                    },
+                )
+                .await?;
             }
-        };
+            InteractionResumeStrategy::AdvanceAfterStep => {
+                let response =
+                    interaction
+                        .response
+                        .clone()
+                        .ok_or_else(|| AgentError::PromptError {
+                            reason: format!(
+                                "resolved interaction '{}' is missing a response",
+                                interaction.id
+                            ),
+                        })?;
 
-        self.dispatch_step(
-            issue,
-            Arc::clone(&current_config),
-            StepDispatchContext {
-                step_name: &current_step.name,
-                agent_name: &current_step.agent,
-                tracker_state: current_step.tracker_state.as_deref(),
-                attempt: Some(attempt),
-                interaction_response: Some(interaction_response),
-                workspace_path,
-            },
-        )
-        .await?;
+                let action = {
+                    let mut state = self.state.write().await;
+                    let run = state.get_pipeline_run_mut(&issue.id).ok_or_else(|| {
+                        AgentError::PromptError {
+                            reason: format!(
+                                "issue '{}' is missing a pipeline run during approval resume",
+                                issue.identifier
+                            ),
+                        }
+                    })?;
+
+                    match response {
+                        InteractionResponse::Approval {
+                            approved, reason, ..
+                        } => {
+                            if approved {
+                                run.approve_gate(&current_step.name)
+                            } else {
+                                run.reject_gate(
+                                    &current_step.name,
+                                    reason.unwrap_or_else(|| {
+                                        format!(
+                                            "approval rejected for step '{}'",
+                                            current_step.name
+                                        )
+                                    }),
+                                )
+                            }
+                        }
+                        _ => {
+                            return Err(AgentError::PromptError {
+                                reason: format!(
+                                    "approval gate '{}' resolved with a non-approval response",
+                                    interaction.id
+                                ),
+                            }
+                            .into())
+                        }
+                    }
+                };
+
+                match action {
+                    PipelineAction::Dispatch(requests) => {
+                        let attempt = {
+                            let mut state = self.state.write().await;
+                            let attempt = state
+                                .get_pipeline_run(&issue.id)
+                                .map(|run| run.cycle)
+                                .unwrap_or(interaction.pipeline_cycle.max(1));
+                            state.add_running(issue, Some(attempt));
+                            attempt
+                        };
+
+                        for req in requests {
+                            let workspace_path =
+                                match self.prepare_step_workspace(issue, &current_config).await {
+                                    Ok(path) => path,
+                                    Err(error) => {
+                                        let mut state = self.state.write().await;
+                                        state.remove_running(&issue.id);
+                                        state.release_claim(&issue.id);
+                                        state.remove_pipeline_run(&issue.id);
+                                        return Err(AgentError::PromptError {
+                                            reason: format!("workspace error: {error}"),
+                                        }
+                                        .into());
+                                    }
+                                };
+
+                            self.dispatch_step(
+                                issue,
+                                Arc::clone(&current_config),
+                                StepDispatchContext {
+                                    step_name: &req.step_name,
+                                    agent_name: &req.agent_name,
+                                    tracker_state: req.tracker_state.as_deref(),
+                                    attempt: Some(attempt),
+                                    interaction_response: None,
+                                    workspace_path,
+                                },
+                            )
+                            .await?;
+                        }
+                    }
+                    PipelineAction::Succeeded => {
+                        let finalize_state = self
+                            .run_finalize_phase(&issue.identifier, &current_config)
+                            .await;
+                        let completed_at = Utc::now();
+                        let (tracker_state, history_record, tracker_error_message) = {
+                            let mut state = self.state.write().await;
+                            let history_record =
+                                state.waiting_on_human.get(&issue.id).and_then(|entry| {
+                                    state.get_pipeline_run(&issue.id).map(|run| {
+                                        self.build_history_record_from_waiting(
+                                            &issue.id,
+                                            HISTORY_OUTCOME_SUCCEEDED,
+                                            None,
+                                            entry,
+                                            run,
+                                            completed_at,
+                                        )
+                                    })
+                                });
+
+                            if matches!(
+                                finalize_state.status,
+                                FinalizeStatus::Succeeded | FinalizeStatus::NotRequired
+                            ) {
+                                state.release_claim(&issue.id);
+                                state.remove_pipeline_run(&issue.id);
+                                state.completed.insert(issue.id.clone());
+                                state.clear_finalize_state(&issue.id);
+
+                                (
+                                    self.tracker
+                                        .supports_writes()
+                                        .then(|| current_config.on_success.clone()),
+                                    history_record,
+                                    "failed to set tracker success state after approval resume",
+                                )
+                            } else {
+                                let tracker_state = (self.tracker.supports_writes()
+                                    && matches!(
+                                        finalize_state.status,
+                                        FinalizeStatus::Failed | FinalizeStatus::SkippedHeadless
+                                    ))
+                                .then(|| current_config.on_failure.clone());
+
+                                state.set_finalize_state(&issue.id, finalize_state);
+                                state.remove_pipeline_run(&issue.id);
+
+                                (
+                                    tracker_state,
+                                    None,
+                                    "failed to set tracker failure state after approval finalize failure",
+                                )
+                            }
+                        };
+
+                        if let Some(tracker_state) = tracker_state {
+                            if let Err(error) = self
+                                .tracker
+                                .set_issue_state(&issue.id, &tracker_state)
+                                .await
+                            {
+                                warn!(
+                                    issue_id = %issue.id,
+                                    error = %error,
+                                    "{tracker_error_message}"
+                                );
+                            }
+                        }
+
+                        if let Some(record) = history_record {
+                            self.append_history_record(record).await;
+                        }
+                    }
+                    PipelineAction::Failed { reason, .. } => {
+                        let completed_at = Utc::now();
+                        let history_record = {
+                            let mut state = self.state.write().await;
+                            let history_record =
+                                state.waiting_on_human.get(&issue.id).and_then(|entry| {
+                                    state.get_pipeline_run(&issue.id).map(|run| {
+                                        self.build_history_record_from_waiting(
+                                            &issue.id,
+                                            HISTORY_OUTCOME_FAILED,
+                                            Some(reason.clone()),
+                                            entry,
+                                            run,
+                                            completed_at,
+                                        )
+                                    })
+                                });
+
+                            state.release_claim(&issue.id);
+                            state.remove_pipeline_run(&issue.id);
+                            state.completed.insert(issue.id.clone());
+                            state.clear_finalize_state(&issue.id);
+
+                            history_record
+                        };
+
+                        if self.tracker.supports_writes() {
+                            if let Err(error) = self
+                                .tracker
+                                .set_issue_state(&issue.id, &current_config.on_failure)
+                                .await
+                            {
+                                warn!(
+                                    issue_id = %issue.id,
+                                    error = %error,
+                                    "failed to set tracker failure state after approval rejection"
+                                );
+                            }
+                        }
+
+                        if let Some(record) = history_record {
+                            self.append_history_record(record).await;
+                        }
+                    }
+                    PipelineAction::Waiting
+                    | PipelineAction::BlockedOnHuman { .. }
+                    | PipelineAction::AwaitingApproval { .. } => {}
+                }
+            }
+        }
 
         self.interaction_store.mark_resumed(&interaction.id).await?;
 
@@ -2427,6 +2975,7 @@ fn build_interaction_request(
     issue: &Issue,
     context: InteractionRequestContext,
     request: InteractionRequestDraft,
+    resume_strategy: InteractionResumeStrategy,
 ) -> crate::interaction::InteractionRequest {
     let requested_at = Utc::now();
     crate::interaction::InteractionRequest {
@@ -2449,11 +2998,16 @@ fn build_interaction_request(
         status: InteractionStatus::Open,
         blocking: request.blocking,
         awaiting_resume: request.blocking,
+        resume_strategy,
         title: request.title,
         body: request.body,
         options: request.options,
         artifacts: request.artifacts,
         response: None,
+        waiting_started_at: None,
+        agent_input_tokens: 0,
+        agent_output_tokens: 0,
+        agent_total_tokens: 0,
         requested_at,
         resolved_at: None,
     }
@@ -2477,11 +3031,14 @@ fn interaction_kind_name(kind: &InteractionKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::events::{AgentEvent, InteractionRequestDraft, WorkerEvent, WorkerResult};
+    use crate::agent::events::{
+        AgentEvent, InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult,
+    };
     use crate::config::ensemble::parse_config;
     use crate::error::AgentError;
     use crate::interaction::{
-        InteractionKind, InteractionResponse, InteractionStatus, InteractionStore,
+        InteractionKind, InteractionResponse, InteractionResumeStrategy, InteractionStatus,
+        InteractionStore,
     };
     use crate::pipeline::verdict::Verdict;
     use crate::tracker::TrackerError;
@@ -2569,6 +3126,7 @@ mod tests {
             }
             Ok(WorkerResult::Success {
                 runtime_verdict: None,
+                approval_request: None,
             })
         }
     }
@@ -2579,6 +3137,103 @@ mod tests {
     impl AgentRunner for PanicRunner {
         async fn run(&self, _request: AgentRunRequest<'_>) -> Result<WorkerResult, AgentError> {
             panic!("boom");
+        }
+    }
+
+    struct RecordingTracker {
+        issues: Arc<RwLock<Vec<Issue>>>,
+        state_writes: Arc<RwLock<Vec<(String, String)>>>,
+    }
+
+    #[async_trait]
+    impl IssueTracker for RecordingTracker {
+        async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+            Ok(self.issues.read().await.clone())
+        }
+
+        async fn fetch_issues_by_states(
+            &self,
+            states: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            let issues = self.issues.read().await;
+            let states_lower: Vec<String> =
+                states.iter().map(|state| state.to_lowercase()).collect();
+            Ok(issues
+                .iter()
+                .filter(|issue| states_lower.contains(&issue.state.to_lowercase()))
+                .cloned()
+                .collect())
+        }
+
+        async fn fetch_issue_states_by_ids(
+            &self,
+            ids: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            let issues = self.issues.read().await;
+            Ok(issues
+                .iter()
+                .filter(|issue| ids.contains(&issue.id))
+                .cloned()
+                .collect())
+        }
+
+        fn supports_writes(&self) -> bool {
+            true
+        }
+
+        async fn set_issue_state(&self, id: &str, state: &str) -> Result<(), TrackerError> {
+            self.state_writes
+                .write()
+                .await
+                .push((id.to_string(), state.to_string()));
+            Ok(())
+        }
+    }
+
+    struct FailingWriteTracker {
+        issues: Arc<RwLock<Vec<Issue>>>,
+    }
+
+    #[async_trait]
+    impl IssueTracker for FailingWriteTracker {
+        async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+            Ok(self.issues.read().await.clone())
+        }
+
+        async fn fetch_issues_by_states(
+            &self,
+            states: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            let issues = self.issues.read().await;
+            let states_lower: Vec<String> =
+                states.iter().map(|state| state.to_lowercase()).collect();
+            Ok(issues
+                .iter()
+                .filter(|issue| states_lower.contains(&issue.state.to_lowercase()))
+                .cloned()
+                .collect())
+        }
+
+        async fn fetch_issue_states_by_ids(
+            &self,
+            ids: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            let issues = self.issues.read().await;
+            Ok(issues
+                .iter()
+                .filter(|issue| ids.contains(&issue.id))
+                .cloned()
+                .collect())
+        }
+
+        fn supports_writes(&self) -> bool {
+            true
+        }
+
+        async fn set_issue_state(&self, _id: &str, _state: &str) -> Result<(), TrackerError> {
+            Err(TrackerError::ApiRequestFailed {
+                reason: "simulated tracker write failure".to_string(),
+            })
         }
     }
 
@@ -2658,6 +3313,134 @@ agent:
   session_mode: code
 "#;
         parse_config(yaml).unwrap()
+    }
+
+    fn make_when_requested_approval_config() -> EnsembleConfig {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress", "Plan Review"]
+  terminal_states: ["Done", "Closed", "Failed"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{ issue.identifier }}."
+steps:
+  - name: build
+    agent: builder
+    approval:
+      mode: when_requested_by_agent
+  - name: review
+    agent: builder
+    depends: ["build"]
+max_cycles: 10
+on_success: Done
+on_failure: Failed
+concurrency:
+  max_concurrent_agents: 5
+polling:
+  interval_ms: 100
+workspace:
+  root: /tmp/ensemble-test
+agent:
+  max_turns: 3
+  command: "echo test"
+  session_mode: code
+"#;
+        parse_config(yaml).unwrap()
+    }
+
+    fn make_always_approval_config(max_cycles: u32) -> EnsembleConfig {
+        let yaml = format!(
+            r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress", "Plan Review"]
+  terminal_states: ["Done", "Closed", "Failed"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{{{ issue.identifier }}}}."
+steps:
+  - name: build
+    agent: builder
+    approval:
+      mode: always
+      state: Plan Review
+  - name: review
+    agent: builder
+    depends: ["build"]
+max_cycles: {max_cycles}
+on_success: Done
+on_failure: Failed
+concurrency:
+  max_concurrent_agents: 5
+polling:
+  interval_ms: 100
+workspace:
+  root: /tmp/ensemble-test
+agent:
+  max_turns: 3
+  command: "echo test"
+  session_mode: code
+"#
+        );
+        parse_config(&yaml).unwrap()
+    }
+
+    fn make_single_step_always_approval_config(max_cycles: u32) -> EnsembleConfig {
+        let yaml = format!(
+            r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress", "Plan Review"]
+  terminal_states: ["Done", "Closed", "Failed"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{{{ issue.identifier }}}}."
+steps:
+  - name: build
+    agent: builder
+    approval:
+      mode: always
+      state: Plan Review
+max_cycles: {max_cycles}
+on_success: Done
+on_failure: Failed
+concurrency:
+  max_concurrent_agents: 5
+polling:
+  interval_ms: 100
+workspace:
+  root: /tmp/ensemble-test
+agent:
+  max_turns: 3
+  command: "echo test"
+  session_mode: code
+"#
+        );
+        parse_config(&yaml).unwrap()
+    }
+
+    async fn write_raw_interaction(
+        config_dir: &std::path::Path,
+        interaction_id: &str,
+        payload: serde_json::Value,
+    ) {
+        let store = InteractionStore::new(config_dir.to_path_buf());
+        let path = store
+            .interactions_dir()
+            .join(format!("{interaction_id}.json"));
+        tokio::fs::create_dir_all(path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(path, serde_json::to_vec_pretty(&payload).unwrap())
+            .await
+            .unwrap();
     }
 
     #[test]
@@ -2784,6 +3567,7 @@ agent:
                 "build",
                 WorkerResult::Success {
                     runtime_verdict: None,
+                    approval_request: None,
                 },
             )
             .await;
@@ -2850,6 +3634,7 @@ agent:
                 "build",
                 WorkerResult::Success {
                     runtime_verdict: Some(serde_json::json!({"verdict":"approve"})),
+                    approval_request: None,
                 },
             )
             .await;
@@ -2913,6 +3698,7 @@ agent:
                 "build",
                 WorkerResult::Success {
                     runtime_verdict: None,
+                    approval_request: None,
                 },
             )
             .await;
@@ -2965,6 +3751,7 @@ agent:
                 "build",
                 WorkerResult::Success {
                     runtime_verdict: None,
+                    approval_request: None,
                 },
             )
             .await;
@@ -3760,6 +4547,578 @@ agent:
     }
 
     #[tokio::test]
+    async fn worker_success_with_approval_request_creates_approval_gate_interaction() {
+        let config = Arc::new(RwLock::new(make_when_requested_approval_config()));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker_writes = Arc::new(RwLock::new(Vec::new()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(RecordingTracker {
+            issues,
+            state_writes: tracker_writes.clone(),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let workspace_dir = tempfile::TempDir::new().unwrap();
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(workspace_dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config.clone(),
+            tracker,
+            runner,
+            workspace_mgr,
+            config_dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    runtime_verdict: None,
+                    approval_request: Some(StepApprovalRequestDraft {
+                        schema_version: 1,
+                        title: "Approve plan".to_string(),
+                        body: "Please review the generated plan.".to_string(),
+                        state: Some("Plan Review".to_string()),
+                    }),
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.is_running("1"));
+        let waiting = state
+            .waiting_on_human
+            .get("1")
+            .expect("approval gate should block the issue");
+        let interaction_request_id = waiting.interaction_request_id.clone();
+        assert_eq!(waiting.kind, InteractionKind::ApprovalGate);
+        let run = state
+            .get_pipeline_run("1")
+            .expect("pipeline run should remain active while awaiting approval");
+        assert!(matches!(
+            run.step_states.get("build"),
+            Some(crate::pipeline::engine::StepState::AwaitingApproval {
+                interaction_request_id: Some(_),
+            })
+        ));
+        assert_eq!(
+            run.step_states.get("review"),
+            Some(&crate::pipeline::engine::StepState::Pending)
+        );
+        drop(state);
+
+        let store = InteractionStore::new(config_dir.path().to_path_buf());
+        let interaction = store
+            .get(&interaction_request_id)
+            .await
+            .unwrap()
+            .expect("approval interaction should be persisted");
+        assert_eq!(interaction.kind, InteractionKind::ApprovalGate);
+        assert_eq!(interaction.title, "Approve plan");
+        assert_eq!(interaction.body, "Please review the generated plan.");
+        assert_eq!(
+            tracker_writes.read().await.as_slice(),
+            &[("1".to_string(), "Plan Review".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn resolved_approval_gate_resumes_into_next_step_without_rerunning_current_step() {
+        let config = Arc::new(RwLock::new(make_always_approval_config(10)));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(config_dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            config_dir.path(),
+            shutdown_rx,
+        );
+
+        write_raw_interaction(
+            config_dir.path(),
+            "approval-1",
+            serde_json::json!({
+                "id": "approval-1",
+                "schema_version": 1,
+                "issue_id": "1",
+                "issue_identifier": "repo#1",
+                "pipeline_cycle": 1,
+                "completed_steps": [],
+                "step_name": "build",
+                "agent_name": "builder",
+                "step_depends": [],
+                "step_tracker_state": null,
+                "kind": "approval_gate",
+                "status": "resolved",
+                "blocking": true,
+                "awaiting_resume": true,
+                "resume_strategy": "advance_after_step",
+                "title": "Approve build",
+                "body": "Please review the build output.",
+                "options": [],
+                "artifacts": [],
+                "response": {
+                    "kind": "approval",
+                    "response_schema_version": 1,
+                    "approved": true,
+                    "reason": "looks good"
+                },
+                "requested_at": Utc::now(),
+                "resolved_at": Utc::now(),
+            }),
+        )
+        .await;
+
+        orchestrator
+            .resume_blocked_issue(&test_issue("1", "Todo"))
+            .await
+            .expect("approval gate resume should succeed");
+
+        let state = orchestrator.state.read().await;
+        assert!(state.is_running("1"));
+        assert!(!state.is_waiting_on_human("1"));
+        let run = state
+            .get_pipeline_run("1")
+            .expect("pipeline run should be reconstructed");
+        assert_eq!(
+            run.step_states.get("build"),
+            Some(&crate::pipeline::engine::StepState::Passed)
+        );
+        assert!(matches!(
+            run.step_states.get("review"),
+            Some(crate::pipeline::engine::StepState::Running { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejected_approval_gate_marks_issue_failed() {
+        let config = Arc::new(RwLock::new(make_always_approval_config(1)));
+        let tracker_writes = Arc::new(RwLock::new(Vec::new()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(RecordingTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+            state_writes: tracker_writes.clone(),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(config_dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            config_dir.path(),
+            shutdown_rx,
+        );
+
+        write_raw_interaction(
+            config_dir.path(),
+            "approval-1",
+            serde_json::json!({
+                "id": "approval-1",
+                "schema_version": 1,
+                "issue_id": "1",
+                "issue_identifier": "repo#1",
+                "pipeline_cycle": 1,
+                "completed_steps": [],
+                "step_name": "build",
+                "agent_name": "builder",
+                "step_depends": [],
+                "step_tracker_state": null,
+                "kind": "approval_gate",
+                "status": "resolved",
+                "blocking": true,
+                "awaiting_resume": true,
+                "resume_strategy": "advance_after_step",
+                "title": "Approve build",
+                "body": "Please review the build output.",
+                "options": [],
+                "artifacts": [],
+                "response": {
+                    "kind": "approval",
+                    "response_schema_version": 1,
+                    "approved": false,
+                    "reason": "needs more work"
+                },
+                "requested_at": Utc::now(),
+                "resolved_at": Utc::now(),
+            }),
+        )
+        .await;
+
+        orchestrator
+            .resume_blocked_issue(&test_issue("1", "Todo"))
+            .await
+            .expect("rejected approval gate should resolve into failure");
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.is_running("1"));
+        assert!(!state.is_waiting_on_human("1"));
+        assert!(!state.is_claimed("1"));
+        assert!(!state.retry_attempts.contains_key("1"));
+        assert!(state.get_pipeline_run("1").is_none());
+        drop(state);
+
+        assert_eq!(
+            tracker_writes.read().await.as_slice(),
+            &[("1".to_string(), "Failed".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_approval_gate_is_marked_terminal_locally_when_tracker_failure_write_fails() {
+        let config = Arc::new(RwLock::new(make_always_approval_config(1)));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(FailingWriteTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(config_dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            config_dir.path(),
+            shutdown_rx,
+        );
+
+        write_raw_interaction(
+            config_dir.path(),
+            "approval-1",
+            serde_json::json!({
+                "id": "approval-1",
+                "schema_version": 1,
+                "issue_id": "1",
+                "issue_identifier": "repo#1",
+                "pipeline_cycle": 1,
+                "completed_steps": [],
+                "step_name": "build",
+                "agent_name": "builder",
+                "step_depends": [],
+                "step_tracker_state": null,
+                "kind": "approval_gate",
+                "status": "resolved",
+                "blocking": true,
+                "awaiting_resume": true,
+                "resume_strategy": "advance_after_step",
+                "title": "Approve build",
+                "body": "Please review the build output.",
+                "options": [],
+                "artifacts": [],
+                "response": {
+                    "kind": "approval",
+                    "response_schema_version": 1,
+                    "approved": false,
+                    "reason": "needs more work"
+                },
+                "requested_at": Utc::now(),
+                "resolved_at": Utc::now(),
+            }),
+        )
+        .await;
+
+        orchestrator
+            .resume_blocked_issue(&test_issue("1", "Todo"))
+            .await
+            .expect("rejected approval gate should still resolve locally");
+
+        let state = orchestrator.state.read().await;
+        assert!(state.completed.contains("1"));
+        assert!(!state.is_claimed("1"));
+        assert!(state.get_pipeline_run("1").is_none());
+    }
+
+    #[tokio::test]
+    async fn approved_final_step_gate_appends_history_record() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut raw_config = make_single_step_always_approval_config(10);
+        raw_config.workspace.root = Some(dir.path().display().to_string());
+        let config = Arc::new(RwLock::new(raw_config));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        write_raw_interaction(
+            dir.path(),
+            "approval-1",
+            serde_json::json!({
+                "id": "approval-1",
+                "schema_version": 1,
+                "issue_id": "1",
+                "issue_identifier": "repo#1",
+                "pipeline_cycle": 1,
+                "completed_steps": [],
+                "step_name": "build",
+                "agent_name": "builder",
+                "step_depends": [],
+                "step_tracker_state": null,
+                "kind": "approval_gate",
+                "status": "resolved",
+                "blocking": true,
+                "awaiting_resume": true,
+                "resume_strategy": "advance_after_step",
+                "title": "Approve build",
+                "body": "Please review the build output.",
+                "options": [],
+                "artifacts": [],
+                "response": {
+                    "kind": "approval",
+                    "response_schema_version": 1,
+                    "approved": true,
+                    "reason": "looks good"
+                },
+                "requested_at": Utc::now(),
+                "resolved_at": Utc::now(),
+            }),
+        )
+        .await;
+
+        orchestrator
+            .resume_blocked_issue(&test_issue("1", "Todo"))
+            .await
+            .expect("approval gate resume should succeed");
+
+        let contents = tokio::fs::read_to_string(dir.path().join("ensemble_history.jsonl"))
+            .await
+            .expect("history should be written");
+        let record = contents
+            .lines()
+            .map(|line| serde_json::from_str::<crate::history::model::HistoryRecord>(line).unwrap())
+            .next()
+            .expect("history record");
+
+        assert_eq!(record.issue_id, "1");
+        assert_eq!(record.outcome, "succeeded");
+        assert_eq!(record.verdict.as_deref(), Some("approved"));
+    }
+
+    #[tokio::test]
+    async fn rejected_final_step_gate_appends_history_record() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut raw_config = make_single_step_always_approval_config(1);
+        raw_config.workspace.root = Some(dir.path().display().to_string());
+        let config = Arc::new(RwLock::new(raw_config));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        write_raw_interaction(
+            dir.path(),
+            "approval-1",
+            serde_json::json!({
+                "id": "approval-1",
+                "schema_version": 1,
+                "issue_id": "1",
+                "issue_identifier": "repo#1",
+                "pipeline_cycle": 1,
+                "completed_steps": [],
+                "step_name": "build",
+                "agent_name": "builder",
+                "step_depends": [],
+                "step_tracker_state": null,
+                "kind": "approval_gate",
+                "status": "resolved",
+                "blocking": true,
+                "awaiting_resume": true,
+                "resume_strategy": "advance_after_step",
+                "title": "Approve build",
+                "body": "Please review the build output.",
+                "options": [],
+                "artifacts": [],
+                "response": {
+                    "kind": "approval",
+                    "response_schema_version": 1,
+                    "approved": false,
+                    "reason": "needs more work"
+                },
+                "requested_at": Utc::now(),
+                "resolved_at": Utc::now(),
+            }),
+        )
+        .await;
+
+        orchestrator
+            .resume_blocked_issue(&test_issue("1", "Todo"))
+            .await
+            .expect("rejected approval gate should resolve into failure");
+
+        let contents = tokio::fs::read_to_string(dir.path().join("ensemble_history.jsonl"))
+            .await
+            .expect("history should be written");
+        let record = contents
+            .lines()
+            .map(|line| serde_json::from_str::<crate::history::model::HistoryRecord>(line).unwrap())
+            .next()
+            .expect("history record");
+
+        assert_eq!(record.issue_id, "1");
+        assert_eq!(record.outcome, "failed");
+        assert_eq!(record.last_error.as_deref(), Some("needs more work"));
+        assert_eq!(record.verdict.as_deref(), Some("rejected"));
+    }
+
+    #[tokio::test]
+    async fn approved_final_step_gate_after_restart_uses_persisted_waiting_metadata_for_history() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut raw_config = make_single_step_always_approval_config(10);
+        raw_config.workspace.root = Some(dir.path().display().to_string());
+        let config = Arc::new(RwLock::new(raw_config));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        let requested_at = Utc::now();
+        let waiting_started_at = requested_at - chrono::Duration::minutes(3);
+        write_raw_interaction(
+            dir.path(),
+            "approval-1",
+            serde_json::json!({
+                "id": "approval-1",
+                "schema_version": 1,
+                "issue_id": "1",
+                "issue_identifier": "repo#1",
+                "pipeline_cycle": 1,
+                "completed_steps": [],
+                "step_name": "build",
+                "agent_name": "builder",
+                "step_depends": [],
+                "step_tracker_state": null,
+                "kind": "approval_gate",
+                "status": "resolved",
+                "blocking": true,
+                "awaiting_resume": true,
+                "resume_strategy": "advance_after_step",
+                "title": "Approve build",
+                "body": "Please review the build output.",
+                "options": [],
+                "artifacts": [],
+                "response": {
+                    "kind": "approval",
+                    "response_schema_version": 1,
+                    "approved": true,
+                    "reason": "looks good"
+                },
+                "waiting_started_at": waiting_started_at,
+                "agent_input_tokens": 123,
+                "agent_output_tokens": 45,
+                "agent_total_tokens": 168,
+                "requested_at": requested_at,
+                "resolved_at": Utc::now(),
+            }),
+        )
+        .await;
+
+        orchestrator
+            .resume_blocked_issue(&test_issue("1", "Todo"))
+            .await
+            .expect("approval gate resume should succeed after restart");
+
+        let contents = tokio::fs::read_to_string(dir.path().join("ensemble_history.jsonl"))
+            .await
+            .expect("history should be written");
+        let record = contents
+            .lines()
+            .map(|line| serde_json::from_str::<crate::history::model::HistoryRecord>(line).unwrap())
+            .next()
+            .expect("history record");
+
+        assert_eq!(record.started_at, waiting_started_at);
+        assert_eq!(record.tokens.input_tokens, 123);
+        assert_eq!(record.tokens.output_tokens, 45);
+        assert_eq!(record.tokens.total_tokens, 168);
+    }
+
+    #[tokio::test]
     async fn blocked_step_keeps_running_state_while_parallel_sibling_is_still_running() {
         let config = Arc::new(RwLock::new(make_parallel_resume_config()));
         let issues = Arc::new(RwLock::new(vec![]));
@@ -3855,7 +5214,7 @@ agent:
             let dag = build_dag(&cfg.steps).unwrap();
             let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
             pipeline_run.start();
-            pipeline_run.step_completed("build", Verdict::Approve);
+            pipeline_run.step_completed("build", Verdict::Approve, false);
             pipeline_run.step_blocked_on_human("review", "interaction-1".to_string());
             pipeline_run.mark_running("docs", "session-docs".to_string());
 
@@ -3870,6 +5229,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
             state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
@@ -3881,6 +5244,7 @@ agent:
                 "docs",
                 WorkerResult::Success {
                     runtime_verdict: None,
+                    approval_request: None,
                 },
             )
             .await;
@@ -3932,6 +5296,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
             "interaction-1".to_string()
@@ -3954,11 +5322,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -4030,6 +5403,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
             state.queue_resume("1");
@@ -4053,6 +5430,7 @@ agent:
                 status: InteractionStatus::Resolved,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
@@ -4062,6 +5440,10 @@ agent:
                     text: "Use staging".to_string(),
                     selected_option: Some("staging".to_string()),
                 }),
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: Some(Utc::now()),
             })
@@ -4129,11 +5511,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -4159,6 +5546,102 @@ agent:
         let state = orchestrator.state.read().await;
         assert!(state.is_running("1"));
         assert!(!state.is_waiting_on_human("1"));
+    }
+
+    #[tokio::test]
+    async fn hydrate_waiting_on_human_preserves_existing_metadata() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        let requested_at = Utc::now();
+        let started_at = requested_at - chrono::Duration::minutes(5);
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_waiting_on_human(crate::orchestrator::state::WaitingOnHumanEntry {
+                issue_id: "1".to_string(),
+                identifier: "repo#1".to_string(),
+                interaction_request_id: "interaction-1".to_string(),
+                step_name: "build".to_string(),
+                kind: crate::interaction::model::InteractionKind::ApprovalGate,
+                prompt: "Approve build".to_string(),
+                agent_name: "builder".to_string(),
+                retry_attempt: Some(2),
+                started_at: Some(started_at),
+                agent_input_tokens: 123,
+                agent_output_tokens: 45,
+                agent_total_tokens: 168,
+                requested_at,
+            });
+        }
+
+        let store = InteractionStore::new(dir.path().to_path_buf());
+        store
+            .create(crate::interaction::InteractionRequest {
+                id: "interaction-1".to_string(),
+                schema_version: 1,
+                issue_id: "1".to_string(),
+                issue_identifier: "repo#1".to_string(),
+                pipeline_cycle: 2,
+                completed_steps: vec![],
+                step_name: "build".to_string(),
+                agent_name: "builder".to_string(),
+                step_depends: vec![],
+                step_tracker_state: None,
+                kind: InteractionKind::ApprovalGate,
+                status: InteractionStatus::Resolved,
+                blocking: true,
+                awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::AdvanceAfterStep,
+                title: "Approve build".to_string(),
+                body: "Please review the build output.".to_string(),
+                options: vec!["approve".to_string(), "reject".to_string()],
+                artifacts: vec![],
+                response: Some(InteractionResponse::Approval {
+                    response_schema_version: 1,
+                    approved: true,
+                    reason: Some("looks good".to_string()),
+                }),
+                waiting_started_at: Some(started_at),
+                agent_input_tokens: 123,
+                agent_output_tokens: 45,
+                agent_total_tokens: 168,
+                requested_at,
+                resolved_at: Some(Utc::now()),
+            })
+            .await
+            .unwrap();
+
+        orchestrator.hydrate_waiting_on_human_from_store().await;
+
+        let state = orchestrator.state.read().await;
+        let entry = state
+            .waiting_on_human
+            .get("1")
+            .expect("waiting entry should still exist");
+        assert_eq!(entry.started_at, Some(started_at));
+        assert_eq!(entry.agent_input_tokens, 123);
+        assert_eq!(entry.agent_output_tokens, 45);
+        assert_eq!(entry.agent_total_tokens, 168);
+        assert_eq!(entry.retry_attempt, Some(2));
     }
 
     #[tokio::test]
@@ -4201,11 +5684,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -4280,11 +5768,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -4366,6 +5859,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
         }
@@ -4387,11 +5884,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -4463,6 +5965,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: Some(1),
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
         }
@@ -4484,11 +5990,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -4562,6 +6073,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
         }
@@ -4583,11 +6098,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -4659,6 +6179,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
         }
@@ -4685,11 +6209,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -4766,6 +6295,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
         }
@@ -4929,6 +6462,7 @@ agent:
                 "build",
                 WorkerResult::Success {
                     runtime_verdict: None,
+                    approval_request: None,
                 },
             )
             .await;
@@ -4981,6 +6515,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
         }
@@ -5002,11 +6540,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -5065,11 +6608,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -5134,6 +6682,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: Some(1),
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
         }
@@ -5155,11 +6707,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })
@@ -5226,6 +6783,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: Some(1),
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
         }
@@ -5281,6 +6842,10 @@ agent:
                 prompt: "Need input".to_string(),
                 agent_name: "builder".to_string(),
                 retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
             });
         }
@@ -5302,11 +6867,16 @@ agent:
                 status: InteractionStatus::Open,
                 blocking: true,
                 awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
                 title: "Need input".to_string(),
                 body: "Choose environment".to_string(),
                 options: vec![],
                 artifacts: vec![],
                 response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
                 requested_at: Utc::now(),
                 resolved_at: None,
             })

--- a/crates/ensemble-core/src/orchestrator/scheduler.rs
+++ b/crates/ensemble-core/src/orchestrator/scheduler.rs
@@ -236,6 +236,10 @@ mod tests {
             prompt: "Need input".to_string(),
             agent_name: "builder".to_string(),
             retry_attempt: None,
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
 

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -20,6 +20,14 @@ pub struct WaitingOnHumanEntry {
     pub prompt: String,
     pub agent_name: String,
     pub retry_attempt: Option<u32>,
+    #[serde(default)]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub agent_input_tokens: u64,
+    #[serde(default)]
+    pub agent_output_tokens: u64,
+    #[serde(default)]
+    pub agent_total_tokens: u64,
     pub requested_at: DateTime<Utc>,
 }
 
@@ -535,6 +543,10 @@ mod tests {
             prompt: "Need input".to_string(),
             agent_name: "builder".to_string(),
             retry_attempt: None,
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
 
@@ -565,6 +577,10 @@ mod tests {
             prompt: "Need input".to_string(),
             agent_name: "builder".to_string(),
             retry_attempt: None,
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
         state.queue_resume("1");

--- a/crates/ensemble-core/src/pipeline/dag.rs
+++ b/crates/ensemble-core/src/pipeline/dag.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::config::ensemble::StepConfig;
+use crate::config::ensemble::{StepApprovalConfig, StepConfig};
 use crate::error::PipelineError;
 
 /// A single step in the resolved DAG, with its explicit dependency list.
@@ -9,6 +9,7 @@ pub struct DagStep {
     pub name: String,
     pub agent: String,
     pub tracker_state: Option<String>,
+    pub approval: Option<StepApprovalConfig>,
     pub depends: Vec<String>,
 }
 
@@ -71,6 +72,7 @@ pub fn build_dag(steps: &[StepConfig]) -> Result<StepDag, PipelineError> {
             name: step.name.clone(),
             agent: step.agent.clone(),
             tracker_state: step.tracker_state.clone(),
+            approval: step.approval.clone(),
             depends: deps,
         });
     }
@@ -158,6 +160,7 @@ mod tests {
             agent: agent.to_string(),
             depends: deps,
             tracker_state: None,
+            approval: None,
         }
     }
 
@@ -167,6 +170,7 @@ mod tests {
             agent: agent.to_string(),
             depends: Some(vec![]), // explicit root
             tracker_state: None,
+            approval: None,
         }
     }
 
@@ -307,5 +311,32 @@ mod tests {
         assert!(roots.contains(&"lint"));
         assert!(roots.contains(&"build"));
         assert!(!roots.contains(&"test"));
+    }
+
+    #[test]
+    fn preserves_step_approval_metadata() {
+        let steps = vec![StepConfig {
+            name: "plan".to_string(),
+            agent: "planner".to_string(),
+            depends: None,
+            tracker_state: Some("Planning".to_string()),
+            approval: Some(StepApprovalConfig {
+                mode: crate::config::ensemble::StepApprovalMode::WhenRequestedByAgent,
+                state: Some("Plan Review".to_string()),
+            }),
+        }];
+
+        let dag = build_dag(&steps).unwrap();
+        let plan = dag.steps.iter().find(|s| s.name == "plan").unwrap();
+
+        let approval = plan
+            .approval
+            .as_ref()
+            .expect("approval metadata should be preserved");
+        assert_eq!(
+            approval.mode,
+            crate::config::ensemble::StepApprovalMode::WhenRequestedByAgent
+        );
+        assert_eq!(approval.state.as_deref(), Some("Plan Review"));
     }
 }

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -12,6 +12,11 @@ pub enum StepState {
     Running { session_id: String },
     /// Step is waiting for a human interaction response before it can resume.
     BlockedOnHuman { interaction_request_id: String },
+    /// Step is waiting for approval on a completed result before downstream
+    /// work can continue.
+    AwaitingApproval {
+        interaction_request_id: Option<String>,
+    },
     /// Step completed and was approved.
     Passed,
     /// Step completed but was rejected by a review agent.
@@ -51,6 +56,12 @@ pub enum PipelineAction {
     BlockedOnHuman {
         step: String,
         interaction_request_id: String,
+    },
+    /// A step has completed but is waiting for approval before downstream
+    /// steps may be dispatched.
+    AwaitingApproval {
+        step: String,
+        approval_state: Option<String>,
     },
     /// All steps have passed — pipeline completed successfully.
     Succeeded,
@@ -108,19 +119,40 @@ impl PipelineRun {
 
     /// Handle a completed step verdict.
     ///
-    /// - [`Verdict::Approve`] → marks the step as [`StepState::Passed`] and
-    ///   checks whether all steps are done or if new steps can be dispatched.
+    /// - [`Verdict::Approve`] → either transitions to
+    ///   [`PipelineAction::AwaitingApproval`] for approval-gated steps, or
+    ///   marks the step as [`StepState::Passed`] and checks whether all steps
+    ///   are done or if new steps can be dispatched.
     /// - [`Verdict::Reject`] → marks the step as [`StepState::Rejected`] and
     ///   returns [`PipelineAction::Failed`].
-    pub fn step_completed(&mut self, step_name: &str, verdict: Verdict) -> PipelineAction {
+    pub fn step_completed(
+        &mut self,
+        step_name: &str,
+        verdict: Verdict,
+        approval_requested: bool,
+    ) -> PipelineAction {
         match verdict {
             Verdict::Approve => {
-                self.step_states
-                    .insert(step_name.to_string(), StepState::Passed);
-                if self.all_passed() {
-                    PipelineAction::Succeeded
+                if self.should_gate_approval(step_name, approval_requested) {
+                    let approval_state = self.approval_state_for(step_name);
+                    self.step_states.insert(
+                        step_name.to_string(),
+                        StepState::AwaitingApproval {
+                            interaction_request_id: None,
+                        },
+                    );
+                    PipelineAction::AwaitingApproval {
+                        step: step_name.to_string(),
+                        approval_state,
+                    }
                 } else {
-                    self.find_dispatchable()
+                    self.step_states
+                        .insert(step_name.to_string(), StepState::Passed);
+                    if self.all_passed() {
+                        PipelineAction::Succeeded
+                    } else {
+                        self.find_dispatchable()
+                    }
                 }
             }
             Verdict::Reject { summary } => {
@@ -135,6 +167,64 @@ impl PipelineRun {
                     reason: summary,
                 }
             }
+        }
+    }
+
+    /// Bind an approval interaction request to a step that is awaiting
+    /// approval.
+    pub fn bind_approval_interaction(
+        &mut self,
+        step_name: &str,
+        interaction_request_id: String,
+    ) -> PipelineAction {
+        if let Some(StepState::AwaitingApproval {
+            interaction_request_id: current_request_id,
+        }) = self.step_states.get_mut(step_name)
+        {
+            if current_request_id.is_none() {
+                *current_request_id = Some(interaction_request_id);
+            }
+        }
+        PipelineAction::Waiting
+    }
+
+    /// Mark an approval gate as approved, transitioning the step to `Passed`
+    /// without re-running it and dispatching any downstream steps.
+    pub fn approve_gate(&mut self, step_name: &str) -> PipelineAction {
+        if !matches!(
+            self.step_states.get(step_name),
+            Some(StepState::AwaitingApproval { .. })
+        ) {
+            return PipelineAction::Waiting;
+        }
+
+        self.step_states
+            .insert(step_name.to_string(), StepState::Passed);
+        if self.all_passed() {
+            PipelineAction::Succeeded
+        } else {
+            self.find_dispatchable()
+        }
+    }
+
+    /// Mark an approval gate as rejected, halting the pipeline.
+    pub fn reject_gate(&mut self, step_name: &str, reason: String) -> PipelineAction {
+        if !matches!(
+            self.step_states.get(step_name),
+            Some(StepState::AwaitingApproval { .. })
+        ) {
+            return PipelineAction::Waiting;
+        }
+
+        self.step_states.insert(
+            step_name.to_string(),
+            StepState::Rejected {
+                summary: reason.clone(),
+            },
+        );
+        PipelineAction::Failed {
+            step: step_name.to_string(),
+            reason,
         }
     }
 
@@ -194,6 +284,34 @@ impl PipelineRun {
             .all(|s| self.step_states.get(&s.name) == Some(&StepState::Passed))
     }
 
+    fn should_gate_approval(&self, step_name: &str, approval_requested: bool) -> bool {
+        matches!(
+            self.dag
+                .steps
+                .iter()
+                .find(|step| step.name == step_name)
+                .and_then(|step| step.approval.as_ref().map(|approval| approval.mode)),
+            Some(crate::config::ensemble::StepApprovalMode::Always)
+        ) || (approval_requested
+            && matches!(
+                self.dag
+                    .steps
+                    .iter()
+                    .find(|step| step.name == step_name)
+                    .and_then(|step| step.approval.as_ref().map(|approval| approval.mode)),
+                Some(crate::config::ensemble::StepApprovalMode::WhenRequestedByAgent)
+            ))
+    }
+
+    fn approval_state_for(&self, step_name: &str) -> Option<String> {
+        self.dag
+            .steps
+            .iter()
+            .find(|step| step.name == step_name)
+            .and_then(|step| step.approval.as_ref())
+            .and_then(|approval| approval.state.clone())
+    }
+
     /// Find all steps that are [`StepState::Pending`] and whose dependencies
     /// are all [`StepState::Passed`].
     ///
@@ -234,7 +352,7 @@ impl PipelineRun {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ensemble::StepConfig;
+    use crate::config::ensemble::{StepApprovalConfig, StepApprovalMode, StepConfig};
     use crate::pipeline::dag::build_dag;
 
     fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
@@ -248,6 +366,7 @@ mod tests {
             agent: agent.to_string(),
             depends: deps,
             tracker_state: None,
+            approval: None,
         }
     }
 
@@ -267,6 +386,31 @@ mod tests {
             agent: agent.to_string(),
             depends: deps,
             tracker_state: Some(tracker_state.to_string()),
+            approval: None,
+        }
+    }
+
+    fn make_step_with_approval(
+        name: &str,
+        agent: &str,
+        depends: &[&str],
+        mode: StepApprovalMode,
+        state: Option<&str>,
+    ) -> StepConfig {
+        let deps = if depends.is_empty() {
+            None
+        } else {
+            Some(depends.iter().map(|s| s.to_string()).collect())
+        };
+        StepConfig {
+            name: name.to_string(),
+            agent: agent.to_string(),
+            depends: deps,
+            tracker_state: None,
+            approval: Some(StepApprovalConfig {
+                mode,
+                state: state.map(|value| value.to_string()),
+            }),
         }
     }
 
@@ -306,7 +450,7 @@ mod tests {
         );
 
         // build completes with approve → should dispatch test next.
-        let action = run.step_completed("build", Verdict::Approve);
+        let action = run.step_completed("build", Verdict::Approve, false);
         assert!(
             matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "test"),
             "expected Dispatch([test]), got {action:?}"
@@ -315,7 +459,7 @@ mod tests {
         run.mark_running("test", "session-2".to_string());
 
         // test completes with approve → all done.
-        let action = run.step_completed("test", Verdict::Approve);
+        let action = run.step_completed("test", Verdict::Approve, false);
         assert_eq!(action, PipelineAction::Succeeded);
     }
 
@@ -341,7 +485,7 @@ mod tests {
         );
 
         run.mark_running("build", "session-build".to_string());
-        let action = run.step_completed("build", Verdict::Approve);
+        let action = run.step_completed("build", Verdict::Approve, false);
 
         // After build passes, both review steps should be dispatched together.
         match action {
@@ -357,9 +501,9 @@ mod tests {
         // Both reviews pass → Succeeded.
         run.mark_running("review-a", "session-ra".to_string());
         run.mark_running("review-b", "session-rb".to_string());
-        let _ = run.step_completed("review-a", Verdict::Approve);
+        let _ = run.step_completed("review-a", Verdict::Approve, false);
         // After review-a passes, review-b is still running → Waiting.
-        let _action = run.step_completed("review-a", Verdict::Approve);
+        let _action = run.step_completed("review-a", Verdict::Approve, false);
         // review-a was already set to Passed; a second approve on it should
         // still produce Waiting (review-b still pending/running).
         // Restart properly: create a fresh run and walk through fully.
@@ -370,12 +514,12 @@ mod tests {
         ];
         let mut run2 = make_run(&steps2);
         run2.mark_running("build", "s-b".to_string());
-        run2.step_completed("build", Verdict::Approve);
+        run2.step_completed("build", Verdict::Approve, false);
         run2.mark_running("review-a", "s-ra".to_string());
         run2.mark_running("review-b", "s-rb".to_string());
 
         // review-a passes first; review-b is still Running → Waiting.
-        let action = run2.step_completed("review-a", Verdict::Approve);
+        let action = run2.step_completed("review-a", Verdict::Approve, false);
         assert_eq!(
             action,
             PipelineAction::Waiting,
@@ -383,8 +527,184 @@ mod tests {
         );
 
         // Now review-b also passes → Succeeded.
-        let action = run2.step_completed("review-b", Verdict::Approve);
+        let action = run2.step_completed("review-b", Verdict::Approve, false);
         assert_eq!(action, PipelineAction::Succeeded);
+    }
+
+    #[test]
+    fn approved_step_with_always_gate_waits_for_approval() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step_with_approval(
+                "implement",
+                "implementer",
+                &["build"],
+                StepApprovalMode::Always,
+                Some("Ready for approval"),
+            ),
+        ];
+        let mut run = make_run(&steps);
+
+        run.mark_running("build", "session-build".to_string());
+        let action = run.step_completed("build", Verdict::Approve, false);
+        assert!(
+            matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "implement"),
+            "expected implement to dispatch after build, got {action:?}"
+        );
+
+        run.mark_running("implement", "session-implement".to_string());
+        let action = run.step_completed("implement", Verdict::Approve, false);
+        assert!(
+            matches!(
+                &action,
+                PipelineAction::AwaitingApproval {
+                    step,
+                    approval_state
+                } if step == "implement" && approval_state.as_deref() == Some("Ready for approval")
+            ),
+            "expected AwaitingApproval for implement, got {action:?}"
+        );
+        assert_eq!(
+            run.step_states["implement"],
+            StepState::AwaitingApproval {
+                interaction_request_id: None
+            }
+        );
+    }
+
+    #[test]
+    fn approve_gate_dispatches_downstream_steps() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step_with_approval(
+                "implement",
+                "implementer",
+                &["build"],
+                StepApprovalMode::Always,
+                Some("Approve implementation"),
+            ),
+            make_step("review", "reviewer", &["implement"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.mark_running("build", "session-build".to_string());
+        assert!(matches!(
+            run.step_completed("build", Verdict::Approve, false),
+            PipelineAction::Dispatch(_)
+        ));
+
+        run.mark_running("implement", "session-implement".to_string());
+        let action = run.step_completed("implement", Verdict::Approve, false);
+        assert!(matches!(action, PipelineAction::AwaitingApproval { .. }));
+
+        let action = run.bind_approval_interaction("implement", "approval-123".to_string());
+        assert_eq!(action, PipelineAction::Waiting);
+        assert_eq!(
+            run.step_states["implement"],
+            StepState::AwaitingApproval {
+                interaction_request_id: Some("approval-123".to_string())
+            }
+        );
+
+        let action = run.approve_gate("implement");
+        assert!(
+            matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "review"),
+            "expected downstream review dispatch after approval, got {action:?}"
+        );
+        assert_eq!(run.step_states["implement"], StepState::Passed);
+    }
+
+    #[test]
+    fn conditional_gate_only_triggers_when_worker_requested_it() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step_with_approval(
+                "implement",
+                "implementer",
+                &["build"],
+                StepApprovalMode::WhenRequestedByAgent,
+                Some("Wait for request"),
+            ),
+        ];
+        let mut run = make_run(&steps);
+
+        run.mark_running("build", "session-build".to_string());
+        assert!(matches!(
+            run.step_completed("build", Verdict::Approve, false),
+            PipelineAction::Dispatch(_)
+        ));
+
+        run.mark_running("implement", "session-implement".to_string());
+        let action = run.step_completed("implement", Verdict::Approve, false);
+        assert!(
+            matches!(&action, PipelineAction::Succeeded),
+            "expected approve without request to complete the pipeline, got {action:?}"
+        );
+        assert_eq!(run.step_states["implement"], StepState::Passed);
+
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step_with_approval(
+                "implement",
+                "implementer",
+                &["build"],
+                StepApprovalMode::WhenRequestedByAgent,
+                Some("Wait for request"),
+            ),
+        ];
+        let mut run = make_run(&steps);
+        run.mark_running("build", "session-build".to_string());
+        let _ = run.step_completed("build", Verdict::Approve, false);
+        run.mark_running("implement", "session-implement".to_string());
+        let action = run.step_completed("implement", Verdict::Approve, true);
+        assert!(
+            matches!(
+                &action,
+                PipelineAction::AwaitingApproval {
+                    step,
+                    approval_state
+                } if step == "implement" && approval_state.as_deref() == Some("Wait for request")
+            ),
+            "expected approval-requested step to gate, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn approve_gate_marks_completed_step_passed_without_rerunning_it() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step_with_approval(
+                "implement",
+                "implementer",
+                &["build"],
+                StepApprovalMode::Always,
+                Some("Ready to gate"),
+            ),
+            make_step("review", "reviewer", &["implement"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.mark_running("build", "session-build".to_string());
+        let _ = run.step_completed("build", Verdict::Approve, false);
+        run.mark_running("implement", "session-implement".to_string());
+        let action = run.step_completed("implement", Verdict::Approve, false);
+        assert!(matches!(action, PipelineAction::AwaitingApproval { .. }));
+
+        let action = run.bind_approval_interaction("implement", "approval-456".to_string());
+        assert_eq!(action, PipelineAction::Waiting);
+        assert_eq!(
+            run.step_states["implement"],
+            StepState::AwaitingApproval {
+                interaction_request_id: Some("approval-456".to_string())
+            }
+        );
+
+        let action = run.approve_gate("implement");
+        assert!(
+            matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "review"),
+            "expected review dispatch after gate approval, got {action:?}"
+        );
+        assert_eq!(run.step_states["implement"], StepState::Passed);
     }
 
     // -------------------------------------------------------------------------
@@ -400,7 +720,7 @@ mod tests {
         let mut run = make_run(&steps);
 
         run.mark_running("build", "s-b".to_string());
-        run.step_completed("build", Verdict::Approve);
+        run.step_completed("build", Verdict::Approve, false);
         run.mark_running("review", "s-r".to_string());
 
         let action = run.step_completed(
@@ -408,6 +728,7 @@ mod tests {
             Verdict::Reject {
                 summary: "code quality is too low".to_string(),
             },
+            false,
         );
 
         assert!(
@@ -479,7 +800,7 @@ mod tests {
 
         // After build passes, review is dispatched with its tracker_state.
         run.mark_running("build", "s-b".to_string());
-        let action = run.step_completed("build", Verdict::Approve);
+        let action = run.step_completed("build", Verdict::Approve, false);
         match &action {
             PipelineAction::Dispatch(reqs) => {
                 assert_eq!(reqs.len(), 1);
@@ -503,6 +824,10 @@ mod tests {
         .is_terminal());
         assert!(!StepState::BlockedOnHuman {
             interaction_request_id: "interaction-1".to_string()
+        }
+        .is_terminal());
+        assert!(!StepState::AwaitingApproval {
+            interaction_request_id: None
         }
         .is_terminal());
         assert!(StepState::Passed.is_terminal());
@@ -531,6 +856,50 @@ mod tests {
                 interaction_request_id: "interaction-123".to_string()
             }
         );
+    }
+
+    #[test]
+    fn reject_gate_rejects_and_halts_from_approval_state() {
+        let steps = vec![make_step_with_approval(
+            "review",
+            "reviewer",
+            &[],
+            StepApprovalMode::Always,
+            Some("Review gate"),
+        )];
+        let mut run = make_run(&steps);
+
+        let action = run.step_completed("review", Verdict::Approve, false);
+        assert!(matches!(action, PipelineAction::AwaitingApproval { .. }));
+
+        let action = run.bind_approval_interaction("review", "approval-789".to_string());
+        assert_eq!(action, PipelineAction::Waiting);
+
+        let action = run.reject_gate("review", "needs more work".to_string());
+        assert_eq!(
+            action,
+            PipelineAction::Failed {
+                step: "review".to_string(),
+                reason: "needs more work".to_string()
+            }
+        );
+        assert_eq!(
+            run.step_states["review"],
+            StepState::Rejected {
+                summary: "needs more work".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn bind_approval_interaction_ignores_non_approval_states() {
+        let steps = vec![make_step("build", "builder", &[])];
+        let mut run = make_run(&steps);
+
+        let action = run.bind_approval_interaction("build", "approval-ignored".to_string());
+
+        assert_eq!(action, PipelineAction::Waiting);
+        assert_eq!(run.step_states["build"], StepState::Pending);
     }
 
     #[test]
@@ -588,7 +957,7 @@ mod tests {
         let mut run = make_run(&steps);
 
         run.mark_running("build", "session-build".to_string());
-        let action = run.step_completed("build", Verdict::Approve);
+        let action = run.step_completed("build", Verdict::Approve, false);
         assert!(
             matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "review"),
             "expected Dispatch([review]), got {action:?}"

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -71,6 +71,18 @@ pub enum PipelineAction {
     Waiting,
 }
 
+/// Result of checking whether a step is eligible for post-step approval gating.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ApprovalGateCheck {
+    /// Step is eligible — approval gate should apply.
+    EligibleGating,
+    /// Step has no approval config and none was requested.
+    NotRequested,
+    /// Worker emitted an approval request but the step has no approval
+    /// configuration. This is a mismatch that should fail the step.
+    UnconfiguredButRequested,
+}
+
 /// Per-issue pipeline execution state machine.
 ///
 /// Tracks step states, drives step dispatch when dependencies are met, and
@@ -132,8 +144,8 @@ impl PipelineRun {
         approval_requested: bool,
     ) -> PipelineAction {
         match verdict {
-            Verdict::Approve => {
-                if self.should_gate_approval(step_name, approval_requested) {
+            Verdict::Approve => match self.gate_check(step_name, approval_requested) {
+                ApprovalGateCheck::EligibleGating => {
                     let approval_state = self.approval_state_for(step_name);
                     self.step_states.insert(
                         step_name.to_string(),
@@ -145,7 +157,24 @@ impl PipelineRun {
                         step: step_name.to_string(),
                         approval_state,
                     }
-                } else {
+                }
+                ApprovalGateCheck::UnconfiguredButRequested => {
+                    self.step_states.insert(
+                            step_name.to_string(),
+                            StepState::Failed {
+                                error: format!(
+                                    "worker requested approval for step '{step_name}' but it has no approval configuration"
+                                ),
+                            },
+                        );
+                    PipelineAction::Failed {
+                            step: step_name.to_string(),
+                            reason: format!(
+                                "step '{step_name}' has no approval configuration but the worker requested one"
+                            ),
+                        }
+                }
+                ApprovalGateCheck::NotRequested => {
                     self.step_states
                         .insert(step_name.to_string(), StepState::Passed);
                     if self.all_passed() {
@@ -154,7 +183,7 @@ impl PipelineRun {
                         self.find_dispatchable()
                     }
                 }
-            }
+            },
             Verdict::Reject { summary } => {
                 self.step_states.insert(
                     step_name.to_string(),
@@ -284,23 +313,33 @@ impl PipelineRun {
             .all(|s| self.step_states.get(&s.name) == Some(&StepState::Passed))
     }
 
-    fn should_gate_approval(&self, step_name: &str, approval_requested: bool) -> bool {
-        matches!(
-            self.dag
-                .steps
-                .iter()
-                .find(|step| step.name == step_name)
-                .and_then(|step| step.approval.as_ref().map(|approval| approval.mode)),
-            Some(crate::config::ensemble::StepApprovalMode::Always)
-        ) || (approval_requested
-            && matches!(
-                self.dag
-                    .steps
-                    .iter()
-                    .find(|step| step.name == step_name)
-                    .and_then(|step| step.approval.as_ref().map(|approval| approval.mode)),
-                Some(crate::config::ensemble::StepApprovalMode::WhenRequestedByAgent)
-            ))
+    fn gate_check(&self, step_name: &str, approval_requested: bool) -> ApprovalGateCheck {
+        let step_approval_mode = self
+            .dag
+            .steps
+            .iter()
+            .find(|step| step.name == step_name)
+            .and_then(|step| step.approval.as_ref().map(|approval| approval.mode));
+
+        match step_approval_mode {
+            Some(crate::config::ensemble::StepApprovalMode::Always) => {
+                ApprovalGateCheck::EligibleGating
+            }
+            Some(crate::config::ensemble::StepApprovalMode::WhenRequestedByAgent) => {
+                if approval_requested {
+                    ApprovalGateCheck::EligibleGating
+                } else {
+                    ApprovalGateCheck::NotRequested
+                }
+            }
+            None => {
+                if approval_requested {
+                    ApprovalGateCheck::UnconfiguredButRequested
+                } else {
+                    ApprovalGateCheck::NotRequested
+                }
+            }
+        }
     }
 
     fn approval_state_for(&self, step_name: &str) -> Option<String> {
@@ -974,5 +1013,27 @@ mod tests {
             }
         );
         assert_eq!(run.find_dispatchable(), PipelineAction::Waiting);
+    }
+
+    #[test]
+    fn step_completed_fails_when_worker_requests_approval_but_step_has_no_approval_config() {
+        let steps = vec![make_step("build", "builder", &[])];
+        let mut run = make_run(&steps);
+
+        run.mark_running("build", "session-build".to_string());
+        let action = run.step_completed("build", Verdict::Approve, true);
+
+        assert!(
+            matches!(
+                &action,
+                PipelineAction::Failed { step, reason }
+                    if step == "build" && reason.contains("no approval configuration")
+            ),
+            "expected Failed for unconfigured approval request, got {action:?}"
+        );
+        assert!(matches!(
+            &run.step_states["build"],
+            StepState::Failed { error } if error.contains("no approval configuration")
+        ));
     }
 }

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -6,7 +6,8 @@ use ensemble_core::agent::cancellation::new_cancellation_registry;
 use ensemble_core::api::router::{create_api_router, AppState, ConfigRuntime};
 use ensemble_core::config::draft::{ConfigDocumentState, ConfigStateKind, DraftValidationReport};
 use ensemble_core::interaction::model::{
-    InteractionKind, InteractionRequest, InteractionResponse, InteractionStatus,
+    InteractionKind, InteractionRequest, InteractionResponse, InteractionResumeStrategy,
+    InteractionStatus,
 };
 use ensemble_core::interaction::store::InteractionStore;
 use ensemble_core::observability::events::EventBus;
@@ -140,11 +141,16 @@ fn test_interaction(id: &str, issue_id: &str, issue_identifier: &str) -> Interac
         status: InteractionStatus::Open,
         blocking: true,
         awaiting_resume: true,
+        resume_strategy: InteractionResumeStrategy::RerunStep,
         title: "Need clarification".to_string(),
         body: "Pick a deployment target".to_string(),
         options: vec!["staging".to_string(), "production".to_string()],
         artifacts: vec!["docs/spec.md".to_string()],
         response: None,
+        waiting_started_at: None,
+        agent_input_tokens: 0,
+        agent_output_tokens: 0,
+        agent_total_tokens: 0,
         requested_at: Utc::now(),
         resolved_at: None,
     }
@@ -909,6 +915,10 @@ async fn resume_blocked_issue_requeues_issue() {
             prompt: "Need input".to_string(),
             agent_name: "builder".to_string(),
             retry_attempt: Some(1),
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
     }
@@ -952,6 +962,10 @@ async fn issue_input_resolves_interaction_and_queues_resume() {
             prompt: "Need input".to_string(),
             agent_name: "builder".to_string(),
             retry_attempt: Some(1),
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
     }
@@ -1023,6 +1037,10 @@ async fn issue_detail_includes_pending_input_summary() {
             prompt: "Need input".to_string(),
             agent_name: "reviewer".to_string(),
             retry_attempt: Some(1),
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
     }
@@ -1063,6 +1081,10 @@ async fn issue_input_supports_rejection_outcome_for_approval_gate() {
             prompt: "Approve deployment?".to_string(),
             agent_name: "reviewer".to_string(),
             retry_attempt: Some(1),
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
     }
@@ -1119,6 +1141,10 @@ async fn issue_input_rejects_invalid_outcome() {
             prompt: "Approve deployment?".to_string(),
             agent_name: "reviewer".to_string(),
             retry_attempt: Some(1),
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
             requested_at: Utc::now(),
         });
     }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -229,6 +229,12 @@ Pipeline step definition:
   implicitly depends on the step directly before it in the list. The first step has no implicit
   dependency. Explicit `depends` overrides the implicit rule.
 - `tracker_state` (string, optional) — tracker state to write on step entry.
+- `approval` (StepApprovalConfig, optional) — post-step approval gate:
+
+  - `mode` (string) — `always` or `when_requested_by_agent`. The latter waits for the agent to
+    request approval via `.ensemble/approval-request.json`.
+  - `state` (string, optional) — tracker state to mirror while waiting for approval. If set, the
+    issue's tracker state is updated to this value during the approval hold.
 
 #### 4.1.5 Workspace
 
@@ -253,9 +259,19 @@ Step states:
 
 - `Pending` — not yet started
 - `Running` — agent dispatched, session active
-- `Passed` — agent exited successfully with approve verdict (or no verdict)
-- `Rejected` — agent exited successfully with reject verdict
+- `AwaitingApproval` — step completed but blocked on an approval gate. The orchestrator
+  holds the pipeline here until a `approve_gate` or `reject_gate` signal is received.
+- `Passed` — agent exited successfully with approve verdict (or no verdict), or approved at an
+  approval gate
+- `Rejected` — agent exited successfully with reject verdict, or rejected at an approval gate
 - `Failed` — agent crashed, timed out, or errored
+
+**Post-step approval checkpoints:** When a step has `approval` configured, the orchestrator
+enters `AwaitingApproval` after the step completes. The orchestrator updates the issue tracker
+state to `approval.state` (if set) and waits. On `approve_gate`: the step transitions to `Passed`
+and downstream steps are dispatched. On `reject_gate`: the step transitions to `Rejected` and the
+pipeline falls back to `on_failure`. The `Rejected` transition does not write a separate rejection
+state — it is treated as a failure in the `on_failure` sense.
 
 #### 4.1.7 Verdict
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,8 +287,22 @@ Pipeline step definitions. Each step invokes one agent.
 | `agent` | string | *required* | Name of an agent defined in `agents` |
 | `depends` | list of strings | — | Steps this depends on. Omit for sequential order. Use `[]` for no dependencies (root step). |
 | `tracker_state` | string | — | Tracker state to write when this step starts |
+| `approval.mode` | string | — | Optional post-step approval policy: `always` or `when_requested_by_agent` |
+| `approval.state` | string | — | Optional tracker state to mirror while waiting for approval |
 
 See [Pipeline Guide](pipelines.md) for details on DAG construction and execution.
+
+**Example with approval gate:**
+
+```yaml
+steps:
+  - name: plan
+    agent: planner
+    tracker_state: Planning
+    approval:
+      mode: when_requested_by_agent
+      state: Plan Review
+```
 
 ### on_success / on_failure
 

--- a/docs/sdd-workflow.md
+++ b/docs/sdd-workflow.md
@@ -150,6 +150,18 @@ Use tracker states for planned approval/review gates:
 - Approval transitions move the issue forward
 - Rejection returns the issue to an earlier state
 
+Step-level approval gates (not just tracker states) are now the orchestration boundary. Ensemble pipelines can include steps with an `approval` block that causes the orchestrator to pause and wait for explicit `approve_gate` or `reject_gate` signals before continuing downstream steps.
+
+### Recommended Superpowers Pipeline
+
+The recommended operating model is a single Ensemble pipeline:
+
+- `plan` — brainstorm, design, and planning. May request a manual approval gate before implementation.
+- `implement` — build the planned solution.
+- `review` — verify the implementation.
+
+This three-step DAG allows the plan step to request human approval before implementation begins, ensuring designs are reviewed before code is written.
+
 ### Retry And Review Handling
 
 Use the same execution issue for retries, review cycles, and ambiguity handling:

--- a/docs/superpowers/specs/2026-04-10-superpowers-config-approval-gates-design.md
+++ b/docs/superpowers/specs/2026-04-10-superpowers-config-approval-gates-design.md
@@ -1,0 +1,332 @@
+# Superpowers Config And Approval Gates Design
+
+## Summary
+
+This design adapts Ensemble's configuration model to better support an Obra Superpowers-style workflow:
+
+- brainstorm
+- design
+- plan
+- implement
+- review
+
+The recommended operating model is a single Ensemble pipeline:
+
+- `plan`
+- `implement`
+- `review`
+
+The `plan` step covers brainstorm, design, and planning internally. It uses a dedicated planner agent, can choose a lightweight path for simple tasks, and can request a manual approval gate before implementation when full planning artifacts are needed.
+
+The key product change is a new generic per-step approval gate in Ensemble. Tracker states remain visible workflow mirrors, but the true orchestration boundary lives in the step DAG and durable approval checkpoint state.
+
+## Problem
+
+The current local config at `/Users/chris/Library/Application Support/ensemble/config.yaml` is a simple two-step pipeline:
+
+- `implement`
+- `review`
+
+That works for direct execution, but it does not express the front half of the desired Superpowers process:
+
+- brainstorming
+- design
+- planning
+- human approval before implementation when needed
+
+Trying to model that workflow only with tracker states is fragile:
+
+- tracker states are operator-facing projections rather than orchestration truth
+- `todo_file` works differently from future GitHub tracking
+- manual state edits do not clearly represent "step complete but downstream dispatch paused pending approval"
+
+The workflow needs an explicit boundary between pipeline steps, not just more tracker labels.
+
+## Goals
+
+- Support a single Ensemble pipeline that matches the desired Superpowers flow.
+- Combine brainstorm, design, and planning into one explicit planning step.
+- Add a dedicated planner agent with its own prompt and model settings.
+- Support a manual approval gate between steps.
+- Keep approval logic generic so it can be reused for other workflows.
+- Allow lightweight tasks to skip heavyweight planning artifacts and continue directly.
+- Keep the design compatible with `todo_file` now and GitHub later.
+
+## Non-Goals
+
+- Adding Obra-specific hardcoding to Ensemble.
+- Making tracker state changes the source of truth for approval.
+- Requiring every issue to produce a full `SPEC.md` and `PLAN.md`.
+- Depending on long-lived interactive sessions that wait for hours outside Ensemble's durable resume model.
+
+## Decision
+
+Add a generic step-level approval gate to Ensemble and rework the local config toward a three-step pipeline:
+
+- `plan`
+- `implement`
+- `review`
+
+The `plan` step uses a new `planner` agent and may operate in two modes:
+
+1. **Full planning path**
+   - produce durable planning artifacts
+   - request human approval
+   - pause before `implement`
+
+2. **Lightweight path**
+   - skip heavyweight artifacts when unnecessary
+   - continue directly to `implement`
+
+This keeps the pipeline unified while preserving a real approval checkpoint when appropriate.
+
+## Recommended Config Shape
+
+Conceptual target:
+
+```yaml
+tracker:
+  kind: todo_file
+  path: /Users/chris/ensemble/TODO.md
+  active_states:
+    - Todo
+    - Ready
+  terminal_states:
+    - Done
+    - Failed
+
+repos:
+  - path: /Users/chris/dev/ensemble
+    branch: main
+
+agents:
+  planner:
+    acpx_agent: codex
+    model: gpt-5.4/high
+    prompt_template: templates/plan.liquid
+
+  builder:
+    acpx_agent: codex
+    model: gpt-5.4/medium
+    prompt_template: templates/implement.liquid
+
+  reviewer:
+    acpx_agent: opencode
+    model: github-copilot/gpt-5.4/xhigh
+    prompt_template: templates/review.liquid
+
+steps:
+  - name: plan
+    agent: planner
+    tracker_state: Planning
+    approval:
+      mode: when_requested_by_agent
+      state: Plan Review
+
+  - name: implement
+    agent: builder
+    depends:
+      - plan
+    tracker_state: In Progress
+
+  - name: review
+    agent: reviewer
+    depends:
+      - implement
+    tracker_state: Review
+
+on_success: Done
+on_failure: Failed
+```
+
+This YAML is an intended target shape, not a statement that the current product already supports every field shown above.
+
+## Approval Gate Model
+
+Approval should be defined on steps, not inferred from tracker movement.
+
+Conceptual shape:
+
+```yaml
+approval:
+  mode: when_requested_by_agent
+  state: Plan Review
+```
+
+Recommended semantics:
+
+- `mode: always`
+  - step success always creates a manual approval checkpoint before downstream steps can dispatch
+
+- `mode: when_requested_by_agent`
+  - step success creates a manual approval checkpoint only when the agent explicitly asks for it
+  - best fit for the `plan` step because some tasks should take the lightweight path
+
+- `state`
+  - optional tracker mirror state written when the checkpoint is created
+  - visible to operators, but not the source of truth
+
+This should be generic so the same mechanism can later gate:
+
+- `implement -> review`
+- `review -> release`
+- any other step boundary
+
+## Runtime Semantics
+
+### Step success without approval
+
+If a step succeeds and has no approval gate, or does not request one under `when_requested_by_agent`, downstream steps dispatch as usual.
+
+### Step success with approval
+
+If a step succeeds and triggers approval:
+
+1. mark the step complete
+2. persist a pending approval checkpoint
+3. optionally write the approval mirror tracker state
+4. do not dispatch downstream steps yet
+5. wait for explicit human action in Ensemble
+
+### Human actions
+
+Minimum actions:
+
+- **Approve**: continue pipeline execution from the next step
+- **Reject**: do not continue; return to a configured rework state or leave awaiting operator intervention
+
+This checkpoint must survive restart just like other human-interaction state.
+
+### Failure semantics
+
+- If the gated step fails, normal pipeline failure behavior applies and no approval checkpoint is created.
+- If approval is rejected, the pipeline does not continue automatically.
+
+## Tracker State Model
+
+Recommended state set for the local `todo_file` workflow:
+
+- `Todo`
+- `Planning`
+- `Plan Review`
+- `Ready`
+- `In Progress`
+- `Review`
+- `Done`
+- `Failed`
+
+Recommended meanings:
+
+- `Todo`: new work eligible for planning
+- `Planning`: planner step currently running
+- `Plan Review`: waiting on a human approval gate created after planning
+- `Ready`: approved or lightweight-planned work eligible for implementation
+- `In Progress`: implementation step running
+- `Review`: review step running
+- `Done`: pipeline succeeded
+- `Failed`: pipeline failed terminally
+
+For dispatch eligibility, prefer keeping active states narrow:
+
+- `Todo`
+- `Ready`
+
+This keeps orchestration entry states separate from in-flight mirror states.
+
+## Artifact Model
+
+For full planning tasks, the planner should write:
+
+- `docs/phases/<slug>/SPEC.md`
+- `docs/phases/<slug>/PLAN.md`
+
+These become the durable handoff into implementation and review.
+
+For lightweight tasks:
+
+- full artifacts are optional
+- the planner may instead leave a concise execution note or simply continue
+
+The implementation and review prompts should treat artifacts as preferred when present, but not required for every task.
+
+## Prompt And Template Responsibilities
+
+### `templates/plan.liquid`
+
+The planner prompt should instruct the agent to:
+
+- follow brainstorm -> design -> plan internally
+- use the correct Superpowers skills
+- decide whether the task needs full planning or a lightweight path
+- write `SPEC.md` and `PLAN.md` when full planning is warranted
+- summarize assumptions, approval questions, and intended next steps
+- explicitly request approval when human review is needed before implementation
+
+### `templates/implement.liquid`
+
+The implementation prompt should instruct the builder to:
+
+- prefer approved planning artifacts when present
+- proceed on lightweight tasks even when no formal artifacts exist
+- avoid unnecessary re-planning
+- produce durable verification output
+
+### `templates/review.liquid`
+
+The review prompt should instruct the reviewer to:
+
+- review code, artifacts, and verification output
+- check alignment with either approved planning artifacts or lightweight task intent
+- produce the normal Ensemble verdict output
+
+## Why Step Gates Are Better Than State Gates
+
+Step-level approval gates are the recommended direction because:
+
+- they make workflow policy explicit in the pipeline DAG
+- they work the same across `todo_file` and future GitHub tracking
+- they align with Ensemble's human-interaction and resume model
+- they avoid overloading tracker states with orchestration semantics
+
+State-only gating is a weaker design because it makes approval depend on external state transitions rather than on durable pipeline checkpoints.
+
+## Migration Plan
+
+### Near term
+
+- keep using `todo_file`
+- add a planner agent and `templates/plan.liquid`
+- update prompts to support full-plan and lightweight paths
+- move toward the new state vocabulary
+
+### Product work
+
+- add generic per-step approval gate support to Ensemble config and runtime
+- persist step approval checkpoints
+- expose approve/reject actions through Ensemble's UI/API
+
+### Later GitHub migration
+
+The same design should carry forward with GitHub project or issue states used only as mirrors:
+
+- `Planning`
+- `Plan Review`
+- `Ready`
+- `In Progress`
+- `Review`
+- `Done`
+- `Failed`
+
+The orchestration truth should remain inside Ensemble rather than in GitHub state movement.
+
+## Open Questions
+
+- What should the config surface for rejection handling be, if any?
+- Should approval checkpoints support operator notes in the first version or only approve/reject?
+- Should the planner emit a small standard metadata file describing whether it chose full or lightweight planning?
+
+## Recommendation
+
+Adopt the Superpowers workflow through a dedicated `plan` step and implement approval as a generic step-level Ensemble feature.
+
+That gives the user a single pipeline matching the desired process while staying generic, durable, and tracker-agnostic.

--- a/docs/superpowers/specs/2026-04-10-superpowers-config-approval-gates-design.md
+++ b/docs/superpowers/specs/2026-04-10-superpowers-config-approval-gates-design.md
@@ -22,7 +22,7 @@ The key product change is a new generic per-step approval gate in Ensemble. Trac
 
 ## Problem
 
-The current local config at `/Users/chris/Library/Application Support/ensemble/config.yaml` is a simple two-step pipeline:
+The current local config at `$HOME/Library/Application Support/ensemble/config.yaml` is a simple two-step pipeline:
 
 - `implement`
 - `review`
@@ -87,7 +87,7 @@ Conceptual target:
 ```yaml
 tracker:
   kind: todo_file
-  path: /Users/chris/ensemble/TODO.md
+  path: $HOME/ensemble/TODO.md
   active_states:
     - Todo
     - Ready
@@ -96,7 +96,7 @@ tracker:
     - Failed
 
 repos:
-  - path: /Users/chris/dev/ensemble
+  - path: $HOME/dev/ensemble
     branch: main
 
 agents:


### PR DESCRIPTION
## Summary
- Add `approval: { mode, state }` to `StepConfig` for post-step approval gates
- Workers emit `.ensemble/approval-request.json` to request approval
- `plan -> implement -> review` pipeline can now pause at approval checkpoints
- Approved → downstream steps dispatch; rejected → pipeline fails with `on_failure`
- Compatible with `todo_file` and GitHub trackers

## Breaking API Change
The `POST /api/v1/issues/{id}/input` endpoint now requires an explicit `outcome` field for `ApprovalGate` and `ManualDecision` interactions. Clients must send `{ response: "...", outcome: "approve" | "reject" }` (or `outcome: "complete" | "pending"` for manual decisions). The previous behavior of inferring approve from a missing outcome is removed. Clients must be updated to send explicit outcomes before this change is deployed.

## Testing
- 804 workspace tests pass
- Clippy clean, fmt clean