### PR TITLE
docs: clarify approval gate operator flow

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -266,12 +266,13 @@ Step states:
 - `Rejected` — agent exited successfully with reject verdict, or rejected at an approval gate
 - `Failed` — agent crashed, timed out, or errored
 
-**Post-step approval checkpoints:** When a step has `approval` configured, the orchestrator
-enters `AwaitingApproval` after the step completes. The orchestrator updates the issue tracker
-state to `approval.state` (if set) and waits. On `approve_gate`: the step transitions to `Passed`
-and downstream steps are dispatched. On `reject_gate`: the step transitions to `Rejected` and the
-pipeline falls back to `on_failure`. The `Rejected` transition does not write a separate rejection
-state — it is treated as a failure in the `on_failure` sense.
+**Post-step approval checkpoints:** When a step succeeds and has `approval` configured, the
+orchestrator may enter `AwaitingApproval` instead of immediately dispatching downstream work. The
+orchestrator updates the issue tracker state to `approval.state` (if set) and waits. On
+`approve_gate`: the step transitions to `Passed` and downstream steps are dispatched. On
+`reject_gate`: the step transitions to `Rejected` and the pipeline falls back to `on_failure`. The
+`Rejected` transition does not write a separate rejection state — it is treated as a failure in the
+`on_failure` sense.
 
 #### 4.1.7 Verdict
 
@@ -1971,11 +1972,41 @@ Minimum endpoints:
     }
     ```
 
+- `POST /api/v1/issues/{identifier}/input`
+  - Submits human input for an issue that is awaiting input (for example an approval gate or
+    manual decision interaction). The orchestrator processes the response on the next tick.
+  - Request body:
+
+    ```json
+    {
+      "response": "Human response text",
+      "outcome": "approve"
+    }
+    ```
+
+    The `outcome` field is required for `ApprovalGate` and `ManualDecision` interactions:
+    - For approval gates: `"approve"` or `"reject"`
+    - For manual decisions: `"complete"` or `"pending"`
+
+  - Suggested response (`202 Accepted`) shape:
+
+    ```json
+    {
+      "accepted": true,
+      "issue_identifier": "MT-649",
+      "submitted_at": "2026-02-24T20:15:30Z"
+    }
+    ```
+
+  - If the issue is not awaiting input, return `409 Conflict` with an error response (for example
+    `{"error":{"code":"not_awaiting_input","message":"..."}}`).
+
 API design notes:
 
 - The JSON shapes above are the recommended baseline for interoperability and debugging ergonomics.
 - Implementations may add fields, but should avoid breaking existing fields within a version.
-- Endpoints should be read-only except for operational triggers like `/refresh`.
+ - Endpoints should be read-only except for operational control endpoints such as `/refresh` and
+   `/issues/{identifier}/input`.
 - Unsupported methods on defined routes should return `405 Method Not Allowed`.
 - API errors should use a JSON envelope such as `{"error":{"code":"...","message":"..."}}`.
 - If the dashboard is a client-side app, it should consume this API rather than duplicating state

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,6 +292,13 @@ Pipeline step definitions. Each step invokes one agent.
 
 See [Pipeline Guide](pipelines.md) for details on DAG construction and execution.
 
+Approval behavior:
+
+- `approval.mode: always` pauses after the step succeeds and waits for explicit approval before any downstream step can start.
+- `approval.mode: when_requested_by_agent` pauses only when the agent requests approval by writing `.ensemble/approval-request.json`.
+- `approval.state` is only a tracker mirror for operators. The approval checkpoint inside Ensemble is the source of truth.
+- Approving the gate resumes the pipeline from the next step. Rejecting the gate ends the pipeline through `on_failure`.
+
 **Example with approval gate:**
 
 ```yaml

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -29,6 +29,51 @@ If a step requests operator input, Ensemble records a **Needs Input** interactio
 that issue. The operator can submit a response from Web/Tauri, and the orchestrator resumes the
 issue on the next tick while other issues continue.
 
