### PR TITLE
Discover ACP model and mode capabilities

### DIFF
--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -4,14 +4,16 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use agent_client_protocol::schema::{
-    ContentBlock, InitializeRequest, PermissionOption, PermissionOptionKind, ProtocolVersion,
-    RequestPermissionRequest, RequestPermissionResponse, SessionNotification, SessionUpdate,
-    SetSessionModeRequest, StopReason as SdkStopReason,
+    ContentBlock, InitializeRequest, NewSessionRequest, PermissionOption, PermissionOptionKind,
+    ProtocolVersion, RequestPermissionRequest, RequestPermissionResponse, SessionConfigKind,
+    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOptions,
+    SessionNotification, SessionUpdate, SetSessionModeRequest, StopReason as SdkStopReason,
 };
 use agent_client_protocol::{AcpAgent, Client, Dispatch, SessionMessage};
 use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, info, warn};
 
+use crate::config::ensemble::{DiscoveredCapabilities, ModeDefinition, ModelDefinition};
 use crate::error::AgentError;
 
 use super::events::{AgentEvent, RuntimeStream, TokenUsage, WorkerEvent};
@@ -24,6 +26,13 @@ pub struct AcpSessionConfig {
     pub permission_request_policy: String,
     pub read_timeout_ms: u64,
     pub turn_timeout_ms: u64,
+}
+
+#[derive(Debug)]
+pub struct AcpCapabilityDiscoveryConfig {
+    pub command: String,
+    pub workspace_path: PathBuf,
+    pub read_timeout_ms: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -196,13 +205,184 @@ fn map_sdk_stop_reason(stop: &SdkStopReason) -> super::events::StopReason {
     }
 }
 
