### PR TITLE
Persist task history and timeline in global SQLite store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "liquid",
  "mime_guess",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1103,6 +1104,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1673,6 +1686,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -2288,6 +2310,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3586,6 +3619,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ dotenvy = "0.15"
 shellexpand = "3"
 mime_guess = "2"
 opener = "0.7"
+rusqlite = { version = "0.33", features = ["bundled"] }

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -30,6 +30,7 @@ dotenvy = { workspace = true }
 shellexpand = { workspace = true }
 shlex = "1"
 mime_guess = { workspace = true }
+rusqlite = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -4,6 +4,7 @@ use crate::api::router::{AppState, ConfigRuntime};
 use crate::config::draft::ConfigDocumentState;
 use crate::config::ensemble::{default_workspace_root, ConcurrencyConfig, PollingConfig};
 use crate::error::{ConfigError, EnsembleError};
+use crate::history_store::store::HistoryStore;
 use crate::observability::events::EventBus;
 use crate::orchestrator::state::OrchestratorState;
 use crate::orchestrator::{Orchestrator, OrchestratorRuntimeParts};
@@ -15,6 +16,7 @@ use std::sync::Arc;
 use std::sync::MutexGuard;
 use tokio::sync::{mpsc, RwLock};
 use tokio::task::JoinHandle;
