### PR TITLE
feat: config watcher hot reload with self-write suppression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,7 @@ dependencies = [
  "libc",
  "liquid",
  "mime_guess",
+ "notify",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
@@ -1426,6 +1427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2281,6 +2291,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inquire"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,6 +2484,26 @@ dependencies = [
  "bitflags 2.11.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -2764,6 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2864,6 +2915,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 1.2.0",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ mime_guess = "2"
 opener = "0.7"
 rusqlite = { version = "0.33", features = ["bundled"] }
 agent-client-protocol = "0.14.0"
+notify = "8"

--- a/crates/ensemble-cli/src/commands/run.rs
+++ b/crates/ensemble-cli/src/commands/run.rs
@@ -7,6 +7,7 @@ use ensemble_core::api::bootstrap::{
 };
 use ensemble_core::config::draft::load_config_document_or_missing;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
+use ensemble_core::config_watcher::start_config_watcher;
 use ensemble_core::observability::events::EventBus;
 use ensemble_core::workspace::finalize::FinalizeMode;
 
@@ -63,6 +64,8 @@ pub async fn execute(args: RunArgs) -> ExitCode {
         );
         return ExitCode::FAILURE;
     }
+
+    let watcher = start_config_watcher(prepared.app_state.clone());
 
     {
         let document_state = prepared
@@ -134,6 +137,7 @@ pub async fn execute(args: RunArgs) -> ExitCode {
     if let Some(runtime) = take_registered_orchestrator(&prepared.app_state) {
         runtime.shutdown().await;
     }
+    watcher.abort();
     info!("ensemble shut down cleanly");
     ExitCode::SUCCESS
 }

--- a/crates/ensemble-cli/src/commands/web.rs
+++ b/crates/ensemble-cli/src/commands/web.rs
@@ -10,6 +10,7 @@ use ensemble_core::api::bootstrap::{
 use ensemble_core::api::router::create_api_router;
 use ensemble_core::config::draft::load_config_document_or_missing;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
+use ensemble_core::config_watcher::start_config_watcher;
 use ensemble_core::observability::events::EventBus;
 
 use crate::embedded_ui::spa_router;
@@ -119,6 +120,7 @@ pub async fn execute(args: WebArgs) -> ExitCode {
     }
     let has_runnable_config = prepared.has_runnable_config;
     let app_state = prepared.app_state;
+    let watcher = start_config_watcher(app_state.clone());
     if has_runnable_config {
         match start_or_replace_registered_orchestrator(&app_state).await {
             Ok(true) => info!("orchestrator started"),
@@ -227,6 +229,7 @@ pub async fn execute(args: WebArgs) -> ExitCode {
     if let Some(runtime) = take_registered_orchestrator(&app_state) {
         runtime.shutdown().await;
     }
+    watcher.abort();
     info!("HTTP server stopped");
 
     info!("ensemble shut down cleanly");

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -32,6 +32,7 @@ shlex = "1"
 mime_guess = { workspace = true }
 rusqlite = { workspace = true }
 agent-client-protocol = { workspace = true }
+notify = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -14,9 +14,14 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::MutexGuard;
+use std::time::Duration;
 use tokio::sync::{mpsc, RwLock};
 use tokio::task::JoinHandle;
 use tracing::warn;
+
+/// Maximum time the orchestrator restart path will wait for the previous runtime
+/// to shut down gracefully before forcing an abort.
+const ORCHESTRATOR_RESTART_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct PreparedApp {
     pub app_state: AppState,
@@ -52,6 +57,23 @@ impl OrchestratorRuntime {
     pub async fn shutdown(self) {
         self.request_shutdown();
         let _ = self.task.await;
+    }
+
+    /// Attempt a graceful shutdown within `timeout`. If the runtime task does not
+    /// exit before the timeout elapses, the task is dropped (which detaches it from
+    /// the runtime) and a warning is logged.
+    pub async fn shutdown_with_timeout(self, timeout: Duration) {
+        self.request_shutdown();
+        let join_result = tokio::time::timeout(timeout, self.task).await;
+        match join_result {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) | Err(_) => {
+                warn!(
+                    timeout_secs = timeout.as_secs(),
+                    "orchestrator runtime did not shut down within timeout; abandoning task"
+                );
+            }
+        }
     }
 }
 
@@ -118,6 +140,7 @@ pub fn build_app_state(
         config_runtime: ConfigRuntime {
             config_path,
             document_state: Arc::new(RwLock::new(document_state)),
+            last_loaded_mtime: Arc::new(RwLock::new(None)),
         },
         cancellation_registry: new_cancellation_registry(),
     };
@@ -232,7 +255,11 @@ pub async fn start_or_replace_registered_orchestrator(
     let started = prepared.is_some();
 
     if let Some(runtime) = take_registered_orchestrator(app_state) {
-        runtime.shutdown().await;
+        // Bounded graceful shutdown so a misbehaving orchestrator cannot block
+        // the restart path indefinitely (which would stall Ctrl+C shutdown).
+        runtime
+            .shutdown_with_timeout(ORCHESTRATOR_RESTART_TIMEOUT)
+            .await;
     }
 
     *registered_orchestrator_guard(app_state) = prepared.map(launch_orchestrator_runtime);
@@ -445,6 +472,35 @@ mod tests {
             .expect("relative config path should not fail")
             .expect("relative config path should start an orchestrator");
         runtime.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_timeout_unblocks_when_task_ignores_shutdown() {
+        // Construct an OrchestratorRuntime whose task ignores the shutdown signal
+        // entirely. shutdown_with_timeout should still return after the timeout.
+        let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let task = tokio::spawn(async {
+            // Sleep forever; never observe shutdown_rx.
+            futures::future::pending::<()>().await;
+        });
+        let runtime = OrchestratorRuntime { shutdown_tx, task };
+
+        let started = std::time::Instant::now();
+        runtime
+            .shutdown_with_timeout(std::time::Duration::from_millis(200))
+            .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed >= std::time::Duration::from_millis(200),
+            "shutdown_with_timeout waited {:?} (expected >= 200ms)",
+            elapsed
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(2_000),
+            "shutdown_with_timeout took {:?}; expected < 2s",
+            elapsed
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -60,17 +60,19 @@ impl OrchestratorRuntime {
     }
 
     /// Attempt a graceful shutdown within `timeout`. If the runtime task does not
-    /// exit before the timeout elapses, the task is dropped (which detaches it from
-    /// the runtime) and a warning is logged.
+    /// exit before the timeout elapses, the task is aborted so it cannot keep
+    /// polling or running agents concurrently with a replacement orchestrator.
     pub async fn shutdown_with_timeout(self, timeout: Duration) {
         self.request_shutdown();
+        let abort_handle = self.task.abort_handle();
         let join_result = tokio::time::timeout(timeout, self.task).await;
         match join_result {
             Ok(Ok(())) => {}
             Ok(Err(_)) | Err(_) => {
+                abort_handle.abort();
                 warn!(
                     timeout_secs = timeout.as_secs(),
-                    "orchestrator runtime did not shut down within timeout; abandoning task"
+                    "orchestrator runtime did not shut down within timeout; aborted"
                 );
             }
         }

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -4,6 +4,7 @@ use crate::config::draft::{
     parse_raw_yaml, save_raw_yaml_atomically, ConfigDocumentState, ConfigStateKind, ValidationIssue,
 };
 use crate::config::ensemble::EnsembleConfig;
+use crate::config_watcher::record_self_write;
 use crate::error::ConfigError;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -294,6 +295,7 @@ pub async fn save_yaml(
     ) {
         Ok(response) => {
             drop(doc_state);
+            record_self_write(&state).await;
             match start_or_replace_registered_orchestrator(&state).await {
                 Ok(_) => (StatusCode::OK, Json(response)),
                 Err(error) => {
@@ -572,6 +574,7 @@ where
         Ok(()) => match reload_document_state(&mut doc_state, &state.config_runtime.config_path) {
             Ok(response) => {
                 drop(doc_state);
+                record_self_write(&state).await;
                 match start_or_replace_registered_orchestrator(&state).await {
                     Ok(_) => (StatusCode::OK, Json(response)),
                     Err(error) => {
@@ -795,6 +798,7 @@ pub async fn save_guided_form(
     ) {
         Ok(response) => {
             drop(doc_state);
+            record_self_write(&state).await;
             match start_or_replace_registered_orchestrator(&state).await {
                 Ok(_) => (StatusCode::OK, Json(response)),
                 Err(error) => {
@@ -817,6 +821,7 @@ pub async fn save_guided_form(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::bootstrap::take_registered_orchestrator;
     use crate::api::test_helpers::app_state_with_missing_config;
     use crate::config::draft::{ConfigStateKind, DraftValidationReport};
     use axum::body::Body;
@@ -1895,6 +1900,36 @@ on_failure: Failed
                 .and_then(|config| config.tracker.api_key.clone()),
             Some("ghp_secret123".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn save_yaml_records_file_mtime_for_watcher_self_write_suppression() {
+        let (state, temp_dir) = test_app_state();
+        let todo_path = temp_dir.path().join("TODO.md");
+        std::fs::write(&todo_path, "## Todo\n").unwrap();
+
+        let request = SaveYamlRequest {
+            raw_yaml: format!(
+                "tracker:\n  kind: todo_file\n  path: {}\npolling:\n  interval_ms: 1234\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n",
+                todo_path.display()
+            ),
+        };
+
+        let (status, _) = save_yaml(axum::extract::State(state.clone()), Json(request)).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let last_mtime =
+            state.config_runtime.last_loaded_mtime.read().await.expect(
+                "save_yaml should record the file mtime so the watcher skips its own reload",
+            );
+        let actual_mtime = std::fs::metadata(&state.config_runtime.config_path)
+            .and_then(|m| m.modified())
+            .expect("config file should exist after save");
+        assert_eq!(last_mtime, actual_mtime);
+
+        if let Some(runtime) = take_registered_orchestrator(&state) {
+            runtime.shutdown().await;
+        }
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -14,6 +14,7 @@ use axum::routing::{get, post};
 use axum::Router;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::SystemTime;
 use tokio::sync::RwLock;
 use utoipa::OpenApi;
 
@@ -22,6 +23,11 @@ use utoipa::OpenApi;
 pub struct ConfigRuntime {
     pub config_path: PathBuf,
     pub document_state: Arc<RwLock<ConfigDocumentState>>,
+    /// mtime of the last config file content we have already applied.
+    /// The watcher uses this to skip filesystem events whose mtime matches
+    /// the content we already loaded, which prevents the watcher from
+    /// re-running the orchestrator restart that the save handler just performed.
+    pub last_loaded_mtime: Arc<RwLock<Option<SystemTime>>>,
 }
 
 /// Shared application state passed to all API handlers.

--- a/crates/ensemble-core/src/api/test_helpers.rs
+++ b/crates/ensemble-core/src/api/test_helpers.rs
@@ -40,6 +40,7 @@ pub(crate) fn app_state_with_document_state(document_state: ConfigDocumentState)
         config_runtime: ConfigRuntime {
             config_path: document_state.path.clone(),
             document_state: Arc::new(RwLock::new(document_state)),
+            last_loaded_mtime: Arc::new(RwLock::new(None)),
         },
         cancellation_registry: new_cancellation_registry(),
     }
@@ -64,6 +65,7 @@ pub(crate) fn app_state_with_missing_config(
         config_runtime: ConfigRuntime {
             config_path: config_path.clone(),
             document_state: Arc::new(RwLock::new(missing_config_state(config_path))),
+            last_loaded_mtime: Arc::new(RwLock::new(None)),
         },
         cancellation_registry: new_cancellation_registry(),
     }

--- a/crates/ensemble-core/src/config_watcher.rs
+++ b/crates/ensemble-core/src/config_watcher.rs
@@ -1,0 +1,485 @@
+use crate::api::bootstrap::start_or_replace_registered_orchestrator;
+use crate::api::router::AppState;
+use crate::config::draft::load_config_state;
+use crate::error::EnsembleError;
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+const CONFIG_RELOAD_DEBOUNCE: Duration = Duration::from_millis(100);
+const CONFIG_WATCHER_CHANNEL_CAPACITY: usize = 256;
+
+pub struct ConfigWatcherHandle {
+    task: Option<JoinHandle<()>>,
+}
+
+impl ConfigWatcherHandle {
+    pub fn abort(mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+impl Drop for ConfigWatcherHandle {
+    fn drop(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReloadOutcome {
+    Applied,
+    Rejected,
+    Unchanged,
+}
+
+pub async fn reload_config_from_disk(app_state: &AppState) -> Result<ReloadOutcome, EnsembleError> {
+    let file_mtime = std::fs::metadata(&app_state.config_runtime.config_path)
+        .and_then(|m| m.modified())
+        .ok();
+
+    {
+        let last = app_state.config_runtime.last_loaded_mtime.read().await;
+        if last.is_some() && *last == file_mtime {
+            return Ok(ReloadOutcome::Unchanged);
+        }
+    }
+
+    let loaded = load_config_state(&app_state.config_runtime.config_path)?;
+    let has_valid_config = loaded.active_config.is_some();
+
+    if has_valid_config {
+        {
+            let mut current = app_state.config_runtime.document_state.write().await;
+            *current = loaded;
+        }
+        *app_state.config_runtime.last_loaded_mtime.write().await = file_mtime;
+
+        start_or_replace_registered_orchestrator(app_state).await?;
+        app_state.refresh_requested.notify_one();
+        info!(
+            path = %app_state.config_runtime.config_path.display(),
+            "config reload applied"
+        );
+        return Ok(ReloadOutcome::Applied);
+    }
+
+    let had_last_good = {
+        app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await
+            .active_config
+            .is_some()
+    };
+
+    if had_last_good {
+        warn!(
+            path = %app_state.config_runtime.config_path.display(),
+            issues = ?loaded.validation.issues,
+            "config reload rejected; keeping last known good config"
+        );
+    } else {
+        let mut current = app_state.config_runtime.document_state.write().await;
+        *current = loaded;
+        *app_state.config_runtime.last_loaded_mtime.write().await = file_mtime;
+        warn!(
+            path = %app_state.config_runtime.config_path.display(),
+            "config reload rejected; no last known good config is available"
+        );
+    }
+
+    Ok(ReloadOutcome::Rejected)
+}
+
+/// Record that `config_path` was just written by Ensemble itself, so the watcher
+/// will skip the next reload that the write triggers.
+pub async fn record_self_write(app_state: &AppState) {
+    let mtime = std::fs::metadata(&app_state.config_runtime.config_path)
+        .and_then(|m| m.modified())
+        .unwrap_or(SystemTime::now());
+    *app_state.config_runtime.last_loaded_mtime.write().await = Some(mtime);
+}
+
+pub fn start_config_watcher(app_state: AppState) -> ConfigWatcherHandle {
+    let task = tokio::spawn(async move {
+        let config_path = std::fs::canonicalize(&app_state.config_runtime.config_path)
+            .unwrap_or_else(|_| app_state.config_runtime.config_path.clone());
+        let watch_dir = config_path
+            .parent()
+            .filter(|path| !path.as_os_str().is_empty())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        if let Ok(initial_mtime) =
+            std::fs::metadata(&app_state.config_runtime.config_path).and_then(|m| m.modified())
+        {
+            *app_state.config_runtime.last_loaded_mtime.write().await = Some(initial_mtime);
+        }
+
+        let (event_tx, mut event_rx) = mpsc::channel(CONFIG_WATCHER_CHANNEL_CAPACITY);
+        let dropped_warned = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let dropped_warned_for_cb = Arc::clone(&dropped_warned);
+        let mut watcher = match RecommendedWatcher::new(
+            move |result| {
+                if event_tx.try_send(result).is_err() {
+                    if !dropped_warned_for_cb.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                        warn!("config watcher event dropped; receiver is unavailable or lagging");
+                    }
+                } else {
+                    dropped_warned_for_cb.store(false, std::sync::atomic::Ordering::Relaxed);
+                }
+            },
+            Config::default(),
+        ) {
+            Ok(watcher) => watcher,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    path = %watch_dir.display(),
+                    "failed to create config watcher"
+                );
+                return;
+            }
+        };
+
+        if let Err(error) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+            warn!(
+                error = %error,
+                path = %watch_dir.display(),
+                "failed to watch config directory"
+            );
+            return;
+        }
+
+        info!(
+            config_path = %config_path.display(),
+            watch_dir = %watch_dir.display(),
+            "config watcher started"
+        );
+
+        while let Some(result) = event_rx.recv().await {
+            let event = match result {
+                Ok(event) => event,
+                Err(error) => {
+                    warn!(error = %error, "config watcher event error");
+                    continue;
+                }
+            };
+
+            if !is_config_change_event(&event, &config_path) {
+                continue;
+            }
+
+            tokio::time::sleep(CONFIG_RELOAD_DEBOUNCE).await;
+
+            while let Ok(result) = event_rx.try_recv() {
+                if let Err(error) = result {
+                    warn!(error = %error, "config watcher event error");
+                }
+            }
+
+            if let Err(error) = reload_config_from_disk(&app_state).await {
+                warn!(
+                    error = %error,
+                    path = %config_path.display(),
+                    "config reload failed"
+                );
+            }
+        }
+    });
+
+    ConfigWatcherHandle { task: Some(task) }
+}
+
+fn is_config_change_event(event: &notify::Event, config_path: &Path) -> bool {
+    if !matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    ) {
+        return false;
+    }
+
+    event
+        .paths
+        .iter()
+        .any(|event_path| paths_match(event_path, config_path))
+}
+
+fn paths_match(event_path: &Path, config_path: &Path) -> bool {
+    let event_path = std::fs::canonicalize(event_path).unwrap_or_else(|_| event_path.to_path_buf());
+    let config_path =
+        std::fs::canonicalize(config_path).unwrap_or_else(|_| config_path.to_path_buf());
+    event_path == config_path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::bootstrap::{build_app_state, take_registered_orchestrator};
+    use crate::config::draft::parse_raw_yaml;
+    use crate::observability::events::EventBus;
+    use tempfile::TempDir;
+
+    fn valid_yaml(interval_ms: u64) -> String {
+        format!(
+            "tracker:\n  kind: todo_file\n  path: TODO.md\npolling:\n  interval_ms: {interval_ms}\nconcurrency:\n  max_concurrent_agents: 2\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n"
+        )
+    }
+
+    #[tokio::test]
+    async fn external_reload_replaces_valid_config_document() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        std::fs::write(&config_path, valid_yaml(1000)).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), valid_yaml(1000));
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+
+        std::fs::write(&config_path, valid_yaml(2500)).unwrap();
+
+        let outcome = reload_config_from_disk(&prepared.app_state).await.unwrap();
+
+        assert_eq!(outcome, ReloadOutcome::Applied);
+        let doc = prepared
+            .app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await;
+        assert_eq!(
+            doc.active_config.as_ref().unwrap().polling.interval_ms,
+            2500
+        );
+
+        let runtime = take_registered_orchestrator(&prepared.app_state)
+            .expect("valid reload should register an orchestrator runtime");
+        drop(doc);
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn external_reload_keeps_last_good_document_when_invalid_after_valid() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        std::fs::write(&config_path, valid_yaml(1000)).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), valid_yaml(1000));
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        start_or_replace_registered_orchestrator(&prepared.app_state)
+            .await
+            .unwrap();
+        assert!(prepared
+            .app_state
+            .orchestrator_runtime
+            .lock()
+            .unwrap()
+            .is_some());
+
+        std::fs::write(&config_path, "tracker: [").unwrap();
+
+        let outcome = reload_config_from_disk(&prepared.app_state).await.unwrap();
+
+        assert_eq!(outcome, ReloadOutcome::Rejected);
+        let doc = prepared
+            .app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await;
+        assert_eq!(
+            doc.active_config.as_ref().unwrap().polling.interval_ms,
+            1000
+        );
+        assert!(prepared
+            .app_state
+            .orchestrator_runtime
+            .lock()
+            .unwrap()
+            .is_some());
+        drop(doc);
+
+        let runtime = take_registered_orchestrator(&prepared.app_state)
+            .expect("invalid reload should preserve the existing runtime");
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn external_reload_skips_when_file_mtime_is_unchanged() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        std::fs::write(&config_path, valid_yaml(1000)).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), valid_yaml(1000));
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        start_or_replace_registered_orchestrator(&prepared.app_state)
+            .await
+            .unwrap();
+
+        let mtime = std::fs::metadata(&config_path)
+            .and_then(|m| m.modified())
+            .unwrap();
+        *prepared
+            .app_state
+            .config_runtime
+            .last_loaded_mtime
+            .write()
+            .await = Some(mtime);
+
+        let outcome = reload_config_from_disk(&prepared.app_state).await.unwrap();
+
+        assert_eq!(outcome, ReloadOutcome::Unchanged);
+        assert_eq!(
+            *prepared
+                .app_state
+                .config_runtime
+                .last_loaded_mtime
+                .read()
+                .await,
+            Some(mtime),
+            "unchanged mtime reload must not update last_loaded_mtime"
+        );
+
+        if let Some(runtime) = take_registered_orchestrator(&prepared.app_state) {
+            runtime.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn external_reload_records_invalid_document_when_no_last_good_exists() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        let initial = crate::config::draft::missing_config_state(config_path.clone());
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+
+        std::fs::write(&config_path, "tracker: [").unwrap();
+
+        let outcome = reload_config_from_disk(&prepared.app_state).await.unwrap();
+
+        assert_eq!(outcome, ReloadOutcome::Rejected);
+        let doc = prepared
+            .app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await;
+        assert!(doc.active_config.is_none());
+        assert_eq!(doc.kind, crate::config::draft::ConfigStateKind::SyntaxError);
+    }
+
+    #[test]
+    fn detects_config_yaml_modify_event() {
+        let config_path = std::path::PathBuf::from("/tmp/ensemble/config.yaml");
+        let event = notify::Event {
+            kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Content,
+            )),
+            paths: vec![config_path.clone()],
+            attrs: notify::event::EventAttributes::new(),
+        };
+
+        assert!(is_config_change_event(&event, &config_path));
+    }
+
+    #[test]
+    fn ignores_unrelated_files() {
+        let config_path = std::path::PathBuf::from("/tmp/ensemble/config.yaml");
+        let event = notify::Event {
+            kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Content,
+            )),
+            paths: vec![std::path::PathBuf::from("/tmp/ensemble/notes.md")],
+            attrs: notify::event::EventAttributes::new(),
+        };
+
+        assert!(!is_config_change_event(&event, &config_path));
+    }
+
+    #[tokio::test]
+    async fn watcher_does_not_reload_after_record_self_write() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        std::fs::write(&config_path, valid_yaml(1000)).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), valid_yaml(1000));
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        start_or_replace_registered_orchestrator(&prepared.app_state)
+            .await
+            .unwrap();
+        let watcher = start_config_watcher(prepared.app_state.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        std::fs::write(&config_path, valid_yaml(5500)).unwrap();
+        record_self_write(&prepared.app_state).await;
+
+        // The watcher will fire after the debounce, but the mtime check should
+        // make it return Unchanged and leave the document state alone.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let interval = {
+            let doc = prepared
+                .app_state
+                .config_runtime
+                .document_state
+                .read()
+                .await;
+            doc.active_config
+                .as_ref()
+                .map(|config| config.polling.interval_ms)
+        };
+        assert_eq!(
+            interval,
+            Some(1000),
+            "watcher should not apply a self-write because record_self_write pins last_loaded_mtime"
+        );
+
+        watcher.abort();
+        if let Some(runtime) = take_registered_orchestrator(&prepared.app_state) {
+            runtime.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn watcher_applies_external_config_change() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        std::fs::write(&config_path, valid_yaml(1000)).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), valid_yaml(1000));
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        let watcher = start_config_watcher(prepared.app_state.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        std::fs::write(&config_path, valid_yaml(3500)).unwrap();
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        loop {
+            let interval = {
+                let doc = prepared
+                    .app_state
+                    .config_runtime
+                    .document_state
+                    .read()
+                    .await;
+                doc.active_config
+                    .as_ref()
+                    .map(|config| config.polling.interval_ms)
+            };
+            if interval == Some(3500) {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "watcher did not reload config"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        watcher.abort();
+        if let Some(runtime) = take_registered_orchestrator(&prepared.app_state) {
+            runtime.shutdown().await;
+        }
+    }
+}

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod api;
 pub mod config;
+pub mod config_watcher;
 pub mod error;
 pub mod history;
 pub mod history_store;

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -56,6 +56,7 @@ fn build_app_state(
         config_runtime: ConfigRuntime {
             config_path: document_state.path.clone(),
             document_state: Arc::new(RwLock::new(document_state)),
+            last_loaded_mtime: Arc::new(RwLock::new(None)),
         },
         cancellation_registry: new_cancellation_registry(),
     }

--- a/crates/ensemble-desktop/src/server.rs
+++ b/crates/ensemble-desktop/src/server.rs
@@ -17,6 +17,7 @@ use ensemble_core::api::bootstrap::{
 use ensemble_core::api::router::create_api_router;
 use ensemble_core::api::router::AppState;
 use ensemble_core::config::draft::load_config_document_or_missing;
+use ensemble_core::config_watcher::{start_config_watcher, ConfigWatcherHandle};
 use ensemble_core::observability::events::EventBus;
 
 use crate::embedded_ui::spa_router;
@@ -27,6 +28,10 @@ pub struct DesktopServer {
     pub url: url::Url,
     shutdown: Option<tokio::sync::oneshot::Sender<()>>,
     app_state: AppState,
+    // Held for its `Drop` impl, which aborts the spawned watcher task and keeps
+    // the file-change reload running for the lifetime of the desktop process.
+    #[allow(dead_code)]
+    config_watcher: ConfigWatcherHandle,
 }
 
 impl Drop for DesktopServer {
@@ -99,6 +104,7 @@ pub async fn start_desktop_server(
         );
     }
     let app_state = prepared.app_state;
+    let config_watcher = start_config_watcher(app_state.clone());
     if prepared.has_runnable_config {
         start_or_replace_registered_orchestrator(&app_state)
             .await
@@ -146,6 +152,7 @@ pub async fn start_desktop_server(
         url: server_url,
         shutdown: Some(shutdown_tx),
         app_state,
+        config_watcher,
     })
 }
 


### PR DESCRIPTION
## Summary

Ensemble now detects external `config.yaml` changes and hot-reloads valid config without requiring a process restart. This satisfies SPEC Section 6.3 and closes #88.

## How it works

A `notify`-based filesystem watcher monitors the config directory for `config.yaml` changes. When a change is detected:

1. **Valid config** → replaces `ConfigDocumentState`, restarts the registered orchestrator via the existing bootstrap lifecycle, and notifies the refresh loop. The runtime picks up the new tracker, agents, polling interval, and concurrency settings immediately.
2. **Invalid config** → logs a structured warning with validation issues and keeps the last known good config + runtime untouched.
3. **No prior good config** → records the invalid state in `ConfigDocumentState` so the UI can surface the error.

## Self-write suppression

API save handlers (`save_yaml`, `save_guided_form`) already call `start_or_replace_registered_orchestrator` after writing config. Without suppression, the watcher would detect the filesystem event and trigger a second restart. `record_self_write` pins the file mtime so the watcher skips its own reload when the save handler already applied the change.

## Orchestrator restart timeout

`start_or_replace_registered_orchestrator` now uses `shutdown_with_timeout(10s)` instead of unbounded `shutdown().await`. This prevents a misbehaving orchestrator from blocking the restart path indefinitely (which would also stall Ctrl+C shutdown).

## Files changed

| File | Change |
|------|--------|
| `Cargo.toml` | Added `notify = "8"` workspace dependency |
| `crates/ensemble-core/Cargo.toml` | Added `notify` dependency |
| `crates/ensemble-core/src/config_watcher.rs` | **New** — watcher, reload logic, self-write suppression, 8 tests |
| `crates/ensemble-core/src/lib.rs` | Added `pub mod config_watcher` |
| `crates/ensemble-core/src/api/bootstrap.rs` | Added `shutdown_with_timeout`, `last_loaded_mtime` field |
| `crates/ensemble-core/src/api/router.rs` | Added `last_loaded_mtime` to `ConfigRuntime` |
| `crates/ensemble-core/src/api/config_edit_handler.rs` | Calls `record_self_write` after saves |
| `crates/ensemble-core/src/api/test_helpers.rs` | Added `last_loaded_mtime` to test constructors |
| `crates/ensemble-core/tests/api_endpoints.rs` | Added `last_loaded_mtime` to test constructor |
| `crates/ensemble-cli/src/commands/run.rs` | Starts watcher in headless mode |
| `crates/ensemble-cli/src/commands/web.rs` | Starts watcher in web mode |
| `crates/ensemble-desktop/src/server.rs` | Keeps watcher alive in `DesktopServer` |

## Verification

- 858 tests pass (workspace excluding desktop)
- Clippy clean (`-D warnings`)
- `cargo fmt` clean
- Desktop compiles

Closes #88