### PR TITLE
feat: step output passing for downstream step consumption (#174)

### DIFF
--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -23,7 +23,7 @@ use super::ResolvedCommand;
 /// Build an `AcpAgent` from a structured `ResolvedCommand`. The SDK's
 /// `McpServerStdio` spawns the child via `async_process::Command`.
 /// Because `McpServerStdio` has no working-directory field, we wrap the
-/// command with `sh -c 'cd "$1" && shift 2 && exec "$@"'` and pass the
+/// command with `sh -c 'cd "$1" && shift && exec "$@"'` and pass the
 /// workspace path as `$1` — the child process starts with the correct CWD
 /// while all agent args arrive as separate `argv` entries (no shell escaping
 /// needed for either the path or the args).

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -357,6 +357,7 @@ mod tests {
     use crate::agent::events::RuntimeStream;
     use crate::agent::test_support::write_mock_acpx_script;
     use crate::config::ensemble::parse_config;
+    use crate::pipeline::engine::StepOutputTemplateContext;
     use crate::tracker::model::test_helpers::test_issue;
 
     fn test_config() -> Arc<crate::config::ensemble::EnsembleConfig> {
@@ -421,6 +422,7 @@ exit 1
             workspace_path: workspace.path(),
             event_tx: tx,
             cancel_token: CancellationToken::new(),
+            step_outputs: StepOutputTemplateContext::default(),
         };
 
         let result = runner.run_step(&request, "finish the task").await.unwrap();
@@ -484,6 +486,7 @@ exit 1
             workspace_path: workspace.path(),
             event_tx: tx,
             cancel_token: CancellationToken::new(),
+            step_outputs: StepOutputTemplateContext::default(),
         };
 
         let result = runner.run_step(&request, "finish the task").await.unwrap();
@@ -538,6 +541,7 @@ exit 1
             workspace_path: workspace.path(),
             event_tx: tx,
             cancel_token: CancellationToken::new(),
+            step_outputs: StepOutputTemplateContext::default(),
         };
 
         let error = runner
@@ -592,6 +596,7 @@ exit 1
             workspace_path: workspace.path(),
             event_tx: tx,
             cancel_token: CancellationToken::new(),
+            step_outputs: StepOutputTemplateContext::default(),
         };
 
         let _ = runner.run_step(&request, "finish the task").await.unwrap();
@@ -648,6 +653,7 @@ exit 1
             workspace_path: workspace.path(),
             event_tx: tx,
             cancel_token: cancel_token.clone(),
+            step_outputs: StepOutputTemplateContext::default(),
         };
 
         let canceller = tokio::spawn({
@@ -753,6 +759,7 @@ exit 1
             workspace_path: workspace.path(),
             event_tx: tx,
             cancel_token: CancellationToken::new(),
+            step_outputs: StepOutputTemplateContext::default(),
         };
 
         let _ = runner.run_step(&request, "finish the task").await.unwrap();
@@ -820,6 +827,7 @@ exit 1
             workspace_path: workspace.path(),
             event_tx: tx,
             cancel_token: CancellationToken::new(),
+            step_outputs: StepOutputTemplateContext::default(),
         };
 
         let _ = runner.run_step(&request, "finish the task").await.unwrap();
@@ -878,6 +886,7 @@ exit 1
             workspace_path: workspace.path(),
             event_tx: tx,
             cancel_token: CancellationToken::new(),
+            step_outputs: StepOutputTemplateContext::default(),
         };
 
         let _ = runner.run_step(&request, "finish the task").await.unwrap();

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -240,6 +240,7 @@ impl AcpxRuntime {
                 Ok(detect_worker_result_with_runtime_verdict(
                     request.workspace_path,
                     outcome.runtime_verdict,
+                    request.step_name,
                 )
                 .await)
             }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -496,9 +496,16 @@ async fn detect_worker_result_with_runtime_verdict(
         }
     };
 
-    let verdict_filename = format!("verdict-{step_name}.json");
-    let verdict_path = workspace_path.join(".ensemble").join(&verdict_filename);
-    let verdict_exists = tokio::fs::try_exists(&verdict_path).await.unwrap_or(false);
+    let step_verdict_path = workspace_path
+        .join(".ensemble")
+        .join(format!("verdict-{step_name}.json"));
+    let legacy_verdict_path = workspace_path.join(".ensemble").join("verdict.json");
+    let verdict_exists = tokio::fs::try_exists(&step_verdict_path)
+        .await
+        .unwrap_or(false)
+        || tokio::fs::try_exists(&legacy_verdict_path)
+            .await
+            .unwrap_or(false);
 
     match interaction_request {
         Some(_) if approval_request.is_some() => WorkerResult::Failed {

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -17,7 +17,7 @@ use crate::config::draft::ConfigDocumentState;
 use crate::config::ensemble::{
     DiscoveredCapabilities, EnsembleConfig, InteractionPolicyOverrideMode, PermissionMode,
 };
-use crate::config::template::render_prompt_with_interaction_response;
+use crate::config::template::render_prompt_with_context;
 use crate::error::AgentError;
 use crate::interaction::InteractionResponse;
 use crate::tracker::model::Issue;
@@ -102,6 +102,7 @@ pub struct AgentRunRequest<'a> {
     /// token — the `agent-client-protocol` SDK owns the child process for the
     /// direct path, so cancellation is handled by dropping the `AcpAgent`.
     pub cancel_token: CancellationToken,
+    pub step_outputs: crate::pipeline::engine::StepOutputTemplateContext,
 }
 
 /// Trait for running an agent session against an issue.
@@ -125,6 +126,7 @@ struct BuildPromptRequest<'a> {
     attempt: Option<u32>,
     workspace_path: &'a Path,
     turn_number: u32,
+    step_outputs: &'a crate::pipeline::engine::StepOutputTemplateContext,
 }
 
 fn update_agent_capabilities(
@@ -226,6 +228,7 @@ impl AcpAgentRunner {
             attempt,
             workspace_path,
             turn_number,
+            step_outputs,
         } = request;
         if turn_number == 1 {
             let agent_config =
@@ -258,13 +261,14 @@ impl AcpAgentRunner {
 
             let interaction_response = load_interaction_response(workspace_path).await?;
 
-            let rendered = render_prompt_with_interaction_response(
+            let rendered = render_prompt_with_context(
                 &template_str,
                 issue,
                 attempt,
                 interaction_response
                     .as_ref()
                     .map(|response| &response.response),
+                Some(step_outputs),
             )
             .map_err(|e| AgentError::PromptError {
                 reason: e.to_string(),
@@ -649,6 +653,7 @@ impl AgentRunner for AcpAgentRunner {
                             attempt: request.attempt,
                             workspace_path,
                             turn_number: 1,
+                            step_outputs: &request.step_outputs,
                         },
                     )
                     .await?;
@@ -711,6 +716,7 @@ impl AcpAgentRunner {
                         attempt: request.attempt,
                         workspace_path: request.workspace_path,
                         turn_number: turn,
+                        step_outputs: &request.step_outputs,
                     },
                 )
                 .await?;
@@ -751,6 +757,7 @@ mod tests {
     use crate::config::draft::parse_raw_yaml;
     use crate::config::ensemble::{parse_config, ModeDefinition, ModelDefinition};
     use crate::interaction::{InteractionKind, InteractionResponse};
+    use crate::pipeline::engine::StepOutputTemplateContext;
     use tokio_util::sync::CancellationToken;
 
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -1042,6 +1049,7 @@ on_failure: Todo
                 workspace_path: workspace.path(),
                 event_tx: tx,
                 cancel_token: CancellationToken::new(),
+                step_outputs: StepOutputTemplateContext::default(),
             })
             .await;
 
@@ -1087,6 +1095,7 @@ on_failure: Todo
                 workspace_path: workspace.path(),
                 event_tx: tx,
                 cancel_token: CancellationToken::new(),
+                step_outputs: StepOutputTemplateContext::default(),
             })
             .await;
 
@@ -1138,6 +1147,7 @@ exit 1
                 workspace_path: workspace.path(),
                 event_tx: tx,
                 cancel_token: CancellationToken::new(),
+                step_outputs: StepOutputTemplateContext::default(),
             })
             .await
             .unwrap();
@@ -1197,6 +1207,7 @@ exit 0
                 workspace_path: workspace.path(),
                 event_tx: tx,
                 cancel_token: CancellationToken::new(),
+                step_outputs: StepOutputTemplateContext::default(),
             })
             .await
             .unwrap();
@@ -1511,6 +1522,7 @@ agent:
                     attempt: None,
                     workspace_path: workspace.path(),
                     turn_number: 1,
+                    step_outputs: &StepOutputTemplateContext::default(),
                 },
             )
             .await
@@ -1695,6 +1707,7 @@ on_failure: Todo
                     attempt: Some(2),
                     workspace_path: workspace.path(),
                     turn_number: 1,
+                    step_outputs: &StepOutputTemplateContext::default(),
                 },
             )
             .await
@@ -1758,6 +1771,7 @@ on_failure: Todo
                     attempt: None,
                     workspace_path: workspace.path(),
                     turn_number: 1,
+                    step_outputs: &StepOutputTemplateContext::default(),
                 },
             )
             .await
@@ -2082,5 +2096,63 @@ on_failure: Failed
             resolved.args,
             vec!["--agent", "builder", "--model", "gpt-5"]
         );
+    }
+
+    #[tokio::test]
+    async fn build_prompt_includes_step_outputs() {
+        use crate::pipeline::engine::StepOutputTemplateEntry;
+        use serde_json::json;
+        use std::collections::HashMap;
+
+        let runner = test_runner();
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    prompt: 'Risk: {{ steps["review-a"].output.risk }}'
+steps:
+  - name: synth
+    agent: synth
+on_success: Done
+on_failure: Todo
+"#,
+        )
+        .unwrap();
+
+        let mut steps = HashMap::new();
+        steps.insert(
+            "review-a".to_string(),
+            StepOutputTemplateEntry {
+                step: "review-a".to_string(),
+                verdict: "approve".to_string(),
+                summary: None,
+                output: Some(json!({"risk":"low"})),
+            },
+        );
+        let context = StepOutputTemplateContext {
+            steps,
+            dependency_outputs: vec![],
+        };
+        let workspace = tempfile::TempDir::new().unwrap();
+
+        let rendered = runner
+            .build_prompt(
+                &config,
+                BuildPromptRequest {
+                    issue: &test_issue(),
+                    agent_name: "synth",
+                    step_name: "synth",
+                    attempt: None,
+                    workspace_path: workspace.path(),
+                    turn_number: 1,
+                    step_outputs: &context,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(rendered.contains("Risk: low"));
     }
 }

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -69,6 +69,8 @@ pub(crate) fn tokenize_command_string(command: &str) -> Result<ResolvedCommand, 
     let mut iter = parts.into_iter();
     let program = PathBuf::from(iter.next().expect("non-empty checked above"));
     let args: Vec<String> = iter.collect();
+    // `AgentConfig` has no env field; all command paths return empty env.
+    // If per-agent env support is added, propagate it here.
     Ok(ResolvedCommand {
         program,
         args,

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -78,11 +78,14 @@ pub(crate) fn tokenize_command_string(command: &str) -> Result<ResolvedCommand, 
     })
 }
 