+fn option_description(option: &SessionConfigOption) -> Option<String> {
+    option.description.clone().filter(|value| !value.is_empty())
+}
+
+fn model_definitions_from_option(option: &SessionConfigOption) -> Vec<ModelDefinition> {
+    match &option.kind {
+        SessionConfigKind::Select(select) => match &select.options {
+            SessionConfigSelectOptions::Ungrouped(options) => options
+                .iter()
+                .map(|value| ModelDefinition {
+                    id: value.value.to_string(),
+                    name: value.name.clone(),
+                    description: option_description(option),
+                })
+                .collect(),
+            SessionConfigSelectOptions::Grouped(groups) => groups
+                .iter()
+                .flat_map(|group| group.options.iter())
+                .map(|value| ModelDefinition {
+                    id: value.value.to_string(),
+                    name: value.name.clone(),
+                    description: option_description(option),
+                })
+                .collect(),
+            _ => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
+}
+
+fn mode_definitions_from_option(option: &SessionConfigOption) -> Vec<ModeDefinition> {
+    match &option.kind {
+        SessionConfigKind::Select(select) => match &select.options {
+            SessionConfigSelectOptions::Ungrouped(options) => options
+                .iter()
+                .map(|value| ModeDefinition {
+                    id: value.value.to_string(),
+                    name: value.name.clone(),
+                    description: option_description(option),
+                })
+                .collect(),
+            SessionConfigSelectOptions::Grouped(groups) => groups
+                .iter()
+                .flat_map(|group| group.options.iter())
+                .map(|value| ModeDefinition {
+                    id: value.value.to_string(),
+                    name: value.name.clone(),
+                    description: option_description(option),
+                })
+                .collect(),
+            _ => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
+}
+
+pub fn discover_capabilities_from_options(
+    options: Option<&[SessionConfigOption]>,
+) -> DiscoveredCapabilities {
+    let mut capabilities = DiscoveredCapabilities::default();
+
+    for option in options.unwrap_or(&[]) {
+        match option.category.as_ref() {
+            Some(SessionConfigOptionCategory::Model) => {
+                if let SessionConfigKind::Select(select) = &option.kind {
+                    capabilities.current_model = Some(select.current_value.to_string());
+                }
+                capabilities
+                    .models
+                    .extend(model_definitions_from_option(option));
+            }
+            Some(SessionConfigOptionCategory::Mode) => {
+                if let SessionConfigKind::Select(select) = &option.kind {
+                    capabilities.current_mode = Some(select.current_value.to_string());
+                }
+                capabilities
+                    .modes
+                    .extend(mode_definitions_from_option(option));
+            }
+            _ => {}
+        }
+    }
+
+    capabilities
+}
+
+pub async fn discover_capabilities(
+    config: AcpCapabilityDiscoveryConfig,
+) -> Result<DiscoveredCapabilities, AgentError> {
+    let transport_command = sdk_transport_command(&config.command, &config.workspace_path);
+    let agent = AcpAgent::from_str(&transport_command).map_err(|e| AgentError::AgentNotFound {
+        command: format!("{}: {}", config.command, e),
+    })?;
+    let read_timeout_ms = config.read_timeout_ms;
+    let workspace_path = config.workspace_path.clone();
+    let discovered = Arc::new(Mutex::new(DiscoveredCapabilities::default()));
+    let discovered_inner = discovered.clone();
+    let session_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let session_error_inner = session_error.clone();
+
+    Client
+        .builder()
+        .name("ensemble-capability-discovery")
+        .connect_with(agent, async move |cx| {
+            match tokio::time::timeout(
+                Duration::from_millis(read_timeout_ms),
+                cx.send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task(),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => {
+                    *session_error_inner.lock().await = Some(format!("initialize failed: {e}"));
+                    return Ok(());
+                }
+                Err(_) => {
+                    *session_error_inner.lock().await =
+                        Some(format!("response timeout after {read_timeout_ms}ms"));
+                    return Ok(());
+                }
+            }
+
+            let session_response = match tokio::time::timeout(
+                Duration::from_millis(read_timeout_ms),
+                cx.send_request(NewSessionRequest::new(&workspace_path))
+                    .block_task(),
+            )
+            .await
+            {
+                Ok(Ok(response)) => response,
+                Ok(Err(e)) => {
+                    *session_error_inner.lock().await = Some(format!("session error: {e}"));
+                    return Ok(());
+                }
+                Err(_) => {
+                    *session_error_inner.lock().await =
+                        Some(format!("response timeout after {read_timeout_ms}ms"));
+                    return Ok(());
+                }
+            };
+
+            *discovered_inner.lock().await =
+                discover_capabilities_from_options(session_response.config_options.as_deref());
+            Ok(())
+        })
+        .await
+        .map_err(|e| AgentError::IoError {
+            reason: e.to_string(),
+        })?;
+
+    if let Some(error_msg) = session_error.lock().await.clone() {
+        if error_msg.contains("response timeout") {
+            return Err(AgentError::ResponseTimeout {
+                timeout_ms: read_timeout_ms,
+            });
+        }
+        return Err(AgentError::SessionStartupFailed { reason: error_msg });
+    }
+
+    let capabilities = discovered.lock().await.clone();
+    Ok(capabilities)
+}
+
 pub async fn run_acp_session(
     config: AcpSessionConfig,
     prompts: Vec<String>,
     issue_id: &str,
     step_name: &str,
     event_tx: &mpsc::Sender<WorkerEvent>,
-) -> Result<(Option<serde_json::Value>, Vec<TurnResult>), AgentError> {
+) -> Result<
+    (
+        Option<serde_json::Value>,
+        Vec<TurnResult>,
+        DiscoveredCapabilities,
+    ),
+    AgentError,
+> {
     let transport_command = sdk_transport_command(&config.command, &config.workspace_path);
     let agent_pid: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let agent_pid_for_debug = agent_pid.clone();
@@ -229,6 +409,8 @@ pub async fn run_acp_session(
     let turn_results: Arc<Mutex<Vec<TurnResult>>> = Arc::new(Mutex::new(Vec::new()));
     let final_verdict: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
     let session_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let discovered_capabilities: Arc<Mutex<DiscoveredCapabilities>> =
+        Arc::new(Mutex::new(DiscoveredCapabilities::default()));
     let prompts = Arc::new(prompts);
     let session_mode = config.session_mode.clone();
     let read_timeout_ms = config.read_timeout_ms;
@@ -239,6 +421,7 @@ pub async fn run_acp_session(
     let final_verdict_inner = final_verdict.clone();
     let session_error_inner = session_error.clone();
     let session_error_outer = session_error.clone();
+    let discovered_capabilities_inner = discovered_capabilities.clone();
 
     let builder = Client.builder().name("ensemble").on_receive_request(
         async move |request: RequestPermissionRequest,
@@ -312,14 +495,14 @@ pub async fn run_acp_session(
                 }
             }
 
-            let session_builder = cx.build_session(&workspace_path);
-            let mut session = match tokio::time::timeout(
+            let session_response = match tokio::time::timeout(
                 Duration::from_millis(read_timeout_ms),
-                session_builder.block_task().start_session(),
+                cx.send_request(NewSessionRequest::new(&workspace_path))
+                    .block_task(),
             )
             .await
             {
-                Ok(Ok(session)) => session,
+                Ok(Ok(response)) => response,
                 Ok(Err(e)) => {
                     let mut err = session_error_inner.lock().await;
                     *err = Some(format!("session error: {e}"));
@@ -328,6 +511,19 @@ pub async fn run_acp_session(
                 Err(_) => {
                     let mut err = session_error_inner.lock().await;
                     *err = Some(format!("response timeout after {read_timeout_ms}ms"));
+                    return Ok(());
+                }
+            };
+
+            let capabilities =
+                discover_capabilities_from_options(session_response.config_options.as_deref());
+            *discovered_capabilities_inner.lock().await = capabilities;
+
+            let mut session = match cx.attach_session(session_response, Vec::new()) {
+                Ok(session) => session,
+                Err(e) => {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("session attach failed: {e}"));
                     return Ok(());
                 }
             };
@@ -347,6 +543,24 @@ pub async fn run_acp_session(
 
             if let Some(ref mode) = session_mode {
                 if !mode.is_empty() {
+                    let discovered = discovered_capabilities_inner.lock().await;
+                    if !discovered.modes.is_empty()
+                        && !discovered.modes.iter().any(|candidate| candidate.id == *mode)
+                    {
+                        let mut err = session_error_inner.lock().await;
+                        *err = Some(format!(
+                            "configured session_mode '{}' is not supported by agent; available modes: {}",
+                            mode,
+                            discovered
+                                .modes
+                                .iter()
+                                .map(|m| m.id.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ));
+                        return Ok(());
+                    }
+                    drop(discovered);
                     match tokio::time::timeout(
                         Duration::from_millis(read_timeout_ms),
                         session
@@ -563,7 +777,8 @@ pub async fn run_acp_session(
 
     let verdict = final_verdict.lock().await.take();
     let results = turn_results.lock().await.clone();
-    Ok((verdict, results))
+    let capabilities = discovered_capabilities.lock().await.clone();
+    Ok((verdict, results, capabilities))
 }
 
 #[cfg(test)]
@@ -670,6 +885,125 @@ mod tests {
                 Ok(Err(AgentError::ResponseTimeout { timeout_ms: 50 }))
             ),
             "startup should return the configured response timeout, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn discover_capabilities_from_options_extracts_models_and_modes() {
+        use agent_client_protocol::schema::{
+            SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
+        };
+
+        let options = vec![
+            SessionConfigOption::select(
+                "model",
+                "Model",
+                "gpt-5",
+                vec![
+                    SessionConfigSelectOption::new("gpt-5", "GPT-5"),
+                    SessionConfigSelectOption::new("sonnet", "Sonnet"),
+                ],
+            )
+            .category(SessionConfigOptionCategory::Model),
+            SessionConfigOption::select(
+                "mode",
+                "Mode",
+                "code",
+                vec![
+                    SessionConfigSelectOption::new("code", "Code"),
+                    SessionConfigSelectOption::new("review", "Review"),
+                ],
+            )
+            .category(SessionConfigOptionCategory::Mode),
+        ];
+
+        let capabilities = discover_capabilities_from_options(Some(&options));
+
+        assert_eq!(capabilities.current_model.as_deref(), Some("gpt-5"));
+        assert_eq!(
+            capabilities
+                .models
+                .iter()
+                .map(|m| m.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gpt-5", "sonnet"]
+        );
+        assert_eq!(capabilities.current_mode.as_deref(), Some("code"));
+        assert_eq!(
+            capabilities
+                .modes
+                .iter()
+                .map(|m| m.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["code", "review"]
+        );
+    }
+
+    #[test]
+    fn discover_capabilities_from_options_flattens_grouped_options_with_descriptions() {
+        use agent_client_protocol::schema::{
+            SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectGroup,
+            SessionConfigSelectOption,
+        };
+
+        let options = vec![SessionConfigOption::select(
+            "model",
+            "Model",
+            "gpt-5",
+            vec![
+                SessionConfigSelectGroup::new(
+                    "openai",
+                    "OpenAI",
+                    vec![
+                        SessionConfigSelectOption::new("gpt-5", "GPT-5"),
+                        SessionConfigSelectOption::new("gpt-5-mini", "GPT-5 mini"),
+                    ],
+                ),
+                SessionConfigSelectGroup::new(
+                    "anthropic",
+                    "Anthropic",
+                    vec![SessionConfigSelectOption::new("sonnet", "Sonnet")],
+                ),
+            ],
+        )
+        .description("Available model")
+        .category(SessionConfigOptionCategory::Model)];
+
+        let capabilities = discover_capabilities_from_options(Some(&options));
+
+        assert_eq!(capabilities.current_model.as_deref(), Some("gpt-5"));
+        assert_eq!(
+            capabilities
+                .models
+                .iter()
+                .map(|m| (m.id.as_str(), m.description.as_deref()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("gpt-5", Some("Available model")),
+                ("gpt-5-mini", Some("Available model")),
+                ("sonnet", Some("Available model")),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_capabilities_times_out_when_agent_does_not_initialize() {
+        let workspace = TempDir::new().unwrap();
+        let config = AcpCapabilityDiscoveryConfig {
+            command: "bash -lc 'while IFS= read -r _line; do sleep 60; done'".to_string(),
+            workspace_path: workspace.path().to_path_buf(),
+            read_timeout_ms: 50,
+        };
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(500), discover_capabilities(config)).await;
+
+        assert!(
+            matches!(
+                result,
+                Ok(Err(AgentError::ResponseTimeout { timeout_ms: 50 }))
+            ),
+            "discovery should return the configured response timeout, got {result:?}"
         );
     }
 }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -205,8 +205,10 @@ fn map_sdk_stop_reason(stop: &SdkStopReason) -> super::events::StopReason {
     }
 }
 
-fn option_description(option: &SessionConfigOption) -> Option<String> {
-    option.description.clone().filter(|value| !value.is_empty())
+fn select_value_description(
+    value: &agent_client_protocol::schema::SessionConfigSelectOption,
+) -> Option<String> {
+    value.description.clone().filter(|text| !text.is_empty())
 }
 
 fn model_definitions_from_option(option: &SessionConfigOption) -> Vec<ModelDefinition> {
@@ -217,7 +219,7 @@ fn model_definitions_from_option(option: &SessionConfigOption) -> Vec<ModelDefin
                 .map(|value| ModelDefinition {
                     id: value.value.to_string(),
                     name: value.name.clone(),
-                    description: option_description(option),
+                    description: select_value_description(value),
                 })
                 .collect(),
             SessionConfigSelectOptions::Grouped(groups) => groups
@@ -226,7 +228,7 @@ fn model_definitions_from_option(option: &SessionConfigOption) -> Vec<ModelDefin
                 .map(|value| ModelDefinition {
                     id: value.value.to_string(),
                     name: value.name.clone(),
-                    description: option_description(option),
+                    description: select_value_description(value),
                 })
                 .collect(),
             _ => Vec::new(),
@@ -243,7 +245,7 @@ fn mode_definitions_from_option(option: &SessionConfigOption) -> Vec<ModeDefinit
                 .map(|value| ModeDefinition {
                     id: value.value.to_string(),
                     name: value.name.clone(),
-                    description: option_description(option),
+                    description: select_value_description(value),
                 })
                 .collect(),
             SessionConfigSelectOptions::Grouped(groups) => groups
@@ -252,7 +254,7 @@ fn mode_definitions_from_option(option: &SessionConfigOption) -> Vec<ModeDefinit
                 .map(|value| ModeDefinition {
                     id: value.value.to_string(),
                     name: value.name.clone(),
-                    description: option_description(option),
+                    description: select_value_description(value),
                 })
                 .collect(),
             _ => Vec::new(),
@@ -955,14 +957,17 @@ mod tests {
                     "openai",
                     "OpenAI",
                     vec![
-                        SessionConfigSelectOption::new("gpt-5", "GPT-5"),
-                        SessionConfigSelectOption::new("gpt-5-mini", "GPT-5 mini"),
+                        SessionConfigSelectOption::new("gpt-5", "GPT-5")
+                            .description("flagship OpenAI model"),
+                        SessionConfigSelectOption::new("gpt-5-mini", "GPT-5 mini")
+                            .description("small OpenAI model"),
                     ],
                 ),
                 SessionConfigSelectGroup::new(
                     "anthropic",
                     "Anthropic",
-                    vec![SessionConfigSelectOption::new("sonnet", "Sonnet")],
+                    vec![SessionConfigSelectOption::new("sonnet", "Sonnet")
+                        .description("Anthropic Sonnet")],
                 ),
             ],
         )
@@ -979,9 +984,9 @@ mod tests {
                 .map(|m| (m.id.as_str(), m.description.as_deref()))
                 .collect::<Vec<_>>(),
             vec![
-                ("gpt-5", Some("Available model")),
-                ("gpt-5-mini", Some("Available model")),
-                ("sonnet", Some("Available model")),
+                ("gpt-5", Some("flagship OpenAI model")),
+                ("gpt-5-mini", Some("small OpenAI model")),
+                ("sonnet", Some("Anthropic Sonnet")),
             ]
         );
     }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -12,7 +12,10 @@ pub(crate) mod test_support;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::config::ensemble::{EnsembleConfig, InteractionPolicyOverrideMode, PermissionMode};
+use crate::config::draft::ConfigDocumentState;
+use crate::config::ensemble::{
+    DiscoveredCapabilities, EnsembleConfig, InteractionPolicyOverrideMode, PermissionMode,
+};
 use crate::config::template::render_prompt_with_interaction_response;
 use crate::error::AgentError;
 use crate::interaction::InteractionResponse;
@@ -25,7 +28,10 @@ use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
-use acp_client::{run_acp_session, AcpSessionConfig, TurnResult};
+use acp_client::{
+    discover_capabilities, run_acp_session, AcpCapabilityDiscoveryConfig, AcpSessionConfig,
+    TurnResult,
+};
 use acpx_runtime::AcpxRuntime;
 
 const VERDICT_FALLBACK_INSTRUCTION: &str = "\
@@ -64,7 +70,10 @@ pub trait AgentRunner: Send + Sync {
 }
 
 /// Real ACP agent runner that implements the full worker loop from SPEC.md Section 16.5.
-pub struct AcpAgentRunner;
+pub struct AcpAgentRunner {
+    config: Arc<RwLock<EnsembleConfig>>,
+    document_state: Option<Arc<RwLock<ConfigDocumentState>>>,
+}
 
 struct BuildPromptRequest<'a> {
     issue: &'a Issue,
@@ -75,9 +84,87 @@ struct BuildPromptRequest<'a> {
     turn_number: u32,
 }
 
+fn update_agent_capabilities(
+    config: &mut EnsembleConfig,
+    agent_name: &str,
+    capabilities: &DiscoveredCapabilities,
+) {
+    if let Some(agent) = config.agents.get_mut(agent_name) {
+        agent.available_models = capabilities.models.clone();
+        agent.available_modes = capabilities.modes.clone();
+    }
+}
+
 impl AcpAgentRunner {
-    pub fn new(_config: Arc<RwLock<EnsembleConfig>>) -> Self {
-        Self
+    pub fn new(config: Arc<RwLock<EnsembleConfig>>) -> Self {
+        Self {
+            config,
+            document_state: None,
+        }
+    }
+
+    pub fn new_with_document_state(
+        config: Arc<RwLock<EnsembleConfig>>,
+        document_state: Arc<RwLock<ConfigDocumentState>>,
+    ) -> Self {
+        Self {
+            config,
+            document_state: Some(document_state),
+        }
+    }
+
+    /// Persist discovered ACP capabilities back into the shared in-memory
+    /// `AgentConfig` snapshots. No-op if the discovery returned no models and
+    /// no modes so that a transient empty discovery does not wipe
+    /// previously-stored data.
+    async fn store_agent_capabilities(
+        &self,
+        agent_name: &str,
+        capabilities: DiscoveredCapabilities,
+    ) {
+        if capabilities.models.is_empty() && capabilities.modes.is_empty() {
+            return;
+        }
+
+        {
+            let mut shared_config = self.config.write().await;
+            update_agent_capabilities(&mut shared_config, agent_name, &capabilities);
+        }
+
+        if let Some(document_state) = &self.document_state {
+            let mut document_state = document_state.write().await;
+            if let Some(active_config) = document_state.active_config.as_mut() {
+                update_agent_capabilities(active_config, agent_name, &capabilities);
+            }
+        }
+    }
+
+    /// Run the ACP handshake-only discovery against the `acpx` runtime for
+    /// the agent referenced by `request` and store the result in shared
+    /// config. Returns `Ok(())` if the agent has no `acpx_agent` configured
+    /// (e.g. direct runtime) — only the `acpx_agent` path advertises models
+    /// and modes via ACP `configOptions`.
+    async fn discover_acpx_capabilities_for_request(
+        &self,
+        request: &AgentRunRequest<'_>,
+    ) -> Result<(), AgentError> {
+        let Some(agent_config) = request.config.agents.get(request.agent_name) else {
+            return Ok(());
+        };
+        let Some(command) = resolve_acpx_acp_command(agent_config) else {
+            return Ok(());
+        };
+
+        let capabilities = discover_capabilities(AcpCapabilityDiscoveryConfig {
+            command,
+            workspace_path: request.workspace_path.to_path_buf(),
+            read_timeout_ms: request.config.agent.read_timeout_ms,
+        })
+        .await?;
+
+        self.store_agent_capabilities(request.agent_name, capabilities)
+            .await;
+        Ok(())
     }
 
     /// Build the prompt for a given turn.
@@ -465,6 +552,21 @@ fn resolve_agent_command(
     shell_escape_command(default_command)
 }
 
+/// Build the ACP spawn command used for the discovery handshake.
+///
+/// Deliberately omits the `permission_mode` flag — discovery only needs the
+/// agent process to start and report `configOptions`; the real run will
+/// re-invoke the agent with the full command built by `resolve_agent_command`.
+fn resolve_acpx_acp_command(agent_config: &crate::config::ensemble::AgentConfig) -> Option<String> {
+    let acpx_name = agent_config.acpx_agent.as_ref()?;
+    let mut cmd = String::from("acpx");
+    cmd.push_str(&format!(" --agent {}", shell_escape(acpx_name)));
+    if let Some(ref model) = agent_config.model {
+        cmd.push_str(&format!(" --model {}", shell_escape(model)));
+    }
+    Some(cmd)
+}
+
 #[allow(dead_code)]
 fn shell_escape_command(command: &str) -> String {
     let parts = shlex::split(command)
@@ -526,6 +628,13 @@ impl AgentRunner for AcpAgentRunner {
                         },
                     )
                     .await?;
+                if let Err(error) = self.discover_acpx_capabilities_for_request(&request).await {
+                    tracing::debug!(
+                        agent_name = request.agent_name,
+                        error = %error,
+                        "ACP capability discovery failed for acpx runtime; continuing without discovered capabilities"
+                    );
+                }
                 AcpxRuntime::new().run_step(&request, &prompt).await
             }
             runtime::RuntimeKind::Direct => self.run_direct_step(request).await,
@@ -583,7 +692,7 @@ impl AcpAgentRunner {
             prompts.push(prompt);
         }
 
-        let (final_verdict, turn_results) = run_acp_session(
+        let (final_verdict, turn_results, capabilities) = run_acp_session(
             session_config,
             prompts,
             &request.issue.id,
@@ -591,6 +700,9 @@ impl AcpAgentRunner {
             &request.event_tx,
         )
         .await?;
+
+        self.store_agent_capabilities(request.agent_name, capabilities)
+            .await;
 
         for (i, result) in turn_results.iter().enumerate() {
             if let TurnResult::Failed { reason, .. } = result {
@@ -611,7 +723,8 @@ mod tests {
     use super::*;
     use crate::agent::events::AgentEvent;
     use crate::agent::test_support::write_mock_acpx_script;
-    use crate::config::ensemble::parse_config;
+    use crate::config::draft::parse_raw_yaml;
+    use crate::config::ensemble::{parse_config, ModeDefinition, ModelDefinition};
     use crate::interaction::{InteractionKind, InteractionResponse};
     use tokio_util::sync::CancellationToken;
 
@@ -767,6 +880,111 @@ on_failure: Todo
             )
             .unwrap(),
         )
+    }
+
+    fn test_runner() -> AcpAgentRunner {
+        AcpAgentRunner::new(Arc::new(RwLock::new(test_config().as_ref().clone())))
+    }
+
+    #[tokio::test]
+    async fn store_agent_capabilities_updates_runtime_and_document_state() {
+        let config_path = std::path::PathBuf::from("/tmp/config.yaml");
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo"]
+  terminal_states: ["Done"]
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: hi
+steps:
+  - name: build
+    agent: builder
+workspace:
+  root: /tmp/test
+on_success: Done
+on_failure: Todo
+"#;
+        let document_state = Arc::new(RwLock::new(parse_raw_yaml(config_path, yaml.to_string())));
+        let runtime_config = Arc::new(RwLock::new(
+            document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .clone(),
+        ));
+        let runner = AcpAgentRunner::new_with_document_state(
+            Arc::clone(&runtime_config),
+            Arc::clone(&document_state),
+        );
+
+        runner
+            .store_agent_capabilities(
+                "builder",
+                DiscoveredCapabilities {
+                    models: vec![ModelDefinition {
+                        id: "gpt-5".to_string(),
+                        name: "GPT-5".to_string(),
+                        description: Some("primary model".to_string()),
+                    }],
+                    modes: vec![ModeDefinition {
+                        id: "code".to_string(),
+                        name: "Code".to_string(),
+                        description: None,
+                    }],
+                    current_model: Some("gpt-5".to_string()),
+                    current_mode: Some("code".to_string()),
+                },
+            )
+            .await;
+
+        assert_eq!(
+            runtime_config
+                .read()
+                .await
+                .agents
+                .get("builder")
+                .unwrap()
+                .available_models[0]
+                .id,
+            "gpt-5"
+        );
+        assert_eq!(
+            document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .agents
+                .get("builder")
+                .unwrap()
+                .available_modes[0]
+                .id,
+            "code"
+        );
+
+        runner
+            .store_agent_capabilities("builder", DiscoveredCapabilities::default())
+            .await;
+
+        assert_eq!(
+            document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .agents
+                .get("builder")
+                .unwrap()
+                .available_models[0]
+                .id,
+            "gpt-5"
+        );
     }
 
     fn collect_event_names(rx: &mut mpsc::Receiver<WorkerEvent>) -> Vec<String> {
@@ -1258,7 +1476,7 @@ agent:
             .await
             .unwrap();
 
-        AcpAgentRunner
+        test_runner()
             .build_prompt(
                 test_config().as_ref(),
                 BuildPromptRequest {
@@ -1299,7 +1517,7 @@ agent:
             resolved_at: chrono::Utc::now(),
         };
 
-        AcpAgentRunner
+        test_runner()
             .prepare_workspace(workspace.path(), Some(&response))
             .await
             .unwrap();
@@ -1328,7 +1546,7 @@ agent:
         .await
         .unwrap();
 
-        AcpAgentRunner
+        test_runner()
             .prepare_workspace(workspace.path(), None)
             .await
             .unwrap();
@@ -1353,7 +1571,7 @@ agent:
         )
         .await;
 
-        AcpAgentRunner
+        test_runner()
             .prepare_workspace(workspace.path(), None)
             .await
             .unwrap();
@@ -1383,7 +1601,7 @@ agent:
         )
         .await;
 
-        AcpAgentRunner
+        test_runner()
             .prepare_workspace(workspace.path(), None)
             .await
             .unwrap();
@@ -1442,7 +1660,7 @@ on_failure: Todo
         .await
         .unwrap();
 
-        let prompt = AcpAgentRunner
+        let prompt = test_runner()
             .build_prompt(
                 config.as_ref(),
                 BuildPromptRequest {
@@ -1505,7 +1723,7 @@ on_failure: Todo
         .await
         .unwrap();
 
-        let prompt = AcpAgentRunner
+        let prompt = test_runner()
             .build_prompt(
                 test_config().as_ref(),
                 BuildPromptRequest {
@@ -1536,7 +1754,7 @@ on_failure: Todo
         .await
         .unwrap();
 
-        AcpAgentRunner
+        test_runner()
             .prepare_workspace(workspace.path(), None)
             .await
             .unwrap();
@@ -1573,6 +1791,7 @@ on_failure: Todo
             prompt: None,
             prompt_template: None,
             reasoning_level: None,
+            ..Default::default()
         };
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
         assert_eq!(cmd, "acpx --agent 'claude' --model 'sonnet'");
@@ -1589,6 +1808,7 @@ on_failure: Todo
             prompt: None,
             prompt_template: None,
             reasoning_level: None,
+            ..Default::default()
         };
 
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
@@ -1607,6 +1827,7 @@ on_failure: Todo
             prompt: None,
             prompt_template: None,
             reasoning_level: None,
+            ..Default::default()
         };
 
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
@@ -1628,6 +1849,7 @@ on_failure: Todo
             prompt: None,
             prompt_template: None,
             reasoning_level: None,
+            ..Default::default()
         };
 
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
@@ -1646,6 +1868,7 @@ on_failure: Todo
             prompt: None,
             prompt_template: None,
             reasoning_level: None,
+            ..Default::default()
         };
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
         assert_eq!(cmd, "acpx --agent 'claude'");
@@ -1662,6 +1885,7 @@ on_failure: Todo
             prompt: None,
             prompt_template: None,
             reasoning_level: None,
+            ..Default::default()
         };
 
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
@@ -1686,6 +1910,7 @@ on_failure: Todo
             prompt: None,
             prompt_template: None,
             reasoning_level: None,
+            ..Default::default()
         };
         let cmd = resolve_agent_command(Some(&config), "default-cmd");
         assert_eq!(cmd, "'codex' '--profile' 'prod;' 'touch' '/tmp/pwned'");
@@ -1752,5 +1977,26 @@ on_failure: Failed
         };
         assert_eq!(event.event_name(), "output_chunk");
         assert_eq!(event.message_for_state().as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn resolve_acpx_acp_command_includes_agent_and_model() {
+        let command = resolve_acpx_acp_command(&crate::config::ensemble::AgentConfig {
+            runtime: Some("acpx".to_string()),
+            executor: None,
+            model: Some("gpt-5".to_string()),
+            acpx_agent: Some("codex".to_string()),
+            permission_mode: None,
+            prompt: Some("Build it.".to_string()),
+            prompt_template: None,
+            reasoning_level: None,
+            available_models: Vec::new(),
+            available_modes: Vec::new(),
+        });
+
+        assert_eq!(
+            command.as_deref(),
+            Some("acpx --agent 'codex' --model 'gpt-5'")
+        );
     }
 }

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -191,7 +191,10 @@ async fn prepare_orchestrator_runtime(
     let tracker: Arc<dyn IssueTracker> = Arc::from(create_tracker(&config.read().await.tracker)?);
     // `AcpAgentRunner` is the shared runtime dispatcher: `acpx_agent` steps run through the
     // acpx CLI/session runtime, while explicit direct configs keep the ACP stdio path.
-    let agent_runner: Arc<dyn AgentRunner> = Arc::new(AcpAgentRunner::new(Arc::clone(&config)));
+    let agent_runner: Arc<dyn AgentRunner> = Arc::new(AcpAgentRunner::new_with_document_state(
+        Arc::clone(&config),
+        Arc::clone(&app_state.config_runtime.document_state),
+    ));
     let workspace_mgr = WorkspaceManager::new(
         Path::new(&app_state.workspace_root),
         Some(config.read().await.repos.clone()),

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -375,6 +375,10 @@ pub struct DiscoveredAgentInfo {
     pub name: String,
     pub label: String,
     pub version: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub available_models: Vec<crate::config::ensemble::ModelDefinition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub available_modes: Vec<crate::config::ensemble::ModeDefinition>,
 }
 
 /// GET /api/v1/config/setup/agents
@@ -401,6 +405,8 @@ pub async fn get_setup_agents(
                     name: a.name.clone(),
                     label: a.label,
                     version: a.version,
+                    available_models: Vec::new(),
+                    available_modes: Vec::new(),
                 })
                 .collect();
 
@@ -447,6 +453,8 @@ pub async fn get_setup_agents_stream() -> impl axum::response::IntoResponse {
                         name,
                         label,
                         version,
+                        available_models: Vec::new(),
+                        available_modes: Vec::new(),
                     })
             });
         }
@@ -1428,6 +1436,8 @@ on_failure: Failed
                 prompt: Some("Build it.".to_string()),
                 prompt_template: None,
                 reasoning_level: None,
+                available_models: None,
+                available_modes: None,
             }],
             steps: vec![crate::config::form::GuidedStepForm {
                 name: "build".to_string(),
@@ -1593,6 +1603,8 @@ on_failure: Failed
                 prompt: Some("Build it.".to_string()),
                 prompt_template: None,
                 reasoning_level: None,
+                available_models: None,
+                available_modes: None,
             }],
             steps: vec![crate::config::form::GuidedStepForm {
                 name: "build".to_string(),
@@ -1745,6 +1757,8 @@ on_failure: Failed
                 prompt: Some("Build it.".to_string()),
                 prompt_template: None,
                 reasoning_level: None,
+                available_models: None,
+                available_modes: None,
             }],
             steps: vec![crate::config::form::GuidedStepForm {
                 name: "build".to_string(),

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -156,12 +156,20 @@ impl ConfigStateResponse {
             ConfigStateKind::Parsed => "parsed",
         };
 
-        // Extract guided form if we have valid YAML
-        let guided_form = state
-            .raw_yaml
-            .as_ref()
-            .and_then(|yaml| crate::config::form::extract_guided_form(yaml).ok())
-            .map(redact_guided_form_secrets);
+        // Prefer the in-memory `active_config` snapshot when available so the
+        // guided form reflects runtime-discovered state (e.g. ACP
+        // `available_models`/`available_modes`) that the user has not yet
+        // written back to YAML. Fall back to the parsed YAML view when no
+        // active snapshot exists.
+        let guided_form = if let Some(ref config) = state.active_config {
+            Some(crate::config::form::guided_form_from_config(config))
+        } else {
+            state
+                .raw_yaml
+                .as_ref()
+                .and_then(|yaml| crate::config::form::extract_guided_form(yaml).ok())
+        }
+        .map(redact_guided_form_secrets);
 
         Self {
             state: state_str.to_string(),
@@ -993,6 +1001,75 @@ on_failure: Failed
         assert_eq!(guided_form.tracker.project_number, Some(9));
         assert_eq!(guided_form.tracker.api_key.as_deref(), Some("[REDACTED]"));
         assert!(response.raw_yaml.unwrap().contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_config_state_response_prefers_active_config_capabilities_over_yaml() {
+        // The YAML has no `available_models`/`available_modes`, but the
+        // in-memory active_config has been mutated by capability discovery.
+        // The guided form response should surface the discovered capabilities
+        // so the UI can show them before the user writes them back to YAML.
+        let config_path = PathBuf::from("/tmp/config.yaml");
+        let mut state = parse_raw_yaml(
+            config_path,
+            r#"
+tracker:
+  kind: todo_file
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: "Build it."
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#
+            .to_string(),
+        );
+        assert!(
+            state.active_config.is_some(),
+            "parse_raw_yaml should populate active_config"
+        );
+
+        // Simulate discovery mutating the in-memory config.
+        {
+            let mut active = state.active_config.as_mut().unwrap();
+            let agent = active.agents.get_mut("builder").unwrap();
+            agent.available_models = vec![crate::config::ensemble::ModelDefinition {
+                id: "gpt-5".to_string(),
+                name: "GPT-5".to_string(),
+                description: Some("flagship".to_string()),
+            }];
+            agent.available_modes = vec![crate::config::ensemble::ModeDefinition {
+                id: "code".to_string(),
+                name: "Code".to_string(),
+                description: None,
+            }];
+        }
+
+        let response = ConfigStateResponse::from_state(&state);
+        let guided_form = response.guided_form.expect("guided form should be built");
+        let builder = guided_form
+            .agents
+            .iter()
+            .find(|a| a.name == "builder")
+            .expect("builder agent present");
+
+        let models = builder
+            .available_models
+            .as_ref()
+            .expect("discovered models should surface in guided form");
+        assert_eq!(models[0].id, "gpt-5");
+        let modes = builder
+            .available_modes
+            .as_ref()
+            .expect("discovered modes should surface in guided form");
+        assert_eq!(modes[0].id, "code");
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -1038,7 +1038,7 @@ on_failure: Failed
 
         // Simulate discovery mutating the in-memory config.
         {
-            let mut active = state.active_config.as_mut().unwrap();
+            let active = state.active_config.as_mut().unwrap();
             let agent = active.agents.get_mut("builder").unwrap();
             agent.available_models = vec![crate::config::ensemble::ModelDefinition {
                 id: "gpt-5".to_string(),

--- a/crates/ensemble-core/src/api/config_handler.rs
+++ b/crates/ensemble-core/src/api/config_handler.rs
@@ -111,10 +111,28 @@ on_failure: Failed
         .unwrap();
         let state = build_app_state(config);
         let (_status, Json(response)) = get_config(State(state)).await;
-        // api_key has skip_serializing, so it must not appear in JSON output.
+        // The literal secret must never appear in the JSON output. The
+        // `api_key` field may appear in the guided form (which is now
+        // derived from the in-memory active_config snapshot) with its
+        // value replaced by the `[REDACTED]` marker, but it must not
+        // contain the original token.
         let json = serde_json::to_string(&response).unwrap();
-        assert!(!json.contains("ghp_secret_token_12345"));
-        assert!(!json.contains("api_key"));
+        assert!(
+            !json.contains("ghp_secret_token_12345"),
+            "secret token leaked into JSON: {json}"
+        );
+        if let Some(idx) = json.find("\"api_key\"") {
+            let after = &json[idx..];
+            let value_start = after.find(':').unwrap() + 1;
+            let value_end_rel = after[value_start..]
+                .find(|c: char| c == ',' || c == '}')
+                .unwrap_or(after.len() - value_start);
+            let value = after[value_start..value_start + value_end_rel].trim();
+            assert!(
+                value == "\"[REDACTED]\"",
+                "api_key value should be the redaction marker, got {value:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -273,8 +273,39 @@ impl TrackerConfig {
     }
 }
 
+/// A selectable model discovered from an ACP session configuration option.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct ModelDefinition {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// A selectable session mode discovered from an ACP session configuration option.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct ModeDefinition {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Runtime-discovered ACP capabilities for an agent.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct DiscoveredCapabilities {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<ModelDefinition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modes: Vec<ModeDefinition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_mode: Option<String>,
+}
+
 /// Per-agent definition: which executor to use and what prompt to send.
-#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct AgentConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
@@ -293,6 +324,10 @@ pub struct AgentConfig {
     pub prompt_template: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_level: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub available_models: Vec<ModelDefinition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub available_modes: Vec<ModeDefinition>,
 }
 
 /// Approval gate metadata for a pipeline step.

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -5,6 +5,7 @@
 //! The key constraint: unknown YAML fields are preserved during the
 //! round-trip to support custom user extensions.
 
+use crate::config::ensemble::{ModeDefinition, ModelDefinition};
 use crate::error::ConfigError;
 use serde::{Deserialize, Serialize};
 
@@ -59,6 +60,10 @@ pub struct GuidedAgentForm {
     pub prompt: Option<String>,
     pub prompt_template: Option<String>,
     pub reasoning_level: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_models: Option<Vec<ModelDefinition>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_modes: Option<Vec<ModeDefinition>>,
 }
 
 /// Step section in guided form.
@@ -173,6 +178,10 @@ pub fn extract_guided_form(raw_yaml: &str) -> Result<GuidedConfigForm, ConfigErr
                     .as_ref()
                     .map(|p| p.to_string_lossy().to_string()),
                 reasoning_level: agent.reasoning_level.clone(),
+                available_models: (!agent.available_models.is_empty())
+                    .then(|| agent.available_models.clone()),
+                available_modes: (!agent.available_modes.is_empty())
+                    .then(|| agent.available_modes.clone()),
             })
             .collect(),
         steps: config
@@ -372,6 +381,34 @@ pub fn apply_guided_form(
                     am.insert("reasoning_level".into(), v);
                 } else {
                     am.remove("reasoning_level");
+                }
+                if let Some(ref available_models) = a.available_models {
+                    if available_models.is_empty() {
+                        am.remove("available_models");
+                    } else {
+                        am.insert(
+                            "available_models".into(),
+                            serde_yaml::to_value(available_models).map_err(|e| {
+                                ConfigError::ConfigParseError {
+                                    reason: e.to_string(),
+                                }
+                            })?,
+                        );
+                    }
+                }
+                if let Some(ref available_modes) = a.available_modes {
+                    if available_modes.is_empty() {
+                        am.remove("available_modes");
+                    } else {
+                        am.insert(
+                            "available_modes".into(),
+                            serde_yaml::to_value(available_modes).map_err(|e| {
+                                ConfigError::ConfigParseError {
+                                    reason: e.to_string(),
+                                }
+                            })?,
+                        );
+                    }
                 }
             }
         }
@@ -599,6 +636,8 @@ mod tests {
                 prompt: Some("hello".to_string()),
                 prompt_template: None,
                 reasoning_level: None,
+                available_models: None,
+                available_modes: None,
             }],
             steps: vec![GuidedStepForm {
                 name: "implement".to_string(),
@@ -690,6 +729,48 @@ on_failure: Failed
         assert!(merged.contains("custom_tracker_field: keep me"));
         assert!(merged.contains("custom_agent_field: 42"));
         assert!(merged.contains("custom_concurrency_field: true"));
+    }
+
+    #[test]
+    fn apply_guided_form_preserves_capabilities_when_omitted() {
+        let raw = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: hello
+    available_models:
+      - id: gpt-5
+        name: GPT-5
+    available_modes:
+      - id: code
+        name: Code
+steps:
+  - name: implement
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+
+        let merged = apply_guided_form(raw, &guided_form_with_workspace_root("/tmp/ws")).unwrap();
+        let val: serde_yaml::Value = serde_yaml::from_str(&merged).unwrap();
+        let builder = val
+            .get("agents")
+            .unwrap()
+            .get("builder")
+            .unwrap()
+            .as_mapping()
+            .unwrap();
+
+        assert!(
+            builder.contains_key("available_models"),
+            "omitted form field should preserve existing available_models"
+        );
+        assert!(
+            builder.contains_key("available_modes"),
+            "omitted form field should preserve existing available_modes"
+        );
     }
 
     #[test]
@@ -832,5 +913,34 @@ on_failure: Failed
             !builder.contains_key("permission_request_policy"),
             "per-agent section should not receive runtime permission_request_policy"
         );
+    }
+
+    #[test]
+    fn extract_guided_form_includes_agent_capabilities() {
+        let raw = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: Build it.
+    available_models:
+      - id: gpt-5
+        name: GPT-5
+    available_modes:
+      - id: code
+        name: Code
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+
+        let form = extract_guided_form(raw).unwrap();
+        let agent = form.agents.iter().find(|a| a.name == "builder").unwrap();
+
+        assert_eq!(agent.available_models.as_ref().unwrap()[0].id, "gpt-5");
+        assert_eq!(agent.available_modes.as_ref().unwrap()[0].id, "code");
     }
 }

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -136,8 +136,24 @@ pub struct GuidedTransitionForm {
 /// guided form representation. If parsing fails, returns a ConfigError.
 pub fn extract_guided_form(raw_yaml: &str) -> Result<GuidedConfigForm, ConfigError> {
     let config = crate::config::ensemble::parse_config(raw_yaml)?;
+    Ok(config_to_guided_form(&config))
+}
 
-    Ok(GuidedConfigForm {
+/// Build a `GuidedConfigForm` from a typed `EnsembleConfig` snapshot.
+///
+/// This is used by the API layer so that the in-memory config — which may
+/// include capabilities discovered at runtime (e.g. `available_models`,
+/// `available_modes`) that the user has not yet written to YAML — is
+/// surfaced in the guided form response. Equivalent to `extract_guided_form`
+/// after parsing, but accepts a typed config directly.
+pub fn guided_form_from_config(
+    config: &crate::config::ensemble::EnsembleConfig,
+) -> GuidedConfigForm {
+    config_to_guided_form(config)
+}
+
+fn config_to_guided_form(config: &crate::config::ensemble::EnsembleConfig) -> GuidedConfigForm {
+    GuidedConfigForm {
         tracker: GuidedTrackerForm {
             kind: config.tracker.kind.clone(),
             path: config
@@ -228,7 +244,7 @@ pub fn extract_guided_form(raw_yaml: &str) -> Result<GuidedConfigForm, ConfigErr
             on_success: config.on_success.clone(),
             on_failure: config.on_failure.clone(),
         },
-    })
+    }
 }
 
 /// Apply a guided form back to the base YAML, preserving unknown fields.

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -1,3 +1,4 @@
+use crate::config::ensemble::ModelDefinition;
 use crate::config::ensemble::{resolve_relative_to_base, StepConfig};
 use crate::error::ConfigError;
 use crate::pipeline::dag::build_dag;
@@ -86,7 +87,15 @@ pub struct DiscoveredAgent {
 /// Capabilities discovered by probing an acpx agent session.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct AgentCapabilities {
+    /// Flat list of model identifiers, used by the setup wizard UI.
     pub available_models: Vec<String>,
+    /// Typed model definitions populated from the same probe when available.
+    /// Empty when the probe only returned string identifiers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub typed_models: Vec<crate::config::ensemble::ModelDefinition>,
+    /// Typed mode definitions populated from the same probe when available.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub available_modes: Vec<crate::config::ensemble::ModeDefinition>,
 }
 
 /// Result of a setup validation check.
@@ -118,6 +127,15 @@ impl AgentCapabilities {
             caps.available_models = models
                 .iter()
                 .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect();
+            caps.typed_models = caps
+                .available_models
+                .iter()
+                .map(|model| ModelDefinition {
+                    id: model.clone(),
+                    name: model.clone(),
+                    description: None,
+                })
                 .collect();
         }
 
@@ -1832,6 +1850,25 @@ on_failure: Failed
         });
         let caps = AgentCapabilities::from_session_json(&json);
         assert_eq!(caps.available_models, vec!["default", "sonnet", "opus"]);
+    }
+
+    #[test]
+    fn agent_capabilities_from_session_json_populates_typed_models() {
+        let json = serde_json::json!({
+            "acpx": {
+                "available_models": ["default", "sonnet"]
+            }
+        });
+
+        let caps = AgentCapabilities::from_session_json(&json);
+
+        assert_eq!(
+            caps.typed_models
+                .iter()
+                .map(|model| (model.id.as_str(), model.name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("default", "default"), ("sonnet", "sonnet")]
+        );
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-06-09-issue-93-acp-model-mode-discovery.md
+++ b/docs/superpowers/plans/2026-06-09-issue-93-acp-model-mode-discovery.md
@@ -1,0 +1,890 @@
+# ACP Model Mode Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Discover ACP model and mode capabilities for normal `acpx_agent` runs from SDK `session/new` handshake data and expose them through Ensemble's serializable agent config/API surface.
+
+**Architecture:** Add small domain structs for discovered ACP capabilities, parse SDK `SessionConfigOption` values by semantic category, and add a handshake-only SDK helper that starts `acpx --agent <name>` just long enough to initialize and create a session. `AcpxRuntime` calls that helper before the existing `acpx sessions ensure/prompt` flow, stores discovered capabilities in the shared in-memory `AgentConfig`, and then continues to execute through the existing `AcpxCli` path. The direct ACP runtime reuses the same parser and can also return capabilities, but issue 93 is considered fixed only when the default `acpx_agent` path stores them.
+
+**Snapshot model:** The orchestrator dispatches each step with a snapshot of the config (`Arc<EnsembleConfig>`) that is independent of the runner's `Arc<RwLock<EnsembleConfig>>`. When the runner mutates its shared config to persist discovered capabilities, the snapshot held by the in-flight `AcpxRuntime` (or direct session) does not see the new fields. This is intentional for this PR — capabilities are surfaced to subsequent reads (the API layer, the next step attempt), not to the step currently being executed. Re-execing the step (or reading after the step completes) sees the new fields.
+
+**Tech Stack:** Rust 2021, `agent-client-protocol` v0.14.0, `serde`, `utoipa`, existing `tokio` tests
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `crates/ensemble-core/src/config/ensemble.rs` | Define `ModelDefinition`, `ModeDefinition`, `DiscoveredCapabilities`; add optional capability fields to `AgentConfig` |
+| Modify | `crates/ensemble-core/src/config/form.rs` | Carry capabilities in guided config responses without requiring them in YAML input |
+| Modify | `crates/ensemble-core/src/agent/acp_client.rs` | Parse `SessionConfigOption` values; add handshake-only capability discovery; return capabilities from direct `run_acp_session` |
+| Modify | `crates/ensemble-core/src/agent/mod.rs` | Store shared config in `AcpAgentRunner` so runtimes can update in-memory agent capabilities |
+| Modify | `crates/ensemble-core/src/agent/acpx_runtime.rs` | Discover and store capabilities before normal `acpx` session execution |
+| Modify | `crates/ensemble-core/src/api/config_edit_handler.rs` | Include discovered capability fields in setup agent API models |
+
+## Task 1: Add Capability Domain Types
+
+**Files:**
+- Modify: `crates/ensemble-core/src/config/ensemble.rs`
+
+- [ ] **Step 1: Add the serializable model/mode structs near `AgentConfig`**
+
+Add these structs immediately above `pub struct AgentConfig`:
+
+```rust
+/// A selectable model discovered from an ACP session configuration option.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct ModelDefinition {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// A selectable session mode discovered from an ACP session configuration option.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct ModeDefinition {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Runtime-discovered ACP capabilities for an agent.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct DiscoveredCapabilities {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<ModelDefinition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modes: Vec<ModeDefinition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_mode: Option<String>,
+}
+```
+
+- [ ] **Step 2: Add optional fields to `AgentConfig`**
+
+Add these fields after `pub model: Option<String>`:
+
+```rust
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub available_models: Vec<ModelDefinition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub available_modes: Vec<ModeDefinition>,
+```
+
+- [ ] **Step 3: Verify existing YAML keeps parsing**
+
+Run: `cargo test -p ensemble-core config::ensemble::tests::test_parse_minimal_config -- --exact`
+
+Expected: PASS. Existing YAML without capability fields must deserialize because both new fields default.
+
+## Task 2: Carry Capabilities Through Guided Config
+
+**Files:**
+- Modify: `crates/ensemble-core/src/config/form.rs`
+
+- [ ] **Step 1: Import the capability types**
+
+At the top of the file, add:
+
+```rust
+use crate::config::ensemble::{ModeDefinition, ModelDefinition};
+```
+
+- [ ] **Step 2: Extend `GuidedAgentForm`**
+
+Add these fields after `pub model: Option<String>`:
+
+```rust
+    #[serde(default)]
+    pub available_models: Vec<ModelDefinition>,
+    #[serde(default)]
+    pub available_modes: Vec<ModeDefinition>,
+```
+
+- [ ] **Step 3: Populate guided form extraction**
+
+In `extract_guided_form`, update the `GuidedAgentForm` construction:
+
+```rust
+                available_models: agent.available_models.clone(),
+                available_modes: agent.available_modes.clone(),
+```
+
+- [ ] **Step 4: Preserve capability fields during guided form merge**
+
+In `apply_guided_form`, where each agent mapping is built, insert:
+
+```rust
+                if !a.available_models.is_empty() {
+                    am.insert(
+                        "available_models".into(),
+                        serde_yaml::to_value(&a.available_models).map_err(|e| {
+                            ConfigError::YamlParseError {
+                                reason: e.to_string(),
+                            }
+                        })?,
+                    );
+                }
+                if !a.available_modes.is_empty() {
+                    am.insert(
+                        "available_modes".into(),
+                        serde_yaml::to_value(&a.available_modes).map_err(|e| {
+                            ConfigError::YamlParseError {
+                                reason: e.to_string(),
+                            }
+                        })?,
+                    );
+                }
+```
+
+- [ ] **Step 5: Test guided extraction**
+
+Add a unit test in `crates/ensemble-core/src/config/form.rs`:
+
+```rust
+#[test]
+fn extract_guided_form_includes_agent_capabilities() {
+    let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: codex
+    prompt: Build it.
+    available_models:
+      - id: gpt-5
+        name: GPT-5
+    available_modes:
+      - id: code
+        name: Code
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#;
+
+    let form = extract_guided_form(yaml).unwrap();
+    let agent = form.agents.iter().find(|a| a.name == "builder").unwrap();
+
+    assert_eq!(agent.available_models[0].id, "gpt-5");
+    assert_eq!(agent.available_modes[0].id, "code");
+}
+```
+
+- [ ] **Step 6: Run the form test**
+
+Run: `cargo test -p ensemble-core config::form::tests::extract_guided_form_includes_agent_capabilities -- --exact`
+
+Expected: PASS.
+
+## Task 3: Parse ACP Session Config Options
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+
+- [ ] **Step 1: Add SDK and config imports**
+
+Extend the `agent_client_protocol::schema` import with:
+
+```rust
+    NewSessionRequest, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigSelectOptions,
+```
+
+Add:
+
+```rust
+use crate::config::ensemble::{DiscoveredCapabilities, ModeDefinition, ModelDefinition};
+```
+
+- [ ] **Step 2: Add parser helpers before `run_acp_session`**
+
+```rust
+fn option_description(option: &SessionConfigOption) -> Option<String> {
+    option.description.clone().filter(|value| !value.is_empty())
+}
+
+fn model_definitions_from_option(option: &SessionConfigOption) -> Vec<ModelDefinition> {
+    match &option.kind {
+        SessionConfigKind::Select(select) => match &select.options {
+            SessionConfigSelectOptions::Ungrouped(options) => options
+                .iter()
+                .map(|value| ModelDefinition {
+                    id: value.value.to_string(),
+                    name: value.name.clone(),
+                    description: option_description(option),
+                })
+                .collect(),
+            SessionConfigSelectOptions::Grouped(groups) => groups
+                .iter()
+                .flat_map(|group| group.options.iter())
+                .map(|value| ModelDefinition {
+                    id: value.value.to_string(),
+                    name: value.name.clone(),
+                    description: option_description(option),
+                })
+                .collect(),
+        },
+        _ => Vec::new(),
+    }
+}
+
+fn mode_definitions_from_option(option: &SessionConfigOption) -> Vec<ModeDefinition> {
+    match &option.kind {
+        SessionConfigKind::Select(select) => match &select.options {
+            SessionConfigSelectOptions::Ungrouped(options) => options
+                .iter()
+                .map(|value| ModeDefinition {
+                    id: value.value.to_string(),
+                    name: value.name.clone(),
+                    description: option_description(option),
+                })
+                .collect(),
+            SessionConfigSelectOptions::Grouped(groups) => groups
+                .iter()
+                .flat_map(|group| group.options.iter())
+                .map(|value| ModeDefinition {
+                    id: value.value.to_string(),
+                    name: value.name.clone(),
+                    description: option_description(option),
+                })
+                .collect(),
+        },
+        _ => Vec::new(),
+    }
+}
+
+pub fn discover_capabilities_from_options(
+    options: Option<&[SessionConfigOption]>,
+) -> DiscoveredCapabilities {
+    let mut capabilities = DiscoveredCapabilities::default();
+
+    for option in options.unwrap_or(&[]) {
+        match option.category.as_ref() {
+            Some(SessionConfigOptionCategory::Model) => {
+                if let SessionConfigKind::Select(select) = &option.kind {
+                    capabilities.current_model = Some(select.current_value.to_string());
+                }
+                capabilities
+                    .models
+                    .extend(model_definitions_from_option(option));
+            }
+            Some(SessionConfigOptionCategory::Mode) => {
+                if let SessionConfigKind::Select(select) = &option.kind {
+                    capabilities.current_mode = Some(select.current_value.to_string());
+                }
+                capabilities.modes.extend(mode_definitions_from_option(option));
+            }
+            _ => {}
+        }
+    }
+
+    capabilities
+}
+```
+
+- [ ] **Step 3: Add parser tests**
+
+Add a test in the existing `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn discover_capabilities_from_options_extracts_models_and_modes() {
+    use agent_client_protocol::schema::{
+        SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
+    };
+
+    let options = vec![
+        SessionConfigOption::select(
+            "model",
+            "Model",
+            "gpt-5",
+            vec![
+                SessionConfigSelectOption::new("gpt-5", "GPT-5"),
+                SessionConfigSelectOption::new("sonnet", "Sonnet"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Model),
+        SessionConfigOption::select(
+            "mode",
+            "Mode",
+            "code",
+            vec![
+                SessionConfigSelectOption::new("code", "Code"),
+                SessionConfigSelectOption::new("review", "Review"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Mode),
+    ];
+
+    let capabilities = discover_capabilities_from_options(Some(&options));
+
+    assert_eq!(capabilities.current_model.as_deref(), Some("gpt-5"));
+    assert_eq!(capabilities.models.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), vec!["gpt-5", "sonnet"]);
+    assert_eq!(capabilities.current_mode.as_deref(), Some("code"));
+    assert_eq!(capabilities.modes.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), vec!["code", "review"]);
+}
+```
+
+- [ ] **Step 4: Run the parser test**
+
+Run: `cargo test -p ensemble-core agent::acp_client::tests::discover_capabilities_from_options_extracts_models_and_modes -- --exact`
+
+Expected: PASS.
+
+## Task 4: Add Handshake-Only ACP Capability Discovery
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+
+- [ ] **Step 1: Add discovery config**
+
+Add this public config struct after `AcpSessionConfig`:
+
+```rust
+#[derive(Debug)]
+pub struct AcpCapabilityDiscoveryConfig {
+    pub command: String,
+    pub workspace_path: PathBuf,
+    pub read_timeout_ms: u64,
+}
+```
+
+- [ ] **Step 2: Add `discover_capabilities` helper**
+
+Add this function before `run_acp_session`:
+
+```rust
+pub async fn discover_capabilities(
+    config: AcpCapabilityDiscoveryConfig,
+) -> Result<DiscoveredCapabilities, AgentError> {
+    let transport_command = sdk_transport_command(&config.command, &config.workspace_path);
+    let agent = AcpAgent::from_str(&transport_command).map_err(|e| AgentError::AgentNotFound {
+        command: format!("{}: {}", config.command, e),
+    })?;
+    let read_timeout_ms = config.read_timeout_ms;
+    let workspace_path = config.workspace_path.clone();
+    let discovered = Arc::new(Mutex::new(DiscoveredCapabilities::default()));
+    let discovered_inner = discovered.clone();
+    let session_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let session_error_inner = session_error.clone();
+
+    Client
+        .builder()
+        .name("ensemble-capability-discovery")
+        .connect_with(agent, async move |cx| {
+            match tokio::time::timeout(
+                Duration::from_millis(read_timeout_ms),
+                cx.send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task(),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => {
+                    *session_error_inner.lock().await = Some(format!("initialize failed: {e}"));
+                    return Ok(());
+                }
+                Err(_) => {
+                    *session_error_inner.lock().await =
+                        Some(format!("response timeout after {read_timeout_ms}ms"));
+                    return Ok(());
+                }
+            }
+
+            let session_response = match tokio::time::timeout(
+                Duration::from_millis(read_timeout_ms),
+                cx.send_request(NewSessionRequest::new(&workspace_path))
+                    .block_task(),
+            )
+            .await
+            {
+                Ok(Ok(response)) => response,
+                Ok(Err(e)) => {
+                    *session_error_inner.lock().await = Some(format!("session error: {e}"));
+                    return Ok(());
+                }
+                Err(_) => {
+                    *session_error_inner.lock().await =
+                        Some(format!("response timeout after {read_timeout_ms}ms"));
+                    return Ok(());
+                }
+            };
+
+            *discovered_inner.lock().await =
+                discover_capabilities_from_options(session_response.config_options.as_deref());
+            Ok(())
+        })
+        .await
+        .map_err(|e| AgentError::IoError {
+            reason: e.to_string(),
+        })?;
+
+    if let Some(error_msg) = session_error.lock().await.clone() {
+        if error_msg.contains("response timeout") {
+            return Err(AgentError::ResponseTimeout {
+                timeout_ms: read_timeout_ms,
+            });
+        }
+        return Err(AgentError::SessionStartupFailed { reason: error_msg });
+    }
+
+    Ok(discovered.lock().await.clone())
+}
+```
+
+- [ ] **Step 3: Add an empty-capability discovery test**
+
+Add this test to `crates/ensemble-core/src/agent/acp_client.rs`:
+
+```rust
+#[tokio::test]
+async fn discover_capabilities_times_out_when_agent_does_not_initialize() {
+    let workspace = TempDir::new().unwrap();
+    let config = AcpCapabilityDiscoveryConfig {
+        command: "bash -lc 'while IFS= read -r _line; do sleep 60; done'".to_string(),
+        workspace_path: workspace.path().to_path_buf(),
+        read_timeout_ms: 50,
+    };
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        discover_capabilities(config),
+    )
+    .await;
+
+    assert!(
+        matches!(
+            result,
+            Ok(Err(AgentError::ResponseTimeout { timeout_ms: 50 }))
+        ),
+        "discovery should return the configured response timeout, got {result:?}"
+    );
+}
+```
+
+- [ ] **Step 4: Run discovery tests**
+
+Run: `cargo test -p ensemble-core agent::acp_client::tests::discover_capabilities -- --nocapture`
+
+Expected: PASS.
+
+## Task 5: Capture Capabilities During Direct Session Startup
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+
+- [ ] **Step 1: Change `run_acp_session` return type**
+
+Change:
+
+```rust
+) -> Result<(Option<serde_json::Value>, Vec<TurnResult>), AgentError> {
+```
+
+to:
+
+```rust
+) -> Result<(Option<serde_json::Value>, Vec<TurnResult>, DiscoveredCapabilities), AgentError> {
+```
+
+- [ ] **Step 2: Store discovered capabilities in `run_acp_session`**
+
+Add next to `final_verdict`:
+
+```rust
+    let discovered_capabilities: Arc<Mutex<DiscoveredCapabilities>> =
+        Arc::new(Mutex::new(DiscoveredCapabilities::default()));
+```
+
+Clone it for the connection closure:
+
+```rust
+    let discovered_capabilities_inner = discovered_capabilities.clone();
+```
+
+Replace the current `let session_builder = cx.build_session(&workspace_path);` and `let mut session = match ... start_session()` block with a direct `session/new` request that captures the typed response before attaching the active session:
+
+```rust
+            let session_response = match tokio::time::timeout(
+                Duration::from_millis(read_timeout_ms),
+                cx.send_request(NewSessionRequest::new(&workspace_path))
+                    .block_task(),
+            )
+            .await
+            {
+                Ok(Ok(response)) => response,
+                Ok(Err(e)) => {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("session error: {e}"));
+                    return Ok(());
+                }
+                Err(_) => {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("response timeout after {read_timeout_ms}ms"));
+                    return Ok(());
+                }
+            };
+
+            let capabilities =
+                discover_capabilities_from_options(session_response.config_options.as_deref());
+            *discovered_capabilities_inner.lock().await = capabilities;
+
+            let mut session = match cx.attach_session(session_response, Vec::new()) {
+                Ok(session) => session,
+                Err(e) => {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(format!("session attach failed: {e}"));
+                    return Ok(());
+                }
+            };
+```
+
+- [ ] **Step 3: Validate configured session mode before setting it**
+
+Before `SetSessionModeRequest::new(...)`, add:
+
+```rust
+                    let discovered = discovered_capabilities_inner.lock().await;
+                    if !discovered.modes.is_empty()
+                        && !discovered.modes.iter().any(|candidate| candidate.id == *mode)
+                    {
+                        let mut err = session_error_inner.lock().await;
+                        *err = Some(format!(
+                            "configured session_mode '{}' is not supported by agent; available modes: {}",
+                            mode,
+                            discovered
+                                .modes
+                                .iter()
+                                .map(|m| m.id.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ));
+                        return Ok(());
+                    }
+```
+
+- [ ] **Step 4: Return capabilities**
+
+At the end of `run_acp_session`, change:
+
+```rust
+    Ok((verdict, results))
+```
+
+to:
+
+```rust
+    let capabilities = discovered_capabilities.lock().await.clone();
+    Ok((verdict, results, capabilities))
+```
+
+- [ ] **Step 5: Store the shared config in `AcpAgentRunner`**
+
+In `crates/ensemble-core/src/agent/mod.rs`, change:
+
+```rust
+pub struct AcpAgentRunner;
+```
+
+to:
+
+```rust
+pub struct AcpAgentRunner {
+    config: Arc<RwLock<EnsembleConfig>>,
+}
+```
+
+Change the constructor:
+
+```rust
+    pub fn new(_config: Arc<RwLock<EnsembleConfig>>) -> Self {
+        Self
+    }
+```
+
+to:
+
+```rust
+    pub fn new(config: Arc<RwLock<EnsembleConfig>>) -> Self {
+        Self { config }
+    }
+```
+
+- [ ] **Step 6: Update `run_direct_step` destructuring**
+
+In `crates/ensemble-core/src/agent/mod.rs`, change:
+
+```rust
+        let (final_verdict, turn_results) = run_acp_session(
+```
+
+to:
+
+```rust
+        let (final_verdict, turn_results, capabilities) = run_acp_session(
+```
+
+- [ ] **Step 7: Update existing acp client tests**
+
+In `startup_initialize_uses_configured_read_timeout`, no destructuring change is needed because it asserts an error. If any success tests destructure the old tuple, update them to bind `_capabilities`.
+
+- [ ] **Step 8: Run the ACP client tests**
+
+Run: `cargo test -p ensemble-core agent::acp_client -- --nocapture`
+
+Expected: PASS.
+
+## Task 6: Discover Capabilities For Acpx Runtime
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+
+- [ ] **Step 1: Import discovery types**
+
+Change the existing `acp_client` import:
+
+```rust
+use acp_client::{run_acp_session, AcpSessionConfig, TurnResult};
+```
+
+to:
+
+```rust
+use acp_client::{
+    discover_capabilities, run_acp_session, AcpCapabilityDiscoveryConfig, AcpSessionConfig,
+    TurnResult,
+};
+```
+
+- [ ] **Step 2: Add an `acpx` ACP command builder**
+
+Add this helper near `resolve_agent_command`:
+
+```rust
+fn resolve_acpx_acp_command(
+    agent_config: &crate::config::ensemble::AgentConfig,
+) -> Option<String> {
+    let acpx_name = agent_config.acpx_agent.as_ref()?;
+    let mut cmd = String::from("acpx");
+    cmd.push_str(&format!(" --agent {}", shell_escape(acpx_name)));
+    if let Some(ref model) = agent_config.model {
+        cmd.push_str(&format!(" --model {}", shell_escape(model)));
+    }
+    Some(cmd)
+}
+```
+
+- [ ] **Step 3: Add capability storage helper**
+
+Add this method inside `impl AcpAgentRunner`:
+
+```rust
+    async fn store_agent_capabilities(
+        &self,
+        agent_name: &str,
+        capabilities: crate::config::ensemble::DiscoveredCapabilities,
+    ) {
+        if capabilities.models.is_empty() && capabilities.modes.is_empty() {
+            return;
+        }
+
+        let mut shared_config = self.config.write().await;
+        if let Some(agent) = shared_config.agents.get_mut(agent_name) {
+            agent.available_models = capabilities.models;
+            agent.available_modes = capabilities.modes;
+        }
+    }
+```
+
+- [ ] **Step 4: Add `acpx` capability discovery method**
+
+Add this method inside `impl AcpAgentRunner`:
+
+```rust
+    async fn discover_acpx_capabilities_for_request(
+        &self,
+        request: &AgentRunRequest<'_>,
+    ) -> Result<(), AgentError> {
+        let Some(agent_config) = request.config.agents.get(request.agent_name) else {
+            return Ok(());
+        };
+        let Some(command) = resolve_acpx_acp_command(agent_config) else {
+            return Ok(());
+        };
+
+        let capabilities = discover_capabilities(AcpCapabilityDiscoveryConfig {
+            command,
+            workspace_path: request.workspace_path.to_path_buf(),
+            read_timeout_ms: request.config.agent.read_timeout_ms,
+        })
+        .await?;
+
+        self.store_agent_capabilities(request.agent_name, capabilities)
+            .await;
+        Ok(())
+    }
+```
+
+- [ ] **Step 5: Call discovery before normal `acpx` execution**
+
+In `AgentRunner::run`, in the `runtime::RuntimeKind::Acpx` branch, insert this before `AcpxRuntime::new().run_step(&request, &prompt).await`:
+
+```rust
+                if let Err(error) = self.discover_acpx_capabilities_for_request(&request).await {
+                    tracing::debug!(
+                        agent_name = request.agent_name,
+                        error = %error,
+                        "ACP capability discovery failed for acpx runtime; continuing without discovered capabilities"
+                    );
+                }
+```
+
+Discovery failure must not fail the actual worker run because some `acpx` versions or agents may not expose `configOptions`.
+
+- [ ] **Step 6: Store direct runtime capabilities with shared helper**
+
+In `run_direct_step`, immediately after the `run_acp_session(...).await?;` call, add:
+
+```rust
+        self.store_agent_capabilities(request.agent_name, capabilities)
+            .await;
+```
+
+- [ ] **Step 7: Add a command builder test**
+
+Add this test to `crates/ensemble-core/src/agent/mod.rs`:
+
+```rust
+#[test]
+fn resolve_acpx_acp_command_includes_agent_and_model() {
+    let command = resolve_acpx_acp_command(&crate::config::ensemble::AgentConfig {
+        runtime: Some("acpx".to_string()),
+        executor: None,
+        model: Some("gpt-5".to_string()),
+        available_models: Vec::new(),
+        available_modes: Vec::new(),
+        acpx_agent: Some("codex".to_string()),
+        permission_mode: None,
+        prompt: Some("Build it.".to_string()),
+        prompt_template: None,
+        reasoning_level: None,
+    });
+
+    assert_eq!(command.as_deref(), Some("acpx --agent 'codex' --model 'gpt-5'"));
+}
+```
+
+- [ ] **Step 8: Run agent runner tests**
+
+Run: `cargo test -p ensemble-core agent::tests::resolve_acpx_acp_command_includes_agent_and_model -- --exact`
+
+Expected: PASS.
+
+## Task 7: Expose Capabilities in Setup Agent API Shape
+
+**Files:**
+- Modify: `crates/ensemble-core/src/api/config_edit_handler.rs`
+- Modify: `crates/ensemble-core/src/config/setup.rs`
+
+- [ ] **Step 1: Extend setup discovery models**
+
+In `crates/ensemble-core/src/config/setup.rs`, change `AgentCapabilities` to:
+
+```rust
+pub struct AgentCapabilities {
+    pub available_models: Vec<crate::config::ensemble::ModelDefinition>,
+    pub available_modes: Vec<crate::config::ensemble::ModeDefinition>,
+}
+```
+
+Update `from_session_json` so existing JSON model strings become definitions:
+
+```rust
+            caps.available_models = models
+                .iter()
+                .filter_map(|v| {
+                    v.as_str().map(|id| crate::config::ensemble::ModelDefinition {
+                        id: id.to_string(),
+                        name: id.to_string(),
+                        description: None,
+                    })
+                })
+                .collect();
+```
+
+- [ ] **Step 2: Extend API response DTO**
+
+In `DiscoveredAgentInfo`, add:
+
+```rust
+    #[serde(default)]
+    pub available_models: Vec<crate::config::ensemble::ModelDefinition>,
+    #[serde(default)]
+    pub available_modes: Vec<crate::config::ensemble::ModeDefinition>,
+```
+
+- [ ] **Step 3: Populate empty capability defaults in existing setup discovery**
+
+In both `get_setup_agents` and `get_setup_agents_stream`, update `DiscoveredAgentInfo` construction:
+
+```rust
+                    available_models: Vec::new(),
+                    available_modes: Vec::new(),
+```
+
+This keeps the endpoint schema ready for UI while avoiding a slow ACP handshake during the broad "which agents are installed?" probe.
+
+- [ ] **Step 4: Run API/config tests**
+
+Run: `cargo test -p ensemble-core api::config_edit_handler config::setup -- --nocapture`
+
+Expected: PASS.
+
+## Task 8: Validation and Final Checks
+
+**Files:**
+- No edits unless verification finds compile or formatting issues.
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt --all -- --check`
+
+Expected: PASS. If it fails, run `cargo fmt --all`, then rerun the check.
+
+- [ ] **Step 2: Check core crate**
+
+Run: `cargo check -p ensemble-core`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core agent::acp_client agent::tests::resolve_acpx_acp_command_includes_agent_and_model config::form config::setup api::config_edit_handler -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run clippy on core**
+
+Run: `cargo clippy -p ensemble-core -- -D warnings`
+
+Expected: PASS.
+
+---
+
+## Self-Review
+
+- Issue coverage: Models and modes are parsed from ACP session `config_options`; current selections are captured; the default `acpx_agent` runtime performs handshake-only discovery before normal `acpx` execution; serializable config/API structs can carry the data; tests verify mock SDK option parsing and `acpx --agent` discovery command construction.
+- Scope decision: The plan does not write discovered runtime capabilities back to `config.yaml` during normal runs. It exposes them through serializable config shapes and return values so the UI can display them later without surprising file edits.
+- Dependency check: This plan assumes the current SDK-backed `acp_client.rs` from #91 is present, which is true in this worktree.


### PR DESCRIPTION
## Summary

Adds ACP model and mode capability discovery for `acpx_agent` and direct ACP runs.

- Defines serializable model, mode, and discovered capability types on agent config.
- Parses ACP `session/new` config options, including grouped select options.
- Runs handshake-only capability discovery before normal `acpx` execution and stores results in both runtime config and API-visible document state.
- Preserves discovered capability fields through guided config form round-trips.
- Populates setup capability typed model definitions from legacy model IDs.

Fixes #93 

## Validation

- `cargo test -p ensemble-core`
- `cargo clippy -p ensemble-core -- -D warnings`
- `cargo fmt --all -- --check`