+## Approval gates
+
+Steps can also pause at an explicit post-step approval boundary:
+
+```yaml
+steps:
+  - name: plan
+    agent: planner
+    tracker_state: Planning
+    approval:
+      mode: when_requested_by_agent
+      state: Plan Review
+  - name: implement
+    agent: builder
+```
+
+How approval gates work:
+
+1. The step runs normally.
+2. If the gate is triggered, Ensemble moves the successful step into an approval hold before it can
+   transition to a final passed or rejected outcome.
+3. If `approval.state` is set, Ensemble mirrors that state to the tracker while waiting.
+4. Downstream steps do not start until a human approves or rejects the gate.
+
+Approval modes:
+
+- `always` pauses after every successful run of that step.
+- `when_requested_by_agent` pauses only when the agent requests approval with `.ensemble/approval-request.json`.
+
+Operator actions:
+
+- **Approve** resumes the pipeline from the next step.
+- **Reject** stops the pipeline and applies `on_failure`.
+
+When submitting input through the API, approval gates require an explicit outcome:
+
+```json
+{
+  "response": "Looks good. Proceed.",
+  "outcome": "approve"
+}
+```
+
+Valid approval outcomes are `approve` and `reject`.
+
 ## Sequential and parallel steps
 
 **Sequential (default):** Steps run one after another in list order. Each step implicitly depends on the one before it.

--- a/docs/superpowers/specs/2026-04-03-human-interaction-requests-design.md
+++ b/docs/superpowers/specs/2026-04-03-human-interaction-requests-design.md
@@ -547,11 +547,9 @@ Recommended v1 HTTP endpoints:
   - returns list of interaction summaries
 - `GET /api/v1/interactions/{id}`
   - returns the full interaction record
-- `POST /api/v1/interactions/{id}/respond`
-  - request body depends on interaction kind
-  - resolves the interaction when valid
-- `POST /api/v1/interactions/{id}/cancel`
-  - cancels the interaction
+- `POST /api/v1/issues/{identifier}/input`
+  - request body uses a normalized shape such as `{ "response": "...", "outcome": "approve" }`
+  - `outcome` is interaction-kind-specific and resolves the blocking interaction when valid
 - `POST /api/v1/issues/{identifier}/resume`
   - re-enqueues a resolved blocked issue for redispatch
 
@@ -637,7 +635,7 @@ The interaction statuses should be interpreted as follows:
 
 `cancelled` is distinct from a negative approval response:
 
-- approval rejection lives inside the `InteractionResponse::Approval { approved: false, ... }` payload
+- approval rejection lives inside the normalized response payload, for example `outcome: "reject"`
 - `cancelled` is an operational abort that can apply to any interaction kind
 
 ## Recommendation

--- a/docs/superpowers/specs/2026-04-10-superpowers-config-approval-gates-design.md
+++ b/docs/superpowers/specs/2026-04-10-superpowers-config-approval-gates-design.md
@@ -182,7 +182,7 @@ If a step succeeds and has no approval gate, or does not request one under `when
 
 If a step succeeds and triggers approval:
 
-1. mark the step complete
+1. mark the step successful but not yet finally passed
 2. persist a pending approval checkpoint
 3. optionally write the approval mirror tracker state
 4. do not dispatch downstream steps yet
@@ -193,7 +193,8 @@ If a step succeeds and triggers approval:
 Minimum actions:
 
 - **Approve**: continue pipeline execution from the next step
-- **Reject**: do not continue; return to a configured rework state or leave awaiting operator intervention
+- **Reject**: do not continue; treat the gate as a pipeline failure and transition through
+  `on_failure`
 
 This checkpoint must survive restart just like other human-interaction state.
 
@@ -226,12 +227,18 @@ Recommended meanings:
 - `Done`: pipeline succeeded
 - `Failed`: pipeline failed terminally
 
-For dispatch eligibility, prefer keeping active states narrow:
+For dispatch eligibility, include all states that should be restart-recoverable after a process
+restart. A conservative local workflow can use:
 
 - `Todo`
+- `Planning`
+- `Plan Review`
 - `Ready`
+- `In Progress`
+- `Review`
 
-This keeps orchestration entry states separate from in-flight mirror states.
+If you narrow `active_states`, make sure no in-flight or approval-hold state can become stranded
+after restart.
 
 ## Artifact Model
 


### PR DESCRIPTION
## Summary
- document the approval gate lifecycle and operator flow in the user-facing pipeline and configuration guides
- add the `POST /api/v1/issues/{identifier}/input` contract to the spec, including required `outcome` values
- reconcile older design docs so approval hold semantics, rejection behavior, and restart guidance match the current implementation

## Testing
- not run (docs-only changes)