### PR TITLE
Simplify ACP agent startup and transport handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,6 @@ dependencies = [
  "serde_yaml",
  "shell-words",
  "shellexpand",
- "shlex",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5094,7 +5094,6 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shell-words",
  "shellexpand",
  "shlex",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,6 +5095,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/chrisbanes/ensemble"
 
 [workspace.dependencies]
 tokio = { version = "1.52.3", features = ["full"] }
-tokio-util = { version = "0.7.18", features = ["compat"] }
+tokio-util = "0.7.18"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_yaml = "0.9.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ rusqlite = { version = "0.40.1", features = ["bundled", "fallible_uint"] }
 agent-client-protocol = "0.14.0"
 notify = "8.2.0"
 pulldown-cmark = "0.13.4"
+shell-words = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/chrisbanes/ensemble"
 
 [workspace.dependencies]
 tokio = { version = "1.52.3", features = ["full"] }
-tokio-util = "0.7.18"
+tokio-util = { version = "0.7.18", features = ["compat"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_yaml = "0.9.34"

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -35,6 +35,7 @@ agent-client-protocol = { workspace = true }
 notify = { workspace = true }
 pulldown-cmark = { workspace = true }
 tempfile = { workspace = true }
+shell-words = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -28,7 +28,6 @@ utoipa = { workspace = true }
 dirs = { workspace = true }
 dotenvy = { workspace = true }
 shellexpand = { workspace = true }
-shlex = "2.0.1"
 mime_guess = { workspace = true }
 rusqlite = { workspace = true }
 agent-client-protocol = { workspace = true }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,6 +11,7 @@ use agent_client_protocol::schema::{
 };
 use agent_client_protocol::{AcpAgent, Client, Dispatch, SessionMessage};
 use tokio::sync::{mpsc, Mutex};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::config::ensemble::{DiscoveredCapabilities, ModeDefinition, ModelDefinition};
@@ -19,21 +20,30 @@ use crate::error::AgentError;
 use super::events::{AgentEvent, RuntimeStream, TokenUsage, WorkerEvent};
 use super::ResolvedCommand;
 
-/// Build an `AcpAgent` from a structured `ResolvedCommand`, eliminating shell
-/// wrapping entirely. The SDK's `McpServerStdio` constructs an
-/// `async_process::Command::new().args()` under the hood — no bash, no
-/// escaping, no PID-extraction hack. The SDK owns the child process for
-/// its full lifetime (the `AcpAgent` value's `ChildGuard` reaps and kills
-/// the child on drop).
-fn build_acp_agent(cmd: &ResolvedCommand) -> AcpAgent {
+/// Build an `AcpAgent` from a structured `ResolvedCommand`. The SDK's
+/// `McpServerStdio` spawns the child via `async_process::Command`.
+/// Because `McpServerStdio` has no working-directory field, we wrap the
+/// command with `sh -c 'cd "$1" && shift 2 && exec "$@"'` and pass the
+/// workspace path as `$1` — the child process starts with the correct CWD
+/// while all agent args arrive as separate `argv` entries (no shell escaping
+/// needed for either the path or the args).
+fn build_acp_agent(cmd: &ResolvedCommand, workspace_path: &Path) -> AcpAgent {
     let name = cmd
         .program
         .file_name()
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_else(|| "agent".to_string());
+    let mut args = vec![
+        "-c".to_string(),
+        r#"cd "$1" && shift && exec "$@""#.to_string(),
+        name.clone(),
+        workspace_path.to_string_lossy().to_string(),
+        cmd.program.to_string_lossy().to_string(),
+    ];
+    args.extend(cmd.args.iter().cloned());
     AcpAgent::new(McpServer::Stdio(
-        McpServerStdio::new(name, cmd.program.clone())
-            .args(cmd.args.clone())
+        McpServerStdio::new(name, PathBuf::from("sh"))
+            .args(args)
             .env(
                 cmd.env
                     .iter()
@@ -51,6 +61,7 @@ pub struct AcpSessionConfig {
     pub permission_request_policy: String,
     pub read_timeout_ms: u64,
     pub turn_timeout_ms: u64,
+    pub cancel_token: CancellationToken,
 }
 
 #[derive(Debug)]
@@ -301,7 +312,7 @@ pub fn discover_capabilities_from_options(
 pub async fn discover_capabilities(
     config: AcpCapabilityDiscoveryConfig,
 ) -> Result<DiscoveredCapabilities, AgentError> {
-    let agent = build_acp_agent(&config.command);
+    let agent = build_acp_agent(&config.command, &config.workspace_path);
     let read_timeout_ms = config.read_timeout_ms;
     let workspace_path = config.workspace_path.clone();
     let discovered = Arc::new(Mutex::new(DiscoveredCapabilities::default()));
@@ -387,7 +398,7 @@ pub async fn run_acp_session(
     ),
     AgentError,
 > {
-    let agent = build_acp_agent(&config.command);
+    let agent = build_acp_agent(&config.command, &config.workspace_path);
     let permission_policy = config.permission_request_policy.clone();
     let issue_id_owned = issue_id.to_string();
     let step_name_owned = step_name.to_string();
@@ -403,6 +414,7 @@ pub async fn run_acp_session(
     let read_timeout_ms = config.read_timeout_ms;
     let turn_timeout_ms = config.turn_timeout_ms;
     let workspace_path = config.workspace_path.clone();
+    let cancel_token = config.cancel_token.clone();
 
     let turn_results_inner = turn_results.clone();
     let final_verdict_inner = final_verdict.clone();
@@ -577,6 +589,19 @@ pub async fn run_acp_session(
             }
 
             for (i, prompt) in prompts.iter().enumerate() {
+                if cancel_token.is_cancelled() {
+                    emit_event(
+                        event_tx,
+                        issue_id,
+                        step_name,
+                        AgentEvent::Cancelled { reason: None },
+                    )
+                    .await;
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some("cancelled by user".to_string());
+                    return Ok(());
+                }
+
                 emit_event(event_tx, issue_id, step_name, AgentEvent::PromptStarted).await;
 
                 if let Err(e) = session.send_prompt(prompt) {
@@ -629,57 +654,74 @@ pub async fn run_acp_session(
                     }
                 };
 
-                let turn_result =
-                    tokio::time::timeout(Duration::from_millis(turn_timeout_ms), turn_future).await;
-
-                let turn_result = match turn_result {
-                    Ok(Ok((stop_reason, usage, verdict))) => match stop_reason {
-                        super::events::StopReason::EndTurn
-                        | super::events::StopReason::MaxTokens => {
-                            emit_event(
-                                event_tx,
-                                issue_id,
-                                step_name,
-                                AgentEvent::RunCompleted {
-                                    usage: usage.clone(),
-                                },
-                            )
-                            .await;
-                            TurnResult::Completed {
-                                usage,
-                                runtime_verdict: verdict,
-                            }
-                        }
-                        _ => {
-                            let reason = format!("stop reason: {:?}", stop_reason);
-                            emit_event(
-                                event_tx,
-                                issue_id,
-                                step_name,
-                                AgentEvent::RunFailed {
-                                    reason: reason.clone(),
-                                    usage: usage.clone(),
-                                },
-                            )
-                            .await;
-                            TurnResult::Failed {
-                                reason,
-                                usage,
-                                runtime_verdict: verdict,
-                            }
-                        }
-                    },
-                    Ok(Err(e)) => {
+                let cancel = cancel_token.clone();
+                let turn_result: TurnResult = tokio::select! {
+                    _ = cancel.cancelled() => {
+                        emit_event(
+                            event_tx,
+                            issue_id,
+                            step_name,
+                            AgentEvent::Cancelled { reason: None },
+                        )
+                        .await;
                         let mut err = session_error_inner.lock().await;
-                        *err = Some(e);
+                        *err = Some("cancelled by user".to_string());
                         return Ok(());
                     }
-                    Err(_) => {
-                        timed_out = true;
-                        TurnResult::Failed {
-                            reason: format!("turn timeout after {turn_timeout_ms}ms"),
-                            usage: None,
-                            runtime_verdict: None,
+                    result = tokio::time::timeout(
+                        Duration::from_millis(turn_timeout_ms),
+                        turn_future,
+                    ) => {
+                        match result {
+                            Ok(Ok((stop_reason, usage, verdict))) => match stop_reason {
+                                super::events::StopReason::EndTurn
+                                | super::events::StopReason::MaxTokens => {
+                                    emit_event(
+                                        event_tx,
+                                        issue_id,
+                                        step_name,
+                                        AgentEvent::RunCompleted {
+                                            usage: usage.clone(),
+                                        },
+                                    )
+                                    .await;
+                                    TurnResult::Completed {
+                                        usage,
+                                        runtime_verdict: verdict,
+                                    }
+                                }
+                                _ => {
+                                    let reason = format!("stop reason: {:?}", stop_reason);
+                                    emit_event(
+                                        event_tx,
+                                        issue_id,
+                                        step_name,
+                                        AgentEvent::RunFailed {
+                                            reason: reason.clone(),
+                                            usage: usage.clone(),
+                                        },
+                                    )
+                                    .await;
+                                    TurnResult::Failed {
+                                        reason,
+                                        usage,
+                                        runtime_verdict: verdict,
+                                    }
+                                }
+                            },
+                            Ok(Err(e)) => {
+                                let mut err = session_error_inner.lock().await;
+                                *err = Some(e);
+                                return Ok(());
+                            }
+                            Err(_) => {
+                                timed_out = true;
+                                TurnResult::Failed {
+                                    reason: format!("turn timeout after {turn_timeout_ms}ms"),
+                                    usage: None,
+                                    runtime_verdict: None,
+                                }
+                            }
                         }
                     }
                 };
@@ -757,6 +799,8 @@ pub async fn run_acp_session(
             });
         } else if error_msg.contains("initialize") || error_msg.contains("session") {
             return Err(AgentError::SessionStartupFailed { reason: error_msg });
+        } else if error_msg.contains("cancelled") {
+            return Err(AgentError::TurnCancelled);
         } else {
             return Err(AgentError::IoError { reason: error_msg });
         }
@@ -848,6 +892,7 @@ mod tests {
             permission_request_policy: "auto_approve_all".to_string(),
             read_timeout_ms: 50,
             turn_timeout_ms: 10_000,
+            cancel_token: CancellationToken::new(),
         };
         let (tx, _rx) = mpsc::channel(10);
 

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -20,9 +20,11 @@ use super::events::{AgentEvent, RuntimeStream, TokenUsage, WorkerEvent};
 use super::ResolvedCommand;
 
 /// Build an `AcpAgent` from a structured `ResolvedCommand`, eliminating shell
-/// wrapping entirely. The agent binary is spawned via
-/// `McpServerStdio` → `async_process::Command::new().args()` — no bash, no
-/// escaping, no PID-extraction hack.
+/// wrapping entirely. The SDK's `McpServerStdio` constructs an
+/// `async_process::Command::new().args()` under the hood — no bash, no
+/// escaping, no PID-extraction hack. The SDK owns the child process for
+/// its full lifetime (the `AcpAgent` value's `ChildGuard` reaps and kills
+/// the child on drop).
 fn build_acp_agent(cmd: &ResolvedCommand) -> AcpAgent {
     let name = cmd
         .program

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -770,7 +770,6 @@ pub async fn run_acp_session(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use std::time::Duration;
 
     use agent_client_protocol::schema::{

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -1,13 +1,13 @@
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use agent_client_protocol::schema::{
-    ContentBlock, InitializeRequest, NewSessionRequest, PermissionOption, PermissionOptionKind,
-    ProtocolVersion, RequestPermissionRequest, RequestPermissionResponse, SessionConfigKind,
-    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOptions,
-    SessionNotification, SessionUpdate, SetSessionModeRequest, StopReason as SdkStopReason,
+    ContentBlock, EnvVariable, InitializeRequest, McpServer, McpServerStdio, NewSessionRequest,
+    PermissionOption, PermissionOptionKind, ProtocolVersion, RequestPermissionRequest,
+    RequestPermissionResponse, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigSelectOptions, SessionNotification, SessionUpdate, SetSessionModeRequest,
+    StopReason as SdkStopReason,
 };
 use agent_client_protocol::{AcpAgent, Client, Dispatch, SessionMessage};
 use tokio::sync::{mpsc, Mutex};
@@ -17,10 +17,33 @@ use crate::config::ensemble::{DiscoveredCapabilities, ModeDefinition, ModelDefin
 use crate::error::AgentError;
 
 use super::events::{AgentEvent, RuntimeStream, TokenUsage, WorkerEvent};
+use super::ResolvedCommand;
+
+/// Build an `AcpAgent` from a structured `ResolvedCommand`, eliminating shell
+/// wrapping entirely. The agent binary is spawned via
+/// `McpServerStdio` → `async_process::Command::new().args()` — no bash, no
+/// escaping, no PID-extraction hack.
+fn build_acp_agent(cmd: &ResolvedCommand) -> AcpAgent {
+    let name = cmd
+        .program
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "agent".to_string());
+    AcpAgent::new(McpServer::Stdio(
+        McpServerStdio::new(name, cmd.program.clone())
+            .args(cmd.args.clone())
+            .env(
+                cmd.env
+                    .iter()
+                    .map(|(k, v)| EnvVariable::new(k.clone(), v.clone()))
+                    .collect(),
+            ),
+    ))
+}
 
 #[derive(Debug)]
 pub struct AcpSessionConfig {
-    pub command: String,
+    pub command: ResolvedCommand,
     pub workspace_path: PathBuf,
     pub session_mode: Option<String>,
     pub permission_request_policy: String,
@@ -30,7 +53,7 @@ pub struct AcpSessionConfig {
 
 #[derive(Debug)]
 pub struct AcpCapabilityDiscoveryConfig {
-    pub command: String,
+    pub command: ResolvedCommand,
     pub workspace_path: PathBuf,
     pub read_timeout_ms: u64,
 }
@@ -101,26 +124,6 @@ fn select_permission_option<'a>(
                 .iter()
                 .find(|option| matches!(option.kind, PermissionOptionKind::AllowAlways))
         })
-}
-
-fn shell_escape(arg: &str) -> String {
-    let mut escaped = String::with_capacity(arg.len() + 2);
-    escaped.push('\'');
-    for ch in arg.chars() {
-        if ch == '\'' {
-            escaped.push_str("'\\''");
-        } else {
-            escaped.push(ch);
-        }
-    }
-    escaped.push('\'');
-    escaped
-}
-
-fn sdk_transport_command(command: &str, workspace_path: &Path) -> String {
-    let cwd = workspace_path.to_string_lossy();
-    let script = format!("echo $$ >&2; cd {}; exec {}", shell_escape(&cwd), command);
-    format!("bash -lc {}", shell_escape(&script))
 }
 
 fn token_usage_from_value(value: serde_json::Value) -> Option<TokenUsage> {
@@ -296,10 +299,7 @@ pub fn discover_capabilities_from_options(
 pub async fn discover_capabilities(
     config: AcpCapabilityDiscoveryConfig,
 ) -> Result<DiscoveredCapabilities, AgentError> {
-    let transport_command = sdk_transport_command(&config.command, &config.workspace_path);
-    let agent = AcpAgent::from_str(&transport_command).map_err(|e| AgentError::AgentNotFound {
-        command: format!("{}: {}", config.command, e),
-    })?;
+    let agent = build_acp_agent(&config.command);
     let read_timeout_ms = config.read_timeout_ms;
     let workspace_path = config.workspace_path.clone();
     let discovered = Arc::new(Mutex::new(DiscoveredCapabilities::default()));
@@ -385,24 +385,7 @@ pub async fn run_acp_session(
     ),
     AgentError,
 > {
-    let transport_command = sdk_transport_command(&config.command, &config.workspace_path);
-    let agent_pid: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-    let agent_pid_for_debug = agent_pid.clone();
-    let agent = AcpAgent::from_str(&transport_command).map_err(|e| AgentError::AgentNotFound {
-        command: format!("{}: {}", config.command, e),
-    })?;
-    let agent = agent.with_debug(move |line, direction| {
-        if matches!(direction, agent_client_protocol::LineDirection::Stderr)
-            && line.chars().all(|c| c.is_ascii_digit())
-        {
-            if let Ok(mut guard) = agent_pid_for_debug.try_lock() {
-                if guard.is_none() {
-                    *guard = Some(line.to_string());
-                }
-            }
-        }
-    });
-
+    let agent = build_acp_agent(&config.command);
     let permission_policy = config.permission_request_policy.clone();
     let issue_id_owned = issue_id.to_string();
     let step_name_owned = step_name.to_string();
@@ -538,7 +521,7 @@ pub async fn run_acp_session(
                 step_name,
                 AgentEvent::SessionStarted {
                     session_id: session_id.clone(),
-                    agent_pid: agent_pid.lock().await.clone(),
+                    agent_pid: None,
                 },
             )
             .await;
@@ -797,18 +780,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn sdk_transport_command_runs_original_command_from_workspace_and_prints_pid() {
-        let command = "acpx --agent 'builder'";
-        let wrapped = sdk_transport_command(command, Path::new("/tmp/work space"));
-
-        assert!(wrapped.starts_with("bash -lc "));
-        assert!(wrapped.contains("echo $$ >&2"));
-        assert!(wrapped.contains("/tmp/work space"));
-        assert!(wrapped.contains("exec acpx --agent"));
-        assert!(wrapped.contains("builder"));
-    }
-
-    #[test]
     fn select_permission_option_prefers_allow_once_over_first_option() {
         let options = vec![
             PermissionOption::new("reject", "Reject", PermissionOptionKind::RejectOnce),
@@ -866,7 +837,11 @@ mod tests {
     async fn startup_initialize_uses_configured_read_timeout() {
         let workspace = TempDir::new().unwrap();
         let config = AcpSessionConfig {
-            command: "bash -lc 'while IFS= read -r _line; do sleep 60; done'".to_string(),
+            command: ResolvedCommand {
+                program: PathBuf::from("sleep"),
+                args: vec!["60".to_string()],
+                env: Vec::new(),
+            },
             workspace_path: workspace.path().to_path_buf(),
             session_mode: None,
             permission_request_policy: "auto_approve_all".to_string(),
@@ -995,7 +970,11 @@ mod tests {
     async fn discover_capabilities_times_out_when_agent_does_not_initialize() {
         let workspace = TempDir::new().unwrap();
         let config = AcpCapabilityDiscoveryConfig {
-            command: "bash -lc 'while IFS= read -r _line; do sleep 60; done'".to_string(),
+            command: ResolvedCommand {
+                program: PathBuf::from("sleep"),
+                args: vec!["60".to_string()],
+                env: Vec::new(),
+            },
             workspace_path: workspace.path().to_path_buf(),
             read_timeout_ms: 50,
         };

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -61,8 +61,10 @@ impl StopReason {
 /// Internal event types emitted by the ACP client to the orchestrator.
 #[derive(Debug, Clone, Serialize)]
 pub enum AgentEvent {
-    /// Runtime session established. `agent_pid` is retained for direct ACP workers so the
-    /// orchestrator/API can still expose process metadata and support stop/cancel controls.
+    /// Runtime session established. `agent_pid` is `None` for both runtimes.
+    /// The direct path uses `AcpAgent` from the SDK (which owns the child), and
+    /// the `acpx` runtime manages its own process lifecycle. Process control
+    /// (kill on cancel, kill on shutdown) is handled inside each runtime.
     SessionStarted {
         session_id: String,
         agent_pid: Option<String>,

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -547,26 +547,6 @@ async fn remove_ensemble_file(workspace_path: &Path, filename: &str) -> Result<(
     }
 }
 
-/// POSIX-compatible single-quote escaping for shell arguments.
-///
-/// Wraps the argument in single quotes and escapes any embedded single-quote
-/// characters. This prevents shell metacharacter injection when arguments are
-/// interpolated into commands executed via `bash -lc`.
-#[allow(dead_code)]
-fn shell_escape(arg: &str) -> String {
-    let mut escaped = String::with_capacity(arg.len() + 2);
-    escaped.push('\'');
-    for ch in arg.chars() {
-        if ch == '\'' {
-            escaped.push_str("'\\''");
-        } else {
-            escaped.push(ch);
-        }
-    }
-    escaped.push('\'');
-    escaped
-}
-
 /// Build the ACP spawn command for an agent.
 ///
 /// When `acpx_agent` is set, uses `acpx --agent <name>` with optional
@@ -634,22 +614,6 @@ fn resolve_acpx_acp_command(
         args,
         env: Vec::new(),
     })
-}
-
-#[allow(dead_code)]
-fn shell_escape_command(command: &str) -> String {
-    let parts = shlex::split(command)
-        .unwrap_or_else(|| command.split_whitespace().map(str::to_string).collect());
-
-    if parts.is_empty() {
-        return shell_escape(command);
-    }
-
-    parts
-        .iter()
-        .map(|part| shell_escape(part))
-        .collect::<Vec<_>>()
-        .join(" ")
 }
 
 #[async_trait]
@@ -1844,216 +1808,6 @@ on_failure: Todo
     }
 
     #[test]
-    fn test_shell_escape_simple() {
-        assert_eq!(shell_escape("claude"), "'claude'");
-    }
-
-    #[test]
-    fn test_shell_escape_with_single_quote() {
-        assert_eq!(shell_escape("it's"), "'it'\\''s'");
-    }
-
-    #[test]
-    fn test_shell_escape_with_metacharacters() {
-        assert_eq!(shell_escape("a; rm -rf /"), "'a; rm -rf /'");
-    }
-
-    #[test]
-    fn test_resolve_agent_command_escapes_acpx_name() {
-        let config = crate::config::ensemble::AgentConfig {
-            runtime: None,
-            acpx_agent: Some("claude".to_string()),
-            model: Some("sonnet".to_string()),
-            executor: None,
-            permission_mode: None,
-            prompt: None,
-            prompt_template: None,
-            reasoning_level: None,
-            ..Default::default()
-        };
-        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
-        assert_eq!(resolved.program, PathBuf::from("acpx"));
-        assert_eq!(
-            resolved.args,
-            vec![
-                "--agent".to_string(),
-                "claude".to_string(),
-                "--model".to_string(),
-                "sonnet".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_resolve_agent_command_includes_approve_all_flag() {
-        let config = crate::config::ensemble::AgentConfig {
-            runtime: None,
-            acpx_agent: Some("claude".to_string()),
-            model: Some("sonnet".to_string()),
-            executor: None,
-            permission_mode: Some("approve_all".to_string()),
-            prompt: None,
-            prompt_template: None,
-            reasoning_level: None,
-            ..Default::default()
-        };
-
-        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
-
-        assert_eq!(resolved.program, PathBuf::from("acpx"));
-        assert_eq!(
-            resolved.args,
-            vec![
-                "--approve-all".to_string(),
-                "--agent".to_string(),
-                "claude".to_string(),
-                "--model".to_string(),
-                "sonnet".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_resolve_agent_command_includes_approve_reads_flag() {
-        let config = crate::config::ensemble::AgentConfig {
-            runtime: None,
-            acpx_agent: Some("claude".to_string()),
-            model: Some("sonnet".to_string()),
-            executor: None,
-            permission_mode: Some("approve_reads".to_string()),
-            prompt: None,
-            prompt_template: None,
-            reasoning_level: None,
-            ..Default::default()
-        };
-
-        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
-
-        assert_eq!(resolved.program, PathBuf::from("acpx"));
-        assert_eq!(
-            resolved.args,
-            vec![
-                "--approve-reads".to_string(),
-                "--agent".to_string(),
-                "claude".to_string(),
-                "--model".to_string(),
-                "sonnet".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_resolve_agent_command_includes_deny_all_flag() {
-        let config = crate::config::ensemble::AgentConfig {
-            runtime: None,
-            acpx_agent: Some("claude".to_string()),
-            model: Some("sonnet".to_string()),
-            executor: None,
-            permission_mode: Some("deny_all".to_string()),
-            prompt: None,
-            prompt_template: None,
-            reasoning_level: None,
-            ..Default::default()
-        };
-
-        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
-
-        assert_eq!(resolved.program, PathBuf::from("acpx"));
-        assert_eq!(
-            resolved.args,
-            vec![
-                "--deny-all".to_string(),
-                "--agent".to_string(),
-                "claude".to_string(),
-                "--model".to_string(),
-                "sonnet".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_resolve_agent_command_no_model() {
-        let config = crate::config::ensemble::AgentConfig {
-            runtime: None,
-            acpx_agent: Some("claude".to_string()),
-            model: None,
-            executor: None,
-            permission_mode: None,
-            prompt: None,
-            prompt_template: None,
-            reasoning_level: None,
-            ..Default::default()
-        };
-        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
-        assert_eq!(resolved.program, PathBuf::from("acpx"));
-        assert_eq!(
-            resolved.args,
-            vec!["--agent".to_string(), "claude".to_string()]
-        );
-    }
-
-    #[test]
-    fn test_resolve_agent_command_omits_permission_flag_when_unset() {
-        let config = crate::config::ensemble::AgentConfig {
-            runtime: None,
-            acpx_agent: Some("claude".to_string()),
-            model: Some("sonnet".to_string()),
-            executor: None,
-            permission_mode: None,
-            prompt: None,
-            prompt_template: None,
-            reasoning_level: None,
-            ..Default::default()
-        };
-
-        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
-
-        assert_eq!(resolved.program, PathBuf::from("acpx"));
-        assert_eq!(
-            resolved.args,
-            vec![
-                "--agent".to_string(),
-                "claude".to_string(),
-                "--model".to_string(),
-                "sonnet".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_resolve_agent_command_falls_back_to_default() {
-        let resolved = resolve_agent_command(None, "default-cmd").unwrap();
-        assert_eq!(resolved.program, PathBuf::from("default-cmd"));
-        assert!(resolved.args.is_empty());
-    }
-
-    #[test]
-    fn test_resolve_agent_command_escapes_executor_tokens() {
-        let config = crate::config::ensemble::AgentConfig {
-            runtime: None,
-            acpx_agent: None,
-            model: None,
-            executor: Some("codex --profile prod; touch /tmp/pwned".to_string()),
-            permission_mode: None,
-            prompt: None,
-            prompt_template: None,
-            reasoning_level: None,
-            ..Default::default()
-        };
-        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
-        assert_eq!(resolved.program, PathBuf::from("codex"));
-        assert_eq!(
-            resolved.args,
-            vec![
-                "--profile".to_string(),
-                "prod;".to_string(),
-                "touch".to_string(),
-                "/tmp/pwned".to_string(),
-            ]
-        );
-    }
-
-    #[test]
     fn runtime_kind_defaults_to_acpx_for_acpx_agent() {
         let config = parse_config(
             r#"
@@ -2183,6 +1937,24 @@ on_failure: Failed
         assert!(
             matches!(err, AgentError::InvalidAgentCommand { .. }),
             "expected InvalidAgentCommand, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_agent_command_with_acpx_agent_builds_structured_args() {
+        use crate::config::ensemble::AgentConfig;
+        let agent = AgentConfig {
+            acpx_agent: Some("builder".to_string()),
+            model: Some("gpt-5".to_string()),
+            permission_mode: None,
+            executor: None,
+            ..Default::default()
+        };
+        let resolved = resolve_agent_command(Some(&agent), "fallback").unwrap();
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec!["--agent", "builder", "--model", "gpt-5"]
         );
     }
 }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -2043,4 +2043,46 @@ on_failure: Failed
             Some("acpx --agent 'codex' --model 'gpt-5'")
         );
     }
+
+    #[test]
+    fn tokenize_command_string_splits_simple_program_and_args() {
+        let resolved = tokenize_command_string("acpx --agent builder").unwrap();
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(resolved.args, vec!["--agent", "builder"]);
+        assert!(resolved.env.is_empty());
+    }
+
+    #[test]
+    fn tokenize_command_string_preserves_args_with_spaces() {
+        let resolved = tokenize_command_string(r#"my-agent --name "My Agent" --verbose"#).unwrap();
+        assert_eq!(resolved.program, PathBuf::from("my-agent"));
+        assert_eq!(resolved.args, vec!["--name", "My Agent", "--verbose"]);
+    }
+
+    #[test]
+    fn tokenize_command_string_rejects_empty_string() {
+        let err = tokenize_command_string("").unwrap_err();
+        assert!(
+            matches!(err, AgentError::InvalidAgentCommand { .. }),
+            "expected InvalidAgentCommand, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn tokenize_command_string_rejects_whitespace_only_string() {
+        let err = tokenize_command_string("   ").unwrap_err();
+        assert!(
+            matches!(err, AgentError::InvalidAgentCommand { .. }),
+            "expected InvalidAgentCommand, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn tokenize_command_string_rejects_unterminated_quote() {
+        let err = tokenize_command_string(r#"foo "bar"#).unwrap_err();
+        assert!(
+            matches!(err, AgentError::InvalidAgentCommand { .. }),
+            "expected InvalidAgentCommand, got {err:?}"
+        );
+    }
 }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -10,6 +10,7 @@ pub mod runtime;
 pub(crate) mod test_support;
 
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::config::draft::ConfigDocumentState;
@@ -33,6 +34,49 @@ use acp_client::{
     TurnResult,
 };
 use acpx_runtime::AcpxRuntime;
+
+/// Fully-resolved description of how to spawn an agent subprocess.
+///
+/// Built by [`resolve_agent_command`] / [`resolve_acpx_acp_command`] from a
+/// combination of `config.yaml` settings and per-agent overrides. The
+/// `acp_client` module spawns the child from this struct directly via
+/// `tokio::process::Command`, then hands the stdio streams to the
+/// `agent-client-protocol` SDK's protocol plumbing. No shell, no escaping.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) struct ResolvedCommand {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+}
+
+/// Tokenize a user-supplied command string (e.g. from `config.yaml`) into a
+/// `ResolvedCommand`. Uses `shell_words::split`, the same tokenizer the ACP
+/// SDK uses in `AcpAgent::from_str`, so user expectations are preserved.
+///
+/// Returns `AgentError::InvalidAgentCommand` if the string is empty or
+/// contains an unterminated quote.
+#[allow(dead_code)]
+pub(crate) fn tokenize_command_string(command: &str) -> Result<ResolvedCommand, AgentError> {
+    let parts = shell_words::split(command).map_err(|e| AgentError::InvalidAgentCommand {
+        command: command.to_string(),
+        reason: e.to_string(),
+    })?;
+    if parts.is_empty() {
+        return Err(AgentError::InvalidAgentCommand {
+            command: command.to_string(),
+            reason: "command string is empty".to_string(),
+        });
+    }
+    let mut iter = parts.into_iter();
+    let program = PathBuf::from(iter.next().expect("non-empty checked above"));
+    let args: Vec<String> = iter.collect();
+    Ok(ResolvedCommand {
+        program,
+        args,
+        env: Vec::new(),
+    })
+}
 
 const VERDICT_FALLBACK_INSTRUCTION: &str = "\
 If you cannot return a structured runtime verdict, write .ensemble/verdict.json with:\n\

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -56,7 +56,6 @@ pub(crate) struct ResolvedCommand {
 ///
 /// Returns `AgentError::InvalidAgentCommand` if the string is empty or
 /// contains an unterminated quote.
-#[allow(dead_code)]
 pub(crate) fn tokenize_command_string(command: &str) -> Result<ResolvedCommand, AgentError> {
     let parts = shell_words::split(command).map_err(|e| AgentError::InvalidAgentCommand {
         command: command.to_string(),
@@ -195,9 +194,15 @@ impl AcpAgentRunner {
         let Some(agent_config) = request.config.agents.get(request.agent_name) else {
             return Ok(());
         };
-        let Some(command) = resolve_acpx_acp_command(agent_config) else {
+        if agent_config.acpx_agent.is_none() {
             return Ok(());
-        };
+        }
+        let resolved = resolve_acpx_acp_command(agent_config)?;
+        let mut command = format!("{}", resolved.program.display());
+        for arg in &resolved.args {
+            command.push(' ');
+            command.push_str(arg);
+        }
 
         let capabilities = discover_capabilities(AcpCapabilityDiscoveryConfig {
             command,
@@ -562,38 +567,41 @@ fn shell_escape(arg: &str) -> String {
 ///
 /// When `acpx_agent` is set, uses `acpx --agent <name>` with optional
 /// launch-time flags derived from per-agent `permission_mode` and `model`.
-/// Arguments are shell-escaped because the command is executed via `bash -lc`.
 /// `agent.permission_request_policy` is handled later when ACP permission
 /// callbacks arrive; it does not change the spawn command. Falls back to
 /// `executor` if set, then to the global default.
-#[allow(dead_code)]
 fn resolve_agent_command(
     agent_config: Option<&crate::config::ensemble::AgentConfig>,
     default_command: &str,
-) -> String {
+) -> Result<ResolvedCommand, AgentError> {
     if let Some(ac) = agent_config {
         if let Some(ref acpx_name) = ac.acpx_agent {
-            let mut cmd = String::from("acpx");
+            let mut args: Vec<String> = Vec::new();
             if let Some(permission_flag) = ac
                 .permission_mode
                 .as_deref()
                 .and_then(PermissionMode::parse)
                 .map(PermissionMode::acpx_flag)
             {
-                cmd.push(' ');
-                cmd.push_str(permission_flag);
+                args.push(permission_flag.to_string());
             }
-            cmd.push_str(&format!(" --agent {}", shell_escape(acpx_name)));
+            args.push("--agent".to_string());
+            args.push(acpx_name.clone());
             if let Some(ref model) = ac.model {
-                cmd.push_str(&format!(" --model {}", shell_escape(model)));
+                args.push("--model".to_string());
+                args.push(model.clone());
             }
-            return cmd;
+            return Ok(ResolvedCommand {
+                program: PathBuf::from("acpx"),
+                args,
+                env: Vec::new(),
+            });
         }
         if let Some(ref executor) = ac.executor {
-            return shell_escape_command(executor);
+            return tokenize_command_string(executor);
         }
     }
-    shell_escape_command(default_command)
+    tokenize_command_string(default_command)
 }
 
 /// Build the ACP spawn command used for the discovery handshake.
@@ -601,14 +609,26 @@ fn resolve_agent_command(
 /// Deliberately omits the `permission_mode` flag — discovery only needs the
 /// agent process to start and report `configOptions`; the real run will
 /// re-invoke the agent with the full command built by `resolve_agent_command`.
-fn resolve_acpx_acp_command(agent_config: &crate::config::ensemble::AgentConfig) -> Option<String> {
-    let acpx_name = agent_config.acpx_agent.as_ref()?;
-    let mut cmd = String::from("acpx");
-    cmd.push_str(&format!(" --agent {}", shell_escape(acpx_name)));
+fn resolve_acpx_acp_command(
+    agent_config: &crate::config::ensemble::AgentConfig,
+) -> Result<ResolvedCommand, AgentError> {
+    let acpx_name = agent_config
+        .acpx_agent
+        .as_ref()
+        .ok_or_else(|| AgentError::InvalidAgentCommand {
+            command: "<acpx capability discovery>".to_string(),
+            reason: "agent is missing acpx_agent".to_string(),
+        })?;
+    let mut args = vec!["--agent".to_string(), acpx_name.clone()];
     if let Some(ref model) = agent_config.model {
-        cmd.push_str(&format!(" --model {}", shell_escape(model)));
+        args.push("--model".to_string());
+        args.push(model.clone());
     }
-    Some(cmd)
+    Ok(ResolvedCommand {
+        program: PathBuf::from("acpx"),
+        args,
+        env: Vec::new(),
+    })
 }
 
 #[allow(dead_code)]
@@ -700,7 +720,12 @@ impl AcpAgentRunner {
     ) -> Result<WorkerResult, AgentError> {
         let config = &request.config;
         let agent_config = config.agents.get(request.agent_name);
-        let command = resolve_agent_command(agent_config, &config.agent.command);
+        let resolved = resolve_agent_command(agent_config, &config.agent.command)?;
+        let mut command = format!("{}", resolved.program.display());
+        for arg in &resolved.args {
+            command.push(' ');
+            command.push_str(arg);
+        }
 
         let session_mode = if config.agent.session_mode.is_empty() {
             None

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -198,6 +198,10 @@ impl AcpAgentRunner {
             return Ok(());
         }
         let resolved = resolve_acpx_acp_command(agent_config)?;
+        // TODO(issue-43/task-8): remove this bridge when AcpSessionConfig.command
+        // and AcpCapabilityDiscoveryConfig.command are changed to ResolvedCommand
+        // (Task 8 of the issue-43 plan). Direct structured spawn eliminates the
+        // need to round-trip through a shell-string.
         let mut command = format!("{}", resolved.program.display());
         for arg in &resolved.args {
             command.push(' ');
@@ -612,13 +616,14 @@ fn resolve_agent_command(
 fn resolve_acpx_acp_command(
     agent_config: &crate::config::ensemble::AgentConfig,
 ) -> Result<ResolvedCommand, AgentError> {
-    let acpx_name = agent_config
-        .acpx_agent
-        .as_ref()
-        .ok_or_else(|| AgentError::InvalidAgentCommand {
-            command: "<acpx capability discovery>".to_string(),
-            reason: "agent is missing acpx_agent".to_string(),
-        })?;
+    let acpx_name =
+        agent_config
+            .acpx_agent
+            .as_ref()
+            .ok_or_else(|| AgentError::InvalidAgentCommand {
+                command: "<acpx capability discovery>".to_string(),
+                reason: "agent is missing acpx_agent".to_string(),
+            })?;
     let mut args = vec!["--agent".to_string(), acpx_name.clone()];
     if let Some(ref model) = agent_config.model {
         args.push("--model".to_string());
@@ -721,6 +726,10 @@ impl AcpAgentRunner {
         let config = &request.config;
         let agent_config = config.agents.get(request.agent_name);
         let resolved = resolve_agent_command(agent_config, &config.agent.command)?;
+        // TODO(issue-43/task-8): remove this bridge when AcpSessionConfig.command
+        // and AcpCapabilityDiscoveryConfig.command are changed to ResolvedCommand
+        // (Task 8 of the issue-43 plan). Direct structured spawn eliminates the
+        // need to round-trip through a shell-string.
         let mut command = format!("{}", resolved.program.display());
         for arg in &resolved.args {
             command.push(' ');
@@ -1862,8 +1871,17 @@ on_failure: Todo
             reasoning_level: None,
             ..Default::default()
         };
-        let cmd = resolve_agent_command(Some(&config), "default-cmd");
-        assert_eq!(cmd, "acpx --agent 'claude' --model 'sonnet'");
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--agent".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -1880,9 +1898,19 @@ on_failure: Todo
             ..Default::default()
         };
 
-        let cmd = resolve_agent_command(Some(&config), "default-cmd");
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
 
-        assert_eq!(cmd, "acpx --approve-all --agent 'claude' --model 'sonnet'");
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--approve-all".to_string(),
+                "--agent".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -1899,11 +1927,18 @@ on_failure: Todo
             ..Default::default()
         };
 
-        let cmd = resolve_agent_command(Some(&config), "default-cmd");
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
 
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
         assert_eq!(
-            cmd,
-            "acpx --approve-reads --agent 'claude' --model 'sonnet'"
+            resolved.args,
+            vec![
+                "--approve-reads".to_string(),
+                "--agent".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ]
         );
     }
 
@@ -1921,9 +1956,19 @@ on_failure: Todo
             ..Default::default()
         };
 
-        let cmd = resolve_agent_command(Some(&config), "default-cmd");
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
 
-        assert_eq!(cmd, "acpx --deny-all --agent 'claude' --model 'sonnet'");
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--deny-all".to_string(),
+                "--agent".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -1939,8 +1984,12 @@ on_failure: Todo
             reasoning_level: None,
             ..Default::default()
         };
-        let cmd = resolve_agent_command(Some(&config), "default-cmd");
-        assert_eq!(cmd, "acpx --agent 'claude'");
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec!["--agent".to_string(), "claude".to_string()]
+        );
     }
 
     #[test]
@@ -1957,15 +2006,25 @@ on_failure: Todo
             ..Default::default()
         };
 
-        let cmd = resolve_agent_command(Some(&config), "default-cmd");
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
 
-        assert_eq!(cmd, "acpx --agent 'claude' --model 'sonnet'");
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--agent".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ]
+        );
     }
 
     #[test]
     fn test_resolve_agent_command_falls_back_to_default() {
-        let cmd = resolve_agent_command(None, "default-cmd");
-        assert_eq!(cmd, "'default-cmd'");
+        let resolved = resolve_agent_command(None, "default-cmd").unwrap();
+        assert_eq!(resolved.program, PathBuf::from("default-cmd"));
+        assert!(resolved.args.is_empty());
     }
 
     #[test]
@@ -1981,8 +2040,17 @@ on_failure: Todo
             reasoning_level: None,
             ..Default::default()
         };
-        let cmd = resolve_agent_command(Some(&config), "default-cmd");
-        assert_eq!(cmd, "'codex' '--profile' 'prod;' 'touch' '/tmp/pwned'");
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
+        assert_eq!(resolved.program, PathBuf::from("codex"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--profile".to_string(),
+                "prod;".to_string(),
+                "touch".to_string(),
+                "/tmp/pwned".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -2050,7 +2118,7 @@ on_failure: Failed
 
     #[test]
     fn resolve_acpx_acp_command_includes_agent_and_model() {
-        let command = resolve_acpx_acp_command(&crate::config::ensemble::AgentConfig {
+        let resolved = resolve_acpx_acp_command(&crate::config::ensemble::AgentConfig {
             runtime: Some("acpx".to_string()),
             executor: None,
             model: Some("gpt-5".to_string()),
@@ -2061,11 +2129,18 @@ on_failure: Failed
             reasoning_level: None,
             available_models: Vec::new(),
             available_modes: Vec::new(),
-        });
+        })
+        .unwrap();
 
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
         assert_eq!(
-            command.as_deref(),
-            Some("acpx --agent 'codex' --model 'gpt-5'")
+            resolved.args,
+            vec![
+                "--agent".to_string(),
+                "codex".to_string(),
+                "--model".to_string(),
+                "gpt-5".to_string(),
+            ]
         );
     }
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -1899,6 +1899,149 @@ on_failure: Failed
     }
 
     #[test]
+    fn test_resolve_agent_command_includes_approve_all_flag() {
+        let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
+            acpx_agent: Some("claude".to_string()),
+            model: Some("sonnet".to_string()),
+            executor: None,
+            permission_mode: Some("approve_all".to_string()),
+            prompt: None,
+            prompt_template: None,
+            reasoning_level: None,
+            ..Default::default()
+        };
+
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
+
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--approve-all".to_string(),
+                "--agent".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_resolve_agent_command_includes_approve_reads_flag() {
+        let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
+            acpx_agent: Some("claude".to_string()),
+            model: Some("sonnet".to_string()),
+            executor: None,
+            permission_mode: Some("approve_reads".to_string()),
+            prompt: None,
+            prompt_template: None,
+            reasoning_level: None,
+            ..Default::default()
+        };
+
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
+
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--approve-reads".to_string(),
+                "--agent".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_resolve_agent_command_includes_deny_all_flag() {
+        let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
+            acpx_agent: Some("claude".to_string()),
+            model: Some("sonnet".to_string()),
+            executor: None,
+            permission_mode: Some("deny_all".to_string()),
+            prompt: None,
+            prompt_template: None,
+            reasoning_level: None,
+            ..Default::default()
+        };
+
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
+
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--deny-all".to_string(),
+                "--agent".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_resolve_agent_command_no_model() {
+        let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
+            acpx_agent: Some("claude".to_string()),
+            model: None,
+            executor: None,
+            permission_mode: None,
+            prompt: None,
+            prompt_template: None,
+            reasoning_level: None,
+            ..Default::default()
+        };
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec!["--agent".to_string(), "claude".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_resolve_agent_command_omits_permission_flag_when_unset() {
+        let config = crate::config::ensemble::AgentConfig {
+            runtime: None,
+            acpx_agent: Some("claude".to_string()),
+            model: Some("sonnet".to_string()),
+            executor: None,
+            permission_mode: None,
+            prompt: None,
+            prompt_template: None,
+            reasoning_level: None,
+            ..Default::default()
+        };
+
+        let resolved = resolve_agent_command(Some(&config), "default-cmd").unwrap();
+
+        assert_eq!(resolved.program, PathBuf::from("acpx"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--agent".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_resolve_agent_command_falls_back_to_default() {
+        let resolved = resolve_agent_command(None, "default-cmd").unwrap();
+        assert_eq!(resolved.program, PathBuf::from("default-cmd"));
+        assert!(resolved.args.is_empty());
+    }
+
+    #[test]
     fn tokenize_command_string_splits_simple_program_and_args() {
         let resolved = tokenize_command_string("acpx --agent builder").unwrap();
         assert_eq!(resolved.program, PathBuf::from("acpx"));

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -695,6 +695,7 @@ impl AcpAgentRunner {
             permission_request_policy: config.agent.permission_request_policy.clone(),
             read_timeout_ms: config.agent.read_timeout_ms,
             turn_timeout_ms: config.agent.turn_timeout_ms,
+            cancel_token: request.cancel_token.clone(),
         };
 
         let max_turns = config.agent.max_turns.max(1);

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -39,9 +39,9 @@ use acpx_runtime::AcpxRuntime;
 ///
 /// Built by [`resolve_agent_command`] / [`resolve_acpx_acp_command`] from a
 /// combination of `config.yaml` settings and per-agent overrides. The
-/// `acp_client` module spawns the child from this struct directly via
-/// `tokio::process::Command`, then hands the stdio streams to the
-/// `agent-client-protocol` SDK's protocol plumbing. No shell, no escaping.
+/// `acp_client` module hands these fields to the `agent-client-protocol`
+/// SDK's `McpServerStdio`, which spawns the child, owns its lifecycle, and
+/// pipes stdio into the protocol plumbing. No shell, no escaping.
 #[derive(Debug, Clone)]
 pub struct ResolvedCommand {
     pub program: PathBuf,
@@ -99,7 +99,8 @@ pub struct AgentRunRequest<'a> {
     /// Token for cooperative cancellation of the agent run.
     /// Used by `AcpxRuntime` to abort the acpx prompt via `tokio::select!`.
     /// The direct ACP path (`AcpAgentRunner::run_direct_step`) ignores this
-    /// token — cancellation there relies on SIGTERM sent to `agent_pid`.
+    /// token — the `agent-client-protocol` SDK owns the child process for the
+    /// direct path, so cancellation is handled by dropping the `AcpAgent`.
     pub cancel_token: CancellationToken,
 }
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -43,8 +43,7 @@ use acpx_runtime::AcpxRuntime;
 /// `tokio::process::Command`, then hands the stdio streams to the
 /// `agent-client-protocol` SDK's protocol plumbing. No shell, no escaping.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub(crate) struct ResolvedCommand {
+pub struct ResolvedCommand {
     pub program: PathBuf,
     pub args: Vec<String>,
     pub env: Vec<(String, String)>,
@@ -197,16 +196,7 @@ impl AcpAgentRunner {
         if agent_config.acpx_agent.is_none() {
             return Ok(());
         }
-        let resolved = resolve_acpx_acp_command(agent_config)?;
-        // TODO(issue-43/task-8): remove this bridge when AcpSessionConfig.command
-        // and AcpCapabilityDiscoveryConfig.command are changed to ResolvedCommand
-        // (Task 8 of the issue-43 plan). Direct structured spawn eliminates the
-        // need to round-trip through a shell-string.
-        let mut command = format!("{}", resolved.program.display());
-        for arg in &resolved.args {
-            command.push(' ');
-            command.push_str(arg);
-        }
+        let command = resolve_acpx_acp_command(agent_config)?;
 
         let capabilities = discover_capabilities(AcpCapabilityDiscoveryConfig {
             command,
@@ -689,16 +679,7 @@ impl AcpAgentRunner {
     ) -> Result<WorkerResult, AgentError> {
         let config = &request.config;
         let agent_config = config.agents.get(request.agent_name);
-        let resolved = resolve_agent_command(agent_config, &config.agent.command)?;
-        // TODO(issue-43/task-8): remove this bridge when AcpSessionConfig.command
-        // and AcpCapabilityDiscoveryConfig.command are changed to ResolvedCommand
-        // (Task 8 of the issue-43 plan). Direct structured spawn eliminates the
-        // need to round-trip through a shell-string.
-        let mut command = format!("{}", resolved.program.display());
-        for arg in &resolved.args {
-            command.push(' ');
-            command.push_str(arg);
-        }
+        let command = resolve_agent_command(agent_config, &config.agent.command)?;
 
         let session_mode = if config.agent.session_mode.is_empty() {
             None

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -104,6 +104,8 @@ pub enum AgentError {
     SessionStartupFailed { reason: String },
     #[error("io error: {reason}")]
     IoError { reason: String },
+    #[error("invalid agent command '{command}': {reason}")]
+    InvalidAgentCommand { command: String, reason: String },
     #[error("hook failed: {reason}")]
     HookFailed { reason: String },
     #[error("prompt error: {reason}")]


### PR DESCRIPTION
Closes #43

Replaces the `bash -lc` shell-string spawning, two bespoke shell-escape helpers, and the `echo $$ >&2` PID-extraction hack in the direct ACP path with structured `AcpAgent::new(McpServer::Stdio(...))` using the SDK's built-in `async_process::Command`.

Key changes:
- `ResolvedCommand { program: PathBuf, args: Vec\<String\>, env: Vec\<(String,String)\> }` type provides structured spawning — no shell string concatenation
- `AcpSessionConfig.command` and `AcpCapabilityDiscoveryConfig.command` changed from `String` to `ResolvedCommand`
- `shell_escape`, `shell_escape_command`, `sdk_transport_command` all deleted
- `agent_pid` is now consistently `None` for both runtimes (direct ACP and acpx) — process lifecycle is handled by the SDK's `ChildGuard` drop
- Removed unused `shlex` dependency
- ~150 lines of transport/parsing code deleted

The `acpx_runtime` path is untouched.