### PR TITLE
Fix flaky acpx_runtime tests on Linux CI

### DIFF
--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -523,6 +523,7 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
+    cat > /dev/null
     exit 1
     ;;
   *" sessions close "*)
@@ -575,6 +576,7 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
+    cat > /dev/null
     printf '%s\n' '{{"jsonrpc":"2.0","id":3,"result":{{"stopReason":"end_turn"}}}}'
     exit 0
     ;;

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -406,6 +406,7 @@ case "$*" in
   exit 0
   ;;
   *" prompt --session "*)
+  cat > /dev/null
   printf '%s\n' \
     '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}' \
     '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
@@ -735,6 +736,7 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
+    cat > /dev/null
     printf '%s\n' '{{"jsonrpc":"2.0","id":4,"result":{{"stopReason":"end_turn"}}}}'
     exit 0
     ;;
@@ -803,6 +805,7 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
+    cat > /dev/null
     printf '%s\n' '{{"jsonrpc":"2.0","id":100,"result":{{"stopReason":"end_turn"}}}}'
     exit 0
     ;;
@@ -859,6 +862,7 @@ case "$*" in
     exit 0
     ;;
   *" prompt --session "*)
+    cat > /dev/null
     printf '%s\n' '{{"jsonrpc":"2.0","id":101,"result":{{"stopReason":"end_turn"}}}}'
     exit 0
     ;;


### PR DESCRIPTION
Two tests in `acpx_runtime.rs` use mock acpx scripts that don't consume stdin. When the child process exits before `run_prompt`'s `write_all` completes, the pipe breaks with `IoError` (Broken pipe) instead of the expected error.

This race condition triggers on Linux CI runners but not locally on macOS. The pattern of consuming stdin via `cat > /dev/null` was already used by `acpx_runtime_tolerates_close_session_failure` — this applies it to the two other tests.

Fixes the CI failures blocking #99, #102, #103.