-const VERDICT_FALLBACK_INSTRUCTION: &str = "\
-If you cannot return a structured runtime verdict, write .ensemble/verdict.json with:\n\
-{\"verdict\":\"approve\"}\n\
-or\n\
-{\"verdict\":\"reject\",\"summary\":\"<reason>\"}";
+fn verdict_fallback_instruction(step_name: &str) -> String {
+    format!(
+        "If you cannot return a structured runtime verdict, write .ensemble/verdict-{step_name}.json with:\n\
+         {{\"verdict\":\"approve\"}}\n\
+         or\n\
+         {{\"verdict\":\"reject\",\"summary\":\"<reason>\"}}"
+    )
+}
 
 const DEFAULT_INTERACTION_POLICY_INSTRUCTION: &str = "\
 When you need human input, prefer batching related questions into a single interaction request instead of asking one-by-one.\n\
@@ -283,6 +286,7 @@ impl AcpAgentRunner {
             Ok(maybe_append_verdict_fallback_instruction(
                 rendered,
                 config.agent.inject_verdict_fallback_instructions,
+                step_name,
             ))
         } else {
             // Continuation turns: send guidance, not the full original prompt
@@ -299,10 +303,12 @@ impl AcpAgentRunner {
         &self,
         workspace_path: &Path,
         interaction_response: Option<&InteractionResponseEnvelope>,
+        step_name: &str,
     ) -> Result<(), AgentError> {
         // Ensure stale verdict and request artifacts from previous attempts
         // cannot influence the current run's resolution path.
-        remove_ensemble_file(workspace_path, "verdict.json").await?;
+        let verdict_filename = format!("verdict-{step_name}.json");
+        remove_ensemble_file(workspace_path, &verdict_filename).await?;
         remove_ensemble_file(workspace_path, "interaction-request.json").await?;
         remove_ensemble_file(workspace_path, "approval-request.json").await?;
 
@@ -316,16 +322,21 @@ impl AcpAgentRunner {
     }
 }
 
-fn maybe_append_verdict_fallback_instruction(prompt: String, enabled: bool) -> String {
-    if !enabled || prompt.contains(VERDICT_FALLBACK_INSTRUCTION) {
+fn maybe_append_verdict_fallback_instruction(
+    prompt: String,
+    enabled: bool,
+    step_name: &str,
+) -> String {
+    let instruction = verdict_fallback_instruction(step_name);
+    if !enabled || prompt.contains(&instruction) {
         return prompt;
     }
 
     let trimmed = prompt.trim_end();
     if trimmed.is_empty() {
-        VERDICT_FALLBACK_INSTRUCTION.to_string()
+        instruction
     } else {
-        format!("{trimmed}\n\n{VERDICT_FALLBACK_INSTRUCTION}")
+        format!("{trimmed}\n\n{instruction}")
     }
 }
 
@@ -442,6 +453,7 @@ async fn load_interaction_response(
 async fn detect_worker_result_with_runtime_verdict(
     workspace_path: &Path,
     runtime_verdict: Option<serde_json::Value>,
+    step_name: &str,
 ) -> WorkerResult {
     let interaction_path = workspace_path
         .join(".ensemble")
@@ -484,7 +496,8 @@ async fn detect_worker_result_with_runtime_verdict(
         }
     };
 
-    let verdict_path = workspace_path.join(".ensemble").join("verdict.json");
+    let verdict_filename = format!("verdict-{step_name}.json");
+    let verdict_path = workspace_path.join(".ensemble").join(&verdict_filename);
     let verdict_exists = tokio::fs::try_exists(&verdict_path).await.unwrap_or(false);
 
     match interaction_request {
@@ -506,8 +519,8 @@ async fn detect_worker_result_with_runtime_verdict(
 }
 
 #[cfg(test)]
-async fn detect_worker_result(workspace_path: &Path) -> WorkerResult {
-    detect_worker_result_with_runtime_verdict(workspace_path, None).await
+async fn detect_worker_result(workspace_path: &Path, step_name: &str) -> WorkerResult {
+    detect_worker_result_with_runtime_verdict(workspace_path, None, step_name).await
 }
 
 async fn write_interaction_response_file(
@@ -619,8 +632,12 @@ impl AgentRunner for AcpAgentRunner {
         let config = Arc::clone(&request.config);
         let workspace_path = request.workspace_path;
 
-        self.prepare_workspace(workspace_path, request.interaction_response.as_ref())
-            .await?;
+        self.prepare_workspace(
+            workspace_path,
+            request.interaction_response.as_ref(),
+            request.step_name,
+        )
+        .await?;
 
         if let Some(ref script) = config.hooks.before_run {
             run_hook(
@@ -745,7 +762,12 @@ impl AcpAgentRunner {
             }
         }
 
-        Ok(detect_worker_result_with_runtime_verdict(request.workspace_path, final_verdict).await)
+        Ok(detect_worker_result_with_runtime_verdict(
+            request.workspace_path,
+            final_verdict,
+            request.step_name,
+        )
+        .await)
     }
 }
 
@@ -1236,23 +1258,29 @@ exit 0
     #[test]
     fn injects_verdict_block_when_enabled() {
         let prompt = "Do the work.".to_string();
-        let rendered = maybe_append_verdict_fallback_instruction(prompt, true);
-        assert!(rendered.contains("write .ensemble/verdict.json"));
+        let rendered = maybe_append_verdict_fallback_instruction(prompt, true, "build");
+        assert!(rendered.contains("write .ensemble/verdict-build.json"));
     }
 
     #[test]
     fn does_not_inject_verdict_block_when_disabled() {
         let prompt = "Do the work.".to_string();
-        let rendered = maybe_append_verdict_fallback_instruction(prompt.clone(), false);
+        let rendered = maybe_append_verdict_fallback_instruction(prompt.clone(), false, "build");
         assert_eq!(rendered, prompt);
     }
 
     #[test]
     fn does_not_duplicate_verdict_block_when_present() {
-        let prompt = format!("Do work.\n\n{VERDICT_FALLBACK_INSTRUCTION}");
-        let rendered = maybe_append_verdict_fallback_instruction(prompt.clone(), true);
+        let instruction = verdict_fallback_instruction("build");
+        let prompt = format!("Do work.\n\n{instruction}");
+        let rendered = maybe_append_verdict_fallback_instruction(prompt.clone(), true, "build");
         assert_eq!(rendered, prompt);
-        assert_eq!(rendered.matches("write .ensemble/verdict.json").count(), 1);
+        assert_eq!(
+            rendered
+                .matches("write .ensemble/verdict-build.json")
+                .count(),
+            1
+        );
     }
 
     #[test]
@@ -1344,7 +1372,7 @@ agent:
         )
         .await;
 
-        let result = detect_worker_result(workspace.path()).await;
+        let result = detect_worker_result(workspace.path(), "build").await;
 
         match result {
             WorkerResult::BlockedOnHuman { request } => {
@@ -1370,9 +1398,9 @@ agent:
 }"#,
         )
         .await;
-        write_workspace_file(&workspace, "verdict.json", r#"{"verdict":"approve"}"#).await;
+        write_workspace_file(&workspace, "verdict-build.json", r#"{"verdict":"approve"}"#).await;
 
-        let result = detect_worker_result(workspace.path()).await;
+        let result = detect_worker_result(workspace.path(), "build").await;
 
         assert!(matches!(
             result,
@@ -1397,7 +1425,7 @@ agent:
         )
         .await;
 
-        let result = detect_worker_result(workspace.path()).await;
+        let result = detect_worker_result(workspace.path(), "build").await;
 
         assert!(matches!(
             result,
@@ -1435,7 +1463,7 @@ agent:
         )
         .await;
 
-        let result = detect_worker_result(workspace.path()).await;
+        let result = detect_worker_result(workspace.path(), "build").await;
 
         assert!(matches!(result, WorkerResult::Failed { .. }));
     }
@@ -1445,7 +1473,7 @@ agent:
         let workspace = tempfile::TempDir::new().unwrap();
         write_workspace_file(&workspace, "approval-request.json", "not json").await;
 
-        let result = detect_worker_result(workspace.path()).await;
+        let result = detect_worker_result(workspace.path(), "build").await;
 
         assert!(matches!(
             result,
@@ -1459,7 +1487,7 @@ agent:
         let workspace = tempfile::TempDir::new().unwrap();
         write_workspace_file(&workspace, "interaction-request.json", "not json").await;
 
-        let result = detect_worker_result(workspace.path()).await;
+        let result = detect_worker_result(workspace.path(), "build").await;
 
         assert!(matches!(
             result,
@@ -1483,9 +1511,9 @@ agent:
 }"#,
         )
         .await;
-        write_workspace_file(&workspace, "verdict.json", "not valid json").await;
+        write_workspace_file(&workspace, "verdict-build.json", "not valid json").await;
 
-        let result = detect_worker_result(workspace.path()).await;
+        let result = detect_worker_result(workspace.path(), "build").await;
 
         assert!(matches!(
             result,
@@ -1557,7 +1585,7 @@ agent:
         };
 
         test_runner()
-            .prepare_workspace(workspace.path(), Some(&response))
+            .prepare_workspace(workspace.path(), Some(&response), "build")
             .await
             .unwrap();
 
@@ -1586,7 +1614,7 @@ agent:
         .unwrap();
 
         test_runner()
-            .prepare_workspace(workspace.path(), None)
+            .prepare_workspace(workspace.path(), None, "build")
             .await
             .unwrap();
 
@@ -1611,11 +1639,11 @@ agent:
         .await;
 
         test_runner()
-            .prepare_workspace(workspace.path(), None)
+            .prepare_workspace(workspace.path(), None, "build")
             .await
             .unwrap();
 
-        let result = detect_worker_result(workspace.path()).await;
+        let result = detect_worker_result(workspace.path(), "build").await;
         assert!(matches!(
             result,
             WorkerResult::Success {
@@ -1641,11 +1669,11 @@ agent:
         .await;
 
         test_runner()
-            .prepare_workspace(workspace.path(), None)
+            .prepare_workspace(workspace.path(), None, "build")
             .await
             .unwrap();
 
-        let result = detect_worker_result(workspace.path()).await;
+        let result = detect_worker_result(workspace.path(), "build").await;
         assert!(matches!(
             result,
             WorkerResult::Success {
@@ -1716,7 +1744,7 @@ on_failure: Todo
             .unwrap();
 
         assert!(prompt.starts_with("question: Use staging"));
-        assert!(prompt.contains("write .ensemble/verdict.json"));
+        assert!(prompt.contains("write .ensemble/verdict-build.json"));
     }
 
     #[tokio::test]
@@ -1780,7 +1808,7 @@ on_failure: Todo
             .unwrap();
 
         assert!(prompt.starts_with("hi"));
-        assert!(prompt.contains("write .ensemble/verdict.json"));
+        assert!(prompt.contains("write .ensemble/verdict-build.json"));
     }
 
     #[tokio::test]
@@ -1789,21 +1817,24 @@ on_failure: Todo
         let ensemble_dir = workspace.path().join(".ensemble");
         tokio::fs::create_dir_all(&ensemble_dir).await.unwrap();
         tokio::fs::write(
-            ensemble_dir.join("verdict.json"),
+            ensemble_dir.join("verdict-build.json"),
             r#"{"verdict":"reject","summary":"stale"}"#,
         )
         .await
         .unwrap();
 
         test_runner()
-            .prepare_workspace(workspace.path(), None)
+            .prepare_workspace(workspace.path(), None, "build")
             .await
             .unwrap();
 
-        let exists = tokio::fs::try_exists(ensemble_dir.join("verdict.json"))
+        let exists = tokio::fs::try_exists(ensemble_dir.join("verdict-build.json"))
             .await
             .unwrap();
-        assert!(!exists, "stale verdict.json should be removed before run");
+        assert!(
+            !exists,
+            "stale verdict-build.json should be removed before run"
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/template.rs
+++ b/crates/ensemble-core/src/config/template.rs
@@ -1,5 +1,6 @@
 use crate::error::ConfigError;
 use crate::interaction::InteractionResponse;
+use crate::pipeline::engine::StepOutputTemplateContext;
 use crate::tracker::model::Issue;
 use liquid::ParserBuilder;
 
@@ -11,7 +12,7 @@ pub fn render_prompt(
     issue: &Issue,
     attempt: Option<u32>,
 ) -> Result<String, ConfigError> {
-    render_prompt_with_interaction_response(template_str, issue, attempt, None)
+    render_prompt_with_context(template_str, issue, attempt, None, None)
 }
 
 pub fn render_prompt_with_interaction_response(
@@ -19,6 +20,16 @@ pub fn render_prompt_with_interaction_response(
     issue: &Issue,
     attempt: Option<u32>,
     interaction_response: Option<&InteractionResponse>,
+) -> Result<String, ConfigError> {
+    render_prompt_with_context(template_str, issue, attempt, interaction_response, None)
+}
+
+pub fn render_prompt_with_context(
+    template_str: &str,
+    issue: &Issue,
+    attempt: Option<u32>,
+    interaction_response: Option<&InteractionResponse>,
+    step_outputs: Option<&StepOutputTemplateContext>,
 ) -> Result<String, ConfigError> {
     let parser =
         ParserBuilder::with_stdlib()
@@ -85,6 +96,19 @@ pub fn render_prompt_with_interaction_response(
                 reason: e.to_string(),
             })?,
         );
+    }
+
+    if let Some(step_outputs) = step_outputs {
+        let value = liquid::model::to_value(step_outputs).map_err(|e| {
+            ConfigError::TemplateRenderError {
+                reason: e.to_string(),
+            }
+        })?;
+        if let liquid::model::Value::Object(object) = value {
+            for (key, value) in object {
+                globals.insert(key, value);
+            }
+        }
     }
 
     template
@@ -197,5 +221,38 @@ mod tests {
                 .unwrap();
 
         assert_eq!(result, "question: Use staging / staging");
+    }
+
+    #[test]
+    fn test_render_with_step_outputs() {
+        use crate::pipeline::engine::{StepOutputTemplateContext, StepOutputTemplateEntry};
+        use serde_json::json;
+        use std::collections::HashMap;
+
+        let mut steps = HashMap::new();
+        steps.insert(
+            "review-a".to_string(),
+            StepOutputTemplateEntry {
+                step: "review-a".to_string(),
+                verdict: "approve".to_string(),
+                summary: Some("looks good".to_string()),
+                output: Some(json!({"risk":"low"})),
+            },
+        );
+        let context = StepOutputTemplateContext {
+            steps: steps.clone(),
+            dependency_outputs: vec![steps["review-a"].clone()],
+        };
+
+        let rendered = render_prompt_with_context(
+            "{{ steps[\"review-a\"].summary }} / {{ dependency_outputs[0].output.risk }}",
+            &test_issue(),
+            None,
+            None,
+            Some(&context),
+        )
+        .unwrap();
+
+        assert_eq!(rendered, "looks good / low");
     }
 }

--- a/crates/ensemble-core/src/config/template.rs
+++ b/crates/ensemble-core/src/config/template.rs
@@ -24,6 +24,13 @@ pub fn render_prompt_with_interaction_response(
     render_prompt_with_context(template_str, issue, attempt, interaction_response, None)
 }
 
+/// Render a Liquid prompt template with full context: issue, attempt, interaction response,
+/// and step outputs.
+///
+/// This is the core rendering entry point used by [`render_prompt`] and
+/// [`render_prompt_with_interaction_response`]. When `step_outputs` is provided, each key from the
+/// serialized map is inserted directly into the Liquid globals so templates can reference fields
+/// like `steps["review-a"].summary` or `dependency_outputs[0].verdict`.
 pub fn render_prompt_with_context(
     template_str: &str,
     issue: &Issue,
@@ -108,6 +115,10 @@ pub fn render_prompt_with_context(
             for (key, value) in object {
                 globals.insert(key, value);
             }
+        } else {
+            return Err(ConfigError::TemplateRenderError {
+                reason: "step_outputs did not serialize to a Liquid object".to_string(),
+            });
         }
     }
 

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -973,7 +973,9 @@ impl Orchestrator {
                         .unwrap_or(issue_id),
                 );
                 let resolved = match workspace_path {
-                    Some(wp) => resolve_verdict_with_source(runtime_verdict.as_ref(), &wp).await,
+                    Some(wp) => {
+                        resolve_verdict_with_source(runtime_verdict.as_ref(), &wp, step_name).await
+                    }
                     None => crate::pipeline::verdict::ResolvedVerdict {
                         verdict: Verdict::Approve,
                         output: crate::pipeline::verdict::StepOutput {
@@ -4452,7 +4454,7 @@ agent:
             .await
             .unwrap();
         tokio::fs::write(
-            workspace.join(".ensemble").join("verdict.json"),
+            workspace.join(".ensemble").join("verdict-build.json"),
             r#"{"verdict":"reject","summary":"broken"}"#,
         )
         .await
@@ -4516,7 +4518,7 @@ agent:
             .await
             .unwrap();
         tokio::fs::write(
-            workspace.join(".ensemble").join("verdict.json"),
+            workspace.join(".ensemble").join("verdict-build.json"),
             r#"{"verdict":"reject","summary":"broken"}"#,
         )
         .await
@@ -4586,7 +4588,7 @@ agent:
                 .await
                 .unwrap();
             tokio::fs::write(
-                workspace.join(".ensemble").join("verdict.json"),
+                workspace.join(".ensemble").join("verdict-build.json"),
                 r#"{"verdict":"reject","summary":"tests failed"}"#,
             )
             .await

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -43,7 +43,9 @@ use crate::observability::events_contract::{
     TRACKER_TRANSITION_SUCCEEDED,
 };
 use crate::pipeline::dag::build_dag;
-use crate::pipeline::engine::{DispatchRequest, PipelineAction, PipelineRun, StepOutputTemplateContext, StepState};
+use crate::pipeline::engine::{
+    DispatchRequest, PipelineAction, PipelineRun, StepOutputTemplateContext, StepState,
+};
 use crate::pipeline::verdict::{resolve_verdict_with_source, Verdict, VerdictSource};
 use crate::timeline::persistence::TimelinePersistence;
 use crate::tracker::model::Issue;
@@ -1016,7 +1018,11 @@ impl Orchestrator {
                     match action {
                         PipelineAction::Dispatch(requests) => {
                             // Collect output contexts while state lock is still held
-                            let dispatch_contexts: Vec<(DispatchRequest, StepOutputTemplateContext)> = {                                let run = state.get_pipeline_run(issue_id);
+                            let dispatch_contexts: Vec<(
+                                DispatchRequest,
+                                StepOutputTemplateContext,
+                            )> = {
+                                let run = state.get_pipeline_run(issue_id);
                                 requests
                                     .into_iter()
                                     .map(|req| {
@@ -3151,9 +3157,8 @@ impl Orchestrator {
                             requests
                                 .iter()
                                 .map(|req| {
-                                    let step_outputs = run
-                                        .output_context_for(&req.step_name)
-                                        .unwrap_or_default();
+                                    let step_outputs =
+                                        run.output_context_for(&req.step_name).unwrap_or_default();
                                     (req.clone(), step_outputs)
                                 })
                                 .collect()

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -797,6 +797,7 @@ impl Orchestrator {
                     workspace_path: &workspace_path,
                     event_tx: event_tx.clone(),
                     cancel_token,
+                    step_outputs: crate::pipeline::engine::StepOutputTemplateContext::default(),
                 }),
                 &issue_clone.id,
                 &step_name_owned,

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -43,7 +43,7 @@ use crate::observability::events_contract::{
     TRACKER_TRANSITION_SUCCEEDED,
 };
 use crate::pipeline::dag::build_dag;
-use crate::pipeline::engine::{PipelineAction, PipelineRun, StepState};
+use crate::pipeline::engine::{DispatchRequest, PipelineAction, PipelineRun, StepOutputTemplateContext, StepState};
 use crate::pipeline::verdict::{resolve_verdict_with_source, Verdict, VerdictSource};
 use crate::timeline::persistence::TimelinePersistence;
 use crate::tracker::model::Issue;
@@ -68,6 +68,7 @@ struct StepDispatchContext<'a> {
     attempt: Option<u32>,
     interaction_response: Option<InteractionResponseEnvelope>,
     workspace_path: std::path::PathBuf,
+    step_outputs: StepOutputTemplateContext,
 }
 
 struct InteractionRequestContext {
@@ -648,6 +649,7 @@ impl Orchestrator {
                             attempt,
                             interaction_response: None,
                             workspace_path,
+                            step_outputs: StepOutputTemplateContext::default(),
                         },
                     )
                     .await;
@@ -782,6 +784,7 @@ impl Orchestrator {
         let event_tx = self.worker_tx.clone();
         let workspace_path = dispatch.workspace_path.clone();
         let attempt = dispatch.attempt;
+        let step_outputs = dispatch.step_outputs.clone();
         let cancel_token = tokio_util::sync::CancellationToken::new();
         register_issue_cancellation(&self.cancellation_registry, &issue.id, cancel_token.clone());
         let cancellation_registry = Arc::clone(&self.cancellation_registry);
@@ -797,7 +800,7 @@ impl Orchestrator {
                     workspace_path: &workspace_path,
                     event_tx: event_tx.clone(),
                     cancel_token,
-                    step_outputs: crate::pipeline::engine::StepOutputTemplateContext::default(),
+                    step_outputs,
                 }),
                 &issue_clone.id,
                 &step_name_owned,
@@ -1012,6 +1015,18 @@ impl Orchestrator {
                 if let Some((action, config_snapshot)) = pipeline_action {
                     match action {
                         PipelineAction::Dispatch(requests) => {
+                            // Collect output contexts while state lock is still held
+                            let dispatch_contexts: Vec<(DispatchRequest, StepOutputTemplateContext)> = {                                let run = state.get_pipeline_run(issue_id);
+                                requests
+                                    .into_iter()
+                                    .map(|req| {
+                                        let step_outputs = run
+                                            .and_then(|r| r.output_context_for(&req.step_name))
+                                            .unwrap_or_default();
+                                        (req, step_outputs)
+                                    })
+                                    .collect()
+                            };
                             // Need to drop state lock before dispatching
                             drop(state);
                             if let Some(ref issue) = issue_snapshot {
@@ -1019,7 +1034,7 @@ impl Orchestrator {
                                     warn!(issue_id = %issue_id, "no config snapshot found for pipeline dispatch");
                                     return;
                                 };
-                                for req in requests {
+                                for (req, step_outputs) in dispatch_contexts {
                                     let workspace_path = match self
                                         .prepare_step_workspace(issue, &config_snapshot)
                                         .await
@@ -1066,6 +1081,7 @@ impl Orchestrator {
                                                 attempt: None,
                                                 interaction_response: None,
                                                 workspace_path,
+                                                step_outputs,
                                             },
                                         )
                                         .await;
@@ -3034,14 +3050,18 @@ impl Orchestrator {
                     resolved_at,
                 );
 
-                let attempt = {
+                let (attempt, step_outputs) = {
                     let mut state = self.state.write().await;
                     let attempt = state
                         .get_pipeline_run(&issue.id)
                         .map(|run| run.cycle)
                         .unwrap_or(interaction.pipeline_cycle.max(1));
+                    let step_outputs = state
+                        .get_pipeline_run(&issue.id)
+                        .and_then(|run| run.output_context_for(&current_step.name))
+                        .unwrap_or_default();
                     state.add_running(issue, Some(attempt));
-                    attempt
+                    (attempt, step_outputs)
                 };
 
                 let workspace_path = match self.prepare_step_workspace(issue, &current_config).await
@@ -3067,6 +3087,7 @@ impl Orchestrator {
                         attempt: Some(attempt),
                         interaction_response: Some(interaction_response),
                         workspace_path,
+                        step_outputs,
                     },
                 )
                 .await?;
@@ -3083,7 +3104,7 @@ impl Orchestrator {
                             ),
                         })?;
 
-                let action = {
+                let (action, dispatch_contexts) = {
                     let mut state = self.state.write().await;
                     let run = state.get_pipeline_run_mut(&issue.id).ok_or_else(|| {
                         AgentError::PromptError {
@@ -3094,7 +3115,7 @@ impl Orchestrator {
                         }
                     })?;
 
-                    match response {
+                    let action = match response {
                         InteractionResponse::Approval {
                             approved, reason, ..
                         } => {
@@ -3121,11 +3142,30 @@ impl Orchestrator {
                             }
                             .into())
                         }
-                    }
+                    };
+
+                    // Collect output contexts while the run is still accessible
+                    let dispatch_contexts: Vec<(DispatchRequest, StepOutputTemplateContext)> =
+                        if let PipelineAction::Dispatch(ref requests) = action {
+                            let run = state.get_pipeline_run(&issue.id).unwrap();
+                            requests
+                                .iter()
+                                .map(|req| {
+                                    let step_outputs = run
+                                        .output_context_for(&req.step_name)
+                                        .unwrap_or_default();
+                                    (req.clone(), step_outputs)
+                                })
+                                .collect()
+                        } else {
+                            vec![]
+                        };
+
+                    (action, dispatch_contexts)
                 };
 
                 match action {
-                    PipelineAction::Dispatch(requests) => {
+                    PipelineAction::Dispatch(_requests) => {
                         let attempt = {
                             let mut state = self.state.write().await;
                             let attempt = state
@@ -3136,7 +3176,7 @@ impl Orchestrator {
                             attempt
                         };
 
-                        for req in requests {
+                        for (req, step_outputs) in dispatch_contexts {
                             let workspace_path =
                                 match self.prepare_step_workspace(issue, &current_config).await {
                                     Ok(path) => path,
@@ -3162,6 +3202,7 @@ impl Orchestrator {
                                     attempt: Some(attempt),
                                     interaction_response: None,
                                     workspace_path,
+                                    step_outputs,
                                 },
                             )
                             .await?;

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -970,6 +970,11 @@ impl Orchestrator {
                     Some(wp) => resolve_verdict_with_source(runtime_verdict.as_ref(), &wp).await,
                     None => crate::pipeline::verdict::ResolvedVerdict {
                         verdict: Verdict::Approve,
+                        output: crate::pipeline::verdict::StepOutput {
+                            verdict: Verdict::Approve,
+                            summary: None,
+                            output: None,
+                        },
                         source: VerdictSource::Default,
                     },
                 };

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1000,7 +1000,7 @@ impl Orchestrator {
                 // Drive the pipeline
                 let pipeline_action = if let Some(run) = state.get_pipeline_run_mut(issue_id) {
                     Some((
-                        run.step_completed(step_name, resolved.verdict, approval_request.is_some()),
+                        run.step_completed(step_name, resolved.output, approval_request.is_some()),
                         state.get_pipeline_config(issue_id).cloned(),
                     ))
                 } else {
@@ -3703,7 +3703,7 @@ mod tests {
         InteractionKind, InteractionResponse, InteractionResumeStrategy, InteractionStatus,
         InteractionStore,
     };
-    use crate::pipeline::verdict::Verdict;
+    use crate::pipeline::verdict::{StepOutput, Verdict};
     use crate::tracker::TrackerError;
     use async_trait::async_trait;
 
@@ -6077,7 +6077,15 @@ agent:
             let dag = build_dag(&cfg.steps).unwrap();
             let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
             pipeline_run.start();
-            pipeline_run.step_completed("build", Verdict::Approve, false);
+            pipeline_run.step_completed(
+                "build",
+                StepOutput {
+                    verdict: Verdict::Approve,
+                    summary: None,
+                    output: None,
+                },
+                false,
+            );
             pipeline_run.step_blocked_on_human("review", "interaction-1".to_string());
             pipeline_run.mark_running("docs", "session-docs".to_string());
 

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
+use serde::Serialize;
+
 use crate::pipeline::dag::StepDag;
-use crate::pipeline::verdict::Verdict;
+use crate::pipeline::verdict::{StepOutput, Verdict};
 
 /// The execution state of a single pipeline step.
 #[derive(Debug, Clone, PartialEq)]
@@ -83,6 +85,20 @@ pub enum ApprovalGateCheck {
     UnconfiguredButRequested,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct StepOutputTemplateEntry {
+    pub step: String,
+    pub verdict: String,
+    pub summary: Option<String>,
+    pub output: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct StepOutputTemplateContext {
+    pub steps: HashMap<String, StepOutputTemplateEntry>,
+    pub dependency_outputs: Vec<StepOutputTemplateEntry>,
+}
+
 /// Per-issue pipeline execution state machine.
 ///
 /// Tracks step states, drives step dispatch when dependencies are met, and
@@ -95,6 +111,8 @@ pub struct PipelineRun {
     pub cycle: u32,
     /// Current state of each step, keyed by step name.
     pub step_states: HashMap<String, StepState>,
+    /// Stored outputs from completed steps.
+    pub step_outputs: HashMap<String, StepOutput>,
     /// The resolved, validated step DAG.
     dag: StepDag,
 }
@@ -112,6 +130,7 @@ impl PipelineRun {
             issue_id,
             cycle,
             step_states,
+            step_outputs: HashMap::new(),
             dag,
         }
     }
@@ -140,9 +159,11 @@ impl PipelineRun {
     pub fn step_completed(
         &mut self,
         step_name: &str,
-        verdict: Verdict,
+        output: StepOutput,
         approval_requested: bool,
     ) -> PipelineAction {
+        let verdict = output.verdict.clone();
+        self.step_outputs.insert(step_name.to_string(), output);
         match verdict {
             Verdict::Approve => match self.gate_check(step_name, approval_requested) {
                 ApprovalGateCheck::EligibleGating => {
@@ -351,6 +372,29 @@ impl PipelineRun {
             .and_then(|approval| approval.state.clone())
     }
 
+    pub fn output_context_for(&self, step_name: &str) -> Option<StepOutputTemplateContext> {
+        let step = self.dag.steps.iter().find(|step| step.name == step_name)?;
+        let steps = self
+            .step_outputs
+            .iter()
+            .map(|(name, output)| (name.clone(), template_entry(name, output)))
+            .collect();
+        let dependency_outputs = step
+            .depends
+            .iter()
+            .filter_map(|dep| {
+                self.step_outputs
+                    .get(dep)
+                    .map(|output| template_entry(dep, output))
+            })
+            .collect();
+
+        Some(StepOutputTemplateContext {
+            steps,
+            dependency_outputs,
+        })
+    }
+
     /// Find all steps that are [`StepState::Pending`] and whose dependencies
     /// are all [`StepState::Passed`].
     ///
@@ -388,11 +432,25 @@ impl PipelineRun {
     }
 }
 
+fn template_entry(step: &str, output: &StepOutput) -> StepOutputTemplateEntry {
+    StepOutputTemplateEntry {
+        step: step.to_string(),
+        verdict: match &output.verdict {
+            Verdict::Approve => "approve".to_string(),
+            Verdict::Reject { .. } => "reject".to_string(),
+        },
+        summary: output.summary.clone(),
+        output: output.output.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::ensemble::{StepApprovalConfig, StepApprovalMode, StepConfig};
     use crate::pipeline::dag::build_dag;
+    use crate::pipeline::verdict::StepOutput;
+    use serde_json::json;
 
     fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
         let deps = if depends.is_empty() {
@@ -459,6 +517,24 @@ mod tests {
         PipelineRun::new("issue-1".to_string(), 1, dag)
     }
 
+    fn approve_output() -> StepOutput {
+        StepOutput {
+            verdict: Verdict::Approve,
+            summary: None,
+            output: None,
+        }
+    }
+
+    fn reject_output(summary: &str) -> StepOutput {
+        StepOutput {
+            verdict: Verdict::Reject {
+                summary: summary.to_string(),
+            },
+            summary: Some(summary.to_string()),
+            output: None,
+        }
+    }
+
     // -------------------------------------------------------------------------
     // test_sequential_pipeline
     // -------------------------------------------------------------------------
@@ -489,7 +565,7 @@ mod tests {
         );
 
         // build completes with approve → should dispatch test next.
-        let action = run.step_completed("build", Verdict::Approve, false);
+        let action = run.step_completed("build", approve_output(), false);
         assert!(
             matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "test"),
             "expected Dispatch([test]), got {action:?}"
@@ -498,7 +574,7 @@ mod tests {
         run.mark_running("test", "session-2".to_string());
 
         // test completes with approve → all done.
-        let action = run.step_completed("test", Verdict::Approve, false);
+        let action = run.step_completed("test", approve_output(), false);
         assert_eq!(action, PipelineAction::Succeeded);
     }
 
@@ -524,7 +600,7 @@ mod tests {
         );
 
         run.mark_running("build", "session-build".to_string());
-        let action = run.step_completed("build", Verdict::Approve, false);
+        let action = run.step_completed("build", approve_output(), false);
 
         // After build passes, both review steps should be dispatched together.
         match action {
@@ -540,9 +616,9 @@ mod tests {
         // Both reviews pass → Succeeded.
         run.mark_running("review-a", "session-ra".to_string());
         run.mark_running("review-b", "session-rb".to_string());
-        let _ = run.step_completed("review-a", Verdict::Approve, false);
+        let _ = run.step_completed("review-a", approve_output(), false);
         // After review-a passes, review-b is still running → Waiting.
-        let _action = run.step_completed("review-a", Verdict::Approve, false);
+        let _action = run.step_completed("review-a", approve_output(), false);
         // review-a was already set to Passed; a second approve on it should
         // still produce Waiting (review-b still pending/running).
         // Restart properly: create a fresh run and walk through fully.
@@ -553,12 +629,12 @@ mod tests {
         ];
         let mut run2 = make_run(&steps2);
         run2.mark_running("build", "s-b".to_string());
-        run2.step_completed("build", Verdict::Approve, false);
+        run2.step_completed("build", approve_output(), false);
         run2.mark_running("review-a", "s-ra".to_string());
         run2.mark_running("review-b", "s-rb".to_string());
 
         // review-a passes first; review-b is still Running → Waiting.
-        let action = run2.step_completed("review-a", Verdict::Approve, false);
+        let action = run2.step_completed("review-a", approve_output(), false);
         assert_eq!(
             action,
             PipelineAction::Waiting,
@@ -566,7 +642,7 @@ mod tests {
         );
 
         // Now review-b also passes → Succeeded.
-        let action = run2.step_completed("review-b", Verdict::Approve, false);
+        let action = run2.step_completed("review-b", approve_output(), false);
         assert_eq!(action, PipelineAction::Succeeded);
     }
 
@@ -585,14 +661,14 @@ mod tests {
         let mut run = make_run(&steps);
 
         run.mark_running("build", "session-build".to_string());
-        let action = run.step_completed("build", Verdict::Approve, false);
+        let action = run.step_completed("build", approve_output(), false);
         assert!(
             matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "implement"),
             "expected implement to dispatch after build, got {action:?}"
         );
 
         run.mark_running("implement", "session-implement".to_string());
-        let action = run.step_completed("implement", Verdict::Approve, false);
+        let action = run.step_completed("implement", approve_output(), false);
         assert!(
             matches!(
                 &action,
@@ -628,12 +704,12 @@ mod tests {
 
         run.mark_running("build", "session-build".to_string());
         assert!(matches!(
-            run.step_completed("build", Verdict::Approve, false),
+            run.step_completed("build", approve_output(), false),
             PipelineAction::Dispatch(_)
         ));
 
         run.mark_running("implement", "session-implement".to_string());
-        let action = run.step_completed("implement", Verdict::Approve, false);
+        let action = run.step_completed("implement", approve_output(), false);
         assert!(matches!(action, PipelineAction::AwaitingApproval { .. }));
 
         let action = run.bind_approval_interaction("implement", "approval-123".to_string());
@@ -669,12 +745,12 @@ mod tests {
 
         run.mark_running("build", "session-build".to_string());
         assert!(matches!(
-            run.step_completed("build", Verdict::Approve, false),
+            run.step_completed("build", approve_output(), false),
             PipelineAction::Dispatch(_)
         ));
 
         run.mark_running("implement", "session-implement".to_string());
-        let action = run.step_completed("implement", Verdict::Approve, false);
+        let action = run.step_completed("implement", approve_output(), false);
         assert!(
             matches!(&action, PipelineAction::Succeeded),
             "expected approve without request to complete the pipeline, got {action:?}"
@@ -693,9 +769,9 @@ mod tests {
         ];
         let mut run = make_run(&steps);
         run.mark_running("build", "session-build".to_string());
-        let _ = run.step_completed("build", Verdict::Approve, false);
+        let _ = run.step_completed("build", approve_output(), false);
         run.mark_running("implement", "session-implement".to_string());
-        let action = run.step_completed("implement", Verdict::Approve, true);
+        let action = run.step_completed("implement", approve_output(), true);
         assert!(
             matches!(
                 &action,
@@ -724,9 +800,9 @@ mod tests {
         let mut run = make_run(&steps);
 
         run.mark_running("build", "session-build".to_string());
-        let _ = run.step_completed("build", Verdict::Approve, false);
+        let _ = run.step_completed("build", approve_output(), false);
         run.mark_running("implement", "session-implement".to_string());
-        let action = run.step_completed("implement", Verdict::Approve, false);
+        let action = run.step_completed("implement", approve_output(), false);
         assert!(matches!(action, PipelineAction::AwaitingApproval { .. }));
 
         let action = run.bind_approval_interaction("implement", "approval-456".to_string());
@@ -759,16 +835,10 @@ mod tests {
         let mut run = make_run(&steps);
 
         run.mark_running("build", "s-b".to_string());
-        run.step_completed("build", Verdict::Approve, false);
+        run.step_completed("build", approve_output(), false);
         run.mark_running("review", "s-r".to_string());
 
-        let action = run.step_completed(
-            "review",
-            Verdict::Reject {
-                summary: "code quality is too low".to_string(),
-            },
-            false,
-        );
+        let action = run.step_completed("review", reject_output("code quality is too low"), false);
 
         assert!(
             matches!(
@@ -839,7 +909,7 @@ mod tests {
 
         // After build passes, review is dispatched with its tracker_state.
         run.mark_running("build", "s-b".to_string());
-        let action = run.step_completed("build", Verdict::Approve, false);
+        let action = run.step_completed("build", approve_output(), false);
         match &action {
             PipelineAction::Dispatch(reqs) => {
                 assert_eq!(reqs.len(), 1);
@@ -908,7 +978,7 @@ mod tests {
         )];
         let mut run = make_run(&steps);
 
-        let action = run.step_completed("review", Verdict::Approve, false);
+        let action = run.step_completed("review", approve_output(), false);
         assert!(matches!(action, PipelineAction::AwaitingApproval { .. }));
 
         let action = run.bind_approval_interaction("review", "approval-789".to_string());
@@ -996,7 +1066,7 @@ mod tests {
         let mut run = make_run(&steps);
 
         run.mark_running("build", "session-build".to_string());
-        let action = run.step_completed("build", Verdict::Approve, false);
+        let action = run.step_completed("build", approve_output(), false);
         assert!(
             matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "review"),
             "expected Dispatch([review]), got {action:?}"
@@ -1016,12 +1086,58 @@ mod tests {
     }
 
     #[test]
+    fn downstream_context_contains_direct_dependency_outputs() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("review-a", "reviewer", &["build"]),
+            make_step("review-b", "reviewer", &["build"]),
+            make_step("synth", "synthesizer", &["review-a", "review-b"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.step_completed(
+            "build",
+            StepOutput {
+                verdict: Verdict::Approve,
+                summary: Some("built".to_string()),
+                output: Some(json!({"artifact":"branch"})),
+            },
+            false,
+        );
+        run.step_completed(
+            "review-a",
+            StepOutput {
+                verdict: Verdict::Approve,
+                summary: Some("a ok".to_string()),
+                output: Some(json!({"risk":"low"})),
+            },
+            false,
+        );
+        run.step_completed(
+            "review-b",
+            StepOutput {
+                verdict: Verdict::Approve,
+                summary: Some("b ok".to_string()),
+                output: Some(json!({"risk":"medium"})),
+            },
+            false,
+        );
+
+        let context = run.output_context_for("synth").unwrap();
+
+        assert_eq!(context.dependency_outputs.len(), 2);
+        assert_eq!(context.dependency_outputs[0].step, "review-a");
+        assert_eq!(context.dependency_outputs[1].step, "review-b");
+        assert_eq!(context.steps["review-a"].summary.as_deref(), Some("a ok"));
+    }
+
+    #[test]
     fn step_completed_fails_when_worker_requests_approval_but_step_has_no_approval_config() {
         let steps = vec![make_step("build", "builder", &[])];
         let mut run = make_run(&steps);
 
         run.mark_running("build", "session-build".to_string());
-        let action = run.step_completed("build", Verdict::Approve, true);
+        let action = run.step_completed("build", approve_output(), true);
 
         assert!(
             matches!(

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -58,19 +58,26 @@ pub fn parse_step_output_from_value(value: &serde_json::Value) -> Option<StepOut
     step_output_from_payload(&payload)
 }
 
-/// Read `.ensemble/verdict.json` from the given workspace directory.
+/// Read `.ensemble/verdict-{step_name}.json` from the given workspace directory.
 ///
 /// Returns `Ok(None)` if the file does not exist. Returns `Ok(Some(verdict))`
 /// if the file exists and parses successfully. Returns an `Err` only on
 /// unexpected I/O failures (not "file not found").
-pub async fn read_verdict_file(workspace: &Path) -> Result<Option<Verdict>, std::io::Error> {
-    read_step_output_file(workspace)
+pub async fn read_verdict_file(
+    workspace: &Path,
+    step_name: &str,
+) -> Result<Option<Verdict>, std::io::Error> {
+    read_step_output_file(workspace, step_name)
         .await
         .map(|value| value.map(|output| output.verdict))
 }
 
-pub async fn read_step_output_file(workspace: &Path) -> Result<Option<StepOutput>, std::io::Error> {
-    let path = workspace.join(".ensemble").join("verdict.json");
+pub async fn read_step_output_file(
+    workspace: &Path,
+    step_name: &str,
+) -> Result<Option<StepOutput>, std::io::Error> {
+    let filename = format!("verdict-{step_name}.json");
+    let path = workspace.join(".ensemble").join(&filename);
     match tokio::fs::read_to_string(&path).await {
         Ok(contents) => {
             let payload: VerdictPayload = serde_json::from_str(&contents)
@@ -86,10 +93,14 @@ pub async fn read_step_output_file(workspace: &Path) -> Result<Option<StepOutput
 ///
 /// Priority:
 /// 1. ACP event value (`acp_verdict`) — checked first.
-/// 2. `.ensemble/verdict.json` in the workspace — checked if ACP yields nothing.
+/// 2. `.ensemble/verdict-{step_name}.json` in the workspace — checked if ACP yields nothing.
 /// 3. Default to [`Verdict::Approve`] if neither source provides a verdict.
-pub async fn resolve_verdict(acp_verdict: Option<&serde_json::Value>, workspace: &Path) -> Verdict {
-    resolve_verdict_with_source(acp_verdict, workspace)
+pub async fn resolve_verdict(
+    acp_verdict: Option<&serde_json::Value>,
+    workspace: &Path,
+    step_name: &str,
+) -> Verdict {
+    resolve_verdict_with_source(acp_verdict, workspace, step_name)
         .await
         .verdict
 }
@@ -98,6 +109,7 @@ pub async fn resolve_verdict(acp_verdict: Option<&serde_json::Value>, workspace:
 pub async fn resolve_verdict_with_source(
     acp_verdict: Option<&serde_json::Value>,
     workspace: &Path,
+    step_name: &str,
 ) -> ResolvedVerdict {
     // 1. Try ACP event.
     if let Some(value) = acp_verdict {
@@ -111,7 +123,7 @@ pub async fn resolve_verdict_with_source(
     }
 
     // 2. Try file.
-    match read_step_output_file(workspace).await {
+    match read_step_output_file(workspace, step_name).await {
         Ok(Some(output)) => {
             return ResolvedVerdict {
                 verdict: output.verdict.clone(),
@@ -122,7 +134,7 @@ pub async fn resolve_verdict_with_source(
         Ok(None) => {} // file doesn't exist — fall through to default
         Err(e) => {
             // Malformed verdict file — treat as rejection, not silent approval.
-            let msg = format!("failed to parse .ensemble/verdict.json: {e}");
+            let msg = format!("failed to parse .ensemble/verdict-{step_name}.json: {e}");
             let reject = Verdict::Reject {
                 summary: msg.clone(),
             };
@@ -218,9 +230,14 @@ mod tests {
     // -------------------------------------------------------------------------
 
     async fn write_verdict_file(dir: &TempDir, contents: &str) {
+        write_step_verdict_file(dir, "build", contents).await;
+    }
+
+    async fn write_step_verdict_file(dir: &TempDir, step_name: &str, contents: &str) {
         let ensemble_dir = dir.path().join(".ensemble");
         tokio::fs::create_dir_all(&ensemble_dir).await.unwrap();
-        tokio::fs::write(ensemble_dir.join("verdict.json"), contents)
+        let filename = format!("verdict-{step_name}.json");
+        tokio::fs::write(ensemble_dir.join(&filename), contents)
             .await
             .unwrap();
     }
@@ -229,7 +246,7 @@ mod tests {
     async fn test_read_verdict_file_approve() {
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, r#"{"verdict":"approve"}"#).await;
-        let result = read_verdict_file(dir.path()).await.unwrap();
+        let result = read_verdict_file(dir.path(), "build").await.unwrap();
         assert_eq!(result, Some(Verdict::Approve));
     }
 
@@ -237,7 +254,7 @@ mod tests {
     async fn test_read_verdict_file_reject() {
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, r#"{"verdict":"reject","summary":"lint errors"}"#).await;
-        let result = read_verdict_file(dir.path()).await.unwrap();
+        let result = read_verdict_file(dir.path(), "build").await.unwrap();
         assert_eq!(
             result,
             Some(Verdict::Reject {
@@ -249,7 +266,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_verdict_file_missing() {
         let dir = TempDir::new().unwrap();
-        let result = read_verdict_file(dir.path()).await.unwrap();
+        let result = read_verdict_file(dir.path(), "build").await.unwrap();
         assert_eq!(result, None);
     }
 
@@ -264,7 +281,7 @@ mod tests {
         write_verdict_file(&dir, r#"{"verdict":"reject","summary":"broken"}"#).await;
 
         let acp = json!({ "verdict": "approve" });
-        let result = resolve_verdict(Some(&acp), dir.path()).await;
+        let result = resolve_verdict(Some(&acp), dir.path(), "build").await;
         assert_eq!(result, Verdict::Approve);
     }
 
@@ -274,7 +291,7 @@ mod tests {
         write_verdict_file(&dir, r#"{"verdict":"reject","summary":"broken"}"#).await;
 
         let acp = json!({ "verdict": "approve" });
-        let result = resolve_verdict_with_source(Some(&acp), dir.path()).await;
+        let result = resolve_verdict_with_source(Some(&acp), dir.path(), "build").await;
         assert_eq!(result.verdict, Verdict::Approve);
         assert_eq!(result.source, VerdictSource::Runtime);
     }
@@ -285,7 +302,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, r#"{"verdict":"reject","summary":"compile error"}"#).await;
 
-        let result = resolve_verdict(None, dir.path()).await;
+        let result = resolve_verdict(None, dir.path(), "build").await;
         assert_eq!(
             result,
             Verdict::Reject {
@@ -299,7 +316,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, r#"{"verdict":"reject","summary":"compile error"}"#).await;
 
-        let result = resolve_verdict_with_source(None, dir.path()).await;
+        let result = resolve_verdict_with_source(None, dir.path(), "build").await;
         assert_eq!(
             result.verdict,
             Verdict::Reject {
@@ -313,14 +330,14 @@ mod tests {
     async fn test_resolve_verdict_no_source_is_approve() {
         // No ACP, no file — defaults to Approve.
         let dir = TempDir::new().unwrap();
-        let result = resolve_verdict(None, dir.path()).await;
+        let result = resolve_verdict(None, dir.path(), "build").await;
         assert_eq!(result, Verdict::Approve);
     }
 
     #[tokio::test]
     async fn test_resolve_verdict_with_source_no_source_is_default_approve() {
         let dir = TempDir::new().unwrap();
-        let result = resolve_verdict_with_source(None, dir.path()).await;
+        let result = resolve_verdict_with_source(None, dir.path(), "build").await;
         assert_eq!(result.verdict, Verdict::Approve);
         assert_eq!(result.source, VerdictSource::Default);
     }
@@ -329,7 +346,7 @@ mod tests {
     async fn test_read_verdict_file_malformed_json_is_error() {
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, "this is not json").await;
-        let result = read_verdict_file(dir.path()).await;
+        let result = read_verdict_file(dir.path(), "build").await;
         assert!(result.is_err());
     }
 
@@ -338,7 +355,7 @@ mod tests {
         // Malformed verdict.json should reject, not silently approve.
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, "not valid json").await;
-        let result = resolve_verdict(None, dir.path()).await;
+        let result = resolve_verdict(None, dir.path(), "build").await;
         assert!(matches!(result, Verdict::Reject { .. }));
     }
 
@@ -370,7 +387,10 @@ mod tests {
         )
         .await;
 
-        let output = read_step_output_file(dir.path()).await.unwrap().unwrap();
+        let output = read_step_output_file(dir.path(), "build")
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(output.verdict, Verdict::Approve);
         assert_eq!(output.summary.as_deref(), Some("ok"));

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -76,17 +76,24 @@ pub async fn read_step_output_file(
     workspace: &Path,
     step_name: &str,
 ) -> Result<Option<StepOutput>, std::io::Error> {
-    let filename = format!("verdict-{step_name}.json");
-    let path = workspace.join(".ensemble").join(&filename);
-    match tokio::fs::read_to_string(&path).await {
-        Ok(contents) => {
-            let payload: VerdictPayload = serde_json::from_str(&contents)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-            Ok(step_output_from_payload(&payload))
+    let step_file = workspace
+        .join(".ensemble")
+        .join(format!("verdict-{step_name}.json"));
+    let legacy_file = workspace.join(".ensemble").join("verdict.json");
+
+    // Try step-scoped file first, fall back to legacy verdict.json.
+    for path in [&step_file, &legacy_file] {
+        match tokio::fs::read_to_string(path).await {
+            Ok(contents) => {
+                let payload: VerdictPayload = serde_json::from_str(&contents)
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+                return Ok(step_output_from_payload(&payload));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => Err(e),
     }
+    Ok(None)
 }
 
 /// Resolve the final verdict for a completed step.
@@ -94,7 +101,8 @@ pub async fn read_step_output_file(
 /// Priority:
 /// 1. ACP event value (`acp_verdict`) — checked first.
 /// 2. `.ensemble/verdict-{step_name}.json` in the workspace — checked if ACP yields nothing.
-/// 3. Default to [`Verdict::Approve`] if neither source provides a verdict.
+/// 3. `.ensemble/verdict.json` (legacy fallback) — checked if step-scoped file is absent.
+/// 4. Default to [`Verdict::Approve`] if no source provides a verdict.
 pub async fn resolve_verdict(
     acp_verdict: Option<&serde_json::Value>,
     workspace: &Path,

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -20,8 +20,16 @@ pub enum VerdictSource {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct StepOutput {
+    pub verdict: Verdict,
+    pub summary: Option<String>,
+    pub output: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedVerdict {
     pub verdict: Verdict,
+    pub output: StepOutput,
     pub source: VerdictSource,
 }
 
@@ -30,6 +38,8 @@ pub struct ResolvedVerdict {
 struct VerdictPayload {
     verdict: Option<String>,
     summary: Option<String>,
+    #[serde(default)]
+    output: Option<serde_json::Value>,
 }
 
 /// Parse a [`Verdict`] from an arbitrary JSON value (e.g. an ACP event body).
@@ -43,18 +53,31 @@ pub fn parse_verdict_from_value(value: &serde_json::Value) -> Option<Verdict> {
     verdict_from_payload(&payload)
 }
 
+pub fn parse_step_output_from_value(value: &serde_json::Value) -> Option<StepOutput> {
+    let payload: VerdictPayload = serde_json::from_value(value.clone()).ok()?;
+    step_output_from_payload(&payload)
+}
+
 /// Read `.ensemble/verdict.json` from the given workspace directory.
 ///
 /// Returns `Ok(None)` if the file does not exist. Returns `Ok(Some(verdict))`
 /// if the file exists and parses successfully. Returns an `Err` only on
 /// unexpected I/O failures (not "file not found").
 pub async fn read_verdict_file(workspace: &Path) -> Result<Option<Verdict>, std::io::Error> {
+    read_step_output_file(workspace)
+        .await
+        .map(|value| value.map(|output| output.verdict))
+}
+
+pub async fn read_step_output_file(
+    workspace: &Path,
+) -> Result<Option<StepOutput>, std::io::Error> {
     let path = workspace.join(".ensemble").join("verdict.json");
     match tokio::fs::read_to_string(&path).await {
         Ok(contents) => {
             let payload: VerdictPayload = serde_json::from_str(&contents)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-            Ok(verdict_from_payload(&payload))
+            Ok(step_output_from_payload(&payload))
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(e),
@@ -80,29 +103,38 @@ pub async fn resolve_verdict_with_source(
 ) -> ResolvedVerdict {
     // 1. Try ACP event.
     if let Some(value) = acp_verdict {
-        if let Some(v) = parse_verdict_from_value(value) {
+        if let Some(output) = parse_step_output_from_value(value) {
             return ResolvedVerdict {
-                verdict: v,
+                verdict: output.verdict.clone(),
+                output,
                 source: VerdictSource::Runtime,
             };
         }
     }
 
     // 2. Try file.
-    match read_verdict_file(workspace).await {
-        Ok(Some(v)) => {
+    match read_step_output_file(workspace).await {
+        Ok(Some(output)) => {
             return ResolvedVerdict {
-                verdict: v,
+                verdict: output.verdict.clone(),
+                output,
                 source: VerdictSource::File,
             };
         }
         Ok(None) => {} // file doesn't exist — fall through to default
         Err(e) => {
             // Malformed verdict file — treat as rejection, not silent approval.
+            let reject = Verdict::Reject {
+                summary: format!("failed to parse .ensemble/verdict.json: {e}"),
+            };
+            let output = StepOutput {
+                verdict: reject.clone(),
+                summary: Some(format!("failed to parse .ensemble/verdict.json: {e}")),
+                output: None,
+            };
             return ResolvedVerdict {
-                verdict: Verdict::Reject {
-                    summary: format!("failed to parse .ensemble/verdict.json: {e}"),
-                },
+                verdict: reject,
+                output,
                 source: VerdictSource::File,
             };
         }
@@ -110,21 +142,37 @@ pub async fn resolve_verdict_with_source(
 
     // 3. Default (no ACP verdict, no file).
     warn!("no verdict source found for step, defaulting to Approve");
-    ResolvedVerdict {
+    let output = StepOutput {
         verdict: Verdict::Approve,
+        summary: None,
+        output: None,
+    };
+    ResolvedVerdict {
+        verdict: output.verdict.clone(),
+        output,
         source: VerdictSource::Default,
     }
 }
 
 /// Convert a [`VerdictPayload`] into an `Option<Verdict>`.
 fn verdict_from_payload(payload: &VerdictPayload) -> Option<Verdict> {
-    match payload.verdict.as_deref() {
-        Some(v) if v.eq_ignore_ascii_case("approve") => Some(Verdict::Approve),
-        Some(v) if v.eq_ignore_ascii_case("reject") => Some(Verdict::Reject {
+    step_output_from_payload(payload).map(|output| output.verdict)
+}
+
+fn step_output_from_payload(payload: &VerdictPayload) -> Option<StepOutput> {
+    let verdict = match payload.verdict.as_deref() {
+        Some(v) if v.eq_ignore_ascii_case("approve") => Verdict::Approve,
+        Some(v) if v.eq_ignore_ascii_case("reject") => Verdict::Reject {
             summary: payload.summary.clone().unwrap_or_default(),
-        }),
-        _ => None,
-    }
+        },
+        _ => return None,
+    };
+
+    Some(StepOutput {
+        verdict,
+        summary: payload.summary.clone(),
+        output: payload.output.clone(),
+    })
 }
 
 #[cfg(test)]
@@ -293,5 +341,40 @@ mod tests {
         write_verdict_file(&dir, "not valid json").await;
         let result = resolve_verdict(None, dir.path()).await;
         assert!(matches!(result, Verdict::Reject { .. }));
+    }
+
+    // -------------------------------------------------------------------------
+    // StepOutput and parse_step_output_from_value
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_step_output_from_runtime_value() {
+        let value = json!({
+            "verdict": "approve",
+            "summary": "review passed",
+            "output": {"risk": "low", "findings": []}
+        });
+
+        let output = parse_step_output_from_value(&value).unwrap();
+
+        assert_eq!(output.verdict, Verdict::Approve);
+        assert_eq!(output.summary.as_deref(), Some("review passed"));
+        assert_eq!(output.output, Some(json!({"risk":"low","findings":[]})));
+    }
+
+    #[tokio::test]
+    async fn test_read_step_output_file_preserves_approve_summary_and_output() {
+        let dir = TempDir::new().unwrap();
+        write_verdict_file(
+            &dir,
+            r#"{"verdict":"approve","summary":"ok","output":{"files":["src/lib.rs"]}}"#,
+        )
+        .await;
+
+        let output = read_step_output_file(dir.path()).await.unwrap().unwrap();
+
+        assert_eq!(output.verdict, Verdict::Approve);
+        assert_eq!(output.summary.as_deref(), Some("ok"));
+        assert_eq!(output.output, Some(json!({"files":["src/lib.rs"]})));
     }
 }

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -69,9 +69,7 @@ pub async fn read_verdict_file(workspace: &Path) -> Result<Option<Verdict>, std:
         .map(|value| value.map(|output| output.verdict))
 }
 
-pub async fn read_step_output_file(
-    workspace: &Path,
-) -> Result<Option<StepOutput>, std::io::Error> {
+pub async fn read_step_output_file(workspace: &Path) -> Result<Option<StepOutput>, std::io::Error> {
     let path = workspace.join(".ensemble").join("verdict.json");
     match tokio::fs::read_to_string(&path).await {
         Ok(contents) => {
@@ -124,12 +122,13 @@ pub async fn resolve_verdict_with_source(
         Ok(None) => {} // file doesn't exist — fall through to default
         Err(e) => {
             // Malformed verdict file — treat as rejection, not silent approval.
+            let msg = format!("failed to parse .ensemble/verdict.json: {e}");
             let reject = Verdict::Reject {
-                summary: format!("failed to parse .ensemble/verdict.json: {e}"),
+                summary: msg.clone(),
             };
             let output = StepOutput {
                 verdict: reject.clone(),
-                summary: Some(format!("failed to parse .ensemble/verdict.json: {e}")),
+                summary: Some(msg),
                 output: None,
             };
             return ResolvedVerdict {

--- a/crates/ensemble-core/tests/step_output_templates.rs
+++ b/crates/ensemble-core/tests/step_output_templates.rs
@@ -1,0 +1,191 @@
+use ensemble_core::config::ensemble::StepConfig;
+use ensemble_core::config::template::render_prompt_with_context;
+use ensemble_core::pipeline::dag::build_dag;
+use ensemble_core::pipeline::engine::PipelineRun;
+use ensemble_core::pipeline::verdict::{StepOutput, Verdict};
+use ensemble_core::tracker::model::Issue;
+use serde_json::json;
+
+fn sample_issue() -> Issue {
+    Issue {
+        id: "NODE_1".to_string(),
+        identifier: "proj#10".to_string(),
+        title: "Add feature X".to_string(),
+        description: Some("Implement feature X".to_string()),
+        priority: Some(1),
+        state: "Todo".to_string(),
+        branch_name: None,
+        url: None,
+        labels: vec![],
+        blocked_by: vec![],
+        created_at: None,
+        updated_at: None,
+    }
+}
+
+fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
+    StepConfig {
+        name: name.to_string(),
+        agent: agent.to_string(),
+        depends: if depends.is_empty() {
+            None
+        } else {
+            Some(depends.iter().map(|s| s.to_string()).collect())
+        },
+        tracker_state: None,
+        approval: None,
+    }
+}
+
+#[test]
+fn render_prompt_with_dependency_outputs() {
+    // DAG: build → review-a + review-b → synth
+    let steps = vec![
+        make_step("build", "builder", &[]),
+        make_step("review-a", "reviewer", &["build"]),
+        make_step("review-b", "reviewer", &["build"]),
+        make_step("synth", "synthesizer", &["review-a", "review-b"]),
+    ];
+    let dag = build_dag(&steps).unwrap();
+    let mut run = PipelineRun::new("issue-10".to_string(), 1, dag);
+
+    // Complete build
+    run.step_completed(
+        "build",
+        StepOutput {
+            verdict: Verdict::Approve,
+            summary: Some("built ok".to_string()),
+            output: Some(json!({"artifact": "branch"})),
+        },
+        false,
+    );
+
+    // Complete review-a
+    run.step_completed(
+        "review-a",
+        StepOutput {
+            verdict: Verdict::Approve,
+            summary: Some("review a passed".to_string()),
+            output: Some(json!({"risk": "low", "findings": ["minor nit"]})),
+        },
+        false,
+    );
+
+    // Complete review-b
+    run.step_completed(
+        "review-b",
+        StepOutput {
+            verdict: Verdict::Approve,
+            summary: Some("review b passed".to_string()),
+            output: Some(json!({"risk": "medium", "findings": ["missing tests"]})),
+        },
+        false,
+    );
+
+    // Get template context for synth step
+    let context = run
+        .output_context_for("synth")
+        .expect("synth step should exist");
+
+    // Verify context structure
+    assert_eq!(
+        context.dependency_outputs.len(),
+        2,
+        "synth has 2 direct dependencies"
+    );
+    assert_eq!(context.dependency_outputs[0].step, "review-a");
+    assert_eq!(context.dependency_outputs[1].step, "review-b");
+    assert!(context.steps.contains_key("build"));
+    assert!(context.steps.contains_key("review-a"));
+    assert!(context.steps.contains_key("review-b"));
+
+    // Render a template that iterates dependency_outputs
+    let template = r#"{% for review in dependency_outputs %}
+## {{ review.step }}
+{{ review.summary }}
+Risk: {{ review.output.risk }}
+{% endfor %}"#;
+
+    let rendered =
+        render_prompt_with_context(template, &sample_issue(), None, None, Some(&context)).unwrap();
+
+    assert!(
+        rendered.contains("## review-a"),
+        "should contain review-a heading"
+    );
+    assert!(
+        rendered.contains("review a passed"),
+        "should contain review-a summary"
+    );
+    assert!(
+        rendered.contains("Risk: low"),
+        "should contain review-a risk"
+    );
+    assert!(
+        rendered.contains("## review-b"),
+        "should contain review-b heading"
+    );
+    assert!(
+        rendered.contains("review b passed"),
+        "should contain review-b summary"
+    );
+    assert!(
+        rendered.contains("Risk: medium"),
+        "should contain review-b risk"
+    );
+
+    // Render a template that accesses specific steps by name
+    let named_template = r#"Risk A: {{ steps["review-a"].output.risk }}, Risk B: {{ steps["review-b"].output.risk }}"#;
+    let rendered =
+        render_prompt_with_context(named_template, &sample_issue(), None, None, Some(&context))
+            .unwrap();
+
+    assert_eq!(rendered, "Risk A: low, Risk B: medium");
+}
+
+#[test]
+fn output_context_for_returns_none_for_unknown_step() {
+    let steps = vec![make_step("build", "builder", &[])];
+    let dag = build_dag(&steps).unwrap();
+    let run = PipelineRun::new("issue-1".to_string(), 1, dag);
+
+    assert!(run.output_context_for("nonexistent").is_none());
+}
+
+#[test]
+fn dependency_outputs_only_include_direct_deps() {
+    // DAG: a → b → c
+    let steps = vec![
+        make_step("a", "agent", &[]),
+        make_step("b", "agent", &["a"]),
+        make_step("c", "agent", &["b"]),
+    ];
+    let dag = build_dag(&steps).unwrap();
+    let mut run = PipelineRun::new("issue-1".to_string(), 1, dag);
+
+    run.step_completed(
+        "a",
+        StepOutput {
+            verdict: Verdict::Approve,
+            summary: Some("a done".to_string()),
+            output: Some(json!({"step": "a"})),
+        },
+        false,
+    );
+    run.step_completed(
+        "b",
+        StepOutput {
+            verdict: Verdict::Approve,
+            summary: Some("b done".to_string()),
+            output: Some(json!({"step": "b"})),
+        },
+        false,
+    );
+
+    let context = run.output_context_for("c").unwrap();
+    // c depends only on b, not on a
+    assert_eq!(context.dependency_outputs.len(), 1);
+    assert_eq!(context.dependency_outputs[0].step, "b");
+    // But steps map contains all completed steps
+    assert_eq!(context.steps.len(), 2);
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -282,11 +282,18 @@ Agent judgment returned after a pipeline step completes:
   - `"reject"` — step failed quality/review check.
   - null/absent — treated as `"approve"` (backwards compatible for non-review agents).
 - `summary` (string or null) — human-readable explanation of the verdict.
+- `output` (JSON value or null) — arbitrary structured data produced by a step for downstream
+  prompt templates.
 
 Verdict sources (checked in priority order):
 
 1. ACP protocol: `verdict` field in the final `session/update` status event.
 2. File-based fallback: `.ensemble/verdict.json` in the workspace directory.
+
+Prompt templates for downstream steps receive:
+
+- `steps` — map of completed step name to `{ step, verdict, summary, output }`.
+- `dependency_outputs` — ordered list of direct dependency outputs for the step being dispatched.
 
 #### 4.1.8 Run Attempt
 
@@ -772,6 +779,12 @@ Template input variables:
 - `attempt` (integer or null)
   - `null`/absent on first attempt.
   - Integer on retry or continuation run.
+- `steps` (map of string to object, optional)
+  - Present when upstream steps have completed. Each entry contains `step`, `verdict`, `summary`,
+    and `output` fields.
+- `dependency_outputs` (list of objects, optional)
+  - Ordered list of outputs from the step's direct dependencies. Each entry has the same shape as
+    `steps` entries: `{ step, verdict, summary, output }`.
 
 Fallback prompt behavior:
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -189,3 +189,55 @@ What happens:
 4. Builder approves → runs the `review` step — reviewer agent checks the work
 5. Reviewer approves → issue moves to "Done"
 6. If reviewer rejects → issue moves to "Needs Rework", retries from step 1 on next cycle
+
+## Accessing dependency outputs
+
+Downstream steps can access outputs from their direct dependencies via the `dependency_outputs` and
+`steps` template variables. This is useful for synthesis steps that merge results from parallel
+branches.
+
+```yaml
+steps:
+  - name: implement
+    agent: implementer
+  - name: review-a
+    agent: reviewer
+    depends: [implement]
+  - name: review-b
+    agent: reviewer
+    depends: [implement]
+  - name: synthesize
+    agent: synthesizer
+    depends: [review-a, review-b]
+```
+
+A synthesizer prompt can iterate over `dependency_outputs`:
+
+```liquid
+{% for review in dependency_outputs %}
+## {{ review.step }}
+{{ review.summary }}
+Risk: {{ review.output.risk }}
+{% endfor %}
+```
+
+Or access a specific step by name via the `steps` map:
+
+```liquid
+Review A risk: {{ steps["review-a"].output.risk }}
+Review B risk: {{ steps["review-b"].output.risk }}
+```
+
+Steps can produce structured `output` data alongside their verdict. Set the `output` field in
+`.ensemble/verdict.json` or in the ACP runtime verdict:
+
+```json
+{
+  "verdict": "approve",
+  "summary": "Looks good, low risk",
+  "output": {
+    "risk": "low",
+    "findings": ["minor style nit on line 42"]
+  }
+}
+```

--- a/docs/superpowers/plans/2026-06-10-issue-174-step-output-passing.md
+++ b/docs/superpowers/plans/2026-06-10-issue-174-step-output-passing.md
@@ -1,0 +1,902 @@
+# Step Output Passing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a completed pipeline step publish a structured output payload that downstream steps can read from Liquid prompt templates.
+
+**Architecture:** Extend the existing verdict payload contract instead of adding a second artifact format: ACP verdict values and `.ensemble/verdict.json` may include `summary` and arbitrary JSON under `output`. Parse that into a new `StepOutput` model, store outputs on `PipelineRun` keyed by step name, and pass a read-only prompt context into each dispatched agent run. Downstream templates can use `steps["review-a"].summary`, `steps["review-a"].output.findings`, or iterate `dependency_outputs` for immediate dependency outputs in configured dependency order.
+
+**Tech Stack:** Rust 2021, `serde`, `serde_json`, `liquid`, existing `tokio` tests
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `crates/ensemble-core/src/pipeline/verdict.rs` | Define `StepOutput`, parse output-bearing verdict payloads, keep verdict resolution source behavior |
+| Modify | `crates/ensemble-core/src/pipeline/engine.rs` | Store per-step outputs on `PipelineRun` and expose prompt context for downstream steps |
+| Modify | `crates/ensemble-core/src/config/template.rs` | Render Liquid prompts with optional step-output globals |
+| Modify | `crates/ensemble-core/src/agent/mod.rs` | Carry output context through `AgentRunRequest` and prompt building |
+| Modify | `crates/ensemble-core/src/orchestrator/mod.rs` | Capture resolved output on worker exit and attach dependency outputs before dispatching next steps |
+| Modify | `docs/SPEC.md`, `docs/pipelines.md`, `docs/configuration.md` | Document the output contract and Liquid variables |
+
+## Contract
+
+Agents may emit:
+
+```json
+{
+  "verdict": "approve",
+  "summary": "Reviewed the implementation and found no blockers.",
+  "output": {
+    "findings": [],
+    "risk": "low"
+  }
+}
+```
+
+`verdict` remains optional and defaults to approve through the existing resolver. `summary` is now retained for both approve and reject verdicts. `output` must be any JSON value; when omitted it is `null` in templates.
+
+Templates get:
+
+```liquid
+{% for dep in dependency_outputs %}
+## {{ dep.step }}
+Verdict: {{ dep.verdict }}
+Summary: {{ dep.summary }}
+{% endfor %}
+
+{% assign review = steps["review-a"] %}
+Risk: {{ review.output.risk }}
+```
+
+`dependency_outputs` contains only the current step's direct dependencies, sorted in the step's configured `depends` order. `steps` contains all outputs already produced in the current pipeline run.
+
+## Task 1: Add Output-Aware Verdict Parsing
+
+**Files:**
+- Modify: `crates/ensemble-core/src/pipeline/verdict.rs`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add tests near the existing verdict parser tests:
+
+```rust
+#[test]
+fn test_parse_step_output_from_runtime_value() {
+    let value = json!({
+        "verdict": "approve",
+        "summary": "review passed",
+        "output": {"risk": "low", "findings": []}
+    });
+
+    let output = parse_step_output_from_value(&value).unwrap();
+
+    assert_eq!(output.verdict, Verdict::Approve);
+    assert_eq!(output.summary.as_deref(), Some("review passed"));
+    assert_eq!(output.output, Some(json!({"risk":"low","findings":[]})));
+}
+
+#[tokio::test]
+async fn test_read_step_output_file_preserves_approve_summary_and_output() {
+    let dir = TempDir::new().unwrap();
+    write_verdict_file(
+        &dir,
+        r#"{"verdict":"approve","summary":"ok","output":{"files":["src/lib.rs"]}}"#,
+    )
+    .await;
+
+    let output = read_step_output_file(dir.path()).await.unwrap().unwrap();
+
+    assert_eq!(output.verdict, Verdict::Approve);
+    assert_eq!(output.summary.as_deref(), Some("ok"));
+    assert_eq!(output.output, Some(json!({"files":["src/lib.rs"]})));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p ensemble-core pipeline::verdict::tests::test_parse_step_output_from_runtime_value -- --exact
+```
+
+Expected: FAIL because `StepOutput` and `parse_step_output_from_value` do not exist.
+
+- [ ] **Step 3: Add `StepOutput` and extend the internal payload**
+
+Add this above `ResolvedVerdict`:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct StepOutput {
+    pub verdict: Verdict,
+    pub summary: Option<String>,
+    pub output: Option<serde_json::Value>,
+}
+```
+
+Change `VerdictPayload` to:
+
+```rust
+#[derive(Debug, Deserialize)]
+struct VerdictPayload {
+    verdict: Option<String>,
+    summary: Option<String>,
+    #[serde(default)]
+    output: Option<serde_json::Value>,
+}
+```
+
+Change `ResolvedVerdict` to:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedVerdict {
+    pub verdict: Verdict,
+    pub output: StepOutput,
+    pub source: VerdictSource,
+}
+```
+
+- [ ] **Step 4: Add parsing helpers**
+
+Add these functions below `parse_verdict_from_value`:
+
+```rust
+pub fn parse_step_output_from_value(value: &serde_json::Value) -> Option<StepOutput> {
+    let payload: VerdictPayload = serde_json::from_value(value.clone()).ok()?;
+    step_output_from_payload(&payload)
+}
+
+pub async fn read_step_output_file(
+    workspace: &Path,
+) -> Result<Option<StepOutput>, std::io::Error> {
+    let path = workspace.join(".ensemble").join("verdict.json");
+    match tokio::fs::read_to_string(&path).await {
+        Ok(contents) => {
+            let payload: VerdictPayload = serde_json::from_str(&contents)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            Ok(step_output_from_payload(&payload))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+```
+
+Change `read_verdict_file` to call `read_step_output_file(workspace).await.map(|value| value.map(|output| output.verdict))`.
+
+- [ ] **Step 5: Preserve existing verdict behavior**
+
+Replace `verdict_from_payload` with:
+
+```rust
+fn verdict_from_payload(payload: &VerdictPayload) -> Option<Verdict> {
+    step_output_from_payload(payload).map(|output| output.verdict)
+}
+
+fn step_output_from_payload(payload: &VerdictPayload) -> Option<StepOutput> {
+    let verdict = match payload.verdict.as_deref() {
+        Some(v) if v.eq_ignore_ascii_case("approve") => Verdict::Approve,
+        Some(v) if v.eq_ignore_ascii_case("reject") => Verdict::Reject {
+            summary: payload.summary.clone().unwrap_or_default(),
+        },
+        _ => return None,
+    };
+
+    Some(StepOutput {
+        verdict,
+        summary: payload.summary.clone(),
+        output: payload.output.clone(),
+    })
+}
+```
+
+- [ ] **Step 6: Update `resolve_verdict_with_source`**
+
+When ACP or file parsing succeeds, return the parsed `StepOutput` and its cloned verdict. For the default case, return:
+
+```rust
+let output = StepOutput {
+    verdict: Verdict::Approve,
+    summary: None,
+    output: None,
+};
+ResolvedVerdict {
+    verdict: output.verdict.clone(),
+    output,
+    source: VerdictSource::Default,
+}
+```
+
+For malformed file rejection, build a `StepOutput` with the generated reject verdict, the same summary text, and `output: None`.
+
+- [ ] **Step 7: Run verdict tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core pipeline::verdict
+```
+
+Expected: PASS.
+
+## Task 2: Store Step Outputs on PipelineRun
+
+**Files:**
+- Modify: `crates/ensemble-core/src/pipeline/engine.rs`
+
+- [ ] **Step 1: Write failing state-machine tests**
+
+Add:
+
+```rust
+#[test]
+fn downstream_context_contains_direct_dependency_outputs() {
+    use crate::pipeline::verdict::StepOutput;
+    use serde_json::json;
+
+    let steps = vec![
+        make_step("build", "builder", &[]),
+        make_step("review-a", "reviewer", &["build"]),
+        make_step("review-b", "reviewer", &["build"]),
+        make_step("synth", "synthesizer", &["review-a", "review-b"]),
+    ];
+    let mut run = make_run(&steps);
+
+    run.step_completed(
+        "build",
+        StepOutput {
+            verdict: Verdict::Approve,
+            summary: Some("built".to_string()),
+            output: Some(json!({"artifact":"branch"})),
+        },
+        false,
+    );
+    run.step_completed(
+        "review-a",
+        StepOutput {
+            verdict: Verdict::Approve,
+            summary: Some("a ok".to_string()),
+            output: Some(json!({"risk":"low"})),
+        },
+        false,
+    );
+    run.step_completed(
+        "review-b",
+        StepOutput {
+            verdict: Verdict::Approve,
+            summary: Some("b ok".to_string()),
+            output: Some(json!({"risk":"medium"})),
+        },
+        false,
+    );
+
+    let context = run.output_context_for("synth").unwrap();
+
+    assert_eq!(context.dependency_outputs.len(), 2);
+    assert_eq!(context.dependency_outputs[0].step, "review-a");
+    assert_eq!(context.dependency_outputs[1].step, "review-b");
+    assert_eq!(context.steps["review-a"].summary.as_deref(), Some("a ok"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p ensemble-core pipeline::engine::tests::downstream_context_contains_direct_dependency_outputs -- --exact
+```
+
+Expected: FAIL because `output_context_for` does not exist and `step_completed` still takes `Verdict`.
+
+- [ ] **Step 3: Add prompt context types**
+
+Import `StepOutput` and `serde::Serialize`, then add:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct StepOutputTemplateEntry {
+    pub step: String,
+    pub verdict: String,
+    pub summary: Option<String>,
+    pub output: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct StepOutputTemplateContext {
+    pub steps: HashMap<String, StepOutputTemplateEntry>,
+    pub dependency_outputs: Vec<StepOutputTemplateEntry>,
+}
+```
+
+- [ ] **Step 4: Store outputs in `PipelineRun`**
+
+Add a field:
+
+```rust
+pub step_outputs: HashMap<String, StepOutput>,
+```
+
+Initialize it in `PipelineRun::new` with `HashMap::new()`.
+
+- [ ] **Step 5: Change `step_completed` to accept `StepOutput`**
+
+Change the signature to:
+
+```rust
+pub fn step_completed(
+    &mut self,
+    step_name: &str,
+    output: StepOutput,
+    approval_requested: bool,
+) -> PipelineAction
+```
+
+At the top of the method:
+
+```rust
+let verdict = output.verdict.clone();
+self.step_outputs.insert(step_name.to_string(), output);
+```
+
+Leave the existing state-transition logic driven by `verdict`.
+
+- [ ] **Step 6: Add context builder**
+
+Add:
+
+```rust
+pub fn output_context_for(&self, step_name: &str) -> Option<StepOutputTemplateContext> {
+    let step = self.dag.steps.iter().find(|step| step.name == step_name)?;
+    let steps = self
+        .step_outputs
+        .iter()
+        .map(|(name, output)| (name.clone(), template_entry(name, output)))
+        .collect();
+    let dependency_outputs = step
+        .depends
+        .iter()
+        .filter_map(|dep| self.step_outputs.get(dep).map(|output| template_entry(dep, output)))
+        .collect();
+
+    Some(StepOutputTemplateContext {
+        steps,
+        dependency_outputs,
+    })
+}
+
+fn template_entry(step: &str, output: &StepOutput) -> StepOutputTemplateEntry {
+    StepOutputTemplateEntry {
+        step: step.to_string(),
+        verdict: match &output.verdict {
+            Verdict::Approve => "approve".to_string(),
+            Verdict::Reject { .. } => "reject".to_string(),
+        },
+        summary: output.summary.clone(),
+        output: output.output.clone(),
+    }
+}
+```
+
+- [ ] **Step 7: Update existing engine tests**
+
+Replace calls like:
+
+```rust
+run.step_completed("build", Verdict::Approve, false)
+```
+
+with:
+
+```rust
+run.step_completed("build", approve_output(), false)
+```
+
+Add test helpers:
+
+```rust
+fn approve_output() -> StepOutput {
+    StepOutput {
+        verdict: Verdict::Approve,
+        summary: None,
+        output: None,
+    }
+}
+
+fn reject_output(summary: &str) -> StepOutput {
+    StepOutput {
+        verdict: Verdict::Reject {
+            summary: summary.to_string(),
+        },
+        summary: Some(summary.to_string()),
+        output: None,
+    }
+}
+```
+
+- [ ] **Step 8: Run pipeline engine tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core pipeline::engine
+```
+
+Expected: PASS.
+
+## Task 3: Expose Outputs to Liquid Templates
+
+**Files:**
+- Modify: `crates/ensemble-core/src/config/template.rs`
+
+- [ ] **Step 1: Write failing template tests**
+
+Add:
+
+```rust
+#[test]
+fn test_render_with_step_outputs() {
+    use crate::pipeline::engine::{StepOutputTemplateContext, StepOutputTemplateEntry};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    let mut steps = HashMap::new();
+    steps.insert(
+        "review-a".to_string(),
+        StepOutputTemplateEntry {
+            step: "review-a".to_string(),
+            verdict: "approve".to_string(),
+            summary: Some("looks good".to_string()),
+            output: Some(json!({"risk":"low"})),
+        },
+    );
+    let context = StepOutputTemplateContext {
+        steps: steps.clone(),
+        dependency_outputs: vec![steps["review-a"].clone()],
+    };
+
+    let rendered = render_prompt_with_context(
+        "{{ steps[\"review-a\"].summary }} / {{ dependency_outputs[0].output.risk }}",
+        &test_issue(),
+        None,
+        None,
+        Some(&context),
+    )
+    .unwrap();
+
+    assert_eq!(rendered, "looks good / low");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p ensemble-core config::template::tests::test_render_with_step_outputs -- --exact
+```
+
+Expected: FAIL because `render_prompt_with_context` does not exist.
+
+- [ ] **Step 3: Add the generalized renderer**
+
+Import `StepOutputTemplateContext` and add:
+
+```rust
+pub fn render_prompt_with_context(
+    template_str: &str,
+    issue: &Issue,
+    attempt: Option<u32>,
+    interaction_response: Option<&InteractionResponse>,
+    step_outputs: Option<&StepOutputTemplateContext>,
+) -> Result<String, ConfigError> {
+    let parser =
+        ParserBuilder::with_stdlib()
+            .build()
+            .map_err(|e| ConfigError::TemplateParseError {
+                reason: e.to_string(),
+            })?;
+
+    let template = parser
+        .parse(template_str)
+        .map_err(|e| ConfigError::TemplateParseError {
+            reason: e.to_string(),
+        })?;
+
+    let mut issue_obj = liquid::object!({
+        "id": issue.id,
+        "identifier": issue.identifier,
+        "title": issue.title,
+        "priority": issue.priority,
+        "state": issue.state,
+        "labels": issue.labels,
+    });
+
+    issue_obj.insert(
+        "description".into(),
+        issue
+            .description
+            .as_ref()
+            .map_or(liquid::model::Value::Nil, |desc| {
+                liquid::model::Value::scalar(desc.clone())
+            }),
+    );
+    issue_obj.insert(
+        "branch_name".into(),
+        issue
+            .branch_name
+            .as_ref()
+            .map_or(liquid::model::Value::Nil, |branch_name| {
+                liquid::model::Value::scalar(branch_name.clone())
+            }),
+    );
+    issue_obj.insert(
+        "url".into(),
+        issue.url.as_ref().map_or(liquid::model::Value::Nil, |url| {
+            liquid::model::Value::scalar(url.clone())
+        }),
+    );
+
+    let mut globals = liquid::object!({
+        "issue": issue_obj,
+    });
+
+    if let Some(a) = attempt {
+        globals.insert("attempt".into(), liquid::model::Value::scalar(a as i64));
+    }
+
+    if let Some(response) = interaction_response {
+        globals.insert(
+            "interaction_response".into(),
+            liquid::model::to_value(response).map_err(|e| ConfigError::TemplateRenderError {
+                reason: e.to_string(),
+            })?,
+        );
+    }
+
+    if let Some(step_outputs) = step_outputs {
+        let value = liquid::model::to_value(step_outputs).map_err(|e| {
+            ConfigError::TemplateRenderError {
+                reason: e.to_string(),
+            }
+        })?;
+        if let liquid::model::Value::Object(object) = value {
+            for (key, value) in object {
+                globals.insert(key, value);
+            }
+        }
+    }
+
+    template
+        .render(&globals)
+        .map_err(|e| ConfigError::TemplateRenderError {
+            reason: e.to_string(),
+        })
+}
+```
+
+Replace the existing wrappers with:
+
+```rust
+pub fn render_prompt(
+    template_str: &str,
+    issue: &Issue,
+    attempt: Option<u32>,
+) -> Result<String, ConfigError> {
+    render_prompt_with_context(template_str, issue, attempt, None, None)
+}
+
+pub fn render_prompt_with_interaction_response(
+    template_str: &str,
+    issue: &Issue,
+    attempt: Option<u32>,
+    interaction_response: Option<&InteractionResponse>,
+) -> Result<String, ConfigError> {
+    render_prompt_with_context(template_str, issue, attempt, interaction_response, None)
+}
+```
+
+- [ ] **Step 4: Run template tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core config::template
+```
+
+Expected: PASS.
+
+## Task 4: Wire Prompt Context Through Agent Runs
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Modify tests in the same file
+
+- [ ] **Step 1: Add fields to request structs**
+
+Import `StepOutputTemplateContext`. Add to `AgentRunRequest`:
+
+```rust
+pub step_outputs: StepOutputTemplateContext,
+```
+
+Add to `BuildPromptRequest`:
+
+```rust
+step_outputs: &'a StepOutputTemplateContext,
+```
+
+- [ ] **Step 2: Render with the output context**
+
+Replace the call to `render_prompt_with_interaction_response` with:
+
+```rust
+let rendered = render_prompt_with_context(
+    &template_str,
+    issue,
+    attempt,
+    interaction_response
+        .as_ref()
+        .map(|response| &response.response),
+    Some(step_outputs),
+)
+.map_err(|e| AgentError::PromptError {
+    reason: e.to_string(),
+})?;
+```
+
+- [ ] **Step 3: Update request construction in tests**
+
+Every `AgentRunRequest` struct literal in `crates/ensemble-core/src/agent/mod.rs` and `crates/ensemble-core/tests/` must include:
+
+```rust
+step_outputs: StepOutputTemplateContext::default(),
+```
+
+- [ ] **Step 4: Add an agent prompt test**
+
+Add:
+
+```rust
+#[tokio::test]
+async fn build_prompt_includes_step_outputs() {
+    use crate::pipeline::engine::{StepOutputTemplateContext, StepOutputTemplateEntry};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    let runner = test_runner();
+    let config = parse_config(
+        r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    prompt: 'Risk: {{ steps["review-a"].output.risk }}'
+steps:
+  - name: synth
+    agent: synth
+on_success: Done
+on_failure: Todo
+"#,
+    )
+    .unwrap();
+
+    let mut steps = HashMap::new();
+    steps.insert(
+        "review-a".to_string(),
+        StepOutputTemplateEntry {
+            step: "review-a".to_string(),
+            verdict: "approve".to_string(),
+            summary: None,
+            output: Some(json!({"risk":"low"})),
+        },
+    );
+    let context = StepOutputTemplateContext {
+        steps,
+        dependency_outputs: vec![],
+    };
+    let workspace = tempfile::TempDir::new().unwrap();
+
+    let rendered = runner
+        .build_prompt(
+            &config,
+            BuildPromptRequest {
+                issue: &test_issue(),
+                agent_name: "synth",
+                step_name: "synth",
+                attempt: None,
+                workspace_path: workspace.path(),
+                turn_number: 1,
+                step_outputs: &context,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(rendered.contains("Risk: low"));
+}
+```
+
+- [ ] **Step 5: Run agent tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core agent::tests::build_prompt_includes_step_outputs -- --exact
+```
+
+Expected: PASS after implementation.
+
+## Task 5: Wire Orchestrator Completion and Dispatch
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs` test request literals that are compiled by orchestrator tests
+
+- [ ] **Step 1: Add output context to `StepDispatchContext`**
+
+Import `StepOutputTemplateContext` and add:
+
+```rust
+step_outputs: StepOutputTemplateContext,
+```
+
+- [ ] **Step 2: Initial dispatch uses empty context**
+
+In `dispatch_issue`, add to the initial `StepDispatchContext`:
+
+```rust
+step_outputs: StepOutputTemplateContext::default(),
+```
+
+- [ ] **Step 3: Worker task passes context into `AgentRunRequest`**
+
+Clone `dispatch.step_outputs` before `tokio::spawn` and include it in `AgentRunRequest`:
+
+```rust
+let step_outputs = dispatch.step_outputs.clone();
+step_outputs,
+```
+
+- [ ] **Step 4: Store resolved output on completion**
+
+In `handle_worker_exit`, change:
+
+```rust
+run.step_completed(step_name, resolved.verdict, approval_request.is_some())
+```
+
+to:
+
+```rust
+run.step_completed(step_name, resolved.output, approval_request.is_some())
+```
+
+- [ ] **Step 5: Build output context for downstream dispatches**
+
+Before each downstream `dispatch_step`, read the context from the pipeline run:
+
+```rust
+let step_outputs = {
+    let state = self.state.read().await;
+    state
+        .get_pipeline_run(issue_id)
+        .and_then(|run| run.output_context_for(&req.step_name))
+        .unwrap_or_default()
+};
+```
+
+Add `step_outputs` to the downstream `StepDispatchContext`.
+
+- [ ] **Step 6: Preserve outputs across approval gates**
+
+In the approval-gate resume path, wherever `PipelineAction::Dispatch(requests)` is handled after `approve_gate`, use the same context builder from Step 5. This matters because the output is recorded when the worker exits, but downstream dispatch happens only after human approval.
+
+- [ ] **Step 7: Update all `AgentRunRequest` literals**
+
+Run:
+
+```bash
+rg -n "AgentRunRequest \\{" crates/ensemble-core/src crates/ensemble-core/tests
+```
+
+Every literal must include `step_outputs: StepOutputTemplateContext::default()` unless it is the real dispatch path from Step 3.
+
+- [ ] **Step 8: Run focused orchestrator tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core orchestrator::tests -- --test-threads=1
+```
+
+Expected: PASS.
+
+## Task 6: Documentation and Contract Tests
+
+**Files:**
+- Modify: `docs/SPEC.md`
+- Modify: `docs/pipelines.md`
+- Modify: `docs/configuration.md`
+- Modify or add integration tests under `crates/ensemble-core/tests/`
+
+- [ ] **Step 1: Update the spec domain model**
+
+In `docs/SPEC.md`, extend the Verdict section to include:
+
+```markdown
+- `output` (JSON value or null) — arbitrary structured data produced by a step for downstream prompt templates.
+
+Prompt templates for downstream steps receive:
+
+- `steps` — map of completed step name to `{ step, verdict, summary, output }`.
+- `dependency_outputs` — ordered list of direct dependency outputs for the step being dispatched.
+```
+
+- [ ] **Step 2: Document the user-facing pipeline pattern**
+
+In `docs/pipelines.md`, add an example:
+
+```yaml
+steps:
+  - name: implement
+    agent: implementer
+  - name: review-a
+    agent: reviewer
+    depends: [implement]
+  - name: review-b
+    agent: reviewer
+    depends: [implement]
+  - name: synthesize
+    agent: synthesizer
+    depends: [review-a, review-b]
+```
+
+With a synthesizer prompt snippet:
+
+```liquid
+{% for review in dependency_outputs %}
+## {{ review.step }}
+{{ review.summary }}
+{{ review.output.findings | json }}
+{% endfor %}
+```
+
+- [ ] **Step 3: Add an integration-level test for rendering dependency outputs**
+
+Add `crates/ensemble-core/tests/step_output_templates.rs` with a small `PipelineRun` and `render_prompt_with_context` test that mirrors the synthesis example. This catches public API drift across modules.
+
+- [ ] **Step 4: Run final checks**
+
+Run:
+
+```bash
+cargo test -p ensemble-core pipeline::verdict
+cargo test -p ensemble-core pipeline::engine
+cargo test -p ensemble-core config::template
+cargo test -p ensemble-core agent::tests::build_prompt_includes_step_outputs -- --exact
+cargo test -p ensemble-core orchestrator::tests -- --test-threads=1
+cargo fmt --all -- --check
+```
+
+Expected: all commands PASS.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Liquid access to hyphenated step names is awkward | Medium | Support `steps["review-a"]` and `dependency_outputs`; document both |
+| Stale `.ensemble/verdict.json` from prior turns affects output | Low | Existing `prepare_workspace` removes `verdict.json` before each run; keep output in that file |
+| Approve summaries are lost if only `Verdict::Approve` is passed around | High | Store `StepOutput` separately and drive state transitions from its `verdict` field |
+| Output context grows large | Medium | Do not persist in global history or UI in this issue; only keep in active `PipelineRun` memory |
+| Strict Liquid rendering breaks templates that reference missing outputs | Medium | Keep `steps` and `dependency_outputs` always defined; missing named step fields should still fail fast |
+
+## Open Questions
+
+- Should output be restricted to JSON objects, or can it be any JSON value? This plan allows any JSON value to preserve flexibility.
+- Should future work persist step outputs into history/timeline after completion? This plan keeps issue 174 scoped to downstream consumption during an active run.


### PR DESCRIPTION
## What

Adds structured output passing between pipeline steps. A completed step can now publish a payload (verdict, summary, arbitrary JSON) that downstream steps read from their Liquid prompt templates.

## Why

Without output passing, multi-agent patterns like adversarial review, cross-examination, and second-opinion workflows can't be built. A review step can't pass its findings to a synthesis step for merging.

## How

**Contract:** ACP verdict values and `.ensemble/verdict.json` may include `summary` and arbitrary JSON under `output`:

```json
{
  "verdict": "approve",
  "summary": "Reviewed the implementation and found no blockers.",
  "output": { "findings": [], "risk": "low" }
}
```

**Template access:**

```liquid
{% for dep in dependency_outputs %}
## {{ dep.step }}
Verdict: {{ dep.verdict }}
Summary: {{ dep.summary }}
{% endfor %}

{% assign review = steps["review-a"] %}
Risk: {{ review.output.risk }}
```

- `steps` — map of all completed step names to `{ step, verdict, summary, output }`
- `dependency_outputs` — ordered list of direct dependency outputs for the step being dispatched

## Changes

| File | Change |
|------|--------|
| `pipeline/verdict.rs` | `StepOutput` struct, `parse_step_output_from_value`, `read_step_output_file` |
| `pipeline/engine.rs` | `step_outputs` on `PipelineRun`, `output_context_for()`, `StepOutputTemplateContext` |
| `config/template.rs` | `render_prompt_with_context` with step output globals |
| `agent/mod.rs` | `step_outputs` field on `AgentRunRequest`, wired through `build_prompt` |
| `orchestrator/mod.rs` | Output context collected and passed through all 3 dispatch paths |
| `docs/SPEC.md` | Documented output contract and template variables |
| `docs/pipelines.md` | Added dependency outputs example |
| `tests/step_output_templates.rs` | Integration test for the full rendering path |

## Unblocks

- #183 — Synthesis step type for merging parallel step outputs
- #177 — Adversarial review pipeline pattern
- #178 — Cross-examination pipeline pattern
- #179 — Second-opinion pattern with disagreement-triggered escalation

## Verification

- 816 tests pass, clippy clean, `cargo fmt` clean
- Every task went through implementer → spec reviewer → code quality reviewer cycle

Fixes #174