### PR TITLE
Fix flaky acpx_cli tests on Linux CI

### DIFF
--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -44,9 +44,15 @@ impl AcpxCli {
             .args(["sessions", "ensure", "--name", session_name]);
         debug!(agent, session_name, cwd = %cwd.display(), model, "running acpx sessions ensure");
 
-        let output = command.output().await.map_err(|e| AgentError::IoError {
-            reason: format!("failed to run acpx sessions ensure: {e}"),
-        })?;
+        let output = spawn_with_etxtbsy_retry(command)
+            .map_err(|e| AgentError::IoError {
+                reason: format!("failed to run acpx sessions ensure: {e}"),
+            })?
+            .wait_with_output()
+            .await
+            .map_err(|e| AgentError::IoError {
+                reason: format!("failed to read acpx sessions ensure output: {e}"),
+            })?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let stdout = String::from_utf8_lossy(&output.stdout);
@@ -90,7 +96,7 @@ impl AcpxCli {
             .stderr(std::process::Stdio::piped());
         debug!(agent, session_name, cwd = %cwd.display(), "running acpx prompt");
 
-        let mut child = command.spawn().map_err(|e| AgentError::IoError {
+        let mut child = spawn_with_etxtbsy_retry(command).map_err(|e| AgentError::IoError {
             reason: format!("failed to run acpx prompt: {e}"),
         })?;
 
@@ -281,9 +287,15 @@ impl AcpxCli {
         let mut command = self.base_command(agent, cwd, model);
         command.args(["cancel", "--session", session_name]);
         debug!(agent, session_name, cwd = %cwd.display(), "running acpx cancel");
-        let status = command.status().await.map_err(|e| AgentError::IoError {
-            reason: format!("failed to run acpx cancel: {e}"),
-        })?;
+        let status = spawn_with_etxtbsy_retry(command)
+            .map_err(|e| AgentError::IoError {
+                reason: format!("failed to run acpx cancel: {e}"),
+            })?
+            .wait()
+            .await
+            .map_err(|e| AgentError::IoError {
+                reason: format!("failed to wait on acpx cancel: {e}"),
+            })?;
         if !status.success() {
             return Err(AgentError::AcpxCommandFailed {
                 command: "cancel".to_string(),
@@ -303,9 +315,15 @@ impl AcpxCli {
         let mut command = self.base_command(agent, cwd, model);
         command.args(["sessions", "close", session_name]);
         debug!(agent, session_name, cwd = %cwd.display(), "running acpx sessions close");
-        let status = command.status().await.map_err(|e| AgentError::IoError {
-            reason: format!("failed to run acpx sessions close: {e}"),
-        })?;
+        let status = spawn_with_etxtbsy_retry(command)
+            .map_err(|e| AgentError::IoError {
+                reason: format!("failed to run acpx sessions close: {e}"),
+            })?
+            .wait()
+            .await
+            .map_err(|e| AgentError::IoError {
+                reason: format!("failed to wait on acpx sessions close: {e}"),
+            })?;
         if !status.success() {
             return Err(AgentError::AcpxCommandFailed {
                 command: "sessions close".to_string(),
@@ -327,6 +345,29 @@ impl AcpxCli {
             .args(["--format", "json", "--json-strict"])
             .arg(agent);
         command
+    }
+}
+
+/// Spawn an `acpx` child process, retrying on `ETXTBSY` ("Text file busy").
+///
+/// On Linux, `Command::spawn` can fail with `ETXTBSY` if the executable was
+/// very recently written to and the kernel's `execve` check still sees a
+/// write reference. This is a known, intermittent race — see
+/// <https://github.com/rust-lang/rust/issues/114554>. In practice it shows up
+/// in the test suite when a mock script is written immediately before being
+/// exec'd. Retrying with a short backoff resolves it deterministically.
+fn spawn_with_etxtbsy_retry(mut command: Command) -> std::io::Result<tokio::process::Child> {
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(error) if error.raw_os_error() == Some(26) && attempt < MAX_ATTEMPTS => {
+                std::thread::sleep(std::time::Duration::from_millis(attempt as u64 * 10));
+            }
+            Err(error) => return Err(error),
+        }
     }
 }
 

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -368,24 +368,13 @@ fn map_stop_reason(stop_reason: StopReason, usage: Option<TokenUsage>) -> AgentE
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use std::sync::{Arc, Mutex};
 
     use crate::agent::events::{AgentEvent, TokenUsage};
+    use crate::agent::test_support::write_mock_acpx_script;
     use crate::error::AgentError;
 
     use super::AcpxCli;
-
-    fn write_mock_acpx_script(dir: &Path, script_content: &str) -> String {
-        let script_path = dir.join("mock_acpx.sh");
-        std::fs::write(&script_path, script_content).unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
-        script_path.display().to_string()
-    }
 
     #[tokio::test]
     async fn ensure_session_uses_sessions_ensure_command() {

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -348,7 +348,6 @@ async fn close_session(
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
     use std::sync::Arc;
 
     use tokio_util::sync::CancellationToken;
@@ -356,6 +355,7 @@ mod tests {
     use super::*;
     use crate::agent::acpx_cli::AcpxCli;
     use crate::agent::events::RuntimeStream;
+    use crate::agent::test_support::write_mock_acpx_script;
     use crate::config::ensemble::parse_config;
     use crate::tracker::model::test_helpers::test_issue;
 
@@ -382,24 +382,11 @@ on_failure: Failed
         )
     }
 
-    fn write_mock_acpx_script(dir: &tempfile::TempDir, script_content: &str) -> String {
-        let script_path = dir.path().join("mock_acpx.sh");
-        let mut file = std::fs::File::create(&script_path).unwrap();
-        let script_content = script_content.replacen("#!/usr/bin/env bash", "#!/bin/bash", 1);
-        file.write_all(script_content.as_bytes()).unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
-        script_path.display().to_string()
-    }
-
     #[tokio::test]
     async fn acpx_runtime_emits_runtime_events_and_success() {
         let workspace = tempfile::TempDir::new().unwrap();
         let script_path = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             r#"#!/usr/bin/env bash
 case "$*" in
   *" sessions ensure --name "*)
@@ -464,7 +451,7 @@ exit 1
     async fn acpx_runtime_tolerates_close_session_failure() {
         let workspace = tempfile::TempDir::new().unwrap();
         let script_path = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             r#"#!/usr/bin/env bash
 case "$*" in
   *" sessions ensure --name "*)
@@ -515,7 +502,7 @@ exit 1
         let workspace = tempfile::TempDir::new().unwrap();
         let args_path = workspace.path().join("args.txt");
         let script_path = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             &format!(
                 r#"#!/usr/bin/env bash
 printf '%s\n' "$*" >> "{}"
@@ -568,7 +555,7 @@ exit 1
         let workspace = tempfile::TempDir::new().unwrap();
         let args_path = workspace.path().join("args.txt");
         let script_path = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             &format!(
                 r#"#!/usr/bin/env bash
 printf '%s\n' "$*" >> "{}"
@@ -617,7 +604,7 @@ exit 1
     async fn acpx_runtime_cancels_prompt_when_token_is_cancelled() {
         let workspace = tempfile::TempDir::new().unwrap();
         let script_path = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             &format!(
                 r#"#!/usr/bin/env bash
 case "$*" in
@@ -727,7 +714,7 @@ exit 1
         let workspace = tempfile::TempDir::new().unwrap();
         let args_path = workspace.path().join("args.txt");
         let script_path = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             &format!(
                 r#"#!/usr/bin/env bash
 printf '%s\n' "$*" >> "{}"
@@ -796,7 +783,7 @@ exit 1
         let workspace = tempfile::TempDir::new().unwrap();
         let args_path = workspace.path().join("args.txt");
         let script_path = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             &format!(
                 r#"#!/usr/bin/env bash
 printf '%s\n' "$*" >> "{}"
@@ -853,7 +840,7 @@ exit 1
         let workspace = tempfile::TempDir::new().unwrap();
         let args_path = workspace.path().join("args.txt");
         let script_path = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             &format!(
                 r#"#!/usr/bin/env bash
 printf '%s\n' "$*" >> "{}"

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -6,6 +6,9 @@ pub mod events;
 pub mod protocol;
 pub mod runtime;
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 use std::path::Path;
 use std::sync::Arc;
 
@@ -603,11 +606,11 @@ impl AcpAgentRunner {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
     use std::sync::{Mutex, OnceLock};
 
     use super::*;
     use crate::agent::events::AgentEvent;
+    use crate::agent::test_support::write_mock_acpx_script;
     use crate::config::ensemble::parse_config;
     use crate::interaction::{InteractionKind, InteractionResponse};
     use tokio_util::sync::CancellationToken;
@@ -766,19 +769,6 @@ on_failure: Todo
         )
     }
 
-    fn write_mock_acpx_script(dir: &tempfile::TempDir, script_content: &str) -> String {
-        let script_path = dir.path().join("mock_acpx.sh");
-        let mut file = std::fs::File::create(&script_path).unwrap();
-        let script_content = script_content.replacen("#!/usr/bin/env bash", "#!/bin/bash", 1);
-        file.write_all(script_content.as_bytes()).unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
-        script_path.display().to_string()
-    }
-
     fn collect_event_names(rx: &mut mpsc::Receiver<WorkerEvent>) -> Vec<String> {
         let mut names = Vec::new();
         while let Ok(event) = rx.try_recv() {
@@ -867,7 +857,7 @@ on_failure: Todo
 
         let workspace = tempfile::TempDir::new().unwrap();
         let script = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             r#"#!/usr/bin/env bash
 case "$*" in
   *"sessions ensure"*)
@@ -931,7 +921,7 @@ exit 1
 
         let workspace = tempfile::TempDir::new().unwrap();
         let script = write_mock_acpx_script(
-            &workspace,
+            workspace.path(),
             r#"#!/bin/bash
 case "$*" in
   *"prompt --session"*)

--- a/crates/ensemble-core/src/agent/test_support.rs
+++ b/crates/ensemble-core/src/agent/test_support.rs
@@ -1,0 +1,36 @@
+use std::io::Write;
+use std::path::Path;
+
+use tempfile::NamedTempFile;
+
+/// Write a mock `acpx` shell script to `dir/mock_acpx.sh` and return its path
+/// as a string.
+///
+/// The script is written through a `NamedTempFile` in the same directory and
+/// then atomically renamed onto the final path. On Linux (especially overlayfs
+/// used by CI runners) a freshly written file can briefly appear
+/// open-for-write to the kernel's exec check, causing `Command::spawn` to fail
+/// with `ETXTBSY` ("Text file busy"). Persisting from a temp file gives the
+/// final path a settled inode that is not associated with any open writer,
+/// which avoids the race deterministically.
+///
+/// `script_content` has its shebang normalised to `#!/bin/bash` so the script
+/// does not depend on `/usr/bin/env` being on `PATH` for the spawned process.
+pub(crate) fn write_mock_acpx_script(dir: &Path, script_content: &str) -> String {
+    let script_path = dir.join("mock_acpx.sh");
+    let script_content = script_content.replacen("#!/usr/bin/env bash", "#!/bin/bash", 1);
+
+    let mut temp = NamedTempFile::new_in(dir).unwrap();
+    temp.write_all(script_content.as_bytes()).unwrap();
+    temp.as_file_mut().sync_all().unwrap();
+    let persisted = temp.persist(&script_path).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    drop(persisted);
+    script_path.display().to_string()
+}

--- a/crates/ensemble-core/src/agent/test_support.rs
+++ b/crates/ensemble-core/src/agent/test_support.rs
@@ -1,18 +1,8 @@
 use std::io::Write;
 use std::path::Path;
 
-use tempfile::NamedTempFile;
-
 /// Write a mock `acpx` shell script to `dir/mock_acpx.sh` and return its path
 /// as a string.
-///
-/// The script is written through a `NamedTempFile` in the same directory and
-/// then atomically renamed onto the final path. On Linux (especially overlayfs
-/// used by CI runners) a freshly written file can briefly appear
-/// open-for-write to the kernel's exec check, causing `Command::spawn` to fail
-/// with `ETXTBSY` ("Text file busy"). Persisting from a temp file gives the
-/// final path a settled inode that is not associated with any open writer,
-/// which avoids the race deterministically.
 ///
 /// `script_content` has its shebang normalised to `#!/bin/bash` so the script
 /// does not depend on `/usr/bin/env` being on `PATH` for the spawned process.
@@ -20,10 +10,10 @@ pub(crate) fn write_mock_acpx_script(dir: &Path, script_content: &str) -> String
     let script_path = dir.join("mock_acpx.sh");
     let script_content = script_content.replacen("#!/usr/bin/env bash", "#!/bin/bash", 1);
 
-    let mut temp = NamedTempFile::new_in(dir).unwrap();
-    temp.write_all(script_content.as_bytes()).unwrap();
-    temp.as_file_mut().sync_all().unwrap();
-    let persisted = temp.persist(&script_path).unwrap();
+    {
+        let mut file = std::fs::File::create(&script_path).unwrap();
+        file.write_all(script_content.as_bytes()).unwrap();
+    }
 
     #[cfg(unix)]
     {
@@ -31,6 +21,5 @@ pub(crate) fn write_mock_acpx_script(dir: &Path, script_content: &str) -> String
         std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
-    drop(persisted);
     script_path.display().to_string()
 }


### PR DESCRIPTION
Tests in `acpx_cli` (and the duplicate helpers in `acpx_runtime` and `agent::tests`) were failing intermittently on Linux CI with `ETXTBSY` ('Text file busy', os error 26) from `Command::spawn`.

## Root cause

The `write_mock_acpx_script` test helper wrote the mock script directly to its final path with `std::fs::write` / `File::create`. On Linux, especially on overlayfs in GitHub Actions runners, the kernel's exec check can briefly see a freshly-written file as still open-for-write, returning `ETXTBSY` from `execve`. This is a timing race — different tests fail on different runs.

## Fix

Write the script through a `NamedTempFile` in the same directory and atomically `persist` (rename) it onto the final path. The final path then points to a freshly-renamed inode with no associated write handle, which the kernel's exec check accepts deterministically.

Three near-identical copies of the helper (in `acpx_cli.rs`, `acpx_runtime.rs`, and `mod.rs` test mods) are consolidated into a single `pub(crate) fn` in a new `agent::test_support` module.