### PR TITLE
Fix useListDirectoryQuery returning wrapper object instead of entries

### DIFF
--- a/crates/ensemble-ui/src-ui/src/hooks.ts
+++ b/crates/ensemble-ui/src-ui/src/hooks.ts
@@ -46,7 +46,7 @@ import type {
   SaveGuidedFormRequest,
   InteractionResponseBody,
   ListDirectoryParams,
-  FsEntry,
+  ListResponse,
 } from "./generated/models";
 import { customFetch } from "./fetch-client";
 
@@ -420,7 +420,7 @@ export function useListDirectoryQuery(params: ListDirectoryParams) {
     enabled: !!params.path,
     queryFn: async () => {
       const resp = await listDirectory(params);
-      return resp.data.entries;
+      return (resp.data as ListResponse).entries;
     },
   });
 }

--- a/crates/ensemble-ui/src-ui/src/hooks.ts
+++ b/crates/ensemble-ui/src-ui/src/hooks.ts
@@ -420,7 +420,7 @@ export function useListDirectoryQuery(params: ListDirectoryParams) {
     enabled: !!params.path,
     queryFn: async () => {
       const resp = await listDirectory(params);
-      return resp.data as unknown as FsEntry[];
+      return resp.data.entries;
     },
   });
 }


### PR DESCRIPTION
Fixes [review comment](https://github.com/chrisbanes/ensemble/pull/140#discussion_r3383664296) from #140.

The hook was casting `resp.data` (a full `ListResponse` object with `entries` and `truncated` fields) to `FsEntry[]` via `as unknown as FsEntry[]`. Any consumer calling `.map()` or iterating the result would crash. Return `resp.data.entries` instead.