+use tracing::warn;
 
 pub struct PreparedApp {
     pub app_state: AppState,
@@ -92,6 +94,17 @@ pub fn build_app_state(
     let history_db_path = PathBuf::from(&workspace_root)
         .join(".ensemble")
         .join("history.db");
+    let history_store = match HistoryStore::new_blocking(history_db_path.clone()) {
+        Ok(store) => Some(store),
+        Err(error) => {
+            warn!(
+                path = %history_db_path.display(),
+                error = %error,
+                "failed to initialize sqlite history store; api will fall back to JSONL history"
+            );
+            None
+        }
+    };
 
     let app_state = AppState {
         orchestrator_state: orchestrator_state_from_document(&document_state),
@@ -100,6 +113,7 @@ pub fn build_app_state(
         workspace_root,
         history_path,
         history_db_path,
+        history_store,
         event_bus,
         config_runtime: ConfigRuntime {
             config_path,

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -89,6 +89,9 @@ pub fn build_app_state(
     let has_runnable_config = document_state.active_config.is_some();
     let workspace_root = workspace_root_from_document(&document_state);
     let history_path = PathBuf::from(&workspace_root).join("ensemble_history.jsonl");
+    let history_db_path = PathBuf::from(&workspace_root)
+        .join(".ensemble")
+        .join("history.db");
 
     let app_state = AppState {
         orchestrator_state: orchestrator_state_from_document(&document_state),
@@ -96,6 +99,7 @@ pub fn build_app_state(
         refresh_requested: Arc::new(tokio::sync::Notify::new()),
         workspace_root,
         history_path,
+        history_db_path,
         event_bus,
         config_runtime: ConfigRuntime {
             config_path,

--- a/crates/ensemble-core/src/api/history_handler.rs
+++ b/crates/ensemble-core/src/api/history_handler.rs
@@ -100,7 +100,9 @@ mod tests {
     async fn test_get_history_with_records() {
         let tmp = tempfile::TempDir::new().unwrap();
         let state = build_app_state(tmp.path());
-        let store = HistoryStore::new(state.history_db_path.clone()).await.unwrap();
+        let store = HistoryStore::new(state.history_db_path.clone())
+            .await
+            .unwrap();
         store
             .append_history_record("run-1", &sample_record("MT-1"))
             .await

--- a/crates/ensemble-core/src/api/history_handler.rs
+++ b/crates/ensemble-core/src/api/history_handler.rs
@@ -1,6 +1,5 @@
 use crate::api::router::AppState;
-use crate::history::reader::{HistoryQuery, HistoryResponse};
-use crate::history_store::store::HistoryStore;
+use crate::history::reader::{read_history, HistoryQuery, HistoryResponse};
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -24,21 +23,13 @@ pub async fn get_history(
     State(state): State<AppState>,
     Query(query): Query<HistoryQuery>,
 ) -> impl IntoResponse {
-    let store = match HistoryStore::new(state.history_db_path.clone()).await {
-        Ok(store) => store,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                crate::api::handlers::api_error(
-                    "history_store_error",
-                    format!("failed to open history store: {}", e),
-                ),
-            )
-                .into_response();
-        }
+    let read_result = if let Some(store) = state.history_store.as_ref() {
+        store.read_history(&query).await
+    } else {
+        read_history(&state.history_path, &query).await
     };
 
-    match store.read_history(&query).await {
+    match read_result {
         Ok(response) => (StatusCode::OK, Json(response)).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -56,13 +47,17 @@ mod tests {
     use super::*;
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
     use crate::history::model::{HistoryRecord, TokenTotals};
+    use crate::history::writer::HistoryWriter;
+    use crate::history_store::store::HistoryStore;
     use chrono::Utc;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     fn build_app_state(base: &Path) -> AppState {
         let mut app_state = app_state_with_document_state(parsed_document_state());
         app_state.history_path = base.join("ensemble_history.jsonl");
         app_state.history_db_path = base.join(".ensemble").join("history.db");
+        app_state.history_store =
+            HistoryStore::new_blocking(app_state.history_db_path.clone()).ok();
         app_state
     }
 
@@ -117,6 +112,16 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
-    #[allow(dead_code)]
-    fn _unused(_path: PathBuf) {}
+    #[tokio::test]
+    async fn test_get_history_falls_back_to_jsonl_when_sqlite_unavailable() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut state = build_app_state(temp.path());
+        state.history_store = None;
+        let writer = HistoryWriter::new(state.history_path.clone());
+        writer.append(&sample_record("MT-JSONL")).await.unwrap();
+
+        let response = get_history(State(state), Query(HistoryQuery::default())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }

--- a/crates/ensemble-core/src/api/history_handler.rs
+++ b/crates/ensemble-core/src/api/history_handler.rs
@@ -1,5 +1,6 @@
 use crate::api::router::AppState;
-use crate::history::reader::{read_history, HistoryQuery, HistoryResponse};
+use crate::history::reader::{HistoryQuery, HistoryResponse};
+use crate::history_store::store::HistoryStore;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -23,7 +24,21 @@ pub async fn get_history(
     State(state): State<AppState>,
     Query(query): Query<HistoryQuery>,
 ) -> impl IntoResponse {
-    match read_history(&state.history_path, &query).await {
+    let store = match HistoryStore::new(state.history_db_path.clone()).await {
+        Ok(store) => store,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                crate::api::handlers::api_error(
+                    "history_store_error",
+                    format!("failed to open history store: {}", e),
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    match store.read_history(&query).await {
         Ok(response) => (StatusCode::OK, Json(response)).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -41,13 +56,13 @@ mod tests {
     use super::*;
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
     use crate::history::model::{HistoryRecord, TokenTotals};
-    use crate::history::writer::HistoryWriter;
     use chrono::Utc;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
-    fn build_app_state(history_path: PathBuf) -> AppState {
+    fn build_app_state(base: &Path) -> AppState {
         let mut app_state = app_state_with_document_state(parsed_document_state());
-        app_state.history_path = history_path;
+        app_state.history_path = base.join("ensemble_history.jsonl");
+        app_state.history_db_path = base.join(".ensemble").join("history.db");
         app_state
     }
 
@@ -74,7 +89,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_history_empty() {
-        let state = build_app_state(PathBuf::from("/tmp/nonexistent_test_history.jsonl"));
+        let temp = tempfile::TempDir::new().unwrap();
+        let state = build_app_state(temp.path());
         let response = get_history(State(state), Query(HistoryQuery::default())).await;
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::OK);
@@ -82,17 +98,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_history_with_records() {
-        let tmp = tempfile::NamedTempFile::new().unwrap();
-        let path = tmp.path().to_path_buf();
-        std::fs::remove_file(&path).ok();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let state = build_app_state(tmp.path());
+        let store = HistoryStore::new(state.history_db_path.clone()).await.unwrap();
+        store
+            .append_history_record("run-1", &sample_record("MT-1"))
+            .await
+            .unwrap();
+        store
+            .append_history_record("run-2", &sample_record("MT-2"))
+            .await
+            .unwrap();
 
-        let writer = HistoryWriter::new(path.clone());
-        writer.append(&sample_record("MT-1")).await.unwrap();
-        writer.append(&sample_record("MT-2")).await.unwrap();
-
-        let state = build_app_state(path);
         let response = get_history(State(state), Query(HistoryQuery::default())).await;
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::OK);
     }
+
+    #[allow(dead_code)]
+    fn _unused(_path: PathBuf) {}
 }

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -5,6 +5,7 @@ use crate::api::{
     history_handler, timeline_handler, ws,
 };
 use crate::config::draft::ConfigDocumentState;
+use crate::history_store::store::HistoryStore;
 use crate::observability::events::EventBus;
 use crate::orchestrator::state::OrchestratorState;
 use axum::http::StatusCode;
@@ -42,6 +43,8 @@ pub struct AppState {
     pub history_path: PathBuf,
     /// Path to the global history sqlite database.
     pub history_db_path: PathBuf,
+    /// Shared history store initialized at app bootstrap. Falls back to JSONL readers when absent.
+    pub history_store: Option<HistoryStore>,
     /// Event bus for pipeline event broadcasting.
     pub event_bus: EventBus,
     /// Runtime configuration store with document state.

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -40,6 +40,8 @@ pub struct AppState {
     pub workspace_root: String,
     /// Path to the history JSONL file.
     pub history_path: PathBuf,
+    /// Path to the global history sqlite database.
+    pub history_db_path: PathBuf,
     /// Event bus for pipeline event broadcasting.
     pub event_bus: EventBus,
     /// Runtime configuration store with document state.

--- a/crates/ensemble-core/src/api/test_helpers.rs
+++ b/crates/ensemble-core/src/api/test_helpers.rs
@@ -4,6 +4,7 @@ use crate::config::draft::{
     missing_config_state, ConfigDocumentState, ConfigStateKind, DraftValidationReport,
 };
 use crate::config::ensemble::ConcurrencyConfig;
+use crate::history_store::store::HistoryStore;
 use crate::observability::events::EventBus;
 use crate::orchestrator::state::OrchestratorState;
 use std::path::PathBuf;
@@ -34,6 +35,7 @@ pub(crate) fn app_state_with_document_state(document_state: ConfigDocumentState)
         workspace_root: "/tmp/workspaces".to_string(),
         history_path: PathBuf::from("/tmp/history.jsonl"),
         history_db_path: PathBuf::from("/tmp/.ensemble/history.db"),
+        history_store: HistoryStore::new_blocking(PathBuf::from("/tmp/.ensemble/history.db")).ok(),
         event_bus: EventBus::new(),
         config_runtime: ConfigRuntime {
             config_path: document_state.path.clone(),
@@ -57,6 +59,7 @@ pub(crate) fn app_state_with_missing_config(
         workspace_root: workspace_root.to_string(),
         history_path: PathBuf::from("/tmp/history.jsonl"),
         history_db_path: PathBuf::from("/tmp/.ensemble/history.db"),
+        history_store: HistoryStore::new_blocking(PathBuf::from("/tmp/.ensemble/history.db")).ok(),
         event_bus: EventBus::new(),
         config_runtime: ConfigRuntime {
             config_path: config_path.clone(),

--- a/crates/ensemble-core/src/api/test_helpers.rs
+++ b/crates/ensemble-core/src/api/test_helpers.rs
@@ -33,6 +33,7 @@ pub(crate) fn app_state_with_document_state(document_state: ConfigDocumentState)
         refresh_requested: Arc::new(tokio::sync::Notify::new()),
         workspace_root: "/tmp/workspaces".to_string(),
         history_path: PathBuf::from("/tmp/history.jsonl"),
+        history_db_path: PathBuf::from("/tmp/.ensemble/history.db"),
         event_bus: EventBus::new(),
         config_runtime: ConfigRuntime {
             config_path: document_state.path.clone(),
@@ -55,6 +56,7 @@ pub(crate) fn app_state_with_missing_config(
         refresh_requested: Arc::new(tokio::sync::Notify::new()),
         workspace_root: workspace_root.to_string(),
         history_path: PathBuf::from("/tmp/history.jsonl"),
+        history_db_path: PathBuf::from("/tmp/.ensemble/history.db"),
         event_bus: EventBus::new(),
         config_runtime: ConfigRuntime {
             config_path: config_path.clone(),

--- a/crates/ensemble-core/src/api/timeline_handler.rs
+++ b/crates/ensemble-core/src/api/timeline_handler.rs
@@ -1,23 +1,15 @@
 use crate::api::router::AppState;
-use crate::timeline::reader::{read_timeline, TimelineQuery, TimelineResponse};
+use crate::history_store::store::HistoryStore;
+use crate::timeline::reader::{TimelineQuery, TimelineResponse};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use std::path::PathBuf;
 
 fn is_safe_run_id(run_id: &str) -> bool {
     !run_id.is_empty()
         && run_id
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-}
-
-fn timeline_path(workspace_root: &str, run_id: &str) -> PathBuf {
-    PathBuf::from(workspace_root)
-        .join(".ensemble")
-        .join("runs")
-        .join(run_id)
-        .join("events.jsonl")
 }
 
 /// GET /api/v1/{identifier}/timeline
@@ -53,8 +45,21 @@ pub async fn get_timeline(
             .into_response();
     }
 
-    let path = timeline_path(&state.workspace_root, &query.run_id);
-    match read_timeline(&path, &query, Some(&identifier)).await {
+    let store = match HistoryStore::new(state.history_db_path.clone()).await {
+        Ok(store) => store,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                crate::api::handlers::api_error(
+                    "timeline_store_error",
+                    format!("failed to open history store: {}", e),
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    match store.read_timeline(&query, Some(&identifier)).await {
         Ok(response) => (StatusCode::OK, axum::Json(response)).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -72,12 +77,14 @@ mod tests {
     use super::*;
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
     use crate::timeline::model::TimelineEventRecord;
-    use crate::timeline::writer::TimelineWriter;
     use chrono::Utc;
 
     fn build_app_state(workspace_root: String) -> AppState {
         let mut app_state = app_state_with_document_state(parsed_document_state());
         app_state.workspace_root = workspace_root;
+        app_state.history_db_path = std::path::PathBuf::from(&app_state.workspace_root)
+            .join(".ensemble")
+            .join("history.db");
         app_state
     }
 
@@ -118,13 +125,13 @@ mod tests {
     async fn get_timeline_returns_paginated_events_for_run_id() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let state = build_app_state(temp_dir.path().to_string_lossy().to_string());
-        let writer = TimelineWriter::new(temp_dir.path().to_path_buf());
-        writer
-            .append("run-abc", &sample_event("run-abc", 1))
+        let store = HistoryStore::new(state.history_db_path.clone()).await.unwrap();
+        store
+            .append_timeline_event(&sample_event("run-abc", 1))
             .await
             .unwrap();
-        writer
-            .append("run-abc", &sample_event("run-abc", 2))
+        store
+            .append_timeline_event(&sample_event("run-abc", 2))
             .await
             .unwrap();
 
@@ -164,10 +171,10 @@ mod tests {
     async fn get_timeline_scopes_results_to_path_identifier() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let state = build_app_state(temp_dir.path().to_string_lossy().to_string());
-        let writer = TimelineWriter::new(temp_dir.path().to_path_buf());
+        let store = HistoryStore::new(state.history_db_path.clone()).await.unwrap();
         let mut wrong_issue = sample_event("run-abc", 1);
         wrong_issue.issue_identifier = "repo#other".to_string();
-        writer.append("run-abc", &wrong_issue).await.unwrap();
+        store.append_timeline_event(&wrong_issue).await.unwrap();
 
         let response = get_timeline(
             State(state),

--- a/crates/ensemble-core/src/api/timeline_handler.rs
+++ b/crates/ensemble-core/src/api/timeline_handler.rs
@@ -125,7 +125,9 @@ mod tests {
     async fn get_timeline_returns_paginated_events_for_run_id() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let state = build_app_state(temp_dir.path().to_string_lossy().to_string());
-        let store = HistoryStore::new(state.history_db_path.clone()).await.unwrap();
+        let store = HistoryStore::new(state.history_db_path.clone())
+            .await
+            .unwrap();
         store
             .append_timeline_event(&sample_event("run-abc", 1))
             .await
@@ -171,7 +173,9 @@ mod tests {
     async fn get_timeline_scopes_results_to_path_identifier() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let state = build_app_state(temp_dir.path().to_string_lossy().to_string());
-        let store = HistoryStore::new(state.history_db_path.clone()).await.unwrap();
+        let store = HistoryStore::new(state.history_db_path.clone())
+            .await
+            .unwrap();
         let mut wrong_issue = sample_event("run-abc", 1);
         wrong_issue.issue_identifier = "repo#other".to_string();
         store.append_timeline_event(&wrong_issue).await.unwrap();

--- a/crates/ensemble-core/src/api/timeline_handler.rs
+++ b/crates/ensemble-core/src/api/timeline_handler.rs
@@ -1,6 +1,6 @@
 use crate::api::router::AppState;
-use crate::history_store::store::HistoryStore;
-use crate::timeline::reader::{TimelineQuery, TimelineResponse};
+use crate::timeline::reader::{read_timeline, TimelineQuery, TimelineResponse};
+use crate::timeline::writer::TimelineWriter;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -45,21 +45,15 @@ pub async fn get_timeline(
             .into_response();
     }
 
-    let store = match HistoryStore::new(state.history_db_path.clone()).await {
-        Ok(store) => store,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                crate::api::handlers::api_error(
-                    "timeline_store_error",
-                    format!("failed to open history store: {}", e),
-                ),
-            )
-                .into_response();
-        }
+    let read_result = if let Some(store) = state.history_store.as_ref() {
+        store.read_timeline(&query, Some(&identifier)).await
+    } else {
+        let path = TimelineWriter::new(std::path::PathBuf::from(&state.workspace_root))
+            .events_path(&query.run_id);
+        read_timeline(&path, &query, Some(&identifier)).await
     };
 
-    match store.read_timeline(&query, Some(&identifier)).await {
+    match read_result {
         Ok(response) => (StatusCode::OK, axum::Json(response)).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -76,7 +70,9 @@ pub async fn get_timeline(
 mod tests {
     use super::*;
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
+    use crate::history_store::store::HistoryStore;
     use crate::timeline::model::TimelineEventRecord;
+    use crate::timeline::writer::TimelineWriter;
     use chrono::Utc;
 
     fn build_app_state(workspace_root: String) -> AppState {
@@ -85,6 +81,8 @@ mod tests {
         app_state.history_db_path = std::path::PathBuf::from(&app_state.workspace_root)
             .join(".ensemble")
             .join("history.db");
+        app_state.history_store =
+            HistoryStore::new_blocking(app_state.history_db_path.clone()).ok();
         app_state
     }
 
@@ -185,6 +183,31 @@ mod tests {
             Path("repo#1".to_string()),
             Query(TimelineQuery {
                 run_id: "run-abc".to_string(),
+                cursor: Some(0),
+                limit: Some(10),
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn get_timeline_falls_back_to_jsonl_when_sqlite_unavailable() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut state = build_app_state(temp_dir.path().to_string_lossy().to_string());
+        state.history_store = None;
+        let writer = TimelineWriter::new(std::path::PathBuf::from(&state.workspace_root));
+        writer
+            .append("run-fallback", &sample_event("run-fallback", 1))
+            .await
+            .unwrap();
+
+        let response = get_timeline(
+            State(state),
+            Path("repo#1".to_string()),
+            Query(TimelineQuery {
+                run_id: "run-fallback".to_string(),
                 cursor: Some(0),
                 limit: Some(10),
             }),

--- a/crates/ensemble-core/src/history/reader.rs
+++ b/crates/ensemble-core/src/history/reader.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::model::HistoryRecord;
 
 /// Query parameters for filtering and paginating history records.
-#[derive(Debug, Default, Deserialize, utoipa::IntoParams)]
+#[derive(Debug, Default, Clone, Deserialize, utoipa::IntoParams)]
 pub struct HistoryQuery {
     /// Filter to records with this outcome (e.g. "succeeded", "failed").
     pub outcome: Option<String>,

--- a/crates/ensemble-core/src/history_store/mod.rs
+++ b/crates/ensemble-core/src/history_store/mod.rs
@@ -1,0 +1,2 @@
+pub mod schema;
+pub mod store;

--- a/crates/ensemble-core/src/history_store/mod.rs
+++ b/crates/ensemble-core/src/history_store/mod.rs
@@ -1,2 +1,3 @@
+pub mod model;
 pub mod schema;
 pub mod store;

--- a/crates/ensemble-core/src/history_store/model.rs
+++ b/crates/ensemble-core/src/history_store/model.rs
@@ -1,0 +1,55 @@
+use crate::history::model::{HistoryRecord, TokenTotals};
+use crate::timeline::model::TimelineEventRecord;
+use chrono::{DateTime, Utc};
+use rusqlite::Row;
+
+fn parse_utc(ts: &str) -> rusqlite::Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(ts)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e)))
+}
+
+pub(crate) fn row_to_history_record(row: &Row<'_>) -> rusqlite::Result<HistoryRecord> {
+    let steps_json: String = row.get("steps_traversed")?;
+    let steps_traversed: Vec<String> = serde_json::from_str(&steps_json).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    let started_at_raw: String = row.get("started_at")?;
+    let completed_at_raw: String = row.get("completed_at")?;
+
+    Ok(HistoryRecord {
+        issue_identifier: row.get("issue_identifier")?,
+        issue_id: row.get("issue_id")?,
+        outcome: row.get("outcome")?,
+        steps_traversed,
+        attempts: row.get("attempts")?,
+        tokens: TokenTotals {
+            input_tokens: row.get("input_tokens")?,
+            output_tokens: row.get("output_tokens")?,
+            total_tokens: row.get("total_tokens")?,
+        },
+        duration_seconds: row.get("duration_seconds")?,
+        started_at: parse_utc(&started_at_raw)?,
+        completed_at: parse_utc(&completed_at_raw)?,
+        last_error: row.get("last_error")?,
+        verdict: row.get("verdict")?,
+        workspace_path: row.get("workspace_path")?,
+    })
+}
+
+pub(crate) fn row_to_timeline_record(row: &Row<'_>) -> rusqlite::Result<TimelineEventRecord> {
+    let timestamp_raw: String = row.get("timestamp")?;
+    Ok(TimelineEventRecord {
+        run_id: row.get("run_id")?,
+        issue_identifier: row.get("issue_identifier")?,
+        sequence: row.get("sequence")?,
+        timestamp: parse_utc(&timestamp_raw)?,
+        event_type: row.get("event_type")?,
+        step_name: row.get("step_name")?,
+        attempt: row.get("attempt")?,
+        detail: row.get("detail")?,
+        verdict: row.get("verdict")?,
+        tool_name: row.get("tool_name")?,
+    })
+}

--- a/crates/ensemble-core/src/history_store/model.rs
+++ b/crates/ensemble-core/src/history_store/model.rs
@@ -6,7 +6,9 @@ use rusqlite::Row;
 fn parse_utc(ts: &str) -> rusqlite::Result<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(ts)
         .map(|dt| dt.with_timezone(&Utc))
-        .map_err(|e| rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e)))
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })
 }
 
 pub(crate) fn row_to_history_record(row: &Row<'_>) -> rusqlite::Result<HistoryRecord> {

--- a/crates/ensemble-core/src/history_store/schema.rs
+++ b/crates/ensemble-core/src/history_store/schema.rs
@@ -1,0 +1,91 @@
+use rusqlite::Connection;
+
+pub fn apply_pragmas(conn: &Connection) -> rusqlite::Result<()> {
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "FULL")?;
+    conn.pragma_update(None, "busy_timeout", 5000i64)?;
+    Ok(())
+}
+
+pub fn bootstrap_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS runs (
+            run_id TEXT PRIMARY KEY,
+            issue_id TEXT NOT NULL,
+            issue_identifier TEXT NOT NULL,
+            outcome TEXT NOT NULL,
+            attempts INTEGER NOT NULL,
+            duration_seconds INTEGER NOT NULL,
+            started_at TEXT NOT NULL,
+            completed_at TEXT NOT NULL,
+            last_error TEXT,
+            verdict TEXT,
+            workspace_path TEXT NOT NULL,
+            input_tokens INTEGER NOT NULL,
+            output_tokens INTEGER NOT NULL,
+            total_tokens INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS run_events (
+            run_id TEXT NOT NULL,
+            sequence INTEGER NOT NULL,
+            timestamp TEXT NOT NULL,
+            issue_identifier TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            step_name TEXT,
+            attempt INTEGER NOT NULL,
+            detail TEXT NOT NULL,
+            verdict TEXT,
+            tool_name TEXT,
+            PRIMARY KEY (run_id, sequence)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_run_events_run_sequence ON run_events(run_id, sequence);
+        CREATE INDEX IF NOT EXISTS idx_runs_identifier_completed_at ON runs(issue_identifier, completed_at);
+        CREATE INDEX IF NOT EXISTS idx_runs_outcome_completed_at ON runs(outcome, completed_at);
+        "#,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    #[test]
+    fn bootstrap_creates_runs_and_run_events_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply_pragmas(&conn).unwrap();
+        bootstrap_schema(&conn).unwrap();
+
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap();
+        let names: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+
+        assert!(names.contains(&"runs".to_string()));
+        assert!(names.contains(&"run_events".to_string()));
+    }
+
+    #[test]
+    fn bootstrap_creates_run_events_sequence_index() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply_pragmas(&conn).unwrap();
+        bootstrap_schema(&conn).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_run_events_run_sequence'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(count, 1);
+    }
+}

--- a/crates/ensemble-core/src/history_store/schema.rs
+++ b/crates/ensemble-core/src/history_store/schema.rs
@@ -15,6 +15,7 @@ pub fn bootstrap_schema(conn: &Connection) -> rusqlite::Result<()> {
             issue_id TEXT NOT NULL,
             issue_identifier TEXT NOT NULL,
             outcome TEXT NOT NULL,
+            steps_traversed TEXT NOT NULL,
             attempts INTEGER NOT NULL,
             duration_seconds INTEGER NOT NULL,
             started_at TEXT NOT NULL,

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -96,7 +96,10 @@ impl HistoryStore {
         .map_err(io::Error::other)?
     }
 
-    pub async fn append_timeline_event(&self, record: &TimelineEventRecord) -> Result<(), io::Error> {
+    pub async fn append_timeline_event(
+        &self,
+        record: &TimelineEventRecord,
+    ) -> Result<(), io::Error> {
         let path = self.db_path.clone();
         let record = record.clone();
         tokio::task::spawn_blocking(move || -> Result<(), io::Error> {
@@ -280,7 +283,9 @@ mod tests {
     #[tokio::test]
     async fn append_history_record_is_queryable() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = HistoryStore::new(dir.path().join("history.db")).await.unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db"))
+            .await
+            .unwrap();
 
         store
             .append_history_record("run-1", &sample_history("repo#1"))
@@ -295,7 +300,9 @@ mod tests {
     #[tokio::test]
     async fn append_timeline_event_is_queryable_in_sequence_order() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = HistoryStore::new(dir.path().join("history.db")).await.unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db"))
+            .await
+            .unwrap();
 
         store
             .append_timeline_event(&sample_event("run-1", "repo#1", 2))
@@ -326,7 +333,9 @@ mod tests {
     #[tokio::test]
     async fn append_timeline_event_is_idempotent_for_duplicate_sequence() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = HistoryStore::new(dir.path().join("history.db")).await.unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db"))
+            .await
+            .unwrap();
         let event = sample_event("run-1", "repo#1", 1);
 
         store.append_timeline_event(&event).await.unwrap();

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -1,7 +1,8 @@
 use std::io;
 use std::path::PathBuf;
 
-use rusqlite::{params, Connection};
+use rusqlite::types::Value;
+use rusqlite::{params, params_from_iter, Connection, TransactionBehavior};
 
 use crate::history::model::HistoryRecord;
 use crate::history::reader::{HistoryQuery, HistoryResponse};
@@ -14,21 +15,20 @@ pub struct HistoryStore {
 }
 
 impl HistoryStore {
-    pub async fn new(db_path: PathBuf) -> Result<Self, io::Error> {
-        let path = db_path.clone();
-        tokio::task::spawn_blocking(move || -> Result<(), io::Error> {
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            let conn = Connection::open(&path).map_err(io::Error::other)?;
-            crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
-            crate::history_store::schema::bootstrap_schema(&conn).map_err(io::Error::other)?;
-            Ok(())
-        })
-        .await
-        .map_err(io::Error::other)??;
-
+    pub fn new_blocking(db_path: PathBuf) -> Result<Self, io::Error> {
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(&db_path).map_err(io::Error::other)?;
+        crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+        crate::history_store::schema::bootstrap_schema(&conn).map_err(io::Error::other)?;
         Ok(Self { db_path })
+    }
+
+    pub async fn new(db_path: PathBuf) -> Result<Self, io::Error> {
+        tokio::task::spawn_blocking(move || Self::new_blocking(db_path))
+            .await
+            .map_err(io::Error::other)?
     }
 
     pub fn db_path(&self) -> &PathBuf {
@@ -46,7 +46,9 @@ impl HistoryStore {
         tokio::task::spawn_blocking(move || -> Result<(), io::Error> {
             let mut conn = Connection::open(path).map_err(io::Error::other)?;
             crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
-            let tx = conn.transaction().map_err(io::Error::other)?;
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(io::Error::other)?;
             tx.execute(
                 r#"
                 INSERT INTO runs (
@@ -105,7 +107,9 @@ impl HistoryStore {
         tokio::task::spawn_blocking(move || -> Result<(), io::Error> {
             let mut conn = Connection::open(path).map_err(io::Error::other)?;
             crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
-            let tx = conn.transaction().map_err(io::Error::other)?;
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(io::Error::other)?;
             tx.execute(
                 r#"
                 INSERT OR IGNORE INTO run_events (
@@ -144,32 +148,57 @@ impl HistoryStore {
             let conn = Connection::open(path).map_err(io::Error::other)?;
             crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
 
-            let mut sql = String::from(
-                "SELECT issue_id, issue_identifier, outcome, steps_traversed, attempts, duration_seconds, started_at, completed_at, last_error, verdict, workspace_path, input_tokens, output_tokens, total_tokens FROM runs",
-            );
-            if outcome.is_some() {
-                sql.push_str(" WHERE outcome = ?1");
+            let mut where_clauses: Vec<&str> = Vec::new();
+            let mut base_params: Vec<Value> = Vec::new();
+            if let Some(ref out) = outcome {
+                where_clauses.push("outcome = ?");
+                base_params.push(Value::from(out.clone()));
             }
-            sql.push_str(" ORDER BY completed_at DESC");
+            if let Some(ref step_name) = step {
+                where_clauses.push("EXISTS (SELECT 1 FROM json_each(runs.steps_traversed) WHERE json_each.value = ?)");
+                base_params.push(Value::from(step_name.clone()));
+            }
 
-            let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
-            let rows = if let Some(outcome) = outcome {
-                stmt.query_map([outcome], crate::history_store::model::row_to_history_record)
+            let where_sql = if where_clauses.is_empty() {
+                String::new()
             } else {
-                stmt.query_map([], crate::history_store::model::row_to_history_record)
-            }
-            .map_err(io::Error::other)?;
+                format!(" WHERE {}", where_clauses.join(" AND "))
+            };
 
-            let mut records: Vec<HistoryRecord> = rows
+            let count_sql = format!("SELECT COUNT(*) FROM runs{where_sql}");
+            let total: usize = conn
+                .query_row(
+                    &count_sql,
+                    params_from_iter(base_params.clone()),
+                    |row| row.get(0),
+                )
+                .map_err(io::Error::other)?;
+
+            let limit_i64 = i64::try_from(limit).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "limit does not fit in i64")
+            })?;
+            let cursor_i64 = i64::try_from(cursor).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "cursor does not fit in i64")
+            })?;
+
+            let page_sql = format!(
+                "SELECT issue_id, issue_identifier, outcome, steps_traversed, attempts, duration_seconds, started_at, completed_at, last_error, verdict, workspace_path, input_tokens, output_tokens, total_tokens FROM runs{where_sql} ORDER BY completed_at DESC LIMIT ? OFFSET ?"
+            );
+            let mut page_params = base_params;
+            page_params.push(Value::from(limit_i64));
+            page_params.push(Value::from(cursor_i64));
+
+            let mut stmt = conn.prepare(&page_sql).map_err(io::Error::other)?;
+            let rows = stmt
+                .query_map(
+                    params_from_iter(page_params),
+                    crate::history_store::model::row_to_history_record,
+                )
+                .map_err(io::Error::other)?;
+
+            let page: Vec<HistoryRecord> = rows
                 .map(|r| r.map_err(io::Error::other))
                 .collect::<Result<_, _>>()?;
-
-            if let Some(step) = step {
-                records.retain(|r| r.steps_traversed.contains(&step));
-            }
-
-            let total = records.len();
-            let page = records.into_iter().skip(cursor).take(limit).collect::<Vec<_>>();
             let next_cursor = if cursor + page.len() < total {
                 Some(cursor + page.len())
             } else {
@@ -199,28 +228,48 @@ impl HistoryStore {
         tokio::task::spawn_blocking(move || -> Result<TimelineResponse, io::Error> {
             let conn = Connection::open(path).map_err(io::Error::other)?;
             crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
-            let mut sql = String::from(
-                "SELECT run_id, issue_identifier, sequence, timestamp, event_type, step_name, attempt, detail, verdict, tool_name FROM run_events WHERE run_id = ?1",
+            let mut where_clauses = vec!["run_id = ?".to_string()];
+            let mut base_params = vec![Value::from(run_id)];
+            if let Some(identifier) = issue_identifier {
+                where_clauses.push("issue_identifier = ?".to_string());
+                base_params.push(Value::from(identifier));
+            }
+            let where_sql = format!(" WHERE {}", where_clauses.join(" AND "));
+
+            let count_sql = format!("SELECT COUNT(*) FROM run_events{where_sql}");
+            let total: usize = conn
+                .query_row(
+                    &count_sql,
+                    params_from_iter(base_params.clone()),
+                    |row| row.get(0),
+                )
+                .map_err(io::Error::other)?;
+
+            let limit_i64 = i64::try_from(limit).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "limit does not fit in i64")
+            })?;
+            let cursor_i64 = i64::try_from(cursor).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "cursor does not fit in i64")
+            })?;
+
+            let query_sql = format!(
+                "SELECT run_id, issue_identifier, sequence, timestamp, event_type, step_name, attempt, detail, verdict, tool_name FROM run_events{where_sql} ORDER BY sequence ASC LIMIT ? OFFSET ?"
             );
-            if issue_identifier.is_some() {
-                sql.push_str(" AND issue_identifier = ?2");
-            }
-            sql.push_str(" ORDER BY sequence ASC");
+            let mut query_params = base_params;
+            query_params.push(Value::from(limit_i64));
+            query_params.push(Value::from(cursor_i64));
 
-            let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
-            let rows = if let Some(identifier) = issue_identifier {
-                stmt.query_map(params![run_id, identifier], crate::history_store::model::row_to_timeline_record)
-            } else {
-                stmt.query_map([run_id], crate::history_store::model::row_to_timeline_record)
-            }
-            .map_err(io::Error::other)?;
+            let mut stmt = conn.prepare(&query_sql).map_err(io::Error::other)?;
+            let rows = stmt
+                .query_map(
+                    params_from_iter(query_params),
+                    crate::history_store::model::row_to_timeline_record,
+                )
+                .map_err(io::Error::other)?;
 
-            let events: Vec<TimelineEventRecord> = rows
+            let page: Vec<TimelineEventRecord> = rows
                 .map(|r| r.map_err(io::Error::other))
                 .collect::<Result<_, _>>()?;
-
-            let total = events.len();
-            let page = events.into_iter().skip(cursor).take(limit).collect::<Vec<_>>();
             let next_cursor = if cursor + page.len() < total {
                 Some(cursor + page.len())
             } else {

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -1,1 +1,349 @@
-// Placeholder for the history store implementation added in later tasks.
+use std::io;
+use std::path::PathBuf;
+
+use rusqlite::{params, Connection};
+
+use crate::history::model::HistoryRecord;
+use crate::history::reader::{HistoryQuery, HistoryResponse};
+use crate::timeline::model::TimelineEventRecord;
+use crate::timeline::reader::{TimelineQuery, TimelineResponse};
+
+#[derive(Debug, Clone)]
+pub struct HistoryStore {
+    db_path: PathBuf,
+}
+
+impl HistoryStore {
+    pub async fn new(db_path: PathBuf) -> Result<Self, io::Error> {
+        let path = db_path.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), io::Error> {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let conn = Connection::open(&path).map_err(io::Error::other)?;
+            crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            crate::history_store::schema::bootstrap_schema(&conn).map_err(io::Error::other)?;
+            Ok(())
+        })
+        .await
+        .map_err(io::Error::other)??;
+
+        Ok(Self { db_path })
+    }
+
+    pub fn db_path(&self) -> &PathBuf {
+        &self.db_path
+    }
+
+    pub async fn append_history_record(
+        &self,
+        run_id: &str,
+        record: &HistoryRecord,
+    ) -> Result<(), io::Error> {
+        let path = self.db_path.clone();
+        let run_id = run_id.to_string();
+        let record = record.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), io::Error> {
+            let mut conn = Connection::open(path).map_err(io::Error::other)?;
+            crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            let tx = conn.transaction().map_err(io::Error::other)?;
+            tx.execute(
+                r#"
+                INSERT INTO runs (
+                    run_id, issue_id, issue_identifier, outcome, steps_traversed, attempts,
+                    duration_seconds, started_at, completed_at, last_error, verdict,
+                    workspace_path, input_tokens, output_tokens, total_tokens
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    issue_id = excluded.issue_id,
+                    issue_identifier = excluded.issue_identifier,
+                    outcome = excluded.outcome,
+                    steps_traversed = excluded.steps_traversed,
+                    attempts = excluded.attempts,
+                    duration_seconds = excluded.duration_seconds,
+                    started_at = excluded.started_at,
+                    completed_at = excluded.completed_at,
+                    last_error = excluded.last_error,
+                    verdict = excluded.verdict,
+                    workspace_path = excluded.workspace_path,
+                    input_tokens = excluded.input_tokens,
+                    output_tokens = excluded.output_tokens,
+                    total_tokens = excluded.total_tokens
+                "#,
+                params![
+                    run_id,
+                    record.issue_id,
+                    record.issue_identifier,
+                    record.outcome,
+                    serde_json::to_string(&record.steps_traversed).map_err(io::Error::other)?,
+                    record.attempts,
+                    record.duration_seconds,
+                    record.started_at.to_rfc3339(),
+                    record.completed_at.to_rfc3339(),
+                    record.last_error,
+                    record.verdict,
+                    record.workspace_path,
+                    record.tokens.input_tokens,
+                    record.tokens.output_tokens,
+                    record.tokens.total_tokens,
+                ],
+            )
+            .map_err(io::Error::other)?;
+            tx.commit().map_err(io::Error::other)?;
+            Ok(())
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    pub async fn append_timeline_event(&self, record: &TimelineEventRecord) -> Result<(), io::Error> {
+        let path = self.db_path.clone();
+        let record = record.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), io::Error> {
+            let mut conn = Connection::open(path).map_err(io::Error::other)?;
+            crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            let tx = conn.transaction().map_err(io::Error::other)?;
+            tx.execute(
+                r#"
+                INSERT OR IGNORE INTO run_events (
+                    run_id, sequence, timestamp, issue_identifier,
+                    event_type, step_name, attempt, detail, verdict, tool_name
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                "#,
+                params![
+                    record.run_id,
+                    record.sequence,
+                    record.timestamp.to_rfc3339(),
+                    record.issue_identifier,
+                    record.event_type,
+                    record.step_name,
+                    record.attempt,
+                    record.detail,
+                    record.verdict,
+                    record.tool_name,
+                ],
+            )
+            .map_err(io::Error::other)?;
+            tx.commit().map_err(io::Error::other)?;
+            Ok(())
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    pub async fn read_history(&self, query: &HistoryQuery) -> Result<HistoryResponse, io::Error> {
+        let path = self.db_path.clone();
+        let outcome = query.outcome.clone();
+        let step = query.step.clone();
+        let cursor = query.cursor.unwrap_or(0);
+        let limit = query.limit.unwrap_or(50).min(200);
+        tokio::task::spawn_blocking(move || -> Result<HistoryResponse, io::Error> {
+            let conn = Connection::open(path).map_err(io::Error::other)?;
+            crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+
+            let mut sql = String::from(
+                "SELECT issue_id, issue_identifier, outcome, steps_traversed, attempts, duration_seconds, started_at, completed_at, last_error, verdict, workspace_path, input_tokens, output_tokens, total_tokens FROM runs",
+            );
+            if outcome.is_some() {
+                sql.push_str(" WHERE outcome = ?1");
+            }
+            sql.push_str(" ORDER BY completed_at DESC");
+
+            let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
+            let rows = if let Some(outcome) = outcome {
+                stmt.query_map([outcome], crate::history_store::model::row_to_history_record)
+            } else {
+                stmt.query_map([], crate::history_store::model::row_to_history_record)
+            }
+            .map_err(io::Error::other)?;
+
+            let mut records: Vec<HistoryRecord> = rows
+                .map(|r| r.map_err(io::Error::other))
+                .collect::<Result<_, _>>()?;
+
+            if let Some(step) = step {
+                records.retain(|r| r.steps_traversed.contains(&step));
+            }
+
+            let total = records.len();
+            let page = records.into_iter().skip(cursor).take(limit).collect::<Vec<_>>();
+            let next_cursor = if cursor + page.len() < total {
+                Some(cursor + page.len())
+            } else {
+                None
+            };
+
+            Ok(HistoryResponse {
+                records: page,
+                total,
+                next_cursor,
+            })
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    pub async fn read_timeline(
+        &self,
+        query: &TimelineQuery,
+        issue_identifier: Option<&str>,
+    ) -> Result<TimelineResponse, io::Error> {
+        let path = self.db_path.clone();
+        let run_id = query.run_id.clone();
+        let issue_identifier = issue_identifier.map(ToString::to_string);
+        let cursor = query.cursor.unwrap_or(0);
+        let limit = query.limit.unwrap_or(50).min(200);
+        tokio::task::spawn_blocking(move || -> Result<TimelineResponse, io::Error> {
+            let conn = Connection::open(path).map_err(io::Error::other)?;
+            crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            let mut sql = String::from(
+                "SELECT run_id, issue_identifier, sequence, timestamp, event_type, step_name, attempt, detail, verdict, tool_name FROM run_events WHERE run_id = ?1",
+            );
+            if issue_identifier.is_some() {
+                sql.push_str(" AND issue_identifier = ?2");
+            }
+            sql.push_str(" ORDER BY sequence ASC");
+
+            let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
+            let rows = if let Some(identifier) = issue_identifier {
+                stmt.query_map(params![run_id, identifier], crate::history_store::model::row_to_timeline_record)
+            } else {
+                stmt.query_map([run_id], crate::history_store::model::row_to_timeline_record)
+            }
+            .map_err(io::Error::other)?;
+
+            let events: Vec<TimelineEventRecord> = rows
+                .map(|r| r.map_err(io::Error::other))
+                .collect::<Result<_, _>>()?;
+
+            let total = events.len();
+            let page = events.into_iter().skip(cursor).take(limit).collect::<Vec<_>>();
+            let next_cursor = if cursor + page.len() < total {
+                Some(cursor + page.len())
+            } else {
+                None
+            };
+
+            Ok(TimelineResponse {
+                events: page,
+                total,
+                next_cursor,
+            })
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::model::TokenTotals;
+    use chrono::Utc;
+
+    fn sample_history(identifier: &str) -> HistoryRecord {
+        HistoryRecord {
+            issue_identifier: identifier.into(),
+            issue_id: format!("id-{identifier}"),
+            outcome: "succeeded".into(),
+            steps_traversed: vec!["build".into(), "review".into()],
+            attempts: 1,
+            tokens: TokenTotals {
+                input_tokens: 1,
+                output_tokens: 2,
+                total_tokens: 3,
+            },
+            duration_seconds: 15,
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+            last_error: None,
+            verdict: Some("approved".into()),
+            workspace_path: format!("/tmp/{identifier}"),
+        }
+    }
+
+    fn sample_event(run_id: &str, issue_identifier: &str, sequence: u64) -> TimelineEventRecord {
+        TimelineEventRecord {
+            run_id: run_id.into(),
+            issue_identifier: issue_identifier.into(),
+            sequence,
+            timestamp: Utc::now(),
+            event_type: "step_started".into(),
+            step_name: Some("build".into()),
+            attempt: 1,
+            detail: format!("event-{sequence}"),
+            verdict: None,
+            tool_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn append_history_record_is_queryable() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db")).await.unwrap();
+
+        store
+            .append_history_record("run-1", &sample_history("repo#1"))
+            .await
+            .unwrap();
+
+        let response = store.read_history(&HistoryQuery::default()).await.unwrap();
+        assert_eq!(response.total, 1);
+        assert_eq!(response.records[0].issue_identifier, "repo#1");
+    }
+
+    #[tokio::test]
+    async fn append_timeline_event_is_queryable_in_sequence_order() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db")).await.unwrap();
+
+        store
+            .append_timeline_event(&sample_event("run-1", "repo#1", 2))
+            .await
+            .unwrap();
+        store
+            .append_timeline_event(&sample_event("run-1", "repo#1", 1))
+            .await
+            .unwrap();
+
+        let response = store
+            .read_timeline(
+                &TimelineQuery {
+                    run_id: "run-1".to_string(),
+                    cursor: None,
+                    limit: None,
+                },
+                Some("repo#1"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.total, 2);
+        assert_eq!(response.events[0].sequence, 1);
+        assert_eq!(response.events[1].sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn append_timeline_event_is_idempotent_for_duplicate_sequence() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db")).await.unwrap();
+        let event = sample_event("run-1", "repo#1", 1);
+
+        store.append_timeline_event(&event).await.unwrap();
+        store.append_timeline_event(&event).await.unwrap();
+
+        let response = store
+            .read_timeline(
+                &TimelineQuery {
+                    run_id: "run-1".to_string(),
+                    cursor: None,
+                    limit: None,
+                },
+                Some("repo#1"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.total, 1);
+    }
+}

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -1,0 +1,1 @@
+// Placeholder for the history store implementation added in later tasks.

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod api;
 pub mod config;
 pub mod error;
 pub mod history;
+pub mod history_store;
 pub mod interaction;
 pub mod observability;
 pub mod orchestrator;

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -28,6 +28,7 @@ use crate::config::ensemble::EnsembleConfig;
 use crate::error::{AgentError, EnsembleError};
 use crate::history::model::{HistoryRecord, TokenTotals};
 use crate::history::writer::HistoryWriter;
+use crate::history_store::store::HistoryStore;
 use crate::interaction::{
     InteractionKind, InteractionResponse, InteractionResumeStrategy, InteractionStatus,
     InteractionStore,
@@ -93,6 +94,7 @@ pub struct Orchestrator {
     refresh_requested: Arc<tokio::sync::Notify>,
     cancellation_registry: CancellationRegistry,
     history_write_lock: Arc<tokio::sync::Mutex<()>>,
+    history_store: Option<HistoryStore>,
     event_bus: EventBus,
     timeline_writer: TimelineWriter,
     worker_tx: mpsc::Sender<WorkerEvent>,
@@ -171,6 +173,17 @@ impl Orchestrator {
             refresh_requested: parts.refresh_requested,
             cancellation_registry: parts.cancellation_registry,
             history_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+            history_store: futures::executor::block_on(HistoryStore::new(
+                parts.workspace_root.join(".ensemble").join("history.db"),
+            ))
+            .map_err(|error| {
+                warn!(
+                    error = %error,
+                    "failed to initialize sqlite history store; continuing with file persistence only"
+                );
+                error
+            })
+            .ok(),
             event_bus: parts.event_bus,
             timeline_writer: TimelineWriter::new(parts.workspace_root),
             worker_tx,
@@ -2285,6 +2298,16 @@ impl Orchestrator {
     }
 
     async fn append_history_record(&self, record: HistoryRecord) {
+        if let Some(store) = &self.history_store {
+            if let Err(error) = store.append_history_record(&record.issue_id, &record).await {
+                warn!(
+                    issue_id = %record.issue_id,
+                    error = %error,
+                    "failed to append history record to sqlite"
+                );
+            }
+        }
+
         let history_path = self.workspace_mgr.root().join("ensemble_history.jsonl");
         let _guard = self.history_write_lock.lock().await;
         let writer = HistoryWriter::new(history_path);
@@ -3015,6 +3038,17 @@ impl Orchestrator {
         self.event_bus.publish(event);
 
         if let Some((run_id, record)) = timeline_entry {
+            if let Some(store) = &self.history_store {
+                if let Err(error) = store.append_timeline_event(&record).await {
+                    warn!(
+                        event = "timeline_persist_failed",
+                        run_id = %run_id,
+                        error = %error,
+                        "failed to persist timeline event to sqlite"
+                    );
+                }
+            }
+
             if let Err(error) = self.timeline_writer.append(&run_id, &record).await {
                 warn!(
                     event = "timeline_persist_failed",

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -398,6 +398,9 @@ impl Orchestrator {
                     if let Some(entry) = running_entry.as_ref() {
                         state.add_runtime_seconds(entry);
                     }
+                    let run_id = running_entry
+                        .as_ref()
+                        .and_then(|entry| entry.run_id.clone());
                     let history_record = running_entry.as_ref().and_then(|entry| {
                         state.get_pipeline_run(&issue.id).map(|run| {
                             self.build_history_record(
@@ -419,9 +422,9 @@ impl Orchestrator {
                         waiting_entry.map(|entry| entry.interaction_request_id);
                     state.release_claim(&issue.id);
                     state.remove_pipeline_run(&issue.id);
-                    (identifier, interaction_request_id, history_record)
+                    (identifier, interaction_request_id, run_id, history_record)
                 };
-                let (identifier, interaction_request_id, history_record) = history_record;
+                let (identifier, interaction_request_id, run_id, history_record) = history_record;
 
                 self.cancel_open_interaction(interaction_request_id).await;
 
@@ -434,7 +437,7 @@ impl Orchestrator {
                 }
 
                 if let Some(record) = history_record {
-                    self.append_history_record(record).await;
+                    self.append_history_record(run_id.as_deref(), record).await;
                 }
             }
 
@@ -446,6 +449,9 @@ impl Orchestrator {
                     if let Some(entry) = running_entry.as_ref() {
                         state.add_runtime_seconds(entry);
                     }
+                    let run_id = running_entry
+                        .as_ref()
+                        .and_then(|entry| entry.run_id.clone());
                     let history_record = running_entry.as_ref().and_then(|entry| {
                         state.get_pipeline_run(&issue.id).map(|run| {
                             self.build_history_record(
@@ -464,14 +470,14 @@ impl Orchestrator {
                         .map(|entry| entry.interaction_request_id.clone());
                     state.release_claim(&issue.id);
                     state.remove_pipeline_run(&issue.id);
-                    (interaction_request_id, history_record)
+                    (interaction_request_id, run_id, history_record)
                 };
-                let (interaction_request_id, history_record) = result;
+                let (interaction_request_id, run_id, history_record) = result;
 
                 self.cancel_open_interaction(interaction_request_id).await;
 
                 if let Some(record) = history_record {
-                    self.append_history_record(record).await;
+                    self.append_history_record(run_id.as_deref(), record).await;
                 }
             }
         }
@@ -1105,7 +1111,13 @@ impl Orchestrator {
 
                                 drop(state);
                                 if let Some(record) = history_record {
-                                    self.append_history_record(record).await;
+                                    self.append_history_record(
+                                        running_entry
+                                            .as_ref()
+                                            .and_then(|entry| entry.run_id.as_deref()),
+                                        record,
+                                    )
+                                    .await;
                                 }
                             } else {
                                 if self.tracker.supports_writes()
@@ -1136,10 +1148,12 @@ impl Orchestrator {
                             let completed_at = Utc::now();
                             let mut final_failure = false;
                             let mut history_record = None;
+                            let mut history_run_id = None;
                             let mut completed_identifier = None;
                             if let Some(entry) = state.remove_running(issue_id) {
                                 state.add_runtime_seconds(&entry);
                                 completed_identifier = Some(entry.identifier.clone());
+                                history_run_id = entry.run_id.clone();
                                 let retry_scheduled = schedule_failure_retry(
                                     &mut state,
                                     issue_id,
@@ -1186,7 +1200,8 @@ impl Orchestrator {
                             drop(state);
                             if final_failure {
                                 if let Some(record) = history_record {
-                                    self.append_history_record(record).await;
+                                    self.append_history_record(history_run_id.as_deref(), record)
+                                        .await;
                                 }
                             }
                         }
@@ -1298,10 +1313,12 @@ impl Orchestrator {
                 let completed_at = Utc::now();
                 let mut final_failure = false;
                 let mut history_record = None;
+                let mut history_run_id = None;
                 let mut completed_identifier = None;
 
                 if let Some(entry) = state.remove_running(issue_id) {
                     completed_identifier = Some(entry.identifier.clone());
+                    history_run_id = entry.run_id.clone();
                     state.add_runtime_seconds(&entry);
                     let retry_scheduled = schedule_failure_retry(
                         &mut state,
@@ -1349,7 +1366,8 @@ impl Orchestrator {
                 drop(state);
                 if final_failure {
                     if let Some(record) = history_record {
-                        self.append_history_record(record).await;
+                        self.append_history_record(history_run_id.as_deref(), record)
+                            .await;
                     }
                 }
             }
@@ -2297,15 +2315,23 @@ impl Orchestrator {
         None
     }
 
-    async fn append_history_record(&self, record: HistoryRecord) {
-        if let Some(store) = &self.history_store {
-            if let Err(error) = store.append_history_record(&record.issue_id, &record).await {
-                warn!(
-                    issue_id = %record.issue_id,
-                    error = %error,
-                    "failed to append history record to sqlite"
-                );
+    async fn append_history_record(&self, run_id: Option<&str>, record: HistoryRecord) {
+        if let Some(run_id) = run_id {
+            if let Some(store) = &self.history_store {
+                if let Err(error) = store.append_history_record(run_id, &record).await {
+                    warn!(
+                        run_id = %run_id,
+                        issue_id = %record.issue_id,
+                        error = %error,
+                        "failed to append history record to sqlite"
+                    );
+                }
             }
+        } else if self.history_store.is_some() {
+            warn!(
+                issue_id = %record.issue_id,
+                "missing run_id; skipping sqlite history write"
+            );
         }
 
         let history_path = self.workspace_mgr.root().join("ensemble_history.jsonl");
@@ -2738,8 +2764,12 @@ impl Orchestrator {
                             .run_finalize_phase(&issue.identifier, &current_config)
                             .await;
                         let completed_at = Utc::now();
-                        let (tracker_state, history_record, tracker_error_message) = {
+                        let (tracker_state, history_run_id, history_record, tracker_error_message) = {
                             let mut state = self.state.write().await;
+                            let history_run_id = state
+                                .waiting_on_human
+                                .get(&issue.id)
+                                .and_then(|entry| entry.run_id.clone());
                             let history_record =
                                 state.waiting_on_human.get(&issue.id).and_then(|entry| {
                                     state.get_pipeline_run(&issue.id).map(|run| {
@@ -2772,6 +2802,7 @@ impl Orchestrator {
                                     self.tracker
                                         .supports_writes()
                                         .then(|| current_config.on_success.clone()),
+                                    history_run_id,
                                     history_record,
                                     "failed to set tracker success state after approval resume",
                                 )
@@ -2788,6 +2819,7 @@ impl Orchestrator {
 
                                 (
                                     tracker_state,
+                                    None,
                                     None,
                                     "failed to set tracker failure state after approval finalize failure",
                                 )
@@ -2809,13 +2841,18 @@ impl Orchestrator {
                         }
 
                         if let Some(record) = history_record {
-                            self.append_history_record(record).await;
+                            self.append_history_record(history_run_id.as_deref(), record)
+                                .await;
                         }
                     }
                     PipelineAction::Failed { reason, .. } => {
                         let completed_at = Utc::now();
-                        let history_record = {
+                        let (history_run_id, history_record) = {
                             let mut state = self.state.write().await;
+                            let history_run_id = state
+                                .waiting_on_human
+                                .get(&issue.id)
+                                .and_then(|entry| entry.run_id.clone());
                             let history_record =
                                 state.waiting_on_human.get(&issue.id).and_then(|entry| {
                                     state.get_pipeline_run(&issue.id).map(|run| {
@@ -2840,7 +2877,7 @@ impl Orchestrator {
                             state.remove_pipeline_run(&issue.id);
                             state.clear_finalize_state(&issue.id);
 
-                            history_record
+                            (history_run_id, history_record)
                         };
 
                         if self.tracker.supports_writes() {
@@ -2858,7 +2895,8 @@ impl Orchestrator {
                         }
 
                         if let Some(record) = history_record {
-                            self.append_history_record(record).await;
+                            self.append_history_record(history_run_id.as_deref(), record)
+                                .await;
                         }
                     }
                     PipelineAction::Waiting

--- a/crates/ensemble-core/src/timeline/reader.rs
+++ b/crates/ensemble-core/src/timeline/reader.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::model::TimelineEventRecord;
 
-#[derive(Debug, Deserialize, utoipa::IntoParams)]
+#[derive(Debug, Clone, Deserialize, utoipa::IntoParams)]
 pub struct TimelineQuery {
     pub run_id: String,
     pub cursor: Option<usize>,

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -6,6 +6,7 @@ use ensemble_core::agent::cancellation::new_cancellation_registry;
 use ensemble_core::api::router::{create_api_router, AppState, ConfigRuntime};
 use ensemble_core::config::draft::{ConfigDocumentState, ConfigStateKind, DraftValidationReport};
 use ensemble_core::config::ensemble::ConcurrencyConfig;
+use ensemble_core::history_store::store::HistoryStore;
 use ensemble_core::interaction::model::{
     InteractionKind, InteractionRequest, InteractionResponse, InteractionResumeStrategy,
     InteractionStatus,
@@ -38,6 +39,7 @@ fn build_app_state(
     orchestrator_state: OrchestratorState,
     document_state: ConfigDocumentState,
 ) -> AppState {
+    let history_db_path = temp_dir.path().join(".ensemble").join("history.db");
     AppState {
         orchestrator_state: Arc::new(RwLock::new(orchestrator_state)),
         orchestrator_runtime: Arc::new(std::sync::Mutex::new(None)),
@@ -48,7 +50,8 @@ fn build_app_state(
             .display()
             .to_string(),
         history_path: temp_dir.path().join("ensemble_test_history.jsonl"),
-        history_db_path: temp_dir.path().join(".ensemble").join("history.db"),
+        history_db_path: history_db_path.clone(),
+        history_store: HistoryStore::new_blocking(history_db_path).ok(),
         event_bus: EventBus::new(),
         config_runtime: ConfigRuntime {
             config_path: document_state.path.clone(),

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -48,6 +48,7 @@ fn build_app_state(
             .display()
             .to_string(),
         history_path: temp_dir.path().join("ensemble_test_history.jsonl"),
+        history_db_path: temp_dir.path().join(".ensemble").join("history.db"),
         event_bus: EventBus::new(),
         config_runtime: ConfigRuntime {
             config_path: document_state.path.clone(),

--- a/docs/superpowers/plans/2026-04-12-global-sqlite-history-store-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-12-global-sqlite-history-store-implementation-plan.md
@@ -1,0 +1,858 @@
+# Global SQLite Task History Store Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace JSONL history/timeline persistence with a single global SQLite store while keeping existing API response shapes unchanged.
+
+**Architecture:** Add a global `history.db` under `<workspace_root>/.ensemble/` and route all orchestrator persistence through a new async SQLite-backed store abstraction. Keep `HistoryRecord` and `TimelineEventRecord` response models stable, but switch readers/writers to SQL queries and transactional writes with WAL + FULL sync durability.
+
+**Tech Stack:** Rust 2021, tokio, rusqlite (+ bundled SQLite), chrono, serde, axum.
+
+---
+
+## File Structure
+
+- Create: `crates/ensemble-core/src/history_store/mod.rs` — public module exports and shared constants.
+- Create: `crates/ensemble-core/src/history_store/schema.rs` — schema bootstrap SQL and pragmas.
+- Create: `crates/ensemble-core/src/history_store/store.rs` — async store API (`append_history_record`, `append_timeline_event`, reads).
+- Create: `crates/ensemble-core/src/history_store/model.rs` — query DTOs/internal row mapping helpers.
+- Modify: `Cargo.toml` — add workspace dependency for `rusqlite`.
+- Modify: `crates/ensemble-core/Cargo.toml` — consume workspace `rusqlite`.
+- Modify: `crates/ensemble-core/src/lib.rs` — expose `history_store` module.
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs` — replace JSONL history/timeline writes with store calls.
+- Modify: `crates/ensemble-core/src/api/router.rs` — swap `history_path` state for global `history_db_path`.
+- Modify: `crates/ensemble-core/src/api/bootstrap.rs` — initialize db path under `.ensemble/history.db`.
+- Modify: `crates/ensemble-core/src/api/history_handler.rs` — SQL-backed history reads.
+- Modify: `crates/ensemble-core/src/api/timeline_handler.rs` — SQL-backed timeline reads.
+- Modify: `crates/ensemble-core/src/history/reader.rs` and `crates/ensemble-core/src/timeline/reader.rs` — deprecate/remove file-read implementations once handlers are switched.
+
+---
+
+### Task 1: Add SQLite dependency and schema bootstrap module
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/ensemble-core/Cargo.toml`
+- Modify: `crates/ensemble-core/src/lib.rs`
+- Create: `crates/ensemble-core/src/history_store/mod.rs`
+- Create: `crates/ensemble-core/src/history_store/schema.rs`
+- Test: `crates/ensemble-core/src/history_store/schema.rs`
+
+- [ ] **Step 1: Write failing schema bootstrap tests**
+
+```rust
+// crates/ensemble-core/src/history_store/schema.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    #[test]
+    fn bootstrap_creates_runs_and_run_events_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply_pragmas(&conn).unwrap();
+        bootstrap_schema(&conn).unwrap();
+
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap();
+        let names: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+
+        assert!(names.contains(&"runs".to_string()));
+        assert!(names.contains(&"run_events".to_string()));
+    }
+
+    #[test]
+    fn bootstrap_creates_run_events_sequence_index() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply_pragmas(&conn).unwrap();
+        bootstrap_schema(&conn).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_run_events_run_sequence'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(count, 1);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk cargo test -p ensemble-core history_store::schema::tests::bootstrap_creates_runs_and_run_events_tables -- --exact`
+Expected: FAIL because `history_store` module/functions do not exist.
+
+- [ ] **Step 3: Add dependency wiring**
+
+```toml
+# Cargo.toml
+[workspace.dependencies]
+rusqlite = { version = "0.33", features = ["bundled"] }
+```
+
+```toml
+# crates/ensemble-core/Cargo.toml
+[dependencies]
+rusqlite = { workspace = true }
+```
+
+```rust
+// crates/ensemble-core/src/lib.rs
+pub mod history_store;
+```
+
+- [ ] **Step 4: Implement schema bootstrap**
+
+```rust
+// crates/ensemble-core/src/history_store/schema.rs
+use rusqlite::Connection;
+
+pub fn apply_pragmas(conn: &Connection) -> rusqlite::Result<()> {
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "FULL")?;
+    conn.pragma_update(None, "busy_timeout", 5000i64)?;
+    Ok(())
+}
+
+pub fn bootstrap_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS runs (
+            run_id TEXT PRIMARY KEY,
+            issue_id TEXT NOT NULL,
+            issue_identifier TEXT NOT NULL,
+            outcome TEXT NOT NULL,
+            attempts INTEGER NOT NULL,
+            duration_seconds INTEGER NOT NULL,
+            started_at TEXT NOT NULL,
+            completed_at TEXT NOT NULL,
+            last_error TEXT,
+            verdict TEXT,
+            workspace_path TEXT NOT NULL,
+            input_tokens INTEGER NOT NULL,
+            output_tokens INTEGER NOT NULL,
+            total_tokens INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS run_events (
+            run_id TEXT NOT NULL,
+            sequence INTEGER NOT NULL,
+            timestamp TEXT NOT NULL,
+            issue_identifier TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            step_name TEXT,
+            attempt INTEGER NOT NULL,
+            detail TEXT NOT NULL,
+            verdict TEXT,
+            tool_name TEXT,
+            PRIMARY KEY (run_id, sequence)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_run_events_run_sequence ON run_events(run_id, sequence);
+        CREATE INDEX IF NOT EXISTS idx_runs_identifier_completed_at ON runs(issue_identifier, completed_at);
+        CREATE INDEX IF NOT EXISTS idx_runs_outcome_completed_at ON runs(outcome, completed_at);
+        "#,
+    )
+}
+```
+
+```rust
+// crates/ensemble-core/src/history_store/mod.rs
+pub mod schema;
+pub mod store;
+```
+
+- [ ] **Step 5: Run schema tests to verify pass**
+
+Run: `rtk cargo test -p ensemble-core history_store::schema::tests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+rtk git add Cargo.toml crates/ensemble-core/Cargo.toml crates/ensemble-core/src/lib.rs crates/ensemble-core/src/history_store/mod.rs crates/ensemble-core/src/history_store/schema.rs
+rtk git commit -m "Add SQLite schema bootstrap for history store"
+```
+
+---
+
+### Task 2: Implement SQLite store write/read API with TDD
+
+**Files:**
+- Create: `crates/ensemble-core/src/history_store/store.rs`
+- Create: `crates/ensemble-core/src/history_store/model.rs`
+- Test: `crates/ensemble-core/src/history_store/store.rs`
+
+- [ ] **Step 1: Write failing store tests for append + read**
+
+```rust
+// crates/ensemble-core/src/history_store/store.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::model::{HistoryRecord, TokenTotals};
+    use crate::timeline::model::TimelineEventRecord;
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn append_history_record_is_queryable() {
+        let dir = TempDir::new().unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db")).await.unwrap();
+
+        let record = HistoryRecord {
+            issue_identifier: "repo#1".into(),
+            issue_id: "issue-1".into(),
+            outcome: "succeeded".into(),
+            steps_traversed: vec!["build".into()],
+            attempts: 1,
+            tokens: TokenTotals { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+            duration_seconds: 10,
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+            last_error: None,
+            verdict: Some("approved".into()),
+            workspace_path: "/tmp/work".into(),
+        };
+
+        store.append_history_record("run-1", &record).await.unwrap();
+        let response = store.read_history(&crate::history::reader::HistoryQuery::default()).await.unwrap();
+
+        assert_eq!(response.total, 1);
+        assert_eq!(response.records[0].issue_identifier, "repo#1");
+    }
+
+    #[tokio::test]
+    async fn append_timeline_event_is_queryable_in_sequence_order() {
+        let dir = TempDir::new().unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db")).await.unwrap();
+
+        store.append_timeline_event(&TimelineEventRecord {
+            run_id: "run-1".into(),
+            issue_identifier: "repo#1".into(),
+            sequence: 2,
+            timestamp: Utc::now(),
+            event_type: "step_started".into(),
+            step_name: Some("review".into()),
+            attempt: 1,
+            detail: "second".into(),
+            verdict: None,
+            tool_name: None,
+        }).await.unwrap();
+
+        store.append_timeline_event(&TimelineEventRecord {
+            run_id: "run-1".into(),
+            issue_identifier: "repo#1".into(),
+            sequence: 1,
+            timestamp: Utc::now(),
+            event_type: "step_started".into(),
+            step_name: Some("build".into()),
+            attempt: 1,
+            detail: "first".into(),
+            verdict: None,
+            tool_name: None,
+        }).await.unwrap();
+
+        let response = store
+            .read_timeline(
+                &crate::timeline::reader::TimelineQuery {
+                    run_id: "run-1".into(),
+                    cursor: Some(0),
+                    limit: Some(50),
+                },
+                Some("repo#1"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.events[0].sequence, 1);
+        assert_eq!(response.events[1].sequence, 2);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `rtk cargo test -p ensemble-core history_store::store::tests::append_history_record_is_queryable -- --exact`
+Expected: FAIL because `HistoryStore` methods do not exist.
+
+- [ ] **Step 3: Implement store with spawn_blocking + rusqlite**
+
+```rust
+// crates/ensemble-core/src/history_store/store.rs
+#[derive(Clone)]
+pub struct HistoryStore {
+    db_path: std::path::PathBuf,
+}
+
+impl HistoryStore {
+    pub async fn new(db_path: std::path::PathBuf) -> Result<Self, std::io::Error> {
+        let path = db_path.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), std::io::Error> {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let conn = rusqlite::Connection::open(&path)
+                .map_err(std::io::Error::other)?;
+            crate::history_store::schema::apply_pragmas(&conn)
+                .map_err(std::io::Error::other)?;
+            crate::history_store::schema::bootstrap_schema(&conn)
+                .map_err(std::io::Error::other)?;
+            Ok(())
+        })
+        .await
+        .map_err(std::io::Error::other)??;
+
+        Ok(Self { db_path })
+    }
+
+    pub async fn append_history_record(
+        &self,
+        run_id: &str,
+        record: &crate::history::model::HistoryRecord,
+    ) -> Result<(), std::io::Error> {
+        let db_path = self.db_path.clone();
+        let run_id = run_id.to_string();
+        let record = record.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), std::io::Error> {
+            let mut conn = rusqlite::Connection::open(db_path).map_err(std::io::Error::other)?;
+            crate::history_store::schema::apply_pragmas(&conn).map_err(std::io::Error::other)?;
+            let tx = conn.transaction().map_err(std::io::Error::other)?;
+            tx.execute(
+                r#"
+                INSERT INTO runs (
+                    run_id, issue_id, issue_identifier, outcome, attempts, duration_seconds,
+                    started_at, completed_at, last_error, verdict, workspace_path,
+                    input_tokens, output_tokens, total_tokens
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    issue_id = excluded.issue_id,
+                    issue_identifier = excluded.issue_identifier,
+                    outcome = excluded.outcome,
+                    attempts = excluded.attempts,
+                    duration_seconds = excluded.duration_seconds,
+                    started_at = excluded.started_at,
+                    completed_at = excluded.completed_at,
+                    last_error = excluded.last_error,
+                    verdict = excluded.verdict,
+                    workspace_path = excluded.workspace_path,
+                    input_tokens = excluded.input_tokens,
+                    output_tokens = excluded.output_tokens,
+                    total_tokens = excluded.total_tokens
+                "#,
+                rusqlite::params![
+                    run_id,
+                    record.issue_id,
+                    record.issue_identifier,
+                    record.outcome,
+                    record.attempts,
+                    record.duration_seconds,
+                    record.started_at.to_rfc3339(),
+                    record.completed_at.to_rfc3339(),
+                    record.last_error,
+                    record.verdict,
+                    record.workspace_path,
+                    record.tokens.input_tokens,
+                    record.tokens.output_tokens,
+                    record.tokens.total_tokens,
+                ],
+            )
+            .map_err(std::io::Error::other)?;
+            tx.commit().map_err(std::io::Error::other)?;
+            Ok(())
+        })
+        .await
+        .map_err(std::io::Error::other)?
+    }
+
+    pub async fn append_timeline_event(
+        &self,
+        record: &crate::timeline::model::TimelineEventRecord,
+    ) -> Result<(), std::io::Error> {
+        let db_path = self.db_path.clone();
+        let record = record.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), std::io::Error> {
+            let mut conn = rusqlite::Connection::open(db_path).map_err(std::io::Error::other)?;
+            crate::history_store::schema::apply_pragmas(&conn).map_err(std::io::Error::other)?;
+            let tx = conn.transaction().map_err(std::io::Error::other)?;
+            tx.execute(
+                r#"
+                INSERT OR IGNORE INTO run_events (
+                    run_id, sequence, timestamp, issue_identifier, event_type,
+                    step_name, attempt, detail, verdict, tool_name
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                "#,
+                rusqlite::params![
+                    record.run_id,
+                    record.sequence,
+                    record.timestamp.to_rfc3339(),
+                    record.issue_identifier,
+                    record.event_type,
+                    record.step_name,
+                    record.attempt,
+                    record.detail,
+                    record.verdict,
+                    record.tool_name,
+                ],
+            )
+            .map_err(std::io::Error::other)?;
+            tx.commit().map_err(std::io::Error::other)?;
+            Ok(())
+        })
+        .await
+        .map_err(std::io::Error::other)?
+    }
+
+    pub async fn read_history(
+        &self,
+        query: &crate::history::reader::HistoryQuery,
+    ) -> Result<crate::history::reader::HistoryResponse, std::io::Error> {
+        let db_path = self.db_path.clone();
+        let outcome = query.outcome.clone();
+        let step = query.step.clone();
+        let cursor = query.cursor.unwrap_or(0);
+        let limit = query.limit.unwrap_or(50).min(200);
+        tokio::task::spawn_blocking(move || -> Result<crate::history::reader::HistoryResponse, std::io::Error> {
+            let conn = rusqlite::Connection::open(db_path).map_err(std::io::Error::other)?;
+            let mut sql = String::from(
+                "SELECT run_id, issue_id, issue_identifier, outcome, attempts, duration_seconds, started_at, completed_at, last_error, verdict, workspace_path, input_tokens, output_tokens, total_tokens FROM runs",
+            );
+            if outcome.is_some() {
+                sql.push_str(" WHERE outcome = ?1");
+            }
+            sql.push_str(" ORDER BY completed_at DESC");
+            let mut stmt = conn.prepare(&sql).map_err(std::io::Error::other)?;
+            let rows = if let Some(outcome) = outcome {
+                stmt.query_map([outcome], |row| crate::history_store::model::row_to_history_record(row))
+            } else {
+                stmt.query_map([], |row| crate::history_store::model::row_to_history_record(row))
+            }
+            .map_err(std::io::Error::other)?;
+
+            let mut records: Vec<crate::history::model::HistoryRecord> =
+                rows.map(|row| row.map_err(std::io::Error::other)).collect::<Result<_, _>>()?;
+
+            if let Some(step) = step {
+                records.retain(|r| r.steps_traversed.contains(&step));
+            }
+
+            let total = records.len();
+            let page = records.into_iter().skip(cursor).take(limit).collect::<Vec<_>>();
+            let next_cursor = if cursor + page.len() < total { Some(cursor + page.len()) } else { None };
+
+            Ok(crate::history::reader::HistoryResponse { records: page, total, next_cursor })
+        })
+        .await
+        .map_err(std::io::Error::other)?
+    }
+
+    pub async fn read_timeline(
+        &self,
+        query: &crate::timeline::reader::TimelineQuery,
+        issue_identifier: Option<&str>,
+    ) -> Result<crate::timeline::reader::TimelineResponse, std::io::Error> {
+        let db_path = self.db_path.clone();
+        let run_id = query.run_id.clone();
+        let cursor = query.cursor.unwrap_or(0);
+        let limit = query.limit.unwrap_or(50).min(200);
+        let issue_identifier = issue_identifier.map(ToString::to_string);
+        tokio::task::spawn_blocking(move || -> Result<crate::timeline::reader::TimelineResponse, std::io::Error> {
+            let conn = rusqlite::Connection::open(db_path).map_err(std::io::Error::other)?;
+            let mut sql = String::from(
+                "SELECT run_id, issue_identifier, sequence, timestamp, event_type, step_name, attempt, detail, verdict, tool_name FROM run_events WHERE run_id = ?1",
+            );
+            if issue_identifier.is_some() {
+                sql.push_str(" AND issue_identifier = ?2");
+            }
+            sql.push_str(" ORDER BY sequence ASC");
+
+            let mut stmt = conn.prepare(&sql).map_err(std::io::Error::other)?;
+            let rows = if let Some(identifier) = issue_identifier {
+                stmt.query_map(rusqlite::params![run_id, identifier], |row| {
+                    crate::history_store::model::row_to_timeline_record(row)
+                })
+            } else {
+                stmt.query_map([run_id], |row| crate::history_store::model::row_to_timeline_record(row))
+            }
+            .map_err(std::io::Error::other)?;
+
+            let events: Vec<crate::timeline::model::TimelineEventRecord> =
+                rows.map(|row| row.map_err(std::io::Error::other)).collect::<Result<_, _>>()?;
+
+            let total = events.len();
+            let page = events.into_iter().skip(cursor).take(limit).collect::<Vec<_>>();
+            let next_cursor = if cursor + page.len() < total { Some(cursor + page.len()) } else { None };
+
+            Ok(crate::timeline::reader::TimelineResponse { events: page, total, next_cursor })
+        })
+        .await
+        .map_err(std::io::Error::other)?
+    }
+}
+```
+
+- [ ] **Step 4: Implement duplicate-protection test and behavior**
+
+```rust
+#[tokio::test]
+async fn append_timeline_event_is_idempotent_for_duplicate_sequence() {
+    let dir = TempDir::new().unwrap();
+    let store = HistoryStore::new(dir.path().join("history.db")).await.unwrap();
+    let event = TimelineEventRecord {
+        run_id: "run-1".into(),
+        issue_identifier: "repo#1".into(),
+        sequence: 1,
+        timestamp: Utc::now(),
+        event_type: "step_started".into(),
+        step_name: Some("build".into()),
+        attempt: 1,
+        detail: "first".into(),
+        verdict: None,
+        tool_name: None,
+    };
+
+    store.append_timeline_event(&event).await.unwrap();
+    store.append_timeline_event(&event).await.unwrap();
+
+    let response = store
+        .read_timeline(&TimelineQuery { run_id: "run-1".into(), cursor: None, limit: None }, Some("repo#1"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.total, 1);
+}
+```
+
+Use SQL insert form:
+
+```sql
+INSERT OR IGNORE INTO run_events (...)
+VALUES (...);
+```
+
+- [ ] **Step 5: Run store test suite**
+
+Run: `rtk cargo test -p ensemble-core history_store::store::tests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+rtk git add crates/ensemble-core/src/history_store/store.rs crates/ensemble-core/src/history_store/model.rs
+rtk git commit -m "Implement SQLite history store reads and writes"
+```
+
+---
+
+### Task 3: Route orchestrator persistence through HistoryStore
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Modify: `crates/ensemble-core/src/api/bootstrap.rs`
+- Test: `crates/ensemble-core/src/orchestrator/mod.rs`
+
+- [ ] **Step 1: Write failing orchestrator tests for SQLite persistence**
+
+```rust
+#[tokio::test]
+async fn orchestrator_writes_history_record_to_sqlite() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let orchestrator = test_orchestrator_with_workspace(dir.path()).await;
+    run_issue_to_completion(&orchestrator, "repo#1").await;
+
+    let store = crate::history_store::store::HistoryStore::new(
+        dir.path().join(".ensemble").join("history.db"),
+    )
+    .await
+    .unwrap();
+    let response = store
+        .read_history(&crate::history::reader::HistoryQuery::default())
+        .await
+        .unwrap();
+    assert_eq!(response.total, 1);
+}
+
+#[tokio::test]
+async fn publish_pipeline_event_persists_timeline_in_sqlite() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let orchestrator = test_orchestrator_with_workspace(dir.path()).await;
+    publish_test_timeline_event(&orchestrator, "run-1", "repo#1").await;
+
+    let store = crate::history_store::store::HistoryStore::new(
+        dir.path().join(".ensemble").join("history.db"),
+    )
+    .await
+    .unwrap();
+    let response = store
+        .read_timeline(
+            &crate::timeline::reader::TimelineQuery {
+                run_id: "run-1".into(),
+                cursor: None,
+                limit: None,
+            },
+            Some("repo#1"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.total, 1);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk cargo test -p ensemble-core orchestrator_writes_history_record_to_sqlite -- --exact`
+Expected: FAIL because orchestrator still writes JSONL.
+
+- [ ] **Step 3: Replace writer fields with store field**
+
+```rust
+// struct Orchestrator
+history_store: crate::history_store::store::HistoryStore,
+```
+
+```rust
+// new_with_state
+let db_path = parts.workspace_root.join(".ensemble").join("history.db");
+let history_store = futures::executor::block_on(crate::history_store::store::HistoryStore::new(db_path))
+    .expect("history store initialization must succeed");
+```
+
+- [ ] **Step 4: Swap persistence callsites**
+
+```rust
+async fn append_history_record(&self, run_id: &str, record: HistoryRecord) {
+    if let Err(error) = self.history_store.append_history_record(run_id, &record).await {
+        warn!(issue_id = %record.issue_id, error = %error, "failed to persist history record");
+    }
+}
+```
+
+```rust
+async fn publish_pipeline_event(...) {
+    self.event_bus.publish(event.clone());
+    if let Some((run_id, record)) = timeline_entry {
+        if let Err(error) = self.history_store.append_timeline_event(&record).await {
+            warn!(event = "timeline_persist_failed", run_id = %run_id, error = %error, "failed to persist timeline event");
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run orchestrator persistence tests**
+
+Run: `rtk cargo test -p ensemble-core orchestrator_writes_history_record_to_sqlite publish_pipeline_event_persists_timeline_in_sqlite`
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+rtk git add crates/ensemble-core/src/orchestrator/mod.rs crates/ensemble-core/src/api/bootstrap.rs
+rtk git commit -m "Wire orchestrator persistence to global SQLite history store"
+```
+
+---
+
+### Task 4: Switch history/timeline API handlers to SQL-backed reads
+
+**Files:**
+- Modify: `crates/ensemble-core/src/api/router.rs`
+- Modify: `crates/ensemble-core/src/api/bootstrap.rs`
+- Modify: `crates/ensemble-core/src/api/history_handler.rs`
+- Modify: `crates/ensemble-core/src/api/timeline_handler.rs`
+- Test: `crates/ensemble-core/src/api/history_handler.rs`
+- Test: `crates/ensemble-core/src/api/timeline_handler.rs`
+
+- [ ] **Step 1: Write failing handler tests using DB-backed app state**
+
+```rust
+#[tokio::test]
+async fn get_history_reads_from_sqlite_store() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let mut state = build_app_state(temp_dir.path().to_string_lossy().to_string());
+    state.history_db_path = temp_dir.path().join(".ensemble").join("history.db");
+
+    let store = crate::history_store::store::HistoryStore::new(state.history_db_path.clone())
+        .await
+        .unwrap();
+    store.append_history_record("run-1", &sample_record("repo#1")).await.unwrap();
+
+    let response = get_history(axum::extract::State(state), axum::extract::Query(crate::history::reader::HistoryQuery::default()))
+        .await
+        .into_response();
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn get_timeline_reads_from_sqlite_store() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let mut state = build_app_state(temp_dir.path().to_string_lossy().to_string());
+    state.history_db_path = temp_dir.path().join(".ensemble").join("history.db");
+
+    let store = crate::history_store::store::HistoryStore::new(state.history_db_path.clone())
+        .await
+        .unwrap();
+    store.append_timeline_event(&sample_event("run-1", 1)).await.unwrap();
+
+    let response = get_timeline(
+        axum::extract::State(state),
+        axum::extract::Path("repo#1".to_string()),
+        axum::extract::Query(crate::timeline::reader::TimelineQuery {
+            run_id: "run-1".to_string(),
+            cursor: Some(0),
+            limit: Some(50),
+        }),
+    )
+    .await
+    .into_response();
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `rtk cargo test -p ensemble-core get_history_reads_from_sqlite_store -- --exact`
+Expected: FAIL because handlers still use file readers.
+
+- [ ] **Step 3: Update AppState and bootstrap**
+
+```rust
+// api/router.rs
+pub struct AppState {
+    pub workspace_root: String,
+    pub history_db_path: PathBuf,
+    // ...
+}
+```
+
+```rust
+// api/bootstrap.rs
+let history_db_path = PathBuf::from(&workspace_root)
+    .join(".ensemble")
+    .join("history.db");
+```
+
+- [ ] **Step 4: Query through HistoryStore in handlers**
+
+```rust
+// api/history_handler.rs
+let store = crate::history_store::store::HistoryStore::new(state.history_db_path.clone()).await?;
+match store.read_history(&query).await {
+    Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+    Err(e) => (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::api::handlers::api_error("history_read_error", format!("failed to read history: {}", e)),
+    )
+        .into_response(),
+}
+```
+
+```rust
+// api/timeline_handler.rs
+let store = crate::history_store::store::HistoryStore::new(state.history_db_path.clone()).await?;
+match store.read_timeline(&query, Some(&identifier)).await {
+    Ok(response) => (StatusCode::OK, axum::Json(response)).into_response(),
+    Err(e) => (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::api::handlers::api_error("timeline_read_error", format!("failed to read timeline: {}", e)),
+    )
+        .into_response(),
+}
+```
+
+- [ ] **Step 5: Run API handler tests**
+
+Run: `rtk cargo test -p ensemble-core history_handler timeline_handler`
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+rtk git add crates/ensemble-core/src/api/router.rs crates/ensemble-core/src/api/bootstrap.rs crates/ensemble-core/src/api/history_handler.rs crates/ensemble-core/src/api/timeline_handler.rs
+rtk git commit -m "Switch history and timeline APIs to SQLite-backed reads"
+```
+
+---
+
+### Task 5: Remove JSONL reader/writer coupling and finalize docs/tests
+
+**Files:**
+- Modify: `crates/ensemble-core/src/history/mod.rs`
+- Modify: `crates/ensemble-core/src/timeline/mod.rs`
+- Modify: `crates/ensemble-core/src/api/openapi.rs` (if schema paths changed)
+- Modify: `docs/superpowers/specs/2026-04-12-persistent-task-history-store-design.md` (implementation notes if needed)
+- Test: `crates/ensemble-core/tests/api_endpoints.rs`
+
+- [ ] **Step 1: Write failing compile/test checkpoint for removed JSONL coupling**
+
+Run: `rtk cargo test -p ensemble-core`
+Expected: FAIL on remaining imports of `history::reader` / `timeline::reader` file-based functions after previous refactors.
+
+- [ ] **Step 2: Remove or isolate obsolete JSONL modules**
+
+```rust
+// history/mod.rs
+pub mod model;
+```
+
+```rust
+// timeline/mod.rs
+pub mod model;
+```
+
+(If compatibility wrappers are needed, keep wrappers but implement them via `HistoryStore` instead of file IO.)
+
+- [ ] **Step 3: Fix dependent tests and helpers**
+
+Update `api/test_helpers.rs` and orchestrator tests to set `history_db_path` instead of `history_path` and seed data through `HistoryStore`.
+
+- [ ] **Step 4: Run full verification for ensemble-core**
+
+Run: `rtk cargo test -p ensemble-core`
+Expected: PASS.
+
+Run: `rtk cargo clippy -p ensemble-core -- -D warnings`
+Expected: PASS.
+
+Run: `rtk cargo fmt --all -- --check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 5**
+
+```bash
+rtk git add crates/ensemble-core/src/history/mod.rs crates/ensemble-core/src/timeline/mod.rs crates/ensemble-core/src/api/openapi.rs crates/ensemble-core/src/api/test_helpers.rs crates/ensemble-core/src
+rtk git commit -m "Remove JSONL persistence paths after SQLite cutover"
+```
+
+---
+
+## Final Verification Checklist
+
+- [ ] `rtk cargo test --workspace --exclude ensemble-desktop`
+- [ ] `rtk cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
+- [ ] `rtk cargo fmt --all -- --check`
+
+## Spec Coverage Check
+
+- Single global DB under `.ensemble/history.db` — covered by Task 1 and Task 4.
+- Durable local writes (WAL + FULL sync + transactional commit semantics) — covered by Task 1 and Task 2.
+- Replace JSONL persistence in orchestrator for history + timeline — covered by Task 3.
+- Keep API response shapes unchanged while swapping backend — covered by Task 4.
+- No migration/backfill from legacy JSONL — covered by Task 5 (cutover cleanup only).
+
+## Placeholder Scan
+
+No TBD/TODO placeholders remain. All tasks include explicit file paths, commands, and concrete code snippets.
+
+## Type Consistency Check
+
+- `HistoryRecord` and `TimelineEventRecord` remain API-facing models.
+- New `HistoryStore` methods are consistently referenced across orchestrator and API handler tasks.
+- `AppState` path field consistently renamed to `history_db_path` in plan tasks.

--- a/docs/superpowers/specs/2026-04-12-persistent-task-history-store-design.md
+++ b/docs/superpowers/specs/2026-04-12-persistent-task-history-store-design.md
@@ -1,0 +1,140 @@
+# Persistent Task History Store Design
+
+## Goal
+Replace JSONL-based task history/timeline persistence with a single global SQLite backing store that provides durable local writes (zero acknowledged data loss on crash/restart), while keeping existing history/timeline API response shapes unchanged.
+
+## Scope
+- In scope:
+  - New global SQLite storage layer for run history + timeline events
+  - Orchestrator write-path integration
+  - API query-path swap from JSONL readers to SQL queries
+  - Durable SQLite settings and crash-safety semantics
+- Out of scope:
+  - Backfill/migration of existing JSONL data
+  - Remote DB support
+  - API contract changes
+
+## Constraints and Decisions
+- Primary driver: durability and recovery guarantees
+- Deployment model: local embedded store
+- Storage topology: **single global DB** (not per-workspace DB)
+- Legacy storage strategy: **replace** JSONL rather than dual-write
+- Migration requirement: **none** (new store starts empty)
+
+## Storage Architecture
+
+### Database location
+- Global DB file under Ensemble runtime state root:
+  - `<workspace_root>/.ensemble/history.db`
+
+### SQLite durability configuration
+On connection initialization:
+- `PRAGMA journal_mode = WAL;`
+- `PRAGMA synchronous = FULL;`
+- `PRAGMA busy_timeout = <configured>;`
+- optional tuning: `wal_autocheckpoint`
+
+### Logical model
+Use one DB as source of truth for both summary history and event timeline.
+
+#### Tables
+1. `runs`
+   - `run_id` (PK)
+   - `issue_id`
+   - `issue_identifier`
+   - `started_at`
+   - `completed_at` (nullable until terminal)
+   - `outcome`
+   - `attempts`
+   - summary fields currently surfaced by history API (duration, token totals, last_error, verdict, workspace_path, etc.)
+
+2. `run_events`
+   - `run_id`
+   - `sequence`
+   - `timestamp`
+   - `issue_identifier`
+   - `event_type`
+   - `step_name` (nullable)
+   - `attempt`
+   - `detail`
+   - `verdict` (nullable)
+   - `tool_name` (nullable)
+   - Unique key: `(run_id, sequence)`
+
+#### Indexes
+- `run_events(run_id, sequence)`
+- `runs(issue_identifier, completed_at)`
+- `runs(outcome, completed_at)`
+
+## Write Path Design
+
+### Orchestrator integration
+At existing persistence points (current history/timeline append sites), call a storage interface instead of file writers.
+
+### Transaction boundary
+Each acknowledged persistence operation uses a transaction:
+1. `BEGIN IMMEDIATE`
+2. upsert/update `runs` row as needed
+3. insert `run_events` row (if event persistence point)
+4. update summary columns in `runs` when applicable
+5. `COMMIT`
+
+### Acknowledgement semantics
+- Success is reported only after `COMMIT` succeeds.
+- Therefore, acknowledged writes are durable across process restart under configured SQLite durability mode.
+
+### Idempotency / duplicate protection
+- Enforce uniqueness on `(run_id, sequence)`.
+- If replay occurs after partial failure/retry, duplicate inserts are no-op or explicitly handled as idempotent conflict.
+
+## Recovery Semantics
+- Crash before `COMMIT`: write is not visible and not acknowledged.
+- Crash after `COMMIT`: write is durable and queryable on restart.
+- Startup behavior:
+  - open DB
+  - apply schema bootstrap if missing
+  - no JSONL import/backfill
+  - optional warning if legacy JSONL files are detected
+
+## Read Path / API Compatibility
+
+### Unchanged API contracts
+- `GET /api/v1/history` response shape unchanged
+- `GET /api/v1/{identifier}/timeline?run_id=...` response shape unchanged
+
+### Implementation swap
+- Replace JSONL `read_history(...)` with SQL query + pagination/filtering mapping.
+- Replace JSONL timeline reader with SQL query over `run_events` filtered by `run_id` (+ identifier path scope).
+- Preserve current pagination semantics (`cursor`, `limit`) at API boundary.
+
+## Error Handling
+- DB initialization failure: startup error with actionable message.
+- Write failure in orchestrator path:
+  - log structured error
+  - keep existing event-bus behavior where possible
+  - fail persistence operation explicitly (no silent success).
+- Busy/lock contention: bounded retry behavior via busy timeout; emit warnings on repeated contention.
+
+## Testing Strategy
+
+### Unit tests
+- Schema bootstrap creates required tables/indexes.
+- Insert/read mapping parity with current model structs.
+- Duplicate `(run_id, sequence)` handling is idempotent.
+
+### Integration tests
+- Orchestrator writes history/timeline records to SQLite at existing lifecycle points.
+- History endpoint returns equivalent shape/content for new writes.
+- Timeline endpoint returns ordered events with filters and pagination.
+
+### Durability-focused tests
+- Simulated restart test: write, drop runtime, reopen, verify committed data present.
+- Transaction atomicity test: induce failure mid-operation, assert no partial visible write.
+
+## Rollout Notes
+- Cutover is immediate to SQLite-backed persistence for new runs.
+- No migration/backfill from JSONL.
+- Legacy JSONL files are ignored by read path.
+
+## Open Questions
+- None for initial implementation scope.


### PR DESCRIPTION
## Summary
- add a global SQLite-backed history store with schema bootstrap + pragmas
- persist history/timeline events through the orchestrator into SQLite
- switch API history/timeline reads to the SQLite store
- keep compatibility paths/tests aligned while replacing JSONL as primary read path

## Validation
- cargo test --workspace --exclude ensemble-desktop
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check