### PR TITLE
Migrate direct ACP runtime to the SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efba6592048ef8a9ac97de8d79b2d9933d8ac4d94f7a2de102348fed0c61103"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rustc-hash",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d176a10d4cb06e0262a738c3c5bf21ff0968db13a666e31cbca94a3d3d72e7c"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
+dependencies = [
+ "anyhow",
+ "derive_more 2.1.1",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "tracing",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +162,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +259,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -297,6 +428,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +459,15 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -536,10 +689,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -804,7 +975,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -826,10 +997,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1026,6 +1199,7 @@ dependencies = [
 name = "ensemble-core"
 version = "0.0.1"
 dependencies = [
+ "agent-client-protocol",
  "async-stream",
  "async-trait",
  "axum",
@@ -1106,6 +1280,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1342,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1263,6 +1464,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1498,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2209,6 +2436,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,6 +3145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,6 +3410,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3440,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -3208,6 +3482,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3769,7 +4057,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -3796,6 +4084,7 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -3805,6 +4094,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4008,11 +4309,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4027,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4121,6 +4423,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"
@@ -4322,6 +4630,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -4808,6 +5137,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ shellexpand = "3"
 mime_guess = "2"
 opener = "0.7"
 rusqlite = { version = "0.33", features = ["bundled"] }
+agent-client-protocol = "0.14.0"

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -31,6 +31,7 @@ shellexpand = { workspace = true }
 shlex = "1"
 mime_guess = { workspace = true }
 rusqlite = { workspace = true }
+agent-client-protocol = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -112,63 +112,57 @@ pub async fn run_acp_session(
     let session_error_inner = session_error.clone();
     let session_error_outer = session_error.clone();
 
-    let builder = Client
-        .builder()
-        .name("ensemble")
-        .on_receive_request(
-            async move |request: RequestPermissionRequest,
-                        responder: agent_client_protocol::Responder<RequestPermissionResponse>,
-                        _cx| {
-                let description = serde_json::to_string(&request.tool_call)
-                    .unwrap_or_default();
+    let builder = Client.builder().name("ensemble").on_receive_request(
+        async move |request: RequestPermissionRequest,
+                    responder: agent_client_protocol::Responder<RequestPermissionResponse>,
+                    _cx| {
+            let description = serde_json::to_string(&request.tool_call).unwrap_or_default();
 
-                emit_event(
-                    &event_tx_clone,
-                    &issue_id_owned,
-                    &step_name_owned,
-                    AgentEvent::Warning {
-                        message: format!("permission requested: {description}"),
-                    },
-                )
-                .await;
+            emit_event(
+                &event_tx_clone,
+                &issue_id_owned,
+                &step_name_owned,
+                AgentEvent::Warning {
+                    message: format!("permission requested: {description}"),
+                },
+            )
+            .await;
 
-                let allowed = resolve_permission(&permission_policy, &description);
+            let allowed = resolve_permission(&permission_policy, &description);
 
-                let outcome = if allowed {
-                    if let Some(first_option) = request.options.first() {
-                        let option_id: agent_client_protocol::schema::PermissionOptionId =
-                            first_option.option_id.clone();
-                        agent_client_protocol::schema::RequestPermissionOutcome::Selected(
-                            agent_client_protocol::schema::SelectedPermissionOutcome::new(
-                                option_id,
-                            ),
-                        )
-                    } else {
-                        agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
-                    }
+            let outcome = if allowed {
+                if let Some(first_option) = request.options.first() {
+                    let option_id: agent_client_protocol::schema::PermissionOptionId =
+                        first_option.option_id.clone();
+                    agent_client_protocol::schema::RequestPermissionOutcome::Selected(
+                        agent_client_protocol::schema::SelectedPermissionOutcome::new(option_id),
+                    )
                 } else {
                     agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
-                };
+                }
+            } else {
+                agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
+            };
 
-                let response = RequestPermissionResponse::new(outcome);
+            let response = RequestPermissionResponse::new(outcome);
 
-                emit_event(
-                    &event_tx_clone,
-                    &issue_id_owned,
-                    &step_name_owned,
-                    AgentEvent::Notification {
-                        message: format!(
-                            "permission {}",
-                            if allowed { "approved" } else { "rejected" }
-                        ),
-                    },
-                )
-                .await;
+            emit_event(
+                &event_tx_clone,
+                &issue_id_owned,
+                &step_name_owned,
+                AgentEvent::Notification {
+                    message: format!(
+                        "permission {}",
+                        if allowed { "approved" } else { "rejected" }
+                    ),
+                },
+            )
+            .await;
 
-                responder.respond(response)
-            },
-            agent_client_protocol::on_receive_request!(),
-        );
+            responder.respond(response)
+        },
+        agent_client_protocol::on_receive_request!(),
+    );
 
     let result = builder
         .connect_with(agent, async move |cx| {

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -1,48 +1,35 @@
-use std::path::Path;
-use std::time::Duration;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
 
-use serde_json::json;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
-use tokio::sync::mpsc;
-use tokio::time::timeout;
-use tracing::{debug, info, trace};
+use agent_client_protocol::schema::{
+    InitializeRequest, ProtocolVersion, RequestPermissionRequest, RequestPermissionResponse,
+    StopReason as SdkStopReason,
+};
+use agent_client_protocol::{AcpAgent, Client, SessionMessage};
+use tokio::sync::{mpsc, Mutex};
+use tracing::{debug, info, warn};
 
 use crate::error::AgentError;
-use crate::observability::events_contract::AGENT_MESSAGE;
-use crate::observability::redaction::{redact_kv, truncate_for_log};
 
-use super::events::{
-    AgentEvent, JsonRpcMessage, RuntimeStream, StopReason, TokenUsage, WorkerEvent,
-};
-use super::protocol;
+use super::events::{AgentEvent, TokenUsage, WorkerEvent};
 
-/// ACP session managing a subprocess and stdio JSON-RPC 2.0 protocol.
-pub struct AcpSession {
-    child: Child,
-    stdin: BufWriter<ChildStdin>,
-    stdout: BufReader<ChildStdout>,
-    session_id: Option<String>,
-    next_request_id: u64,
-    agent_pid: Option<String>,
+#[derive(Debug)]
+pub struct AcpSessionConfig {
+    pub command: String,
+    pub workspace_path: PathBuf,
+    pub session_mode: Option<String>,
+    pub permission_request_policy: String,
+    pub read_timeout_ms: u64,
+    pub turn_timeout_ms: u64,
 }
 
-/// Result of an ACP initialize call.
-#[derive(Debug)]
-pub struct InitializeResult {
-    pub protocol_version: Option<String>,
-    pub agent_info: Option<serde_json::Value>,
-}
-
-/// Result of a single turn.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum TurnResult {
-    /// Turn completed successfully (end_turn or max_tokens).
     Completed {
         usage: Option<TokenUsage>,
         runtime_verdict: Option<serde_json::Value>,
     },
-    /// Turn failed with a reason.
     Failed {
         reason: String,
         usage: Option<TokenUsage>,
@@ -56,1206 +43,349 @@ impl TurnResult {
     }
 }
 
-impl AcpSession {
-    /// Spawn an ACP agent subprocess.
-    pub async fn spawn(command: &str, workspace_path: &Path) -> Result<Self, AgentError> {
-        info!(command = command, cwd = %workspace_path.display(), "spawning ACP agent");
-
-        let mut child = Command::new("bash")
-            .arg("-lc")
-            .arg(command)
-            .current_dir(workspace_path)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(|e| AgentError::AgentNotFound {
-                command: format!("{command}: {e}"),
-            })?;
-
-        let pid = child.id().map(|p| p.to_string());
-
-        let stdin = child.stdin.take().ok_or_else(|| AgentError::IoError {
-            reason: "failed to capture stdin".to_string(),
-        })?;
-        let stdout = child.stdout.take().ok_or_else(|| AgentError::IoError {
-            reason: "failed to capture stdout".to_string(),
-        })?;
-
-        Ok(Self {
-            child,
-            stdin: BufWriter::new(stdin),
-            stdout: BufReader::new(stdout),
-            session_id: None,
-            next_request_id: 1,
-            agent_pid: pid,
-        })
-    }
-
-    /// Get the agent PID if available.
-    pub fn agent_pid(&self) -> Option<&str> {
-        self.agent_pid.as_deref()
-    }
-
-    /// Get the session ID if established.
-    pub fn session_id(&self) -> Option<&str> {
-        self.session_id.as_deref()
-    }
-
-    /// Send the ACP initialize request and wait for the response.
-    pub async fn initialize(
-        &mut self,
-        read_timeout_ms: u64,
-    ) -> Result<InitializeResult, AgentError> {
-        let id = self.next_id();
-        let msg = json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2025-07-09",
-                "clientCapabilities": { "terminal": true },
-                "clientInfo": { "name": "ensemble", "version": "0.1.0" }
-            }
-        });
-
-        self.send_json_rpc(&msg).await?;
-
-        let response = self.read_response(id, read_timeout_ms).await?;
-
-        let result = response.result.ok_or_else(|| {
-            let err_msg = response
-                .error
-                .map(|e| e.message)
-                .unwrap_or_else(|| "no result in initialize response".to_string());
-            AgentError::SessionStartupFailed { reason: err_msg }
-        })?;
-
-        Ok(InitializeResult {
-            protocol_version: result
-                .get("protocolVersion")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string()),
-            agent_info: result.get("agentInfo").cloned(),
-        })
-    }
-
-    /// Send session/new and return the session ID.
-    pub async fn start_session(
-        &mut self,
-        cwd: &str,
-        mcp_servers: serde_json::Value,
-        read_timeout_ms: u64,
-    ) -> Result<String, AgentError> {
-        let id = self.next_id();
-        let msg = json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": "session/new",
-            "params": {
-                "cwd": cwd,
-                "mcpServers": mcp_servers
-            }
-        });
-
-        self.send_json_rpc(&msg).await?;
-
-        let response = self.read_response(id, read_timeout_ms).await?;
-
-        let result = response.result.ok_or_else(|| {
-            let err_msg = response
-                .error
-                .map(|e| e.message)
-                .unwrap_or_else(|| "no result in session/new response".to_string());
-            AgentError::SessionStartupFailed { reason: err_msg }
-        })?;
-
-        let session_id = result
-            .get("sessionId")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| AgentError::SessionStartupFailed {
-                reason: "missing sessionId in session/new response".to_string(),
-            })?
-            .to_string();
-
-        self.session_id = Some(session_id.clone());
-        Ok(session_id)
-    }
-
-    /// Send session/set_mode notification.
-    pub async fn set_mode(&mut self, session_id: &str, mode: &str) -> Result<(), AgentError> {
-        let msg = json!({
-            "jsonrpc": "2.0",
-            "method": "session/set_mode",
-            "params": {
-                "sessionId": session_id,
-                "mode": mode
-            }
-        });
-        self.send_json_rpc(&msg).await
-    }
-
-    /// Send session/prompt and stream events until the turn completes.
-    /// Returns a TurnResult indicating success or failure.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn run_turn(
-        &mut self,
-        session_id: &str,
-        content: &str,
-        turn_timeout_ms: u64,
-        permission_request_policy: &str,
-        issue_id: &str,
-        step_name: &str,
-        event_tx: &mpsc::Sender<WorkerEvent>,
-    ) -> Result<TurnResult, AgentError> {
-        let id = self.next_id();
-        let msg = json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": "session/prompt",
-            "params": {
-                "sessionId": session_id,
-                "content": [{ "type": "text", "text": content }]
-            }
-        });
-
-        self.send_json_rpc(&msg).await?;
-
-        Self::emit_event(event_tx, issue_id, step_name, AgentEvent::PromptStarted).await;
-
-        let turn_duration = Duration::from_millis(turn_timeout_ms);
-        let result = timeout(
-            turn_duration,
-            self.stream_turn(
-                id,
-                session_id,
-                permission_request_policy,
-                issue_id,
-                step_name,
-                event_tx,
-            ),
-        )
-        .await;
-
-        match result {
-            Ok(Ok(turn_result)) => Ok(turn_result),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Err(AgentError::TurnTimeout {
-                timeout_ms: turn_timeout_ms,
-            }),
-        }
-    }
-
-    /// Internal: stream session/update messages until turn completion.
-    async fn stream_turn(
-        &mut self,
-        prompt_request_id: u64,
-        _session_id: &str,
-        permission_request_policy: &str,
-        issue_id: &str,
-        step_name: &str,
-        event_tx: &mpsc::Sender<WorkerEvent>,
-    ) -> Result<TurnResult, AgentError> {
-        let mut last_usage: Option<TokenUsage> = None;
-        let mut last_runtime_verdict: Option<serde_json::Value> = None;
-
-        loop {
-            let line = self.read_line().await?;
-
-            // Keep direct deserialization here so malformed JSON can emit
-            // `AgentEvent::Malformed` with the raw original line content.
-            let msg: JsonRpcMessage = match serde_json::from_str(&line) {
-                Ok(m) => m,
-                Err(_) => {
-                    Self::emit_event(
-                        event_tx,
-                        issue_id,
-                        step_name,
-                        AgentEvent::Malformed { line: line.clone() },
-                    )
-                    .await;
-                    continue;
-                }
-            };
-
-            // Handle response to our prompt request
-            if msg.is_response() {
-                if let Some(ref msg_id) = msg.id {
-                    if msg_id.as_u64() == Some(prompt_request_id) {
-                        // Prompt response received — this confirms the turn is done
-                        if let Some(ref err) = msg.error {
-                            return Ok(TurnResult::Failed {
-                                reason: err.message.clone(),
-                                usage: last_usage,
-                                runtime_verdict: last_runtime_verdict,
-                            });
-                        }
-                        if let Some(stop_reason) = msg
-                            .result
-                            .as_ref()
-                            .and_then(protocol::parse_stop_reason_from_result)
-                        {
-                            return self
-                                .map_stop_reason_to_turn_result(
-                                    stop_reason,
-                                    issue_id,
-                                    step_name,
-                                    event_tx,
-                                    last_usage,
-                                    last_runtime_verdict.clone(),
-                                )
-                                .await;
-                        }
-                        // A prompt response without error means turn completed
-                        return Ok(TurnResult::Completed {
-                            usage: last_usage,
-                            runtime_verdict: last_runtime_verdict,
-                        });
-                    }
-                }
-                continue;
-            }
-
-            // Handle agent-to-client requests (e.g., permission)
-            if msg.is_request() {
-                if let Some(ref method) = msg.method {
-                    if method == "session/request_permission" {
-                        self.handle_permission_request(
-                            &msg,
-                            permission_request_policy,
-                            issue_id,
-                            step_name,
-                            event_tx,
-                        )
-                        .await?;
-                        continue;
-                    }
-                }
-                // Unknown request — respond with method not found
-                if let Some(ref req_id) = msg.id {
-                    let err_resp = json!({
-                        "jsonrpc": "2.0",
-                        "id": req_id,
-                        "error": { "code": -32601, "message": "Method not found" }
-                    });
-                    self.send_json_rpc(&err_resp).await?;
-                }
-                Self::emit_event(
-                    event_tx,
-                    issue_id,
-                    step_name,
-                    AgentEvent::OtherMessage { raw: line.clone() },
-                )
-                .await;
-                continue;
-            }
-
-            // Handle notifications
-            if let Some(ref method) = msg.method {
-                match method.as_str() {
-                    "session/update" => {
-                        if let Some(ref params) = msg.params {
-                            if let Some(parsed) = protocol::parse_session_update(params) {
-                                if let Some(usage) = parsed.usage {
-                                    last_usage = Some(usage);
-                                }
-                                if let Some(verdict) = parsed.verdict {
-                                    last_runtime_verdict = Some(verdict);
-                                }
-
-                                if let Some(stop_reason) = parsed.stop_reason {
-                                    return self
-                                        .map_stop_reason_to_turn_result(
-                                            stop_reason,
-                                            issue_id,
-                                            step_name,
-                                            event_tx,
-                                            last_usage,
-                                            last_runtime_verdict.clone(),
-                                        )
-                                        .await;
-                                }
-
-                                if let Some(content) = parsed.output_text {
-                                    Self::emit_event(
-                                        event_tx,
-                                        issue_id,
-                                        step_name,
-                                        AgentEvent::OutputChunk {
-                                            stream: RuntimeStream::Stdout,
-                                            content,
-                                        },
-                                    )
-                                    .await;
-                                }
-                            } else {
-                                Self::emit_event(
-                                    event_tx,
-                                    issue_id,
-                                    step_name,
-                                    AgentEvent::Notification {
-                                        message: line.chars().take(200).collect(),
-                                    },
-                                )
-                                .await;
-                            }
-                        }
-                    }
-                    _ => {
-                        Self::emit_event(
-                            event_tx,
-                            issue_id,
-                            step_name,
-                            AgentEvent::OtherMessage { raw: line.clone() },
-                        )
-                        .await;
-                    }
-                }
-            }
-        }
-    }
-
-    async fn map_stop_reason_to_turn_result(
-        &self,
-        stop_reason: StopReason,
-        issue_id: &str,
-        step_name: &str,
-        event_tx: &mpsc::Sender<WorkerEvent>,
-        usage: Option<TokenUsage>,
-        runtime_verdict: Option<serde_json::Value>,
-    ) -> Result<TurnResult, AgentError> {
-        match stop_reason {
-            StopReason::EndTurn | StopReason::MaxTokens => {
-                Self::emit_event(
-                    event_tx,
-                    issue_id,
-                    step_name,
-                    AgentEvent::RunCompleted {
-                        usage: usage.clone(),
-                    },
-                )
-                .await;
-                Ok(TurnResult::Completed {
-                    usage,
-                    runtime_verdict,
-                })
-            }
-            StopReason::Cancelled => {
-                let reason = "stop reason: cancelled".to_string();
-                Self::emit_event(
-                    event_tx,
-                    issue_id,
-                    step_name,
-                    AgentEvent::RunFailed {
-                        reason: reason.clone(),
-                        usage: usage.clone(),
-                    },
-                )
-                .await;
-
-                Ok(TurnResult::Failed {
-                    reason,
-                    usage,
-                    runtime_verdict,
-                })
-            }
-            StopReason::Refusal => {
-                let reason = "stop reason: refusal".to_string();
-                Self::emit_event(
-                    event_tx,
-                    issue_id,
-                    step_name,
-                    AgentEvent::RunFailed {
-                        reason: reason.clone(),
-                        usage: usage.clone(),
-                    },
-                )
-                .await;
-
-                Ok(TurnResult::Failed {
-                    reason,
-                    usage,
-                    runtime_verdict,
-                })
-            }
-            StopReason::MaxTurnRequests => {
-                let reason = "stop reason: max_turn_requests".to_string();
-                Self::emit_event(
-                    event_tx,
-                    issue_id,
-                    step_name,
-                    AgentEvent::RunFailed {
-                        reason: reason.clone(),
-                        usage: usage.clone(),
-                    },
-                )
-                .await;
-
-                Ok(TurnResult::Failed {
-                    reason,
-                    usage,
-                    runtime_verdict,
-                })
-            }
-        }
-    }
-
-    /// Handle a session/request_permission request from the agent.
-    async fn handle_permission_request(
-        &mut self,
-        msg: &JsonRpcMessage,
-        permission_request_policy: &str,
-        issue_id: &str,
-        step_name: &str,
-        event_tx: &mpsc::Sender<WorkerEvent>,
-    ) -> Result<(), AgentError> {
-        let params = msg.params.as_ref().unwrap_or(&serde_json::Value::Null);
-        let permission_id = params
-            .get("permissionId")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown")
-            .to_string();
-        let description = params
-            .get("description")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        Self::emit_event(
-            event_tx,
-            issue_id,
-            step_name,
-            AgentEvent::Warning {
-                message: format!(
-                    "permission requested ({permission_id}): {}",
-                    description.as_str()
-                ),
-            },
-        )
-        .await;
-
-        let allowed = match permission_request_policy {
-            "auto_approve_all" => true,
-            "reject_all" => false,
-            "approve_reads_reject_writes" => {
-                // Heuristic: approve if description contains read-like terms
-                let desc_lower = description.to_lowercase();
-                desc_lower.contains("read")
-                    || desc_lower.contains("list")
-                    || desc_lower.contains("view")
-            }
-            _ => true, // default to approve
-        };
-
-        let response_option = if allowed {
-            "allow_always"
-        } else {
-            "reject_once"
-        };
-
-        if let Some(ref req_id) = msg.id {
-            let resp = json!({
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "result": {
-                    "permissionId": permission_id,
-                    "option": response_option
-                }
-            });
-            self.send_json_rpc(&resp).await?;
-        }
-
-        Self::emit_event(
-            event_tx,
-            issue_id,
-            step_name,
-            AgentEvent::Notification {
-                message: format!(
-                    "permission {} ({permission_id})",
-                    if allowed { "approved" } else { "rejected" }
-                ),
-            },
-        )
-        .await;
-
-        Ok(())
-    }
-
-    /// Send session/cancel notification.
-    pub async fn cancel(&mut self, session_id: &str) -> Result<(), AgentError> {
-        let msg = json!({
-            "jsonrpc": "2.0",
-            "method": "session/cancel",
-            "params": { "sessionId": session_id }
-        });
-        // Best effort — ignore errors
-        let _ = self.send_json_rpc(&msg).await;
-        Ok(())
-    }
-
-    /// Kill the agent subprocess: SIGTERM, then SIGKILL after grace period.
-    pub async fn kill(&mut self) {
-        // Try graceful termination first
-        if let Some(pid) = self.child.id() {
-            debug!(pid = pid, "sending SIGTERM to agent");
-            unsafe {
-                libc::kill(pid as i32, libc::SIGTERM);
-            }
-
-            // Wait up to 5 seconds for graceful exit
-            match timeout(Duration::from_secs(5), self.child.wait()).await {
-                Ok(_) => {
-                    debug!(pid = pid, "agent exited after SIGTERM");
-                    return;
-                }
-                Err(_) => {
-                    debug!(
-                        pid = pid,
-                        "agent did not exit after SIGTERM, sending SIGKILL"
-                    );
-                }
-            }
-        }
-
-        // Force kill
-        let _ = self.child.kill().await;
-        let _ = self.child.wait().await;
-    }
-
-    /// Send a JSON-RPC message (write JSON + newline to stdin).
-    async fn send_json_rpc(&mut self, msg: &serde_json::Value) -> Result<(), AgentError> {
-        let line = serde_json::to_string(msg).map_err(|e| AgentError::IoError {
-            reason: format!("json serialize error: {e}"),
-        })?;
-        trace!(
-            event = AGENT_MESSAGE,
-            direction = "outbound",
-            bytes = line.len(),
-            preview = %truncate_for_log(&redact_kv(&line), 160),
-            "sending JSON-RPC"
-        );
-
-        let mut buf = Vec::with_capacity(line.len() + 1);
-        buf.extend_from_slice(line.as_bytes());
-        buf.push(b'\n');
-
-        self.stdin
-            .write_all(&buf)
-            .await
-            .map_err(|e| AgentError::IoError {
-                reason: format!("stdin write error: {e}"),
-            })?;
-        self.stdin.flush().await.map_err(|e| AgentError::IoError {
-            reason: format!("stdin flush error: {e}"),
-        })?;
-        Ok(())
-    }
-
-    /// Read one line from stdout.
-    async fn read_line(&mut self) -> Result<String, AgentError> {
-        let mut line = String::new();
-        let bytes_read =
-            self.stdout
-                .read_line(&mut line)
-                .await
-                .map_err(|e| AgentError::IoError {
-                    reason: format!("stdout read error: {e}"),
-                })?;
-
-        if bytes_read == 0 {
-            return Err(AgentError::AgentExit {
-                reason: "agent process closed stdout (EOF)".to_string(),
-            });
-        }
-
-        let trimmed = line.trim_end().to_string();
-        trace!(
-            event = AGENT_MESSAGE,
-            direction = "inbound",
-            bytes = trimmed.len(),
-            preview = %truncate_for_log(&redact_kv(&trimmed), 160),
-            "received from agent"
-        );
-        Ok(trimmed)
-    }
-
-    /// Read a specific response by request ID with timeout.
-    async fn read_response(
-        &mut self,
-        expected_id: u64,
-        timeout_ms: u64,
-    ) -> Result<JsonRpcMessage, AgentError> {
-        let duration = Duration::from_millis(timeout_ms);
-
-        let result = timeout(duration, async {
-            loop {
-                let line = self.read_line().await?;
-                let msg: JsonRpcMessage =
-                    serde_json::from_str(&line).map_err(|e| AgentError::ResponseError {
-                        reason: format!("invalid JSON-RPC response: {e} — line: {line}"),
-                    })?;
-
-                if msg.is_response() {
-                    if let Some(ref id) = msg.id {
-                        if id.as_u64() == Some(expected_id) {
-                            return Ok(msg);
-                        }
-                    }
-                }
-                // Not the response we're looking for — skip and continue
-            }
+async fn emit_event(
+    tx: &mpsc::Sender<WorkerEvent>,
+    issue_id: &str,
+    step_name: &str,
+    event: AgentEvent,
+) {
+    let _ = tx
+        .send(WorkerEvent::AgentUpdate {
+            issue_id: issue_id.to_string(),
+            step_name: step_name.to_string(),
+            event,
+            timestamp: chrono::Utc::now(),
         })
         .await;
+}
 
-        match result {
-            Ok(Ok(msg)) => Ok(msg),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Err(AgentError::ResponseTimeout { timeout_ms }),
+fn resolve_permission(permission_request_policy: &str, description: &str) -> bool {
+    match permission_request_policy {
+        "auto_approve_all" => true,
+        "reject_all" => false,
+        "approve_reads_reject_writes" => {
+            let desc_lower = description.to_lowercase();
+            desc_lower.contains("read")
+                || desc_lower.contains("list")
+                || desc_lower.contains("view")
         }
-    }
-
-    /// Get next request ID.
-    fn next_id(&mut self) -> u64 {
-        let id = self.next_request_id;
-        self.next_request_id += 1;
-        id
-    }
-
-    /// Helper to emit a WorkerEvent::AgentUpdate.
-    async fn emit_event(
-        tx: &mpsc::Sender<WorkerEvent>,
-        issue_id: &str,
-        step_name: &str,
-        event: AgentEvent,
-    ) {
-        let _ = tx
-            .send(WorkerEvent::AgentUpdate {
-                issue_id: issue_id.to_string(),
-                step_name: step_name.to_string(),
-                event,
-                timestamp: chrono::Utc::now(),
-            })
-            .await;
+        _ => true,
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::Write;
-    use tempfile::TempDir;
-
-    /// Create a mock ACP agent script that reads JSON-RPC from stdin and responds.
-    fn write_mock_agent_script(dir: &Path, script_content: &str) -> String {
-        let script_path = dir.join("mock_agent.sh");
-        let mut f = std::fs::File::create(&script_path).unwrap();
-        f.write_all(script_content.as_bytes()).unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
-        script_path.display().to_string()
+fn map_sdk_stop_reason(stop: &SdkStopReason) -> super::events::StopReason {
+    match stop {
+        SdkStopReason::EndTurn => super::events::StopReason::EndTurn,
+        SdkStopReason::MaxTokens => super::events::StopReason::MaxTokens,
+        SdkStopReason::Cancelled => super::events::StopReason::Cancelled,
+        SdkStopReason::Refusal => super::events::StopReason::Refusal,
+        SdkStopReason::MaxTurnRequests => super::events::StopReason::MaxTurnRequests,
+        _ => super::events::StopReason::Cancelled,
     }
+}
 
-    #[tokio::test]
-    async fn test_spawn_nonexistent_command() {
-        let dir = TempDir::new().unwrap();
-        // Spawn a bash script that immediately exits with error (simulating command not found).
-        // Note: bash itself spawns fine, but trying to initialize will fail with EOF.
-        let result = AcpSession::spawn("nonexistent_binary_xyz_12345", dir.path()).await;
-        // The spawn itself may succeed (bash starts), but the subsequent operations will fail.
-        // If spawn succeeds, verify we get an error on the first operation.
-        match result {
-            Err(_) => {} // Direct spawn failure is acceptable
-            Ok(mut session) => {
-                // bash started but the command failed — initialize should fail with EOF or timeout
-                let init_result = session.initialize(2000).await;
-                assert!(init_result.is_err());
-                session.kill().await;
-            }
-        }
-    }
+pub async fn run_acp_session(
+    config: AcpSessionConfig,
+    prompts: Vec<String>,
+    issue_id: &str,
+    step_name: &str,
+    event_tx: &mpsc::Sender<WorkerEvent>,
+) -> Result<(Option<serde_json::Value>, Vec<TurnResult>), AgentError> {
+    let agent = AcpAgent::from_str(&config.command).map_err(|e| AgentError::AgentNotFound {
+        command: format!("{}: {}", config.command, e),
+    })?;
 
-    #[tokio::test]
-    async fn test_successful_handshake_and_turn() {
-        let dir = TempDir::new().unwrap();
-        let workspace = TempDir::new().unwrap();
+    let permission_policy = config.permission_request_policy.clone();
+    let issue_id_owned = issue_id.to_string();
+    let step_name_owned = step_name.to_string();
+    let event_tx_clone = event_tx.clone();
 
-        // Mock agent: responds to initialize, session/new, then session/update with end_turn
-        // Uses pure bash string matching (no python3) to extract JSON-RPC method and id fields.
-        let script = r#"#!/bin/bash
-while IFS= read -r line; do
-    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
-    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
+    let turn_results: Arc<Mutex<Vec<TurnResult>>> = Arc::new(Mutex::new(Vec::new()));
+    let final_verdict: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+    let session_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let prompts = Arc::new(prompts);
+    let session_mode = config.session_mode.clone();
+    let turn_timeout_ms = config.turn_timeout_ms;
 
-    if [ "$method" = "initialize" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\",\"agentCapabilities\":{},\"agentInfo\":{\"name\":\"mock\"}}}"
-    elif [ "$method" = "session/new" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"test-session-1\"}}"
-    elif [ "$method" = "session/set_mode" ]; then
-        true  # notification, no response needed
-    elif [ "$method" = "session/prompt" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"test-session-1\",\"content\":\"Working on it...\"}}"
-        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"test-session-1\",\"stopReason\":\"end_turn\",\"usage\":{\"input_tokens\":100,\"output_tokens\":50,\"total_tokens\":150}}}"
-    elif [ "$method" = "session/cancel" ]; then
-        true
-    fi
-done
-"#;
-        let script_path = write_mock_agent_script(dir.path(), script);
+    let turn_results_inner = turn_results.clone();
+    let final_verdict_inner = final_verdict.clone();
+    let session_error_inner = session_error.clone();
+    let session_error_outer = session_error.clone();
 
-        let mut session = AcpSession::spawn(&script_path, workspace.path())
-            .await
-            .unwrap();
+    let builder = Client
+        .builder()
+        .name("ensemble")
+        .on_receive_request(
+            async move |request: RequestPermissionRequest,
+                        responder: agent_client_protocol::Responder<RequestPermissionResponse>,
+                        _cx| {
+                let description = serde_json::to_string(&request.tool_call)
+                    .unwrap_or_default();
 
-        // Initialize
-        let init_result = session.initialize(15000).await.unwrap();
-        assert_eq!(init_result.protocol_version.as_deref(), Some("2025-07-09"));
+                emit_event(
+                    &event_tx_clone,
+                    &issue_id_owned,
+                    &step_name_owned,
+                    AgentEvent::Warning {
+                        message: format!("permission requested: {description}"),
+                    },
+                )
+                .await;
 
-        // Start session
-        let session_id = session
-            .start_session(
-                workspace.path().to_str().unwrap(),
-                serde_json::json!({}),
-                15000,
-            )
-            .await
-            .unwrap();
-        assert_eq!(session_id, "test-session-1");
+                let allowed = resolve_permission(&permission_policy, &description);
 
-        // Set mode
-        session.set_mode(&session_id, "code").await.unwrap();
+                let outcome = if allowed {
+                    if let Some(first_option) = request.options.first() {
+                        let option_id: agent_client_protocol::schema::PermissionOptionId =
+                            first_option.option_id.clone();
+                        agent_client_protocol::schema::RequestPermissionOutcome::Selected(
+                            agent_client_protocol::schema::SelectedPermissionOutcome::new(
+                                option_id,
+                            ),
+                        )
+                    } else {
+                        agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
+                    }
+                } else {
+                    agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
+                };
 
-        // Run turn
-        let (tx, mut rx) = mpsc::channel(100);
-        let turn_result = session
-            .run_turn(
-                &session_id,
-                "Fix the bug",
-                30000,
-                "auto_approve_all",
-                "issue-1",
-                "build",
-                &tx,
-            )
-            .await
-            .unwrap();
+                let response = RequestPermissionResponse::new(outcome);
 
-        assert!(turn_result.is_success());
-        if let TurnResult::Completed { usage, .. } = &turn_result {
-            let u = usage.as_ref().unwrap();
-            assert_eq!(u.input_tokens, 100);
-            assert_eq!(u.output_tokens, 50);
-            assert_eq!(u.total_tokens, 150);
-        }
+                emit_event(
+                    &event_tx_clone,
+                    &issue_id_owned,
+                    &step_name_owned,
+                    AgentEvent::Notification {
+                        message: format!(
+                            "permission {}",
+                            if allowed { "approved" } else { "rejected" }
+                        ),
+                    },
+                )
+                .await;
 
-        // Check runtime-agnostic events were emitted
-        let mut events = vec![];
-        while let Ok(evt) = rx.try_recv() {
-            events.push(evt);
-        }
-        // Should have: PromptStarted, OutputChunk or Notification, RunCompleted
-        assert!(events.len() >= 2);
-
-        session.kill().await;
-    }
-
-    #[tokio::test]
-    async fn run_turn_handles_nested_session_update_content() {
-        let dir = TempDir::new().unwrap();
-        let workspace = TempDir::new().unwrap();
-
-        let script = r#"#!/bin/bash
-while IFS= read -r line; do
-    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
-    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
-
-    if [ "$method" = "initialize" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
-    elif [ "$method" = "session/new" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"nested-session\"}}"
-    elif [ "$method" = "session/prompt" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"nested-session\",\"update\":{\"sessionUpdate\":\"agent_message_chunk\",\"content\":{\"type\":\"text\",\"text\":\"hello nested\"}}}}"
-        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"nested-session\",\"update\":{\"sessionUpdate\":\"turn_complete\",\"stopReason\":\"end_turn\",\"usage\":{\"input_tokens\":3,\"output_tokens\":4,\"total_tokens\":7}}}}"
-    fi
-done
-"#;
-        let script_path = write_mock_agent_script(dir.path(), script);
-
-        let mut session = AcpSession::spawn(&script_path, workspace.path())
-            .await
-            .unwrap();
-        session.initialize(15000).await.unwrap();
-        let session_id = session
-            .start_session(
-                workspace.path().to_str().unwrap(),
-                serde_json::json!({}),
-                15000,
-            )
-            .await
-            .unwrap();
-
-        let (tx, mut rx) = mpsc::channel(100);
-        let result = session
-            .run_turn(
-                &session_id,
-                "Do work",
-                30000,
-                "auto_approve_all",
-                "issue-nested",
-                "build",
-                &tx,
-            )
-            .await
-            .unwrap();
-
-        assert!(matches!(result, TurnResult::Completed { .. }));
-
-        let mut saw_output = false;
-        while let Ok(evt) = rx.try_recv() {
-            if let WorkerEvent::AgentUpdate {
-                event: AgentEvent::OutputChunk { content, .. },
-                ..
-            } = evt
-            {
-                if content == "hello nested" {
-                    saw_output = true;
-                }
-            }
-        }
-        assert!(saw_output);
-
-        session.kill().await;
-    }
-
-    #[tokio::test]
-    async fn run_turn_usage_only_update_does_not_emit_notification() {
-        let dir = TempDir::new().unwrap();
-        let workspace = TempDir::new().unwrap();
-
-        let script = r#"#!/bin/bash
-while IFS= read -r line; do
-    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
-    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
-
-    if [ "$method" = "initialize" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
-    elif [ "$method" = "session/new" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"usage-only-session\"}}"
-    elif [ "$method" = "session/prompt" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"usage-only-session\",\"update\":{\"sessionUpdate\":\"usage_update\",\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}}}"
-        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"usage-only-session\",\"stopReason\":\"end_turn\"}}"
-    fi
-done
-"#;
-        let script_path = write_mock_agent_script(dir.path(), script);
-
-        let mut session = AcpSession::spawn(&script_path, workspace.path())
-            .await
-            .unwrap();
-        session.initialize(15000).await.unwrap();
-        let session_id = session
-            .start_session(
-                workspace.path().to_str().unwrap(),
-                serde_json::json!({}),
-                15000,
-            )
-            .await
-            .unwrap();
-
-        let (tx, mut rx) = mpsc::channel(100);
-        let result = session
-            .run_turn(
-                &session_id,
-                "Do work",
-                30000,
-                "auto_approve_all",
-                "issue-usage-only",
-                "build",
-                &tx,
-            )
-            .await
-            .unwrap();
-
-        assert!(matches!(result, TurnResult::Completed { .. }));
-
-        let mut saw_notification = false;
-        while let Ok(evt) = rx.try_recv() {
-            if let WorkerEvent::AgentUpdate {
-                event: AgentEvent::Notification { .. },
-                ..
-            } = evt
-            {
-                saw_notification = true;
-            }
-        }
-        assert!(!saw_notification);
-
-        session.kill().await;
-    }
-
-    #[tokio::test]
-    async fn test_turn_timeout() {
-        let dir = TempDir::new().unwrap();
-        let workspace = TempDir::new().unwrap();
-
-        // Mock agent that does handshake but never completes the turn
-        let script = r#"#!/bin/bash
-while IFS= read -r line; do
-    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
-    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
-
-    if [ "$method" = "initialize" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
-    elif [ "$method" = "session/new" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"test-session-2\"}}"
-    elif [ "$method" = "session/prompt" ]; then
-        # Never send stopReason — simulate hanging
-        sleep 60
-    fi
-done
-"#;
-        let script_path = write_mock_agent_script(dir.path(), script);
-
-        let mut session = AcpSession::spawn(&script_path, workspace.path())
-            .await
-            .unwrap();
-        session.initialize(15000).await.unwrap();
-        let session_id = session
-            .start_session(
-                workspace.path().to_str().unwrap(),
-                serde_json::json!({}),
-                15000,
-            )
-            .await
-            .unwrap();
-
-        let (tx, _rx) = mpsc::channel(100);
-        let result = session
-            .run_turn(
-                &session_id,
-                "Do work",
-                200,
-                "auto_approve_all",
-                "issue-2",
-                "build",
-                &tx,
-            )
-            .await;
-
-        assert!(matches!(result, Err(AgentError::TurnTimeout { .. })));
-        session.kill().await;
-    }
-
-    #[tokio::test]
-    async fn test_agent_exit_during_turn() {
-        let dir = TempDir::new().unwrap();
-        let workspace = TempDir::new().unwrap();
-
-        // Mock agent that exits immediately after handshake on prompt
-        let script = r#"#!/bin/bash
-while IFS= read -r line; do
-    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
-    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
-
-    if [ "$method" = "initialize" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
-    elif [ "$method" = "session/new" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"test-session-3\"}}"
-    elif [ "$method" = "session/prompt" ]; then
-        exit 0  # exit abruptly
-    fi
-done
-"#;
-        let script_path = write_mock_agent_script(dir.path(), script);
-
-        let mut session = AcpSession::spawn(&script_path, workspace.path())
-            .await
-            .unwrap();
-        session.initialize(15000).await.unwrap();
-        let session_id = session
-            .start_session(
-                workspace.path().to_str().unwrap(),
-                serde_json::json!({}),
-                15000,
-            )
-            .await
-            .unwrap();
-
-        let (tx, _rx) = mpsc::channel(100);
-        let result = session
-            .run_turn(
-                &session_id,
-                "Do work",
-                30000,
-                "auto_approve_all",
-                "issue-3",
-                "build",
-                &tx,
-            )
-            .await;
-
-        assert!(matches!(result, Err(AgentError::AgentExit { .. })));
-        session.kill().await;
-    }
-
-    #[tokio::test]
-    async fn test_malformed_json_handling() {
-        let dir = TempDir::new().unwrap();
-        let workspace = TempDir::new().unwrap();
-
-        // Mock agent that sends malformed JSON then a valid turn completion
-        let script = r#"#!/bin/bash
-while IFS= read -r line; do
-    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
-    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
-
-    if [ "$method" = "initialize" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
-    elif [ "$method" = "session/new" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"test-session-4\"}}"
-    elif [ "$method" = "session/prompt" ]; then
-        echo "this is not valid json at all"
-        echo "{also broken json"
-        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"test-session-4\",\"stopReason\":\"end_turn\"}}"
-    fi
-done
-"#;
-        let script_path = write_mock_agent_script(dir.path(), script);
-
-        let mut session = AcpSession::spawn(&script_path, workspace.path())
-            .await
-            .unwrap();
-        session.initialize(15000).await.unwrap();
-        let session_id = session
-            .start_session(
-                workspace.path().to_str().unwrap(),
-                serde_json::json!({}),
-                15000,
-            )
-            .await
-            .unwrap();
-
-        let (tx, mut rx) = mpsc::channel(100);
-        let result = session
-            .run_turn(
-                &session_id,
-                "Do work",
-                30000,
-                "auto_approve_all",
-                "issue-4",
-                "build",
-                &tx,
-            )
-            .await
-            .unwrap();
-
-        assert!(result.is_success());
-
-        // Verify malformed events were emitted
-        let mut malformed_count = 0;
-        while let Ok(evt) = rx.try_recv() {
-            if let WorkerEvent::AgentUpdate {
-                event: AgentEvent::Malformed { .. },
-                ..
-            } = evt
-            {
-                malformed_count += 1;
-            }
-        }
-        assert!(
-            malformed_count >= 2,
-            "expected at least 2 malformed events, got {malformed_count}"
+                responder.respond(response)
+            },
+            agent_client_protocol::on_receive_request!(),
         );
 
-        session.kill().await;
-    }
-
-    #[tokio::test]
-    async fn test_permission_request_auto_approve() {
-        let dir = TempDir::new().unwrap();
-        let workspace = TempDir::new().unwrap();
-
-        // Mock agent that sends a permission request, then completes
-        let script = r#"#!/bin/bash
-while IFS= read -r line; do
-    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
-    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
-
-    if [ "$method" = "initialize" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
-    elif [ "$method" = "session/new" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"test-session-5\"}}"
-    elif [ "$method" = "session/prompt" ]; then
-        echo "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"session/request_permission\",\"params\":{\"permissionId\":\"perm-1\",\"description\":\"Execute command: ls\"}}"
-        # Read the permission response
-        read -r perm_response
-        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"test-session-5\",\"stopReason\":\"end_turn\"}}"
-    fi
-done
-"#;
-        let script_path = write_mock_agent_script(dir.path(), script);
-
-        let mut session = AcpSession::spawn(&script_path, workspace.path())
-            .await
-            .unwrap();
-        session.initialize(15000).await.unwrap();
-        let session_id = session
-            .start_session(
-                workspace.path().to_str().unwrap(),
-                serde_json::json!({}),
-                15000,
-            )
-            .await
-            .unwrap();
-
-        let (tx, mut rx) = mpsc::channel(100);
-        let result = session
-            .run_turn(
-                &session_id,
-                "Do work",
-                30000,
-                "auto_approve_all",
-                "issue-5",
-                "build",
-                &tx,
-            )
-            .await
-            .unwrap();
-
-        assert!(result.is_success());
-
-        // Verify permission events are normalized into warning/notification messages
-        let mut saw_permission_warning = false;
-        let mut saw_permission_resolution = false;
-        while let Ok(evt) = rx.try_recv() {
-            match evt {
-                WorkerEvent::AgentUpdate {
-                    event: AgentEvent::Warning { ref message },
-                    ..
-                } => {
-                    assert!(message.contains("perm-1"));
-                    saw_permission_warning = true;
-                }
-                WorkerEvent::AgentUpdate {
-                    event: AgentEvent::Notification { ref message },
-                    ..
-                } => {
-                    assert!(message.contains("approved"));
-                    assert!(message.contains("perm-1"));
-                    saw_permission_resolution = true;
-                }
-                _ => {}
+    let result = builder
+        .connect_with(agent, async move |cx| {
+            if let Err(e) = cx
+                .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .block_task()
+                .await
+            {
+                let mut err = session_error_inner.lock().await;
+                *err = Some(format!("initialize failed: {e}"));
+                return Ok(());
             }
-        }
-        assert!(saw_permission_warning, "expected permission warning event");
-        assert!(
-            saw_permission_resolution,
-            "expected permission resolution notification event"
-        );
 
-        session.kill().await;
+            let session_builder = match cx.build_session_cwd() {
+                Ok(sb) => sb,
+                Err(e) => {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("build_session_cwd failed: {e}"));
+                    return Ok(());
+                }
+            };
+
+            if let Err(e) = session_builder
+                .block_task()
+                .run_until(async |mut session| {
+                    let session_id = session.session_id().to_string();
+
+                    emit_event(
+                        event_tx,
+                        issue_id,
+                        step_name,
+                        AgentEvent::SessionStarted {
+                            session_id: session_id.clone(),
+                            agent_pid: None,
+                        },
+                    )
+                    .await;
+
+                    if let Some(ref mode) = session_mode {
+                        if !mode.is_empty() {
+                            debug!(session_id = %session_id, mode = %mode, "session mode note (SDK manages mode internally)");
+                        }
+                    }
+
+                    for (i, prompt) in prompts.iter().enumerate() {
+                        emit_event(
+                            event_tx,
+                            issue_id,
+                            step_name,
+                            AgentEvent::PromptStarted,
+                        )
+                        .await;
+
+                        if let Err(e) = session.send_prompt(prompt) {
+                            let mut err = session_error_inner.lock().await;
+                            *err = Some(format!("send_prompt failed: {e}"));
+                            return Ok(());
+                        }
+
+                        let last_usage: Option<TokenUsage> = None;
+                        let last_runtime_verdict: Option<serde_json::Value> = None;
+                        let mut timed_out = false;
+
+                        let turn_future = async {
+                            loop {
+                                match session.read_update().await {
+                                    Ok(SessionMessage::StopReason(stop)) => {
+                                        let mapped = map_sdk_stop_reason(&stop);
+                                        return Ok((mapped, last_usage, last_runtime_verdict));
+                                    }
+                                    Ok(SessionMessage::SessionMessage(_dispatch)) => {}
+                                    Err(e) => {
+                                        return Err(format!("read_update failed: {e}"));
+                                    }
+                                    Ok(_) => {}
+                                }
+                            }
+                        };
+
+                        let turn_result = tokio::time::timeout(
+                            std::time::Duration::from_millis(turn_timeout_ms),
+                            turn_future,
+                        )
+                        .await;
+
+                        let turn_result = match turn_result {
+                            Ok(Ok((stop_reason, usage, verdict))) => match stop_reason {
+                                super::events::StopReason::EndTurn
+                                | super::events::StopReason::MaxTokens => {
+                                    emit_event(
+                                        event_tx,
+                                        issue_id,
+                                        step_name,
+                                        AgentEvent::RunCompleted {
+                                            usage: usage.clone(),
+                                        },
+                                    )
+                                    .await;
+                                    TurnResult::Completed {
+                                        usage,
+                                        runtime_verdict: verdict,
+                                    }
+                                }
+                                _ => {
+                                    let reason = format!("stop reason: {:?}", stop_reason);
+                                    emit_event(
+                                        event_tx,
+                                        issue_id,
+                                        step_name,
+                                        AgentEvent::RunFailed {
+                                            reason: reason.clone(),
+                                            usage: usage.clone(),
+                                        },
+                                    )
+                                    .await;
+                                    TurnResult::Failed {
+                                        reason,
+                                        usage,
+                                        runtime_verdict: verdict,
+                                    }
+                                }
+                            },
+                            Ok(Err(e)) => {
+                                let mut err = session_error_inner.lock().await;
+                                *err = Some(e);
+                                return Ok(());
+                            }
+                            Err(_) => {
+                                timed_out = true;
+                                TurnResult::Failed {
+                                    reason: format!("turn timeout after {turn_timeout_ms}ms"),
+                                    usage: None,
+                                    runtime_verdict: None,
+                                }
+                            }
+                        };
+
+                        if let TurnResult::Completed {
+                            ref runtime_verdict,
+                            ..
+                        } = turn_result
+                        {
+                            if runtime_verdict.is_some() {
+                                let mut v = final_verdict_inner.lock().await;
+                                *v = runtime_verdict.clone();
+                            }
+                        }
+
+                        if let TurnResult::Failed { ref reason, .. } = turn_result {
+                            if timed_out {
+                                let mut err = session_error_inner.lock().await;
+                                *err = Some(reason.clone());
+                                turn_results_inner.lock().await.push(turn_result);
+                                return Ok(());
+                            }
+                            if i < prompts.len() - 1 {
+                                warn!(
+                                    issue_id = %issue_id,
+                                    step = step_name,
+                                    turn = i + 1,
+                                    reason = %reason,
+                                    "turn failed, stopping remaining turns"
+                                );
+                                turn_results_inner.lock().await.push(turn_result);
+                                return Ok(());
+                            }
+                        }
+
+                        info!(
+                            issue_id = %issue_id,
+                            step = step_name,
+                            turn = i + 1,
+                            "turn completed successfully"
+                        );
+                        turn_results_inner.lock().await.push(turn_result);
+                    }
+
+                    Ok(())
+                })
+                .await
+            {
+                let mut err = session_error_inner.lock().await;
+                if err.is_none() {
+                    *err = Some(format!("session error: {e}"));
+                }
+            }
+
+            Ok(())
+        })
+        .await;
+
+    if let Err(e) = result {
+        let error_msg = e.to_string();
+        let captured = session_error_outer.lock().await.clone();
+        let msg = captured.unwrap_or(error_msg);
+        if msg.contains("timeout") || msg.contains("TimedOut") {
+            return Err(AgentError::TurnTimeout {
+                timeout_ms: config.turn_timeout_ms,
+            });
+        }
+        return Err(AgentError::IoError { reason: msg });
     }
+
+    let captured_error = session_error_outer.lock().await.clone();
+    if let Some(error_msg) = captured_error {
+        if error_msg.contains("timeout") || error_msg.contains("TimedOut") {
+            return Err(AgentError::TurnTimeout {
+                timeout_ms: config.turn_timeout_ms,
+            });
+        } else if error_msg.contains("initialize") || error_msg.contains("session") {
+            return Err(AgentError::SessionStartupFailed { reason: error_msg });
+        } else {
+            return Err(AgentError::IoError { reason: error_msg });
+        }
+    }
+
+    let verdict = final_verdict.lock().await.take();
+    let results = turn_results.lock().await.clone();
+    Ok((verdict, results))
 }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use agent_client_protocol::schema::{
     ContentBlock, InitializeRequest, PermissionOption, PermissionOptionKind, ProtocolVersion,
@@ -230,6 +231,7 @@ pub async fn run_acp_session(
     let session_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let prompts = Arc::new(prompts);
     let session_mode = config.session_mode.clone();
+    let read_timeout_ms = config.read_timeout_ms;
     let turn_timeout_ms = config.turn_timeout_ms;
     let workspace_path = config.workspace_path.clone();
 
@@ -290,212 +292,235 @@ pub async fn run_acp_session(
 
     let result = builder
         .connect_with(agent, async move |cx| {
-            if let Err(e) = cx
-                .send_request(InitializeRequest::new(ProtocolVersion::V1))
-                .block_task()
-                .await
+            match tokio::time::timeout(
+                Duration::from_millis(read_timeout_ms),
+                cx.send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task(),
+            )
+            .await
             {
-                let mut err = session_error_inner.lock().await;
-                *err = Some(format!("initialize failed: {e}"));
-                return Ok(());
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("initialize failed: {e}"));
+                    return Ok(());
+                }
+                Err(_) => {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("response timeout after {read_timeout_ms}ms"));
+                    return Ok(());
+                }
             }
 
             let session_builder = cx.build_session(&workspace_path);
+            let mut session = match tokio::time::timeout(
+                Duration::from_millis(read_timeout_ms),
+                session_builder.block_task().start_session(),
+            )
+            .await
+            {
+                Ok(Ok(session)) => session,
+                Ok(Err(e)) => {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("session error: {e}"));
+                    return Ok(());
+                }
+                Err(_) => {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("response timeout after {read_timeout_ms}ms"));
+                    return Ok(());
+                }
+            };
 
-            if let Err(e) = session_builder
-                .block_task()
-                .run_until(async |mut session| {
-                    let session_id = session.session_id().to_string();
+            let session_id = session.session_id().to_string();
 
-                    emit_event(
-                        event_tx,
-                        issue_id,
-                        step_name,
-                        AgentEvent::SessionStarted {
-                            session_id: session_id.clone(),
-                            agent_pid: agent_pid.lock().await.clone(),
-                        },
+            emit_event(
+                event_tx,
+                issue_id,
+                step_name,
+                AgentEvent::SessionStarted {
+                    session_id: session_id.clone(),
+                    agent_pid: agent_pid.lock().await.clone(),
+                },
+            )
+            .await;
+
+            if let Some(ref mode) = session_mode {
+                if !mode.is_empty() {
+                    match tokio::time::timeout(
+                        Duration::from_millis(read_timeout_ms),
+                        session
+                            .connection()
+                            .send_request(SetSessionModeRequest::new(
+                                session.session_id().clone(),
+                                mode.clone(),
+                            ))
+                            .block_task(),
                     )
-                    .await;
-
-                    if let Some(ref mode) = session_mode {
-                        if !mode.is_empty() {
-                            if let Err(e) = session
-                                .connection()
-                                .send_request(SetSessionModeRequest::new(
-                                    session.session_id().clone(),
-                                    mode.clone(),
-                                ))
-                                .block_task()
-                                .await
-                            {
-                                let mut err = session_error_inner.lock().await;
-                                *err = Some(format!("set_mode failed: {e}"));
-                                return Ok(());
-                            }
-                            debug!(session_id = %session_id, mode = %mode, "session mode set");
-                        }
-                    }
-
-                    for (i, prompt) in prompts.iter().enumerate() {
-                        emit_event(event_tx, issue_id, step_name, AgentEvent::PromptStarted).await;
-
-                        if let Err(e) = session.send_prompt(prompt) {
+                    .await
+                    {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(e)) => {
                             let mut err = session_error_inner.lock().await;
-                            *err = Some(format!("send_prompt failed: {e}"));
+                            *err = Some(format!("set_mode failed: {e}"));
                             return Ok(());
                         }
+                        Err(_) => {
+                            let mut err = session_error_inner.lock().await;
+                            *err = Some(format!("response timeout after {read_timeout_ms}ms"));
+                            return Ok(());
+                        }
+                    }
+                    debug!(session_id = %session_id, mode = %mode, "session mode set");
+                }
+            }
 
-                        let mut last_usage: Option<TokenUsage> = None;
-                        let mut last_runtime_verdict: Option<serde_json::Value> = None;
-                        let mut timed_out = false;
+            for (i, prompt) in prompts.iter().enumerate() {
+                emit_event(event_tx, issue_id, step_name, AgentEvent::PromptStarted).await;
 
-                        let turn_future = async {
-                            loop {
-                                match session.read_update().await {
-                                    Ok(SessionMessage::StopReason(stop)) => {
-                                        let mapped = map_sdk_stop_reason(&stop);
-                                        return Ok((mapped, last_usage, last_runtime_verdict));
+                if let Err(e) = session.send_prompt(prompt) {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("send_prompt failed: {e}"));
+                    return Ok(());
+                }
+
+                let mut last_usage: Option<TokenUsage> = None;
+                let mut last_runtime_verdict: Option<serde_json::Value> = None;
+                let mut timed_out = false;
+
+                let turn_future = async {
+                    loop {
+                        match session.read_update().await {
+                            Ok(SessionMessage::StopReason(stop)) => {
+                                let mapped = map_sdk_stop_reason(&stop);
+                                return Ok((mapped, last_usage, last_runtime_verdict));
+                            }
+                            Ok(SessionMessage::SessionMessage(dispatch)) => {
+                                if let Some(parsed) = parse_sdk_dispatch(dispatch)
+                                    .await
+                                    .map_err(|e| e.to_string())?
+                                {
+                                    if let Some(usage) = parsed.usage {
+                                        last_usage = Some(usage);
                                     }
-                                    Ok(SessionMessage::SessionMessage(dispatch)) => {
-                                        if let Some(parsed) = parse_sdk_dispatch(dispatch)
-                                            .await
-                                            .map_err(|e| e.to_string())?
-                                        {
-                                            if let Some(usage) = parsed.usage {
-                                                last_usage = Some(usage);
-                                            }
-                                            if let Some(verdict) = parsed.verdict {
-                                                last_runtime_verdict = Some(verdict);
-                                            }
-                                            if let Some(content) = parsed.output_text {
-                                                emit_event(
-                                                    event_tx,
-                                                    issue_id,
-                                                    step_name,
-                                                    AgentEvent::OutputChunk {
-                                                        stream: RuntimeStream::Stdout,
-                                                        content,
-                                                    },
-                                                )
-                                                .await;
-                                            }
-                                        }
+                                    if let Some(verdict) = parsed.verdict {
+                                        last_runtime_verdict = Some(verdict);
                                     }
-                                    Err(e) => {
-                                        return Err(format!("read_update failed: {e}"));
+                                    if let Some(content) = parsed.output_text {
+                                        emit_event(
+                                            event_tx,
+                                            issue_id,
+                                            step_name,
+                                            AgentEvent::OutputChunk {
+                                                stream: RuntimeStream::Stdout,
+                                                content,
+                                            },
+                                        )
+                                        .await;
                                     }
-                                    Ok(_) => {}
                                 }
                             }
-                        };
-
-                        let turn_result = tokio::time::timeout(
-                            std::time::Duration::from_millis(turn_timeout_ms),
-                            turn_future,
-                        )
-                        .await;
-
-                        let turn_result = match turn_result {
-                            Ok(Ok((stop_reason, usage, verdict))) => match stop_reason {
-                                super::events::StopReason::EndTurn
-                                | super::events::StopReason::MaxTokens => {
-                                    emit_event(
-                                        event_tx,
-                                        issue_id,
-                                        step_name,
-                                        AgentEvent::RunCompleted {
-                                            usage: usage.clone(),
-                                        },
-                                    )
-                                    .await;
-                                    TurnResult::Completed {
-                                        usage,
-                                        runtime_verdict: verdict,
-                                    }
-                                }
-                                _ => {
-                                    let reason = format!("stop reason: {:?}", stop_reason);
-                                    emit_event(
-                                        event_tx,
-                                        issue_id,
-                                        step_name,
-                                        AgentEvent::RunFailed {
-                                            reason: reason.clone(),
-                                            usage: usage.clone(),
-                                        },
-                                    )
-                                    .await;
-                                    TurnResult::Failed {
-                                        reason,
-                                        usage,
-                                        runtime_verdict: verdict,
-                                    }
-                                }
-                            },
-                            Ok(Err(e)) => {
-                                let mut err = session_error_inner.lock().await;
-                                *err = Some(e);
-                                return Ok(());
+                            Err(e) => {
+                                return Err(format!("read_update failed: {e}"));
                             }
-                            Err(_) => {
-                                timed_out = true;
-                                TurnResult::Failed {
-                                    reason: format!("turn timeout after {turn_timeout_ms}ms"),
-                                    usage: None,
-                                    runtime_verdict: None,
-                                }
-                            }
-                        };
+                            Ok(_) => {}
+                        }
+                    }
+                };
 
-                        if let TurnResult::Completed {
-                            ref runtime_verdict,
-                            ..
-                        } = turn_result
-                        {
-                            if runtime_verdict.is_some() {
-                                let mut v = final_verdict_inner.lock().await;
-                                *v = runtime_verdict.clone();
+                let turn_result =
+                    tokio::time::timeout(Duration::from_millis(turn_timeout_ms), turn_future).await;
+
+                let turn_result = match turn_result {
+                    Ok(Ok((stop_reason, usage, verdict))) => match stop_reason {
+                        super::events::StopReason::EndTurn
+                        | super::events::StopReason::MaxTokens => {
+                            emit_event(
+                                event_tx,
+                                issue_id,
+                                step_name,
+                                AgentEvent::RunCompleted {
+                                    usage: usage.clone(),
+                                },
+                            )
+                            .await;
+                            TurnResult::Completed {
+                                usage,
+                                runtime_verdict: verdict,
                             }
                         }
-
-                        if let TurnResult::Failed { ref reason, .. } = turn_result {
-                            if timed_out {
-                                let mut err = session_error_inner.lock().await;
-                                *err = Some(reason.clone());
-                                turn_results_inner.lock().await.push(turn_result);
-                                return Ok(());
-                            }
-                            if i < prompts.len() - 1 {
-                                warn!(
-                                    issue_id = %issue_id,
-                                    step = step_name,
-                                    turn = i + 1,
-                                    reason = %reason,
-                                    "turn failed, stopping remaining turns"
-                                );
-                                turn_results_inner.lock().await.push(turn_result);
-                                return Ok(());
+                        _ => {
+                            let reason = format!("stop reason: {:?}", stop_reason);
+                            emit_event(
+                                event_tx,
+                                issue_id,
+                                step_name,
+                                AgentEvent::RunFailed {
+                                    reason: reason.clone(),
+                                    usage: usage.clone(),
+                                },
+                            )
+                            .await;
+                            TurnResult::Failed {
+                                reason,
+                                usage,
+                                runtime_verdict: verdict,
                             }
                         }
+                    },
+                    Ok(Err(e)) => {
+                        let mut err = session_error_inner.lock().await;
+                        *err = Some(e);
+                        return Ok(());
+                    }
+                    Err(_) => {
+                        timed_out = true;
+                        TurnResult::Failed {
+                            reason: format!("turn timeout after {turn_timeout_ms}ms"),
+                            usage: None,
+                            runtime_verdict: None,
+                        }
+                    }
+                };
 
-                        info!(
+                if let TurnResult::Completed {
+                    ref runtime_verdict,
+                    ..
+                } = turn_result
+                {
+                    if runtime_verdict.is_some() {
+                        let mut v = final_verdict_inner.lock().await;
+                        *v = runtime_verdict.clone();
+                    }
+                }
+
+                if let TurnResult::Failed { ref reason, .. } = turn_result {
+                    if timed_out {
+                        let mut err = session_error_inner.lock().await;
+                        *err = Some(reason.clone());
+                        turn_results_inner.lock().await.push(turn_result);
+                        return Ok(());
+                    }
+                    if i < prompts.len() - 1 {
+                        warn!(
                             issue_id = %issue_id,
                             step = step_name,
                             turn = i + 1,
-                            "turn completed successfully"
+                            reason = %reason,
+                            "turn failed, stopping remaining turns"
                         );
                         turn_results_inner.lock().await.push(turn_result);
+                        return Ok(());
                     }
-
-                    Ok(())
-                })
-                .await
-            {
-                let mut err = session_error_inner.lock().await;
-                if err.is_none() {
-                    *err = Some(format!("session error: {e}"));
                 }
+
+                info!(
+                    issue_id = %issue_id,
+                    step = step_name,
+                    turn = i + 1,
+                    "turn completed successfully"
+                );
+                turn_results_inner.lock().await.push(turn_result);
             }
 
             Ok(())
@@ -506,7 +531,12 @@ pub async fn run_acp_session(
         let error_msg = e.to_string();
         let captured = session_error_outer.lock().await.clone();
         let msg = captured.unwrap_or(error_msg);
-        if msg.contains("timeout") || msg.contains("TimedOut") {
+        if msg.contains("response timeout") {
+            return Err(AgentError::ResponseTimeout {
+                timeout_ms: read_timeout_ms,
+            });
+        }
+        if msg.contains("turn timeout") || msg.contains("TimedOut") {
             return Err(AgentError::TurnTimeout {
                 timeout_ms: turn_timeout_ms,
             });
@@ -516,7 +546,11 @@ pub async fn run_acp_session(
 
     let captured_error = session_error_outer.lock().await.clone();
     if let Some(error_msg) = captured_error {
-        if error_msg.contains("timeout") || error_msg.contains("TimedOut") {
+        if error_msg.contains("response timeout") {
+            return Err(AgentError::ResponseTimeout {
+                timeout_ms: read_timeout_ms,
+            });
+        } else if error_msg.contains("turn timeout") || error_msg.contains("TimedOut") {
             return Err(AgentError::TurnTimeout {
                 timeout_ms: turn_timeout_ms,
             });
@@ -535,11 +569,13 @@ pub async fn run_acp_session(
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::time::Duration;
 
     use agent_client_protocol::schema::{
         ContentBlock, ContentChunk, PermissionOption, PermissionOptionKind, SessionNotification,
         SessionUpdate, TextContent, UsageUpdate,
     };
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -607,5 +643,33 @@ mod tests {
         let parsed = parse_session_notification(notification);
 
         assert_eq!(parsed.usage.map(|usage| usage.total_tokens), Some(42));
+    }
+
+    #[tokio::test]
+    async fn startup_initialize_uses_configured_read_timeout() {
+        let workspace = TempDir::new().unwrap();
+        let config = AcpSessionConfig {
+            command: "bash -lc 'while IFS= read -r _line; do sleep 60; done'".to_string(),
+            workspace_path: workspace.path().to_path_buf(),
+            session_mode: None,
+            permission_request_policy: "auto_approve_all".to_string(),
+            read_timeout_ms: 50,
+            turn_timeout_ms: 10_000,
+        };
+        let (tx, _rx) = mpsc::channel(10);
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            run_acp_session(config, vec!["hello".to_string()], "issue-1", "build", &tx),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Ok(Err(AgentError::ResponseTimeout { timeout_ms: 50 }))
+            ),
+            "startup should return the configured response timeout, got {result:?}"
+        );
     }
 }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -1,18 +1,19 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
 use agent_client_protocol::schema::{
-    InitializeRequest, ProtocolVersion, RequestPermissionRequest, RequestPermissionResponse,
-    StopReason as SdkStopReason,
+    ContentBlock, InitializeRequest, PermissionOption, PermissionOptionKind, ProtocolVersion,
+    RequestPermissionRequest, RequestPermissionResponse, SessionNotification, SessionUpdate,
+    SetSessionModeRequest, StopReason as SdkStopReason,
 };
-use agent_client_protocol::{AcpAgent, Client, SessionMessage};
+use agent_client_protocol::{AcpAgent, Client, Dispatch, SessionMessage};
 use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, info, warn};
 
 use crate::error::AgentError;
 
-use super::events::{AgentEvent, TokenUsage, WorkerEvent};
+use super::events::{AgentEvent, RuntimeStream, TokenUsage, WorkerEvent};
 
 #[derive(Debug)]
 pub struct AcpSessionConfig {
@@ -73,6 +74,116 @@ fn resolve_permission(permission_request_policy: &str, description: &str) -> boo
     }
 }
 
+fn select_permission_option<'a>(
+    permission_request_policy: &str,
+    description: &str,
+    options: &'a [PermissionOption],
+) -> Option<&'a PermissionOption> {
+    if !resolve_permission(permission_request_policy, description) {
+        return None;
+    }
+
+    options
+        .iter()
+        .find(|option| matches!(option.kind, PermissionOptionKind::AllowOnce))
+        .or_else(|| {
+            options
+                .iter()
+                .find(|option| matches!(option.kind, PermissionOptionKind::AllowAlways))
+        })
+}
+
+fn shell_escape(arg: &str) -> String {
+    let mut escaped = String::with_capacity(arg.len() + 2);
+    escaped.push('\'');
+    for ch in arg.chars() {
+        if ch == '\'' {
+            escaped.push_str("'\\''");
+        } else {
+            escaped.push(ch);
+        }
+    }
+    escaped.push('\'');
+    escaped
+}
+
+fn sdk_transport_command(command: &str, workspace_path: &Path) -> String {
+    let cwd = workspace_path.to_string_lossy();
+    let script = format!("echo $$ >&2; cd {}; exec {}", shell_escape(&cwd), command);
+    format!("bash -lc {}", shell_escape(&script))
+}
+
+fn token_usage_from_value(value: serde_json::Value) -> Option<TokenUsage> {
+    #[derive(serde::Deserialize)]
+    struct CamelUsage {
+        #[serde(default, alias = "input_tokens", alias = "inputTokens")]
+        input_tokens: u64,
+        #[serde(default, alias = "output_tokens", alias = "outputTokens")]
+        output_tokens: u64,
+        #[serde(default, alias = "total_tokens", alias = "totalTokens", alias = "used")]
+        total_tokens: u64,
+    }
+
+    serde_json::from_value::<CamelUsage>(value)
+        .ok()
+        .map(|u| TokenUsage {
+            input_tokens: u.input_tokens,
+            output_tokens: u.output_tokens,
+            total_tokens: u.total_tokens,
+        })
+}
+
+fn text_from_content(content: &ContentBlock) -> Option<String> {
+    match content {
+        ContentBlock::Text(text) => Some(text.text.clone()).filter(|s| !s.is_empty()),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Default)]
+struct ParsedSdkDispatch {
+    output_text: Option<String>,
+    usage: Option<TokenUsage>,
+    verdict: Option<serde_json::Value>,
+}
+
+fn parse_session_notification(notification: SessionNotification) -> ParsedSdkDispatch {
+    match notification.update {
+        SessionUpdate::AgentMessageChunk(chunk) => ParsedSdkDispatch {
+            output_text: text_from_content(&chunk.content),
+            ..ParsedSdkDispatch::default()
+        },
+        update => {
+            let value = serde_json::to_value(update).ok();
+            ParsedSdkDispatch {
+                usage: value
+                    .as_ref()
+                    .and_then(|v| v.get("usage").cloned())
+                    .or_else(|| value.clone())
+                    .and_then(token_usage_from_value),
+                verdict: value.as_ref().and_then(|v| v.get("verdict").cloned()),
+                output_text: None,
+            }
+        }
+    }
+}
+
+async fn parse_sdk_dispatch(dispatch: Dispatch) -> Result<Option<ParsedSdkDispatch>, AgentError> {
+    let mut parsed: Option<ParsedSdkDispatch> = None;
+    agent_client_protocol::util::MatchDispatch::new(dispatch)
+        .if_notification(async |notification: SessionNotification| {
+            parsed = Some(parse_session_notification(notification));
+            Ok(())
+        })
+        .await
+        .otherwise_ignore()
+        .map_err(|e| AgentError::IoError {
+            reason: format!("failed to parse session update: {e}"),
+        })?;
+
+    Ok(parsed)
+}
+
 fn map_sdk_stop_reason(stop: &SdkStopReason) -> super::events::StopReason {
     match stop {
         SdkStopReason::EndTurn => super::events::StopReason::EndTurn,
@@ -91,9 +202,23 @@ pub async fn run_acp_session(
     step_name: &str,
     event_tx: &mpsc::Sender<WorkerEvent>,
 ) -> Result<(Option<serde_json::Value>, Vec<TurnResult>), AgentError> {
-    let agent = AcpAgent::from_str(&config.command).map_err(|e| AgentError::AgentNotFound {
+    let transport_command = sdk_transport_command(&config.command, &config.workspace_path);
+    let agent_pid: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let agent_pid_for_debug = agent_pid.clone();
+    let agent = AcpAgent::from_str(&transport_command).map_err(|e| AgentError::AgentNotFound {
         command: format!("{}: {}", config.command, e),
     })?;
+    let agent = agent.with_debug(move |line, direction| {
+        if matches!(direction, agent_client_protocol::LineDirection::Stderr)
+            && line.chars().all(|c| c.is_ascii_digit())
+        {
+            if let Ok(mut guard) = agent_pid_for_debug.try_lock() {
+                if guard.is_none() {
+                    *guard = Some(line.to_string());
+                }
+            }
+        }
+    });
 
     let permission_policy = config.permission_request_policy.clone();
     let issue_id_owned = issue_id.to_string();
@@ -106,6 +231,7 @@ pub async fn run_acp_session(
     let prompts = Arc::new(prompts);
     let session_mode = config.session_mode.clone();
     let turn_timeout_ms = config.turn_timeout_ms;
+    let workspace_path = config.workspace_path.clone();
 
     let turn_results_inner = turn_results.clone();
     let final_verdict_inner = final_verdict.clone();
@@ -128,18 +254,16 @@ pub async fn run_acp_session(
             )
             .await;
 
-            let allowed = resolve_permission(&permission_policy, &description);
+            let selected_option =
+                select_permission_option(&permission_policy, &description, &request.options);
+            let allowed = selected_option.is_some();
 
-            let outcome = if allowed {
-                if let Some(first_option) = request.options.first() {
-                    let option_id: agent_client_protocol::schema::PermissionOptionId =
-                        first_option.option_id.clone();
-                    agent_client_protocol::schema::RequestPermissionOutcome::Selected(
-                        agent_client_protocol::schema::SelectedPermissionOutcome::new(option_id),
-                    )
-                } else {
-                    agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
-                }
+            let outcome = if let Some(option) = selected_option {
+                let option_id: agent_client_protocol::schema::PermissionOptionId =
+                    option.option_id.clone();
+                agent_client_protocol::schema::RequestPermissionOutcome::Selected(
+                    agent_client_protocol::schema::SelectedPermissionOutcome::new(option_id),
+                )
             } else {
                 agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
             };
@@ -176,14 +300,7 @@ pub async fn run_acp_session(
                 return Ok(());
             }
 
-            let session_builder = match cx.build_session_cwd() {
-                Ok(sb) => sb,
-                Err(e) => {
-                    let mut err = session_error_inner.lock().await;
-                    *err = Some(format!("build_session_cwd failed: {e}"));
-                    return Ok(());
-                }
-            };
+            let session_builder = cx.build_session(&workspace_path);
 
             if let Err(e) = session_builder
                 .block_task()
@@ -196,25 +313,32 @@ pub async fn run_acp_session(
                         step_name,
                         AgentEvent::SessionStarted {
                             session_id: session_id.clone(),
-                            agent_pid: None,
+                            agent_pid: agent_pid.lock().await.clone(),
                         },
                     )
                     .await;
 
                     if let Some(ref mode) = session_mode {
                         if !mode.is_empty() {
-                            debug!(session_id = %session_id, mode = %mode, "session mode note (SDK manages mode internally)");
+                            if let Err(e) = session
+                                .connection()
+                                .send_request(SetSessionModeRequest::new(
+                                    session.session_id().clone(),
+                                    mode.clone(),
+                                ))
+                                .block_task()
+                                .await
+                            {
+                                let mut err = session_error_inner.lock().await;
+                                *err = Some(format!("set_mode failed: {e}"));
+                                return Ok(());
+                            }
+                            debug!(session_id = %session_id, mode = %mode, "session mode set");
                         }
                     }
 
                     for (i, prompt) in prompts.iter().enumerate() {
-                        emit_event(
-                            event_tx,
-                            issue_id,
-                            step_name,
-                            AgentEvent::PromptStarted,
-                        )
-                        .await;
+                        emit_event(event_tx, issue_id, step_name, AgentEvent::PromptStarted).await;
 
                         if let Err(e) = session.send_prompt(prompt) {
                             let mut err = session_error_inner.lock().await;
@@ -222,8 +346,8 @@ pub async fn run_acp_session(
                             return Ok(());
                         }
 
-                        let last_usage: Option<TokenUsage> = None;
-                        let last_runtime_verdict: Option<serde_json::Value> = None;
+                        let mut last_usage: Option<TokenUsage> = None;
+                        let mut last_runtime_verdict: Option<serde_json::Value> = None;
                         let mut timed_out = false;
 
                         let turn_future = async {
@@ -233,7 +357,31 @@ pub async fn run_acp_session(
                                         let mapped = map_sdk_stop_reason(&stop);
                                         return Ok((mapped, last_usage, last_runtime_verdict));
                                     }
-                                    Ok(SessionMessage::SessionMessage(_dispatch)) => {}
+                                    Ok(SessionMessage::SessionMessage(dispatch)) => {
+                                        if let Some(parsed) = parse_sdk_dispatch(dispatch)
+                                            .await
+                                            .map_err(|e| e.to_string())?
+                                        {
+                                            if let Some(usage) = parsed.usage {
+                                                last_usage = Some(usage);
+                                            }
+                                            if let Some(verdict) = parsed.verdict {
+                                                last_runtime_verdict = Some(verdict);
+                                            }
+                                            if let Some(content) = parsed.output_text {
+                                                emit_event(
+                                                    event_tx,
+                                                    issue_id,
+                                                    step_name,
+                                                    AgentEvent::OutputChunk {
+                                                        stream: RuntimeStream::Stdout,
+                                                        content,
+                                                    },
+                                                )
+                                                .await;
+                                            }
+                                        }
+                                    }
                                     Err(e) => {
                                         return Err(format!("read_update failed: {e}"));
                                     }
@@ -360,7 +508,7 @@ pub async fn run_acp_session(
         let msg = captured.unwrap_or(error_msg);
         if msg.contains("timeout") || msg.contains("TimedOut") {
             return Err(AgentError::TurnTimeout {
-                timeout_ms: config.turn_timeout_ms,
+                timeout_ms: turn_timeout_ms,
             });
         }
         return Err(AgentError::IoError { reason: msg });
@@ -370,7 +518,7 @@ pub async fn run_acp_session(
     if let Some(error_msg) = captured_error {
         if error_msg.contains("timeout") || error_msg.contains("TimedOut") {
             return Err(AgentError::TurnTimeout {
-                timeout_ms: config.turn_timeout_ms,
+                timeout_ms: turn_timeout_ms,
             });
         } else if error_msg.contains("initialize") || error_msg.contains("session") {
             return Err(AgentError::SessionStartupFailed { reason: error_msg });
@@ -382,4 +530,82 @@ pub async fn run_acp_session(
     let verdict = final_verdict.lock().await.take();
     let results = turn_results.lock().await.clone();
     Ok((verdict, results))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use agent_client_protocol::schema::{
+        ContentBlock, ContentChunk, PermissionOption, PermissionOptionKind, SessionNotification,
+        SessionUpdate, TextContent, UsageUpdate,
+    };
+
+    use super::*;
+
+    #[test]
+    fn sdk_transport_command_runs_original_command_from_workspace_and_prints_pid() {
+        let command = "acpx --agent 'builder'";
+        let wrapped = sdk_transport_command(command, Path::new("/tmp/work space"));
+
+        assert!(wrapped.starts_with("bash -lc "));
+        assert!(wrapped.contains("echo $$ >&2"));
+        assert!(wrapped.contains("/tmp/work space"));
+        assert!(wrapped.contains("exec acpx --agent"));
+        assert!(wrapped.contains("builder"));
+    }
+
+    #[test]
+    fn select_permission_option_prefers_allow_once_over_first_option() {
+        let options = vec![
+            PermissionOption::new("reject", "Reject", PermissionOptionKind::RejectOnce),
+            PermissionOption::new("allow", "Allow", PermissionOptionKind::AllowOnce),
+        ];
+
+        let selected = select_permission_option("auto_approve_all", "write file", &options);
+
+        assert_eq!(
+            selected.map(|option| option.option_id.to_string()),
+            Some("allow".to_string())
+        );
+    }
+
+    #[test]
+    fn select_permission_option_rejects_when_policy_denies_request() {
+        let options = vec![PermissionOption::new(
+            "allow",
+            "Allow",
+            PermissionOptionKind::AllowOnce,
+        )];
+
+        let selected = select_permission_option("reject_all", "read file", &options);
+
+        assert!(selected.is_none());
+    }
+
+    #[test]
+    fn parse_session_notification_extracts_agent_message_text() {
+        let notification = SessionNotification::new(
+            "session-1",
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                TextContent::new("hello"),
+            ))),
+        );
+
+        let parsed = parse_session_notification(notification);
+
+        assert_eq!(parsed.output_text.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn parse_session_notification_maps_usage_update_to_total_tokens() {
+        let notification = SessionNotification::new(
+            "session-1",
+            SessionUpdate::UsageUpdate(UsageUpdate::new(42, 100)),
+        );
+
+        let parsed = parse_session_notification(notification);
+
+        assert_eq!(parsed.usage.map(|usage| usage.total_tokens), Some(42));
+    }
 }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -14,8 +14,6 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
-
 use crate::config::ensemble::{EnsembleConfig, InteractionPolicyOverrideMode, PermissionMode};
 use crate::config::template::render_prompt_with_interaction_response;
 use crate::error::AgentError;
@@ -23,10 +21,9 @@ use crate::interaction::InteractionResponse;
 use crate::tracker::model::Issue;
 use crate::workspace::hooks::{run_hook, run_hook_best_effort};
 use events::{
-    AgentEvent, InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult,
+    InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult,
 };
 
-use acp_client::{AcpSession, TurnResult};
 use acpx_runtime::AcpxRuntime;
 
 const VERDICT_FALLBACK_INSTRUCTION: &str = "\
@@ -413,6 +410,7 @@ async fn remove_ensemble_file(workspace_path: &Path, filename: &str) -> Result<(
 /// Wraps the argument in single quotes and escapes any embedded single-quote
 /// characters. This prevents shell metacharacter injection when arguments are
 /// interpolated into commands executed via `bash -lc`.
+#[allow(dead_code)]
 fn shell_escape(arg: &str) -> String {
     let mut escaped = String::with_capacity(arg.len() + 2);
     escaped.push('\'');
@@ -435,6 +433,7 @@ fn shell_escape(arg: &str) -> String {
 /// `agent.permission_request_policy` is handled later when ACP permission
 /// callbacks arrive; it does not change the spawn command. Falls back to
 /// `executor` if set, then to the global default.
+#[allow(dead_code)]
 fn resolve_agent_command(
     agent_config: Option<&crate::config::ensemble::AgentConfig>,
     default_command: &str,
@@ -464,6 +463,7 @@ fn resolve_agent_command(
     shell_escape_command(default_command)
 }
 
+#[allow(dead_code)]
 fn shell_escape_command(command: &str) -> String {
     let parts = shlex::split(command)
         .unwrap_or_else(|| command.split_whitespace().map(str::to_string).collect());
@@ -541,153 +541,11 @@ impl AgentRunner for AcpAgentRunner {
 impl AcpAgentRunner {
     async fn run_direct_step(
         &self,
-        request: AgentRunRequest<'_>,
+        _request: AgentRunRequest<'_>,
     ) -> Result<WorkerResult, AgentError> {
-        let AgentRunRequest {
-            config,
-            issue,
-            agent_name,
-            step_name,
-            attempt,
-            workspace_path,
-            event_tx,
-            ..
-        } = request;
-
-        let agent_config = config.agents.get(agent_name);
-        let spawn_command = resolve_agent_command(agent_config, &config.agent.command);
-
-        let mut session = AcpSession::spawn(&spawn_command, workspace_path).await?;
-
-        let cwd_str = workspace_path
-            .to_str()
-            .ok_or_else(|| AgentError::InvalidWorkspaceCwd {
-                path: workspace_path.display().to_string(),
-            })?;
-
-        session.initialize(config.agent.read_timeout_ms).await?;
-
-        let session_id = session
-            .start_session(cwd_str, serde_json::json!({}), config.agent.read_timeout_ms)
-            .await?;
-
-        let _ = event_tx
-            .send(WorkerEvent::AgentUpdate {
-                issue_id: issue.id.clone(),
-                step_name: step_name.to_string(),
-                event: AgentEvent::SessionStarted {
-                    session_id: session_id.clone(),
-                    agent_pid: session.agent_pid().map(|s| s.to_string()),
-                },
-                timestamp: chrono::Utc::now(),
-            })
-            .await;
-
-        if !config.agent.session_mode.is_empty() {
-            session
-                .set_mode(&session_id, &config.agent.session_mode)
-                .await?;
-        }
-
-        let max_turns = config.agent.max_turns;
-        let mut turn_number: u32 = 1;
-
-        let mut final_runtime_verdict: Option<serde_json::Value> = None;
-        let result = loop {
-            let prompt = match self
-                .build_prompt(
-                    config.as_ref(),
-                    BuildPromptRequest {
-                        issue,
-                        agent_name,
-                        step_name,
-                        attempt,
-                        workspace_path,
-                        turn_number,
-                    },
-                )
-                .await
-            {
-                Ok(p) => p,
-                Err(e) => {
-                    session.cancel(&session_id).await?;
-                    break Err(e);
-                }
-            };
-
-            let turn_result = session
-                .run_turn(
-                    &session_id,
-                    &prompt,
-                    config.agent.turn_timeout_ms,
-                    &config.agent.permission_request_policy,
-                    &issue.id,
-                    step_name,
-                    &event_tx,
-                )
-                .await;
-
-            match turn_result {
-                Ok(TurnResult::Completed {
-                    runtime_verdict, ..
-                }) => {
-                    if runtime_verdict.is_some() {
-                        final_runtime_verdict = runtime_verdict;
-                    }
-                    info!(
-                        issue_id = %issue.id,
-                        identifier = %issue.identifier,
-                        turn = turn_number,
-                        agent = agent_name,
-                        step = step_name,
-                        "turn completed successfully"
-                    );
-                }
-                Ok(TurnResult::Failed {
-                    reason,
-                    runtime_verdict,
-                    ..
-                }) => {
-                    if runtime_verdict.is_some() {
-                        final_runtime_verdict = runtime_verdict;
-                    }
-                    warn!(
-                        issue_id = %issue.id,
-                        identifier = %issue.identifier,
-                        turn = turn_number,
-                        agent = agent_name,
-                        step = step_name,
-                        reason = %reason,
-                        "turn failed"
-                    );
-                    session.cancel(&session_id).await?;
-                    break Err(AgentError::TurnFailed { reason });
-                }
-                Err(e) => {
-                    session.cancel(&session_id).await?;
-                    break Err(e);
-                }
-            }
-
-            if turn_number >= max_turns {
-                info!(
-                    issue_id = %issue.id,
-                    identifier = %issue.identifier,
-                    turns = turn_number,
-                    "reached max turns"
-                );
-                break Ok(());
-            }
-
-            turn_number += 1;
-        };
-
-        let _ = session.cancel(&session_id).await;
-        session.kill().await;
-
-        result?;
-
-        Ok(detect_worker_result_with_runtime_verdict(workspace_path, final_runtime_verdict).await)
+        Err(AgentError::TurnFailed {
+            reason: "direct ACP path is being migrated to SDK backend (Task 3)".to_string(),
+        })
     }
 }
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -9,23 +9,21 @@ pub mod runtime;
 use std::path::Path;
 use std::sync::Arc;
 
-use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
-use tokio::sync::RwLock;
-use tokio_util::sync::CancellationToken;
 use crate::config::ensemble::{EnsembleConfig, InteractionPolicyOverrideMode, PermissionMode};
 use crate::config::template::render_prompt_with_interaction_response;
 use crate::error::AgentError;
 use crate::interaction::InteractionResponse;
 use crate::tracker::model::Issue;
 use crate::workspace::hooks::{run_hook, run_hook_best_effort};
-use events::{
-    InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult,
-};
+use async_trait::async_trait;
+use events::{InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
-use acpx_runtime::AcpxRuntime;
 use acp_client::{run_acp_session, AcpSessionConfig, TurnResult};
+use acpx_runtime::AcpxRuntime;
 
 const VERDICT_FALLBACK_INSTRUCTION: &str = "\
 If you cannot return a structured runtime verdict, write .ensemble/verdict.json with:\n\

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -609,6 +609,7 @@ mod tests {
     use std::sync::{Mutex, OnceLock};
 
     use super::*;
+    use crate::agent::events::AgentEvent;
     use crate::config::ensemble::parse_config;
     use crate::interaction::{InteractionKind, InteractionResponse};
     use tokio_util::sync::CancellationToken;

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -25,6 +25,7 @@ use events::{
 };
 
 use acpx_runtime::AcpxRuntime;
+use acp_client::{run_acp_session, AcpSessionConfig, TurnResult};
 
 const VERDICT_FALLBACK_INSTRUCTION: &str = "\
 If you cannot return a structured runtime verdict, write .ensemble/verdict.json with:\n\
@@ -541,11 +542,64 @@ impl AgentRunner for AcpAgentRunner {
 impl AcpAgentRunner {
     async fn run_direct_step(
         &self,
-        _request: AgentRunRequest<'_>,
+        request: AgentRunRequest<'_>,
     ) -> Result<WorkerResult, AgentError> {
-        Err(AgentError::TurnFailed {
-            reason: "direct ACP path is being migrated to SDK backend (Task 3)".to_string(),
-        })
+        let config = &request.config;
+        let agent_config = config.agents.get(request.agent_name);
+        let command = resolve_agent_command(agent_config, &config.agent.command);
+
+        let session_mode = if config.agent.session_mode.is_empty() {
+            None
+        } else {
+            Some(config.agent.session_mode.clone())
+        };
+
+        let session_config = AcpSessionConfig {
+            command,
+            workspace_path: request.workspace_path.to_path_buf(),
+            session_mode,
+            permission_request_policy: config.agent.permission_request_policy.clone(),
+            read_timeout_ms: config.agent.read_timeout_ms,
+            turn_timeout_ms: config.agent.turn_timeout_ms,
+        };
+
+        let max_turns = config.agent.max_turns.max(1);
+        let mut prompts = Vec::with_capacity(max_turns as usize);
+        for turn in 1..=max_turns {
+            let prompt = self
+                .build_prompt(
+                    config.as_ref(),
+                    BuildPromptRequest {
+                        issue: request.issue,
+                        agent_name: request.agent_name,
+                        step_name: request.step_name,
+                        attempt: request.attempt,
+                        workspace_path: request.workspace_path,
+                        turn_number: turn,
+                    },
+                )
+                .await?;
+            prompts.push(prompt);
+        }
+
+        let (final_verdict, turn_results) = run_acp_session(
+            session_config,
+            prompts,
+            &request.issue.id,
+            request.step_name,
+            &request.event_tx,
+        )
+        .await?;
+
+        for (i, result) in turn_results.iter().enumerate() {
+            if let TurnResult::Failed { reason, .. } = result {
+                return Err(AgentError::TurnFailed {
+                    reason: format!("turn {} failed: {}", i + 1, reason),
+                });
+            }
+        }
+
+        Ok(detect_worker_result_with_runtime_verdict(request.workspace_path, final_verdict).await)
     }
 }
 

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -99,6 +99,7 @@ impl PermissionMode {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn acpx_flag(self) -> &'static str {
         match self {
             Self::ApproveAll => "--approve-all",

--- a/docs/superpowers/plans/2026-06-07-acp-sdk-migration.md
+++ b/docs/superpowers/plans/2026-06-07-acp-sdk-migration.md
@@ -1,0 +1,1023 @@
+# ACP SDK Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hand-rolled ACP JSON-RPC implementation in `acp_client.rs` with the official `agent-client-protocol` Rust SDK v0.14.0, eliminating manual NDJSON parsing, JSON-RPC message construction, and request ID tracking.
+
+**Architecture:** The SDK's `Client` + `AcpAgent` + `ActiveSession` types replace `AcpSession`'s manual subprocess management. The entire direct ACP lifecycle (initialize → session/new → prompt loop → cancel → kill) moves inside the SDK's `connect_with` callback, which manages the connection lifetime. Permission handling uses the SDK's typed `on_receive_request` callback with `RequestPermissionRequest` and structured `PermissionOption` selection instead of string heuristics. The `protocol.rs` module is retained only for the `acpx_cli.rs` path (which wraps the external `acpx` CLI and is out of scope). Internal event types (`AgentEvent`, `WorkerEvent`, `TokenUsage`, `StopReason`) remain unchanged.
+
+**Tech Stack:** `agent-client-protocol` v0.14.0 (SDK), `tokio` (async runtime), existing `events.rs` types
+
+**Scope:** Only the "Direct" ACP runtime path (`RuntimeKind::Direct`) is migrated. The ACPX path (`AcpxCli`/`AcpxRuntime`) is unchanged.
+
+**Known tradeoffs:**
+- `AgentEvent::Malformed` and `AgentEvent::OtherMessage` are lost — the SDK handles JSON-RPC parsing internally and never surfaces raw lines. The `with_debug` callback on `AcpAgent` can intercept raw lines for logging only.
+- Process kill is drop-based (`kill()` on drop) — no SIGTERM → grace → SIGKILL escalation. This is a regression from the current behavior.
+- Token usage in `PromptResponse` is behind `#[cfg(feature = "unstable_end_turn_token_usage")]`. The stable path extracts usage from `SessionUpdate::UsageUpdate` notifications during the turn.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `Cargo.toml` (workspace) | Add `agent-client-protocol = "0.14.0"` to workspace dependencies |
+| Modify | `crates/ensemble-core/Cargo.toml` | Add `agent-client-protocol` dependency |
+| Rewrite | `crates/ensemble-core/src/agent/acp_client.rs` | Replace `AcpSession` with SDK-backed implementation; keep `TurnResult` adapter type |
+| Keep | `crates/ensemble-core/src/agent/protocol.rs` | Retained for `acpx_cli.rs` usage (out of scope) |
+| Keep | `crates/ensemble-core/src/agent/events.rs` | Internal event types unchanged |
+| Modify | `crates/ensemble-core/src/agent/mod.rs` | Update `run_direct_step` to use new SDK-backed API |
+
+---
+
+### Task 1: Add SDK Dependency
+
+**Files:**
+- Modify: `Cargo.toml:1-42` (workspace root)
+- Modify: `crates/ensemble-core/Cargo.toml:8-33`
+
+- [ ] **Step 1: Add `agent-client-protocol` to workspace dependencies**
+
+In the workspace root `Cargo.toml`, add to `[workspace.dependencies]`:
+
+```toml
+agent-client-protocol = "0.14.0"
+```
+
+- [ ] **Step 2: Add `agent-client-protocol` to ensemble-core dependencies**
+
+In `crates/ensemble-core/Cargo.toml`, add to `[dependencies]`:
+
+```toml
+agent-client-protocol = { workspace = true }
+```
+
+- [ ] **Step 3: Verify the dependency resolves and builds**
+
+Run: `cargo check -p ensemble-core`
+Expected: BUILD SUCCESS (no code changes yet, just dependency resolution)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml crates/ensemble-core/Cargo.toml
+git commit -m "feat: add agent-client-protocol SDK dependency"
+```
+
+---
+
+### Task 2: Rewrite `acp_client.rs` with SDK Backend
+
+**Files:**
+- Rewrite: `crates/ensemble-core/src/agent/acp_client.rs`
+
+This task replaces the entire `AcpSession` implementation. The verified SDK API surface:
+
+- `AcpAgent::from_str(cmd)` — parses a shell command string into a subprocess config
+- `Client.builder()` — returns `Builder<Client>` with `.on_receive_request()`, `.on_receive_notification()`, `.connect_with()`
+- `cx.send_request(InitializeRequest::new(ProtocolVersion::V1)).block_task().await` — sends initialize and awaits response
+- `cx.build_session(cwd).block_task().run_until(async |session| { ... })` — creates session and runs closure with `ActiveSession`
+- `session.send_prompt(text)` — non-blocking; sends prompt and registers callback for response
+- `session.read_update()` — blocks until next `SessionMessage`; returns `SessionMessage::SessionMessage(Dispatch)` or `SessionMessage::StopReason(StopReason)`
+- `SessionNotification` — has `session_id: SessionId` and `update: SessionUpdate`
+- `SessionUpdate::AgentMessageChunk(ContentChunk)` — text content with `content.content.text`
+- `SessionUpdate::UsageUpdate(UsageUpdate)` — token usage during turn
+- `RequestPermissionRequest` — has `session_id`, `tool_call: ToolCallUpdate`, `options: Vec<PermissionOption>`
+- `PermissionOption` — has `option_id: PermissionOptionId`, `name: String`, `kind: PermissionOptionKind`
+- `PermissionOptionKind` — enum: `AllowOnce`, `AllowAlways`, `RejectOnce`, `RejectAlways`
+- `RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(option_id))` — approve
+- `RequestPermissionOutcome::Cancelled` — reject
+- `MatchDispatch::new(dispatch).if_notification(async |notif: SessionNotification| { ... }).otherwise_ignore()` — typed dispatch matching
+
+- [ ] **Step 1: Write the new `acp_client.rs`**
+
+Replace the entire contents of `crates/ensemble-core/src/agent/acp_client.rs` with:
+
+```rust
+use std::str::FromStr;
+use std::time::Duration;
+
+use agent_client_protocol::schema::{
+    ContentBlock, InitializeRequest, PermissionOptionKind, ProtocolVersion,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    SelectedPermissionOutcome, SessionNotification, SessionUpdate, StopReason as SdkStopReason,
+};
+use agent_client_protocol::{
+    AcpAgent, Client, ConnectionTo, Dispatch, MatchDispatch,
+};
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+use tracing::{debug, info, warn};
+
+use crate::error::AgentError;
+
+use super::events::{AgentEvent, RuntimeStream, StopReason, TokenUsage, WorkerEvent};
+
+/// Result of a single turn.
+#[derive(Debug)]
+pub enum TurnResult {
+    Completed {
+        usage: Option<TokenUsage>,
+        runtime_verdict: Option<serde_json::Value>,
+    },
+    Failed {
+        reason: String,
+        usage: Option<TokenUsage>,
+        runtime_verdict: Option<serde_json::Value>,
+    },
+}
+
+impl TurnResult {
+    pub fn is_success(&self) -> bool {
+        matches!(self, TurnResult::Completed { .. })
+    }
+
+    fn runtime_verdict(&self) -> Option<&serde_json::Value> {
+        match self {
+            TurnResult::Completed { runtime_verdict, .. } => runtime_verdict.as_ref(),
+            TurnResult::Failed { runtime_verdict, .. } => runtime_verdict.as_ref(),
+        }
+    }
+}
+
+/// Configuration for creating an ACP session via the SDK.
+pub struct AcpSessionConfig {
+    pub command: String,
+    pub workspace_path: std::path::PathBuf,
+    pub session_mode: Option<String>,
+    pub permission_request_policy: String,
+    pub turn_timeout_ms: u64,
+}
+
+/// Run a full ACP session lifecycle using the SDK.
+///
+/// The entire lifecycle (initialize → session/new → prompt loop → cancel) runs
+/// inside the SDK's `connect_with` callback. The callback architecture means
+/// this function owns the connection lifetime.
+pub async fn run_acp_session(
+    config: AcpSessionConfig,
+    prompts: Vec<String>,
+    issue_id: &str,
+    step_name: &str,
+    event_tx: &mpsc::Sender<WorkerEvent>,
+) -> Result<(Option<serde_json::Value>, Vec<TurnResult>), AgentError> {
+    let agent = AcpAgent::from_str(&config.command).map_err(|e| AgentError::AgentNotFound {
+        command: format!("{}: {}", config.command, e),
+    })?;
+
+    let permission_policy = config.permission_request_policy.clone();
+    let turn_timeout_ms = config.turn_timeout_ms;
+    let issue_id = issue_id.to_string();
+    let step_name = step_name.to_string();
+    let event_tx_clone = event_tx.clone();
+
+    info!(
+        command = %config.command,
+        cwd = %config.workspace_path.display(),
+        "spawning ACP agent via SDK"
+    );
+
+    let result = Client
+        .builder()
+        .name("ensemble")
+        .on_receive_request(
+            move |request: RequestPermissionRequest,
+                  responder: agent_client_protocol::Responder<RequestPermissionResponse>,
+                  _cx: ConnectionTo<agent_client_protocol::Agent>| {
+                let policy = permission_policy.clone();
+                let issue_id = issue_id.clone();
+                let step_name = step_name.clone();
+                let tx = event_tx_clone.clone();
+                async move {
+                    let outcome = handle_permission_request(
+                        &request,
+                        &policy,
+                        &issue_id,
+                        &step_name,
+                        &tx,
+                    )
+                    .await;
+
+                    responder.respond(RequestPermissionResponse::new(outcome))
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .connect_with(agent, |cx: ConnectionTo<agent_client_protocol::Agent>| {
+            let event_tx = event_tx.clone();
+            let workspace_path = config.workspace_path.clone();
+            let session_mode = config.session_mode.clone();
+            async move {
+                // Step 1: Initialize
+                cx.send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await
+                    .map_err(|e| AgentError::SessionStartupFailed {
+                        reason: format!("initialize failed: {e}"),
+                    })?;
+
+                // Step 2: Create session
+                let mut session = cx
+                    .build_session(&workspace_path)
+                    .block_task()
+                    .run_until(async |session| Ok(session))
+                    .await
+                    .map_err(|e| AgentError::SessionStartupFailed {
+                        reason: format!("session/new failed: {e}"),
+                    })?;
+
+                let session_id = session.session_id().to_string();
+
+                let _ = event_tx
+                    .send(WorkerEvent::AgentUpdate {
+                        issue_id: issue_id.clone(),
+                        step_name: step_name.clone(),
+                        event: AgentEvent::SessionStarted {
+                            session_id: session_id.clone(),
+                            agent_pid: None,
+                        },
+                        timestamp: chrono::Utc::now(),
+                    })
+                    .await;
+
+                // Step 3: Set mode if configured
+                // Note: SDK does not expose set_mode as a direct method on ActiveSession.
+                // The session mode would need to be set via SetSessionModeRequest.
+                // For now, skip if the SDK doesn't support it directly.
+                // TODO: implement via cx.send_request(SetSessionModeRequest) if needed.
+
+                // Step 4: Run turn loop
+                let mut turn_results = Vec::new();
+                let mut final_verdict: Option<serde_json::Value> = None;
+
+                for prompt in &prompts {
+                    let _ = event_tx
+                        .send(WorkerEvent::AgentUpdate {
+                            issue_id: issue_id.clone(),
+                            step_name: step_name.clone(),
+                            event: AgentEvent::PromptStarted,
+                            timestamp: chrono::Utc::now(),
+                        })
+                        .await;
+
+                    session.send_prompt(prompt).map_err(|e| AgentError::PromptError {
+                        reason: format!("failed to send prompt: {e}"),
+                    })?;
+
+                    let turn_result = read_turn_updates(
+                        &mut session,
+                        turn_timeout_ms,
+                        &issue_id,
+                        &step_name,
+                        &event_tx,
+                    )
+                    .await;
+
+                    match turn_result {
+                        Ok(result) => {
+                            if let Some(verdict) = result.runtime_verdict() {
+                                final_verdict = Some(verdict.clone());
+                            }
+                            turn_results.push(result);
+                        }
+                        Err(e) => {
+                            turn_results.push(TurnResult::Failed {
+                                reason: e.to_string(),
+                                usage: None,
+                                runtime_verdict: None,
+                            });
+                            break;
+                        }
+                    }
+                }
+
+                Ok((final_verdict, turn_results))
+            }
+        })
+        .await;
+
+    // connect_with returns Result<Result<(Vec<TurnResult>, ...), AgentError>, agent_client_protocol::Error>
+    match result {
+        Ok(inner) => inner,
+        Err(e) => Err(AgentError::IoError {
+            reason: format!("ACP session error: {e}"),
+        }),
+    }
+}
+
+/// Handle a permission request from the agent using structured SDK types.
+///
+/// Maps the configured policy to a `RequestPermissionOutcome`:
+/// - `auto_approve_all`: pick the first `Allow*` option
+/// - `reject_all`: cancel
+/// - `approve_reads_reject_writes`: inspect tool call details (fallback to approve)
+async fn handle_permission_request(
+    request: &RequestPermissionRequest,
+    policy: &str,
+    issue_id: &str,
+    step_name: &str,
+    event_tx: &mpsc::Sender<WorkerEvent>,
+) -> RequestPermissionOutcome {
+    let tool_desc = format!("{:?}", request.tool_call);
+
+    let _ = event_tx
+        .send(WorkerEvent::AgentUpdate {
+            issue_id: issue_id.to_string(),
+            step_name: step_name.to_string(),
+            event: AgentEvent::Warning {
+                message: format!("permission requested: {tool_desc}"),
+            },
+            timestamp: chrono::Utc::now(),
+        })
+        .await;
+
+    let outcome = match policy {
+        "auto_approve_all" => {
+            // Pick the first Allow* option
+            let allow_option = request.options.iter().find(|opt| {
+                matches!(opt.kind, PermissionOptionKind::AllowOnce | PermissionOptionKind::AllowAlways)
+            });
+            match allow_option {
+                Some(opt) => RequestPermissionOutcome::Selected(
+                    SelectedPermissionOutcome::new(opt.option_id.clone()),
+                ),
+                None => RequestPermissionOutcome::Cancelled,
+            }
+        }
+        "reject_all" => RequestPermissionOutcome::Cancelled,
+        "approve_reads_reject_writes" => {
+            // Heuristic: allow if any option is Allow* and tool description looks read-like
+            let desc_lower = tool_desc.to_lowercase();
+            let is_read_like = desc_lower.contains("read")
+                || desc_lower.contains("list")
+                || desc_lower.contains("view")
+                || desc_lower.contains("get");
+            if is_read_like {
+                let allow_option = request.options.iter().find(|opt| {
+                    matches!(opt.kind, PermissionOptionKind::AllowOnce | PermissionOptionKind::AllowAlways)
+                });
+                match allow_option {
+                    Some(opt) => RequestPermissionOutcome::Selected(
+                        SelectedPermissionOutcome::new(opt.option_id.clone()),
+                    ),
+                    None => RequestPermissionOutcome::Cancelled,
+                }
+            } else {
+                RequestPermissionOutcome::Cancelled
+            }
+        }
+        _ => {
+            // Default: approve
+            let allow_option = request.options.iter().find(|opt| {
+                matches!(opt.kind, PermissionOptionKind::AllowOnce | PermissionOptionKind::AllowAlways)
+            });
+            match allow_option {
+                Some(opt) => RequestPermissionOutcome::Selected(
+                    SelectedPermissionOutcome::new(opt.option_id.clone()),
+                ),
+                None => RequestPermissionOutcome::Cancelled,
+            }
+        }
+    };
+
+    let allowed = matches!(&outcome, RequestPermissionOutcome::Selected(_));
+    let _ = event_tx
+        .send(WorkerEvent::AgentUpdate {
+            issue_id: issue_id.to_string(),
+            step_name: step_name.to_string(),
+            event: AgentEvent::Notification {
+                message: format!("permission {}", if allowed { "approved" } else { "rejected" }),
+            },
+            timestamp: chrono::Utc::now(),
+        })
+        .await;
+
+    outcome
+}
+
+/// Read session updates until the turn completes.
+///
+/// Uses `MatchDispatch` to extract typed `SessionNotification` from `Dispatch`,
+/// then pattern-matches on `SessionUpdate` variants to emit events and track usage.
+async fn read_turn_updates(
+    session: &mut agent_client_protocol::ActiveSession<'_, agent_client_protocol::Agent>,
+    turn_timeout_ms: u64,
+    issue_id: &str,
+    step_name: &str,
+    event_tx: &mpsc::Sender<WorkerEvent>,
+) -> Result<TurnResult, AgentError> {
+    let mut last_usage: Option<TokenUsage> = None;
+    let mut last_runtime_verdict: Option<serde_json::Value> = None;
+
+    let result = timeout(Duration::from_millis(turn_timeout_ms), async {
+        loop {
+            let msg = session.read_update().await.map_err(|e| AgentError::IoError {
+                reason: format!("failed to read session update: {e}"),
+            })?;
+
+            match msg {
+                agent_client_protocol::SessionMessage::StopReason(sdk_stop) => {
+                    let stop_reason = convert_stop_reason(&sdk_stop);
+                    return map_stop_reason_to_turn_result(
+                        stop_reason,
+                        issue_id,
+                        step_name,
+                        event_tx,
+                        last_usage,
+                        last_runtime_verdict,
+                    );
+                }
+                agent_client_protocol::SessionMessage::SessionMessage(dispatch) => {
+                    handle_dispatch(
+                        dispatch,
+                        issue_id,
+                        step_name,
+                        event_tx,
+                        &mut last_usage,
+                        &mut last_runtime_verdict,
+                    )
+                    .await;
+                }
+            }
+        }
+    })
+    .await;
+
+    match result {
+        Ok(turn_result) => turn_result,
+        Err(_) => Err(AgentError::TurnTimeout {
+            timeout_ms: turn_timeout_ms,
+        }),
+    }
+}
+
+/// Extract typed data from a `Dispatch` message using `MatchDispatch`.
+///
+/// Matches on `SessionNotification` and pattern-matches `SessionUpdate` variants:
+/// - `AgentMessageChunk` → `AgentEvent::OutputChunk`
+/// - `UsageUpdate` → updates `last_usage`
+/// - Other variants → ignored (tool calls, plans, etc.)
+async fn handle_dispatch(
+    dispatch: Dispatch,
+    issue_id: &str,
+    step_name: &str,
+    event_tx: &mpsc::Sender<WorkerEvent>,
+    last_usage: &mut Option<TokenUsage>,
+    last_runtime_verdict: &mut Option<serde_json::Value>,
+) {
+    MatchDispatch::new(dispatch)
+        .if_notification(async |notif: SessionNotification| {
+            match notif.update {
+                SessionUpdate::AgentMessageChunk(chunk) => {
+                    if let ContentBlock::Text(text) = chunk.content {
+                        if !text.text.is_empty() {
+                            let _ = event_tx
+                                .send(WorkerEvent::AgentUpdate {
+                                    issue_id: issue_id.to_string(),
+                                    step_name: step_name.to_string(),
+                                    event: AgentEvent::OutputChunk {
+                                        stream: RuntimeStream::Stdout,
+                                        content: text.text,
+                                    },
+                                    timestamp: chrono::Utc::now(),
+                                })
+                                .await;
+                        }
+                    }
+                    Ok(())
+                }
+                SessionUpdate::UsageUpdate(usage) => {
+                    *last_usage = Some(TokenUsage {
+                        input_tokens: usage.input_tokens.unwrap_or(0) as u64,
+                        output_tokens: usage.output_tokens.unwrap_or(0) as u64,
+                        total_tokens: usage.total_tokens.unwrap_or(0) as u64,
+                    });
+                    Ok(())
+                }
+                _ => Ok(()),
+            }
+        })
+        .await
+        .otherwise_ignore()
+        .unwrap_or_else(|e| {
+            warn!(error = %e, "error handling dispatch");
+        });
+}
+
+fn convert_stop_reason(sdk_stop: &SdkStopReason) -> StopReason {
+    match sdk_stop {
+        SdkStopReason::EndTurn => StopReason::EndTurn,
+        SdkStopReason::MaxTokens => StopReason::MaxTokens,
+        SdkStopReason::Cancelled => StopReason::Cancelled,
+        SdkStopReason::Refusal => StopReason::Refusal,
+        SdkStopReason::MaxTurnRequests => StopReason::MaxTurnRequests,
+        _ => StopReason::EndTurn,
+    }
+}
+
+fn map_stop_reason_to_turn_result(
+    stop_reason: StopReason,
+    issue_id: &str,
+    step_name: &str,
+    event_tx: &mpsc::Sender<WorkerEvent>,
+    usage: Option<TokenUsage>,
+    runtime_verdict: Option<serde_json::Value>,
+) -> Result<TurnResult, AgentError> {
+    match stop_reason {
+        StopReason::EndTurn | StopReason::MaxTokens => {
+            let _ = event_tx
+                .send(WorkerEvent::AgentUpdate {
+                    issue_id: issue_id.to_string(),
+                    step_name: step_name.to_string(),
+                    event: AgentEvent::RunCompleted { usage: usage.clone() },
+                    timestamp: chrono::Utc::now(),
+                })
+                .await;
+            Ok(TurnResult::Completed { usage, runtime_verdict })
+        }
+        StopReason::Cancelled => {
+            let reason = "stop reason: cancelled".to_string();
+            let _ = event_tx
+                .send(WorkerEvent::AgentUpdate {
+                    issue_id: issue_id.to_string(),
+                    step_name: step_name.to_string(),
+                    event: AgentEvent::RunFailed {
+                        reason: reason.clone(),
+                        usage: usage.clone(),
+                    },
+                    timestamp: chrono::Utc::now(),
+                })
+                .await;
+            Ok(TurnResult::Failed { reason, usage, runtime_verdict })
+        }
+        StopReason::Refusal => {
+            let reason = "stop reason: refusal".to_string();
+            let _ = event_tx
+                .send(WorkerEvent::AgentUpdate {
+                    issue_id: issue_id.to_string(),
+                    step_name: step_name.to_string(),
+                    event: AgentEvent::RunFailed {
+                        reason: reason.clone(),
+                        usage: usage.clone(),
+                    },
+                    timestamp: chrono::Utc::now(),
+                })
+                .await;
+            Ok(TurnResult::Failed { reason, usage, runtime_verdict })
+        }
+        StopReason::MaxTurnRequests => {
+            let reason = "stop reason: max_turn_requests".to_string();
+            let _ = event_tx
+                .send(WorkerEvent::AgentUpdate {
+                    issue_id: issue_id.to_string(),
+                    step_name: step_name.to_string(),
+                    event: AgentEvent::RunFailed {
+                        reason: reason.clone(),
+                        usage: usage.clone(),
+                    },
+                    timestamp: chrono::Utc::now(),
+                })
+                .await;
+            Ok(TurnResult::Failed { reason, usage, runtime_verdict })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_mock_agent_script(dir: &std::path::Path, script_content: &str) -> String {
+        let script_path = dir.join("mock_agent.sh");
+        let mut f = std::fs::File::create(&script_path).unwrap();
+        f.write_all(script_content.as_bytes()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        script_path.display().to_string()
+    }
+
+    #[tokio::test]
+    async fn test_spawn_nonexistent_command() {
+        let dir = TempDir::new().unwrap();
+        let config = AcpSessionConfig {
+            command: "nonexistent_binary_xyz_12345".to_string(),
+            workspace_path: dir.path().to_path_buf(),
+            session_mode: None,
+            permission_request_policy: "auto_approve_all".to_string(),
+            turn_timeout_ms: 5000,
+        };
+        let (tx, _rx) = mpsc::channel(100);
+        let result = run_acp_session(
+            config,
+            vec!["hello".to_string()],
+            "issue-1",
+            "build",
+            &tx,
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_successful_handshake_and_turn() {
+        let dir = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+
+        let script = r#"#!/bin/bash
+while IFS= read -r line; do
+    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
+    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
+
+    if [ "$method" = "initialize" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\",\"agentCapabilities\":{},\"agentInfo\":{\"name\":\"mock\"}}}"
+    elif [ "$method" = "session/new" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"test-session-1\"}}"
+    elif [ "$method" = "session/set_mode" ]; then
+        true
+    elif [ "$method" = "session/prompt" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"test-session-1\",\"sessionUpdate\":\"agent_message_chunk\",\"content\":{\"type\":\"text\",\"text\":\"Working on it...\"}}}"
+        echo "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"test-session-1\",\"sessionUpdate\":\"usage_update\",\"inputTokens\":100,\"outputTokens\":50,\"totalTokens\":150}}"
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"stopReason\":\"end_turn\"}}"
+    elif [ "$method" = "session/cancel" ]; then
+        true
+    fi
+done
+"#;
+        let script_path = write_mock_agent_script(dir.path(), script);
+        let config = AcpSessionConfig {
+            command: script_path,
+            workspace_path: workspace.path().to_path_buf(),
+            session_mode: None,
+            permission_request_policy: "auto_approve_all".to_string(),
+            turn_timeout_ms: 30000,
+        };
+
+        let (tx, mut rx) = mpsc::channel(100);
+        let (verdict, results) = run_acp_session(
+            config,
+            vec!["Fix the bug".to_string()],
+            "issue-1",
+            "build",
+            &tx,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_success());
+        assert!(verdict.is_none());
+
+        // Check events were emitted
+        let mut events = vec![];
+        while let Ok(evt) = rx.try_recv() {
+            events.push(evt);
+        }
+        // Should have: SessionStarted, PromptStarted, OutputChunk, RunCompleted
+        assert!(events.len() >= 3);
+    }
+
+    #[tokio::test]
+    async fn test_turn_timeout() {
+        let dir = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+
+        let script = r#"#!/bin/bash
+while IFS= read -r line; do
+    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
+    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
+
+    if [ "$method" = "initialize" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
+    elif [ "$method" = "session/new" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"test-session-2\"}}"
+    elif [ "$method" = "session/prompt" ]; then
+        sleep 60
+    fi
+done
+"#;
+        let script_path = write_mock_agent_script(dir.path(), script);
+        let config = AcpSessionConfig {
+            command: script_path,
+            workspace_path: workspace.path().to_path_buf(),
+            session_mode: None,
+            permission_request_policy: "auto_approve_all".to_string(),
+            turn_timeout_ms: 200,
+        };
+
+        let (tx, _rx) = mpsc::channel(100);
+        let result = run_acp_session(
+            config,
+            vec!["Do work".to_string()],
+            "issue-2",
+            "build",
+            &tx,
+        )
+        .await;
+
+        assert!(matches!(result, Err(AgentError::TurnTimeout { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_agent_exit_during_turn() {
+        let dir = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+
+        let script = r#"#!/bin/bash
+while IFS= read -r line; do
+    method=$(echo "$line" | grep -o '"method":"[^"]*"' | head -1 | sed 's/"method":"//;s/"//')
+    id=$(echo "$line" | grep -o '"id":[0-9]*' | head -1 | sed 's/"id"://')
+
+    if [ "$method" = "initialize" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2025-07-09\"}}"
+    elif [ "$method" = "session/new" ]; then
+        echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"test-session-3\"}}"
+    elif [ "$method" = "session/prompt" ]; then
+        exit 0
+    fi
+done
+"#;
+        let script_path = write_mock_agent_script(dir.path(), script);
+        let config = AcpSessionConfig {
+            command: script_path,
+            workspace_path: workspace.path().to_path_buf(),
+            session_mode: None,
+            permission_request_policy: "auto_approve_all".to_string(),
+            turn_timeout_ms: 30000,
+        };
+
+        let (tx, _rx) = mpsc::channel(100);
+        let result = run_acp_session(
+            config,
+            vec!["Do work".to_string()],
+            "issue-3",
+            "build",
+            &tx,
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Verify the `UsageUpdate` struct fields**
+
+Run: `cargo check -p ensemble-core 2>&1`
+
+The `UsageUpdate` struct may have different field names than `input_tokens`/`output_tokens`/`total_tokens`. Check the compiler output and adjust the `handle_dispatch` function. The fields might be:
+- `input_tokens: Option<u64>` or `input_tokens: Option<i64>`
+- Or they might be nested under a `usage` field
+
+Adjust the `TokenUsage` extraction in `handle_dispatch` based on the actual `UsageUpdate` struct definition.
+
+- [ ] **Step 3: Verify `build_session` vs `build_session_cwd` and `run_until` signature**
+
+The `run_until` closure takes `ActiveSession<'responder, Agent>`. Verify the lifetime and role type compile. If `build_session(path).block_task().run_until(...)` doesn't compile, check:
+- Whether `build_session` takes `&Path` or `impl AsRef<Path>`
+- Whether `block_task()` is needed before `run_until()`
+- Whether the closure return type needs to be `Result<(), agent_client_protocol::Error>` or `Result<T, AgentError>`
+
+- [ ] **Step 4: Iterate on compiler errors until `cargo check` passes**
+
+Run: `cargo check -p ensemble-core 2>&1`
+
+Common adjustments:
+- `UsageUpdate` field types (may be `i64` not `u64`)
+- `ContentBlock::Text` variant name (may be `ContentBlock::Text(TextContent { text })`)
+- `MatchDispatch` import path
+- `Responder` type in `on_receive_request` callback
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/acp_client.rs
+git commit -m "feat: rewrite AcpSession using agent-client-protocol SDK"
+```
+
+---
+
+### Task 3: Update `run_direct_step` in `mod.rs`
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/mod.rs:29` (import)
+- Modify: `crates/ensemble-core/src/agent/mod.rs:542-691` (method body)
+
+The `run_direct_step` method currently calls `AcpSession::spawn()`, `initialize()`, `start_session()`, `set_mode()`, `run_turn()`, `cancel()`, and `kill()` imperatively. It must be rewritten to use the new `run_acp_session` function.
+
+- [ ] **Step 1: Update imports in `mod.rs`**
+
+Replace line 29:
+```rust
+use acp_client::{AcpSession, TurnResult};
+```
+
+With:
+```rust
+use acp_client::{run_acp_session, AcpSessionConfig, TurnResult};
+```
+
+- [ ] **Step 2: Rewrite `run_direct_step`**
+
+Replace the body of `run_direct_step` (lines 542-691) with:
+
+```rust
+    async fn run_direct_step(
+        &self,
+        request: AgentRunRequest<'_>,
+    ) -> Result<WorkerResult, AgentError> {
+        let AgentRunRequest {
+            config,
+            issue,
+            agent_name,
+            step_name,
+            attempt,
+            workspace_path,
+            event_tx,
+            ..
+        } = request;
+
+        let agent_config = config.agents.get(agent_name);
+        let spawn_command = resolve_agent_command(agent_config, &config.agent.command);
+
+        // Collect all prompts upfront. The current code's prompt loop depends on
+        // `build_prompt` which uses issue/agent/step/attempt/turn_number but does
+        // NOT depend on previous turn results. This is safe to batch.
+        let max_turns = config.agent.max_turns;
+        let mut prompts = Vec::new();
+        for turn_number in 1..=max_turns {
+            let prompt = self
+                .build_prompt(
+                    config.as_ref(),
+                    BuildPromptRequest {
+                        issue,
+                        agent_name,
+                        step_name,
+                        attempt,
+                        workspace_path,
+                        turn_number,
+                    },
+                )
+                .await?;
+            prompts.push(prompt);
+        }
+
+        let session_config = AcpSessionConfig {
+            command: spawn_command,
+            workspace_path: workspace_path.to_path_buf(),
+            session_mode: if config.agent.session_mode.is_empty() {
+                None
+            } else {
+                Some(config.agent.session_mode.clone())
+            },
+            permission_request_policy: config.agent.permission_request_policy.clone(),
+            turn_timeout_ms: config.agent.turn_timeout_ms,
+        };
+
+        let (final_verdict, turn_results) = run_acp_session(
+            session_config,
+            prompts,
+            &issue.id,
+            step_name,
+            &event_tx,
+        )
+        .await?;
+
+        // Check if any turn failed
+        for result in &turn_results {
+            if !result.is_success() {
+                if let TurnResult::Failed { reason, .. } = result {
+                    return Err(AgentError::TurnFailed {
+                        reason: reason.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(detect_worker_result_with_runtime_verdict(workspace_path, final_verdict).await)
+    }
+```
+
+- [ ] **Step 3: Remove unused `protocol` import**
+
+In `mod.rs`, check if `use super::protocol;` (line 19) is still used after the migration. If `acp_client.rs` no longer imports `protocol::`, and `mod.rs` only used it via `acp_client.rs`, remove the import.
+
+- [ ] **Step 4: Compile and fix errors**
+
+Run: `cargo check -p ensemble-core 2>&1`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/mod.rs
+git commit -m "feat: update run_direct_step to use SDK-backed ACP session"
+```
+
+---
+
+### Task 4: Update Tests in `mod.rs`
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/mod.rs` (test module)
+
+The `mod.rs` tests that reference `AcpSession` directly need to be updated. Check for tests that:
+- Call `AcpSession::spawn()` → change to `run_acp_session()`
+- Call `session.initialize()` → removed (SDK handles internally)
+- Call `session.start_session()` → removed (SDK handles internally)
+- Call `session.run_turn()` → removed (SDK handles internally)
+- Call `session.kill()` → removed (SDK handles via drop)
+
+- [ ] **Step 1: Find all tests referencing `AcpSession` in `mod.rs`**
+
+Run: `grep -n "AcpSession\|acp_client::" crates/ensemble-core/src/agent/mod.rs`
+
+- [ ] **Step 2: Update each test to use `run_acp_session`**
+
+For each test, replace the imperative `AcpSession` calls with `run_acp_session(config, prompts, ...)`.
+
+- [ ] **Step 3: Run the affected tests**
+
+Run: `cargo test -p ensemble-core --lib agent::tests 2>&1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/mod.rs
+git commit -m "test: update mod.rs tests for SDK-backed ACP session"
+```
+
+---
+
+### Task 5: Full Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run clippy**
+
+Run: `cargo clippy -p ensemble-core -- -D warnings 2>&1`
+
+Fix any new clippy warnings.
+
+- [ ] **Step 2: Run formatter**
+
+Run: `cargo fmt -p ensemble-core -- --check 2>&1`
+
+Fix formatting if needed: `cargo fmt -p ensemble-core`
+
+- [ ] **Step 3: Run full workspace checks**
+
+Run:
+```bash
+cargo test --workspace --exclude ensemble-desktop
+cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+cargo fmt --all -- --check
+```
+
+- [ ] **Step 4: Verify `protocol.rs` is still used only by `acpx_cli.rs`**
+
+Run: `grep -r "protocol::" crates/ensemble-core/src/ --include="*.rs"`
+
+Expected: Only `acpx_cli.rs` should reference `protocol::`. If `acp_client.rs` or `mod.rs` still reference it, remove those imports.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: finalize ACP SDK migration — clippy, fmt, cleanup"
+```
+
+---
+
+## Self-Review Checklist
+
+**1. Spec coverage:**
+- [x] SDK dependency added (Task 1)
+- [x] AcpSession replaced with SDK-backed implementation (Task 2)
+- [x] Permission handling uses structured SDK types (Task 2, `handle_permission_request`)
+- [x] Turn loop uses `send_prompt` + `read_update` (Task 2, `read_turn_updates`)
+- [x] Token usage extracted from `SessionUpdate::UsageUpdate` (Task 2, `handle_dispatch`)
+- [x] Text content extracted from `SessionUpdate::AgentMessageChunk` (Task 2, `handle_dispatch`)
+- [x] `run_direct_step` updated to use new API (Task 3)
+- [x] Tests updated (Task 4)
+- [x] `protocol.rs` retained for `acpx_cli.rs` (verified in Task 5 Step 4)
+
+**2. Placeholder scan:**
+- [x] No "TBD", "TODO" (except one note about `set_mode` which is a genuine open question)
+- [x] No vague "add error handling" steps
+- [x] All code blocks are complete
+- [x] All file paths are exact
+
+**3. Type consistency:**
+- [x] `AcpSessionConfig` fields match usage in `run_direct_step`
+- [x] `TurnResult` variants match usage in `run_acp_session` and `map_stop_reason_to_turn_result`
+- [x] `TokenUsage` construction in `handle_dispatch` matches `events.rs` definition
+- [x] `AgentEvent` variants match `events.rs` definitions
+
+**Gaps:**
+- `session/set_mode` — the SDK may not expose this as a direct method on `ActiveSession`. May need `cx.send_request(SetSessionModeRequest)` before creating the session. Needs compiler verification.
+- `UsageUpdate` field types — may be `i64` instead of `u64`. Needs compiler verification.
+- `Malformed` and `OtherMessage` events are no longer emitted — documented in tradeoffs section.


### PR DESCRIPTION
## Summary

Migrates the direct ACP runtime to the `agent-client-protocol` SDK and wires it through the existing agent runner path.

- add the ACP SDK dependency and replace the raw direct ACP JSON-RPC session loop with an SDK-backed session implementation
- route `run_direct_step` through the SDK runtime while preserving workspace command execution and runtime event emission
- parse SDK dispatch notifications so output chunks, token usage, stop reasons, and runtime verdicts are surfaced to Ensemble
- apply configured `session_mode` with `session/set_mode`
- capture a launcher-reported agent PID for session state, process tracking, and cancellation controls
- select permission responses by ACP option kind instead of blindly choosing the first option
- honor `read_timeout_ms` during startup requests (`initialize`, session creation, and `set_mode`) separately from turn timeouts

## Notes

The SDK migration changed the direct ACP boundary from manual JSON-RPC message handling to typed SDK requests and session updates. The follow-up review fixes cover behavior that the old path already depended on: streaming output, usage accounting, session mode configuration, permission handling, PID tracking, and bounded startup waits.

## Validation

- `cargo test -p ensemble-core agent::acp_client --lib`
- `cargo test -p ensemble-core agent:: --lib`
- `cargo fmt --all -- --check`
- `cargo clippy -p ensemble-core -- -D warnings`
- `cargo test -p ensemble-core --lib` (rerun outside the sandbox so wiremock tests could bind local ports; 744 passed)

Fixes #91 