### PR TITLE
docs: reconcile ACP launch contract with tokenized command definition

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -943,7 +943,7 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `hooks.timeout_ms`: integer, default `60000`
 - `agent.max_turns`: integer, default `20`
 - `agent.max_retry_backoff_ms`: integer, default `300000` (5m)
-- `agent.command`: shell command string, default implementation-defined
+- `agent.command`: command string (tokenized into program + args, no shell interpolation), default implementation-defined
 - `agent.session_mode`: string (`code`, `architect`, `ask`), default `code`
 - `agent.permission_request_policy`: string, default implementation-defined; only applies to direct runtime paths
 - `agent.turn_timeout_ms`: integer, default `3600000`
@@ -1288,7 +1288,9 @@ Compatibility profile:
 Subprocess launch parameters:
 
 - Command: `agent.command`
-- Invocation: `bash -lc <agent.command>`
+- Invocation: the command string is tokenized into program + args using shell-style quoting rules;
+  the runtime launches the resulting program directly (without shell interpolation) in the workspace
+  directory via the ACP transport.
 - Working directory: workspace path
 - Stdout/stderr: separate streams
 - Framing: line-delimited JSON-RPC 2.0 messages on stdout
@@ -2483,7 +2485,7 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - `tracker.api_key` works (including `$VAR` indirection)
 - `$VAR` resolution works for tracker API key and path values
 - `~` path expansion works
-- `agent.command` is preserved as a shell command string
+- `agent.command` is preserved as a command string (tokenized, not shell-interpolated)
 - Per-state concurrency override map normalizes state names and ignores invalid values
 - Prompt template renders `issue` and `attempt`
 - Prompt rendering fails on unknown variables (strict mode)
@@ -2537,7 +2539,8 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 
 ### 17.5 ACP Agent Client
 
-- Launch command uses workspace cwd and invokes `bash -lc <agent.command>`
+- Launch command uses workspace cwd; the command string is tokenized into program + args and
+  launched directly without shell interpolation
 - Startup handshake sends `initialize`, `session/new`, `session/prompt`
 - `initialize` includes `protocolVersion`, `clientCapabilities`, and `clientInfo` per ACP spec
 - `session/new` returns `sessionId` and implementation emits `session_started`


### PR DESCRIPTION
## Summary

PR 186 updated the `command` field definition to describe direct execution with tokenization (no shell interpolation), but left `bash -lc <agent.command>` references in sections 10.1, 17.5, and the config/validation summaries — creating a contradiction in the spec.

Reconcile all remaining references to match the updated contract.

## Changes

- **§10.1 Launch Contract**: Replaced `bash -lc <agent.command>` with tokenized direct-execution description
- **§17.5 ACP Agent Client**: Same reconciliation
- **Config summary (§8.3)**: "shell command string" → "command string (tokenized, no shell interpolation)"
- **Validation checklist (§17.1)**: Updated to match

Hook invocation at §9.2 (`sh -lc <script>`) intentionally unchanged — hooks are shell scripts, not ACP commands.

Refs #186 review comment from @chatgpt-codex-connector.