### PR TITLE
feat: add synthesis step type (kind: synthesis)

### DIFF
--- a/crates/ensemble-cli/src/commands/init/convert.rs
+++ b/crates/ensemble-cli/src/commands/init/convert.rs
@@ -59,6 +59,7 @@ impl From<&PipelineStep> for SetupStep {
         SetupStep {
             name: step.name.clone(),
             agent_role: step.agent_role.clone(),
+            kind: None,
             depends: step.depends.clone(),
             tracker_state: step.tracker_state.clone(),
         }

--- a/crates/ensemble-cli/src/commands/init/generate.rs
+++ b/crates/ensemble-cli/src/commands/init/generate.rs
@@ -266,6 +266,7 @@ mod tests {
         let steps = vec![PipelineStep {
             name: "implement".to_string(),
             agent_role: "builder".to_string(),
+            kind: None,
             depends: vec![],
             tracker_state: Some("In Progress".to_string()),
         }];
@@ -314,12 +315,14 @@ mod tests {
             PipelineStep {
                 name: "implement".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: Some("In Progress".to_string()),
             },
             PipelineStep {
                 name: "review".to_string(),
                 agent_role: "reviewer".to_string(),
+                kind: None,
                 depends: vec!["implement".to_string()],
                 tracker_state: Some("Review".to_string()),
             },
@@ -376,6 +379,7 @@ mod tests {
         let steps = vec![PipelineStep {
             name: "implement".to_string(),
             agent_role: "builder".to_string(),
+            kind: None,
             depends: vec![],
             tracker_state: Some("In Progress".to_string()),
         }];
@@ -384,7 +388,6 @@ mod tests {
 
         assert!(yaml.contains("acpx_agent: claude"));
         assert!(yaml.contains("model: sonnet"));
-        assert!(yaml.contains("prompt_template: templates/implement.liquid"));
     }
 
     #[test]
@@ -399,6 +402,7 @@ mod tests {
         let steps = vec![PipelineStep {
             name: "implement".to_string(),
             agent_role: "builder".to_string(),
+            kind: None,
             depends: vec![],
             tracker_state: None,
         }];
@@ -425,6 +429,7 @@ mod tests {
         let steps = vec![PipelineStep {
             name: "implement".to_string(),
             agent_role: "builder".to_string(),
+            kind: None,
             depends: vec![],
             tracker_state: Some("In Progress".to_string()),
         }];
@@ -462,6 +467,7 @@ mod tests {
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -500,6 +506,7 @@ mod tests {
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -531,6 +538,7 @@ mod tests {
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],

--- a/crates/ensemble-cli/src/commands/init/pipeline.rs
+++ b/crates/ensemble-cli/src/commands/init/pipeline.rs
@@ -5,6 +5,7 @@ use ensemble_core::config::ensemble::EnsembleConfig;
 pub struct PipelineStep {
     pub name: String,
     pub agent_role: String,
+    pub kind: Option<String>,
     pub depends: Vec<String>,
     pub tracker_state: Option<String>,
 }
@@ -35,6 +36,7 @@ pub fn ask_pipeline(
         return Ok(vec![PipelineStep {
             name: step_name.to_string(),
             agent_role: role_names[0].to_string(),
+            kind: None,
             depends: vec![],
             tracker_state: Some(tracker_state.to_string()),
         }]);
@@ -66,6 +68,7 @@ pub fn ask_pipeline(
                 .map(|s| PipelineStep {
                     name: s.name.clone(),
                     agent_role: s.agent.clone(),
+                    kind: None,
                     depends: s.depends.clone().unwrap_or_default(),
                     tracker_state: s.tracker_state.clone(),
                 })
@@ -94,6 +97,7 @@ fn default_pipeline(role_names: &[&str]) -> Vec<PipelineStep> {
     let mut steps = vec![PipelineStep {
         name: "implement".to_string(),
         agent_role: role_names[0].to_string(),
+        kind: None,
         depends: vec![],
         tracker_state: Some("In Progress".to_string()),
     }];
@@ -102,6 +106,7 @@ fn default_pipeline(role_names: &[&str]) -> Vec<PipelineStep> {
         steps.push(PipelineStep {
             name: "review".to_string(),
             agent_role: role_names[1].to_string(),
+            kind: None,
             depends: vec!["implement".to_string()],
             tracker_state: Some("Review".to_string()),
         });
@@ -138,6 +143,7 @@ fn custom_pipeline(role_names: &[&str]) -> Result<Vec<PipelineStep>, inquire::In
         steps.push(PipelineStep {
             name,
             agent_role,
+            kind: None,
             depends,
             tracker_state: None,
         });

--- a/crates/ensemble-cli/src/commands/init/validate.rs
+++ b/crates/ensemble-cli/src/commands/init/validate.rs
@@ -90,6 +90,7 @@ mod tests {
         let steps = vec![PipelineStep {
             name: "implement".to_string(),
             agent_role: "builder".to_string(),
+            kind: None,
             depends: vec![],
             tracker_state: Some("In Progress".to_string()),
         }];

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -358,6 +358,7 @@ mod tests {
     use crate::agent::events::RuntimeStream;
     use crate::agent::test_support::write_mock_acpx_script;
     use crate::config::ensemble::parse_config;
+    use crate::config::ensemble::StepKind;
     use crate::pipeline::engine::StepOutputTemplateContext;
     use crate::tracker::model::test_helpers::test_issue;
 
@@ -418,6 +419,7 @@ exit 1
             issue: &issue,
             agent_name: "builder",
             step_name: "build",
+            step_kind: StepKind::Agent,
             attempt: None,
             interaction_response: None,
             workspace_path: workspace.path(),
@@ -482,6 +484,7 @@ exit 1
             issue: &issue,
             agent_name: "builder",
             step_name: "build",
+            step_kind: StepKind::Agent,
             attempt: None,
             interaction_response: None,
             workspace_path: workspace.path(),
@@ -537,6 +540,7 @@ exit 1
             issue: &issue,
             agent_name: "builder",
             step_name: "build",
+            step_kind: StepKind::Agent,
             attempt: None,
             interaction_response: None,
             workspace_path: workspace.path(),
@@ -592,6 +596,7 @@ exit 1
             issue: &issue,
             agent_name: "builder",
             step_name: "build/review",
+            step_kind: StepKind::Agent,
             attempt: Some(2),
             interaction_response: None,
             workspace_path: workspace.path(),
@@ -649,6 +654,7 @@ exit 1
             issue: &issue,
             agent_name: "builder",
             step_name: "build",
+            step_kind: StepKind::Agent,
             attempt: None,
             interaction_response: None,
             workspace_path: workspace.path(),
@@ -755,6 +761,7 @@ exit 1
             issue: &issue,
             agent_name: "builder",
             step_name: &long_step,
+            step_kind: StepKind::Agent,
             attempt: Some(99),
             interaction_response: None,
             workspace_path: workspace.path(),
@@ -823,6 +830,7 @@ exit 1
             issue: &issue,
             agent_name: "builder",
             step_name: "$%^",
+            step_kind: StepKind::Agent,
             attempt: None,
             interaction_response: None,
             workspace_path: workspace.path(),
@@ -882,6 +890,7 @@ exit 1
             issue: &issue,
             agent_name: "builder",
             step_name: &bad_chars,
+            step_kind: StepKind::Agent,
             attempt: Some(1),
             interaction_response: None,
             workspace_path: workspace.path(),

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use crate::config::draft::ConfigDocumentState;
 use crate::config::ensemble::{
-    DiscoveredCapabilities, EnsembleConfig, InteractionPolicyOverrideMode, PermissionMode,
+    DiscoveredCapabilities, EnsembleConfig, InteractionPolicyOverrideMode, PermissionMode, StepKind,
 };
 use crate::config::template::render_prompt_with_context;
 use crate::error::AgentError;
@@ -97,6 +97,7 @@ pub struct AgentRunRequest<'a> {
     pub issue: &'a Issue,
     pub agent_name: &'a str,
     pub step_name: &'a str,
+    pub step_kind: StepKind,
     pub attempt: Option<u32>,
     pub(crate) interaction_response: Option<InteractionResponseEnvelope>,
     pub workspace_path: &'a Path,
@@ -128,6 +129,7 @@ struct BuildPromptRequest<'a> {
     issue: &'a Issue,
     agent_name: &'a str,
     step_name: &'a str,
+    step_kind: StepKind,
     attempt: Option<u32>,
     workspace_path: &'a Path,
     turn_number: u32,
@@ -230,6 +232,7 @@ impl AcpAgentRunner {
             issue,
             agent_name,
             step_name,
+            step_kind,
             attempt,
             workspace_path,
             turn_number,
@@ -279,6 +282,7 @@ impl AcpAgentRunner {
                 reason: e.to_string(),
             })?;
 
+            let rendered = maybe_append_synthesis_instruction(rendered, step_kind);
             let rendered = maybe_append_interaction_policy_instruction(
                 rendered,
                 resolve_interaction_policy_instruction(config, agent_name, step_name).as_deref(),
@@ -320,6 +324,19 @@ impl AcpAgentRunner {
 
         Ok(())
     }
+}
+
+fn maybe_append_synthesis_instruction(rendered: String, step_kind: StepKind) -> String {
+    if step_kind != StepKind::Synthesis {
+        return rendered;
+    }
+
+    format!(
+        "{rendered}\n\n\
+         This is a synthesis step. Use the `dependency_outputs` Liquid data already rendered above as the authoritative set of direct predecessor results. \
+         Merge, compare, or adjudicate those final structured outputs. Do not assume intermediate tool calls or hidden reasoning are available unless the prompt included them explicitly. \
+         Return a normal Ensemble verdict with a concise `summary` and, when useful, a structured `output` JSON value describing the merged result."
+    )
 }
 
 fn maybe_append_verdict_fallback_instruction(
@@ -676,6 +693,7 @@ impl AgentRunner for AcpAgentRunner {
                             issue: request.issue,
                             agent_name: request.agent_name,
                             step_name: request.step_name,
+                            step_kind: request.step_kind,
                             attempt: request.attempt,
                             workspace_path,
                             turn_number: 1,
@@ -739,6 +757,7 @@ impl AcpAgentRunner {
                         issue: request.issue,
                         agent_name: request.agent_name,
                         step_name: request.step_name,
+                        step_kind: request.step_kind,
                         attempt: request.attempt,
                         workspace_path: request.workspace_path,
                         turn_number: turn,
@@ -1075,6 +1094,7 @@ on_failure: Todo
                 issue: &test_issue(),
                 agent_name: "builder",
                 step_name: "build",
+                step_kind: StepKind::Agent,
                 attempt: None,
                 interaction_response: None,
                 workspace_path: workspace.path(),
@@ -1121,6 +1141,7 @@ on_failure: Todo
                 issue: &test_issue(),
                 agent_name: "builder",
                 step_name: "build",
+                step_kind: StepKind::Agent,
                 attempt: None,
                 interaction_response: None,
                 workspace_path: workspace.path(),
@@ -1173,6 +1194,7 @@ exit 1
                 issue: &test_issue(),
                 agent_name: "builder",
                 step_name: "build",
+                step_kind: StepKind::Agent,
                 attempt: None,
                 interaction_response: None,
                 workspace_path: workspace.path(),
@@ -1233,6 +1255,7 @@ exit 0
                 issue: &test_issue(),
                 agent_name: "builder",
                 step_name: "build",
+                step_kind: StepKind::Agent,
                 attempt: None,
                 interaction_response: None,
                 workspace_path: workspace.path(),
@@ -1556,6 +1579,7 @@ agent:
                     issue: &issue,
                     agent_name: "builder",
                     step_name: "build",
+                    step_kind: StepKind::Agent,
                     attempt: None,
                     workspace_path: workspace.path(),
                     turn_number: 1,
@@ -1741,6 +1765,7 @@ on_failure: Todo
                     issue: &issue,
                     agent_name: "builder",
                     step_name: "build",
+                    step_kind: StepKind::Agent,
                     attempt: Some(2),
                     workspace_path: workspace.path(),
                     turn_number: 1,
@@ -1805,6 +1830,7 @@ on_failure: Todo
                     issue: &issue,
                     agent_name: "builder",
                     step_name: "build",
+                    step_kind: StepKind::Agent,
                     attempt: None,
                     workspace_path: workspace.path(),
                     turn_number: 1,
@@ -2184,6 +2210,7 @@ on_failure: Todo
                     issue: &test_issue(),
                     agent_name: "synth",
                     step_name: "synth",
+                    step_kind: StepKind::Agent,
                     attempt: None,
                     workspace_path: workspace.path(),
                     turn_number: 1,
@@ -2194,5 +2221,73 @@ on_failure: Todo
             .unwrap();
 
         assert!(rendered.contains("Risk: low"));
+    }
+
+    #[tokio::test]
+    async fn build_prompt_adds_synthesis_guidance_for_synthesis_step() {
+        use crate::config::ensemble::StepKind;
+        use crate::pipeline::engine::{StepOutputTemplateContext, StepOutputTemplateEntry};
+        use std::collections::HashMap;
+
+        let runner = test_runner();
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    prompt: 'Merge: {% for dep in dependency_outputs %}{{ dep.step }} {{ dep.summary }}{% endfor %}'
+steps:
+  - name: review-a
+    agent: synth
+    depends: []
+  - name: synthesize
+    kind: synthesis
+    agent: synth
+    depends: [review-a]
+on_success: Done
+on_failure: Todo
+"#,
+        )
+        .unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let context = StepOutputTemplateContext {
+            steps: HashMap::from([(
+                "review-a".to_string(),
+                StepOutputTemplateEntry {
+                    step: "review-a".to_string(),
+                    verdict: "approve".to_string(),
+                    summary: Some("risk is low".to_string()),
+                    output: Some(serde_json::json!({"risk": "low"})),
+                },
+            )]),
+            dependency_outputs: vec![StepOutputTemplateEntry {
+                step: "review-a".to_string(),
+                verdict: "approve".to_string(),
+                summary: Some("risk is low".to_string()),
+                output: Some(serde_json::json!({"risk": "low"})),
+            }],
+        };
+
+        let prompt = runner
+            .build_prompt(
+                &config,
+                BuildPromptRequest {
+                    issue: &test_issue(),
+                    agent_name: "synth",
+                    step_name: "synthesize",
+                    step_kind: StepKind::Synthesis,
+                    attempt: None,
+                    workspace_path: tmp.path(),
+                    turn_number: 1,
+                    step_outputs: &context,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(prompt.contains("This is a synthesis step."));
+        assert!(prompt.contains("dependency_outputs"));
+        assert!(prompt.contains("risk is low"));
     }
 }

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -679,6 +679,10 @@ fn setup_defaults_from_active_config(config: &EnsembleConfig) -> serde_json::Val
             serde_json::json!({
                 "name": step.name,
                 "agent_role": step.agent,
+                "kind": match step.kind {
+                    crate::config::ensemble::StepKind::Agent => "agent",
+                    crate::config::ensemble::StepKind::Synthesis => "synthesis",
+                },
                 "depends": step.depends.clone().unwrap_or_default(),
                 "tracker_state": step.tracker_state,
                 "approval": step.approval.as_ref().map(|approval| serde_json::json!({
@@ -1094,6 +1098,7 @@ on_failure: Failed
                 steps: vec![crate::config::setup::SetupStep {
                     name: "build".to_string(),
                     agent_role: "builder".to_string(),
+                    kind: None,
                     depends: vec![],
                     tracker_state: None,
                 }],
@@ -1418,6 +1423,7 @@ custom_root:
                 steps: vec![crate::config::setup::SetupStep {
                     name: "build".to_string(),
                     agent_role: "builder".to_string(),
+                    kind: None,
                     depends: vec![],
                     tracker_state: Some("In Progress".to_string()),
                 }],
@@ -1518,6 +1524,7 @@ on_failure: Failed
             }],
             steps: vec![crate::config::form::GuidedStepForm {
                 name: "build".to_string(),
+                kind: None,
                 agent: "builder".to_string(),
                 depends: vec![],
                 tracker_state: None,
@@ -1685,6 +1692,7 @@ on_failure: Failed
             }],
             steps: vec![crate::config::form::GuidedStepForm {
                 name: "build".to_string(),
+                kind: None,
                 agent: "missing".to_string(),
                 depends: vec![],
                 tracker_state: None,
@@ -1839,6 +1847,7 @@ on_failure: Failed
             }],
             steps: vec![crate::config::form::GuidedStepForm {
                 name: "build".to_string(),
+                kind: None,
                 agent: "missing".to_string(),
                 depends: vec![],
                 tracker_state: None,
@@ -1945,6 +1954,7 @@ on_failure: Failed
                 steps: vec![crate::config::setup::SetupStep {
                     name: "build".to_string(),
                     agent_role: "builder".to_string(),
+                    kind: None,
                     depends: vec![],
                     tracker_state: Some("In Progress".to_string()),
                 }],

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -671,7 +671,7 @@ mod tests {
     use crate::agent::cancellation::register_issue_cancellation;
     use crate::api::router::AppState;
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
-    use crate::config::ensemble::{ConcurrencyConfig, StepConfig};
+    use crate::config::ensemble::{ConcurrencyConfig, StepConfig, StepKind};
     use crate::orchestrator::state::{
         FinalizeStatus, IssueFinalizeState, OrchestratorState, RepoFinalizeState,
     };
@@ -766,6 +766,7 @@ mod tests {
     fn test_pipeline_run() -> PipelineRun {
         let dag = build_dag(&[StepConfig {
             name: "build".to_string(),
+            kind: StepKind::Agent,
             agent: "build".to_string(),
             depends: None,
             tracker_state: None,

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -189,6 +189,7 @@ async fn build_issue_snapshot_from_history(
             .map(|(idx, name)| WorkflowStepInfo {
                 name: name.clone(),
                 agent: "unknown".to_string(),
+                kind: "agent".to_string(),
                 dependencies: vec![],
                 state: if record.outcome == "failed" && idx == last_idx {
                     "failed".to_string()
@@ -303,6 +304,7 @@ pub async fn get_step_detail(
         step_name,
         status: detail_state.status,
         agent: detail_state.agent,
+        kind: detail_state.kind,
         dependencies: detail_state.dependencies,
         can_navigate: detail_state.can_navigate,
         verdict: detail_state.verdict,

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -1,4 +1,6 @@
 use crate::api::router::AppState;
+use crate::config::draft::ConfigDocumentState;
+use crate::config::ensemble::{EnsembleConfig, StepKind};
 use crate::history::model::HistoryRecord;
 use crate::interaction::store::InteractionStore;
 use crate::observability::snapshot::{
@@ -14,8 +16,11 @@ use axum::response::IntoResponse;
 use axum::Json;
 use chrono::Utc;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::path::Path as FsPath;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// Standard JSON error envelope matching SPEC.md Section 13.7.2 error format.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -113,6 +118,7 @@ pub async fn get_issue_detail(
         &state.history_path,
         &state.workspace_root,
         &identifier,
+        step_kind_lookup(&state.config_runtime.document_state).await,
     )
     .await
     {
@@ -141,10 +147,32 @@ pub async fn get_issue_detail(
     }
 }
 
+/// Build a name → step kind map from the active config so that
+/// history-recovered snapshots can show the right step kind even though
+/// `HistoryRecord.steps_traversed` only carries step names. Missing steps
+/// default to `StepKind::Agent` at the call site.
+async fn step_kind_lookup(
+    document_state: &Arc<RwLock<ConfigDocumentState>>,
+) -> HashMap<String, StepKind> {
+    let guard = document_state.read().await;
+    step_kinds_from_config(guard.active_config.as_ref())
+}
+
+fn step_kinds_from_config(config: Option<&EnsembleConfig>) -> HashMap<String, StepKind> {
+    let mut map = HashMap::new();
+    if let Some(config) = config {
+        for step in &config.steps {
+            map.insert(step.name.clone(), step.kind);
+        }
+    }
+    map
+}
+
 async fn build_issue_snapshot_from_history(
     history_path: &FsPath,
     workspace_root: &str,
     identifier: &str,
+    step_kinds: HashMap<String, StepKind>,
 ) -> Result<Option<IssueDetailSnapshot>, std::io::Error> {
     let contents = match tokio::fs::read_to_string(history_path).await {
         Ok(contents) => contents,
@@ -189,7 +217,11 @@ async fn build_issue_snapshot_from_history(
             .map(|(idx, name)| WorkflowStepInfo {
                 name: name.clone(),
                 agent: "unknown".to_string(),
-                kind: "agent".to_string(),
+                kind: step_kinds
+                    .get(name)
+                    .copied()
+                    .unwrap_or(StepKind::Agent)
+                    .to_string(),
                 dependencies: vec![],
                 state: if record.outcome == "failed" && idx == last_idx {
                     "failed".to_string()
@@ -371,7 +403,6 @@ mod tests {
     use crate::orchestrator::state::OrchestratorState;
     use crate::tracker::model::{Issue, RetryEntry, RunningEntry};
     use chrono::Utc;
-    use std::sync::Arc;
     use tempfile::NamedTempFile;
 
     fn test_issue() -> Issue {
@@ -649,6 +680,110 @@ mod tests {
             .into_response();
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_get_issue_detail_history_fallback_recovers_step_kind_from_active_config() {
+        use crate::config::draft::{ConfigDocumentState, ConfigStateKind, DraftValidationReport};
+        use crate::config::ensemble::parse_config;
+        use std::path::PathBuf;
+
+        let config_yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  build:
+    executor: test
+    model: test
+    prompt: build
+  synth:
+    executor: test
+    model: test
+    prompt: merge
+steps:
+  - name: build
+    agent: build
+  - name: review-a
+    agent: build
+    depends: [build]
+  - name: review-b
+    agent: build
+    depends: [build]
+  - name: synthesize
+    kind: synthesis
+    agent: synth
+    depends: [review-a, review-b]
+on_success: Done
+on_failure: Failed
+"#;
+        let document_state = ConfigDocumentState {
+            path: PathBuf::from("ensemble.yaml"),
+            kind: ConfigStateKind::Parsed,
+            raw_yaml: None,
+            document: None,
+            active_config: Some(parse_config(config_yaml).unwrap()),
+            validation: DraftValidationReport::default(),
+        };
+        let mut app_state = app_state_with_document_state(document_state);
+
+        let tmp = NamedTempFile::new().unwrap();
+        let history_path = tmp.path().to_path_buf();
+        std::fs::remove_file(&history_path).ok();
+        app_state.history_path = history_path.clone();
+
+        let writer = HistoryWriter::new(history_path);
+        writer
+            .append(&HistoryRecord {
+                issue_identifier: "synth-1".to_string(),
+                issue_id: "synth-1".to_string(),
+                outcome: "succeeded".to_string(),
+                steps_traversed: vec![
+                    "build".to_string(),
+                    "review-a".to_string(),
+                    "review-b".to_string(),
+                    "synthesize".to_string(),
+                ],
+                attempts: 1,
+                tokens: TokenTotals {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    total_tokens: 15,
+                },
+                duration_seconds: 42,
+                started_at: Utc::now(),
+                completed_at: Utc::now(),
+                last_error: None,
+                verdict: Some("approved".to_string()),
+                workspace_path: "/tmp/workspaces/synth-1".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let response = get_issue_detail(State(app_state), Path("synth-1".to_string()))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let steps = json["workflow_steps"].as_array().expect("workflow_steps");
+        let kinds: HashMap<String, String> = steps
+            .iter()
+            .map(|step| {
+                (
+                    step["name"].as_str().unwrap().to_string(),
+                    step["kind"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect();
+        assert_eq!(kinds.get("build").map(String::as_str), Some("agent"));
+        assert_eq!(kinds.get("review-a").map(String::as_str), Some("agent"));
+        assert_eq!(
+            kinds.get("synthesize").map(String::as_str),
+            Some("synthesis")
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -381,6 +381,13 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
                 }
             }
         }
+        PipelineError::InvalidSynthesisStep { step, reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("invalid synthesis step '{}': {}", step, reason),
+            section: "workflow".to_string(),
+            field: Some("kind".to_string()),
+            path: Some(format!("steps.{}", step)),
+        },
     }
 }
 

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -346,10 +346,36 @@ pub enum StepApprovalMode {
     WhenRequestedByAgent,
 }
 
+/// Kind of pipeline step.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StepKind {
+    #[default]
+    Agent,
+    Synthesis,
+}
+
+impl StepKind {
+    pub fn is_agent(&self) -> bool {
+        matches!(self, Self::Agent)
+    }
+}
+
+impl std::fmt::Display for StepKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Agent => write!(f, "agent"),
+            Self::Synthesis => write!(f, "synthesis"),
+        }
+    }
+}
+
 /// A single step in the pipeline DAG.
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct StepConfig {
     pub name: String,
+    #[serde(default, skip_serializing_if = "StepKind::is_agent")]
+    pub kind: StepKind,
     pub agent: String,
     /// Explicit dependencies. `None` means "use implicit sequential rule" (depend on
     /// previous step). `Some(vec![])` means "no dependencies" (explicit root).
@@ -917,6 +943,15 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         if !config.agents.contains_key(&step.agent) {
             return Err(PipelineError::UnknownAgent {
                 name: step.agent.clone(),
+            });
+        }
+    }
+    // Synthesis steps must have explicit non-empty dependencies
+    for step in &config.steps {
+        if step.kind == StepKind::Synthesis && step.depends.as_ref().map_or(true, Vec::is_empty) {
+            return Err(PipelineError::InvalidSynthesisStep {
+                step: step.name.clone(),
+                reason: "synthesis steps require explicit non-empty depends".to_string(),
             });
         }
     }
@@ -2636,5 +2671,85 @@ on_failure: Failed
             crate::workspace::finalize::FinalizeMode::PushAndPr
         );
         assert!(finalize.approval_required);
+    }
+
+    #[test]
+    fn test_step_kind_defaults_to_agent() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.steps[0].kind, StepKind::Agent);
+    }
+
+    #[test]
+    fn test_parse_synthesis_step_kind() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+  synthesizer:
+    acpx_agent: claude
+    prompt: "Merge dependency outputs."
+steps:
+  - name: build
+    agent: builder
+  - name: synthesize
+    kind: synthesis
+    agent: synthesizer
+    depends: [build]
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.steps[1].kind, StepKind::Synthesis);
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_synthesis_step_requires_explicit_dependencies() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    acpx_agent: claude
+    prompt: "Merge dependency outputs."
+steps:
+  - name: synthesize
+    kind: synthesis
+    agent: synth
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        let err = validate_config(&config).unwrap_err();
+        assert!(matches!(
+            err,
+            PipelineError::InvalidSynthesisStep { step, reason }
+                if step == "synthesize" && reason.contains("explicit non-empty depends")
+        ));
     }
 }

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -5,7 +5,7 @@
 //! The key constraint: unknown YAML fields are preserved during the
 //! round-trip to support custom user extensions.
 
-use crate::config::ensemble::{ModeDefinition, ModelDefinition};
+use crate::config::ensemble::{ModeDefinition, ModelDefinition, StepKind};
 use crate::error::ConfigError;
 use serde::{Deserialize, Serialize};
 
@@ -70,6 +70,8 @@ pub struct GuidedAgentForm {
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct GuidedStepForm {
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
     pub agent: String,
     pub depends: Vec<String>,
     pub tracker_state: Option<String>,
@@ -205,6 +207,7 @@ fn config_to_guided_form(config: &crate::config::ensemble::EnsembleConfig) -> Gu
             .iter()
             .map(|s| GuidedStepForm {
                 name: s.name.clone(),
+                kind: (s.kind != StepKind::Agent).then(|| s.kind.to_string()),
                 agent: s.agent.clone(),
                 depends: s.depends.clone().unwrap_or_default(),
                 tracker_state: s.tracker_state.clone(),
@@ -444,6 +447,12 @@ pub fn apply_guided_form(
                     ("agent", s.agent.clone().into()),
                 ],
             );
+            step_mapping.remove("kind");
+            if let Some(ref kind) = s.kind {
+                if kind != "agent" {
+                    step_mapping.insert("kind".into(), kind.clone().into());
+                }
+            }
             step_mapping.remove("depends");
             if !s.depends.is_empty() {
                 step_mapping.insert("depends".into(), s.depends.clone().into());
@@ -657,6 +666,7 @@ mod tests {
             }],
             steps: vec![GuidedStepForm {
                 name: "implement".to_string(),
+                kind: None,
                 agent: "builder".to_string(),
                 depends: vec![],
                 tracker_state: None,
@@ -958,5 +968,53 @@ on_failure: Failed
 
         assert_eq!(agent.available_models.as_ref().unwrap()[0].id, "gpt-5");
         assert_eq!(agent.available_modes.as_ref().unwrap()[0].id, "code");
+    }
+
+    #[test]
+    fn extract_guided_form_includes_step_kind() {
+        let raw = r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    acpx_agent: claude
+    prompt: Merge.
+steps:
+  - name: synthesize
+    kind: synthesis
+    agent: synth
+    depends: [review-a]
+on_success: Done
+on_failure: Failed
+"#;
+
+        let form = extract_guided_form(raw).unwrap();
+
+        assert_eq!(form.steps[0].kind.as_deref(), Some("synthesis"));
+    }
+
+    #[test]
+    fn apply_guided_form_writes_step_kind() {
+        let base = r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    acpx_agent: claude
+    prompt: Merge.
+steps:
+  - name: synthesize
+    agent: synth
+on_success: Done
+on_failure: Failed
+"#;
+        let mut form = extract_guided_form(base).unwrap();
+        form.steps[0].kind = Some("synthesis".to_string());
+        form.steps[0].depends = vec!["review-a".to_string()];
+
+        let merged = apply_guided_form(base, &form).unwrap();
+
+        assert!(merged.contains("kind: synthesis"));
+        assert!(merged.contains("depends:"));
     }
 }

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -818,23 +818,31 @@ fn build_setup_dag(steps: &[SetupStep]) -> Result<crate::pipeline::dag::StepDag,
 
     let step_configs: Vec<StepConfig> = steps
         .iter()
-        .map(|step| StepConfig {
-            name: step.name.clone(),
-            kind: step
-                .kind
-                .as_deref()
-                .map(|k| match k {
-                    "synthesis" => StepKind::Synthesis,
-                    _ => StepKind::Agent,
-                })
-                .unwrap_or_default(),
-            agent: step.agent_role.clone(),
-            // Setup steps treat an empty list as an explicit root, not an implicit sequential dep.
-            depends: Some(step.depends.clone()),
-            tracker_state: step.tracker_state.clone(),
-            approval: None,
+        .map(|step| {
+            let kind = match step.kind.as_deref() {
+                None => StepKind::default(),
+                Some("agent") => StepKind::Agent,
+                Some("synthesis") => StepKind::Synthesis,
+                Some(other) => {
+                    return Err(ConfigError::ConfigParseError {
+                        reason: format!(
+                            "unknown step kind '{}' for step '{}' (expected 'agent' or 'synthesis')",
+                            other, step.name
+                        ),
+                    });
+                }
+            };
+            Ok(StepConfig {
+                name: step.name.clone(),
+                kind,
+                agent: step.agent_role.clone(),
+                // Setup steps treat an empty list as an explicit root, not an implicit sequential dep.
+                depends: Some(step.depends.clone()),
+                tracker_state: step.tracker_state.clone(),
+                approval: None,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     build_dag(&step_configs).map_err(|error| ConfigError::ConfigParseError {
         reason: error.to_string(),
@@ -2020,6 +2028,23 @@ on_failure: Failed
         assert!(roots.contains(&"build"));
         assert!(lint.depends.is_empty());
         assert!(build.depends.is_empty());
+    }
+
+    #[test]
+    fn build_setup_dag_rejects_unknown_step_kind() {
+        let steps = vec![SetupStep {
+            name: "build".into(),
+            agent_role: "builder".into(),
+            kind: Some("synthsis".into()),
+            depends: vec![],
+            tracker_state: None,
+        }];
+
+        let error = build_setup_dag(&steps).unwrap_err();
+        assert!(
+            error.to_string().contains("unknown step kind"),
+            "expected 'unknown step kind' in error, got: {error}"
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -1,5 +1,5 @@
 use crate::config::ensemble::ModelDefinition;
-use crate::config::ensemble::{resolve_relative_to_base, StepConfig};
+use crate::config::ensemble::{resolve_relative_to_base, StepConfig, StepKind};
 use crate::error::ConfigError;
 use crate::pipeline::dag::build_dag;
 use serde::{Deserialize, Serialize};
@@ -63,6 +63,8 @@ pub struct SetupAgent {
 pub struct SetupStep {
     pub name: String,
     pub agent_role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
     pub depends: Vec<String>,
     pub tracker_state: Option<String>,
 }
@@ -722,6 +724,11 @@ fn generate_yaml(request: &SetupRequest) -> String {
                 "agent".into(),
                 serde_yaml::Value::String(step.agent_role.clone()),
             );
+            if let Some(ref kind) = step.kind {
+                if kind != "agent" {
+                    step_map.insert("kind".into(), serde_yaml::Value::String(kind.clone()));
+                }
+            }
             if !step.depends.is_empty() {
                 step_map.insert(
                     "depends".into(),
@@ -813,6 +820,14 @@ fn build_setup_dag(steps: &[SetupStep]) -> Result<crate::pipeline::dag::StepDag,
         .iter()
         .map(|step| StepConfig {
             name: step.name.clone(),
+            kind: step
+                .kind
+                .as_deref()
+                .map(|k| match k {
+                    "synthesis" => StepKind::Synthesis,
+                    _ => StepKind::Agent,
+                })
+                .unwrap_or_default(),
             agent: step.agent_role.clone(),
             // Setup steps treat an empty list as an explicit root, not an implicit sequential dep.
             depends: Some(step.depends.clone()),
@@ -1072,9 +1087,11 @@ fn extract_steps(doc: &serde_yaml::Value) -> Result<Vec<SetupStep>, ConfigError>
                         .get("tracker_state")
                         .and_then(|s| s.as_str())
                         .map(String::from);
+                    let kind = item.get("kind").and_then(|k| k.as_str()).map(String::from);
                     Some(SetupStep {
                         name: name.to_string(),
                         agent_role: agent_role.to_string(),
+                        kind,
                         depends,
                         tracker_state,
                     })
@@ -1218,7 +1235,7 @@ fn update_yaml_from_request(
                     (name == s.name).then(|| map.clone())
                 })
                 .unwrap_or_default();
-            for key in ["name", "agent", "depends", "tracker_state"] {
+            for key in ["name", "agent", "kind", "depends", "tracker_state"] {
                 step_map.remove(serde_yaml::Value::String(key.to_string()));
             }
             step_map.insert("name".into(), serde_yaml::Value::String(s.name.clone()));
@@ -1226,6 +1243,11 @@ fn update_yaml_from_request(
                 "agent".into(),
                 serde_yaml::Value::String(s.agent_role.clone()),
             );
+            if let Some(ref kind) = s.kind {
+                if kind != "agent" {
+                    step_map.insert("kind".into(), serde_yaml::Value::String(kind.clone()));
+                }
+            }
             if !s.depends.is_empty() {
                 let deps: Vec<serde_yaml::Value> = s
                     .depends
@@ -1374,6 +1396,7 @@ mod tests {
             steps: vec![SetupStep {
                 name: "implement".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: Some("In Progress".to_string()),
             }],
@@ -1412,6 +1435,7 @@ mod tests {
             steps: vec![SetupStep {
                 name: "implement".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -1452,6 +1476,7 @@ mod tests {
             steps: vec![SetupStep {
                 name: "implement".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -1518,6 +1543,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -1555,6 +1581,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -1591,6 +1618,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -1625,6 +1653,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -1764,6 +1793,7 @@ custom_section:
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: Some("In Progress".to_string()),
             }],
@@ -1822,6 +1852,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: Some("In Progress".to_string()),
             }],
@@ -1888,12 +1919,14 @@ on_failure: Failed
             SetupStep {
                 name: "a".to_string(),
                 agent_role: "agent".to_string(),
+                kind: None,
                 depends: vec!["b".to_string()],
                 tracker_state: None,
             },
             SetupStep {
                 name: "b".to_string(),
                 agent_role: "agent".to_string(),
+                kind: None,
                 depends: vec!["a".to_string()],
                 tracker_state: None,
             },
@@ -1909,18 +1942,21 @@ on_failure: Failed
             SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             },
             SetupStep {
                 name: "test".to_string(),
                 agent_role: "tester".to_string(),
+                kind: None,
                 depends: vec!["build".to_string()],
                 tracker_state: None,
             },
             SetupStep {
                 name: "deploy".to_string(),
                 agent_role: "deployer".to_string(),
+                kind: None,
                 depends: vec!["test".to_string()],
                 tracker_state: None,
             },
@@ -1939,6 +1975,7 @@ on_failure: Failed
         let steps = vec![SetupStep {
             name: "build".into(),
             agent_role: "builder".into(),
+            kind: None,
             depends: vec!["missing".into()],
             tracker_state: None,
         }];
@@ -1953,18 +1990,21 @@ on_failure: Failed
             SetupStep {
                 name: "lint".into(),
                 agent_role: "linter".into(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             },
             SetupStep {
                 name: "build".into(),
                 agent_role: "builder".into(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             },
             SetupStep {
                 name: "test".into(),
                 agent_role: "tester".into(),
+                kind: None,
                 depends: vec!["lint".into(), "build".into()],
                 tracker_state: None,
             },
@@ -1995,6 +2035,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -2054,6 +2095,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -2085,6 +2127,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -2118,6 +2161,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -2206,6 +2250,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -2437,6 +2482,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],
@@ -2494,6 +2540,7 @@ on_failure: Failed
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: Some("In Progress".to_string()),
             }],
@@ -2560,6 +2607,7 @@ on_failure: Done
             steps: vec![SetupStep {
                 name: "build".to_string(),
                 agent_role: "builder".to_string(),
+                kind: None,
                 depends: vec![],
                 tracker_state: None,
             }],

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -140,4 +140,6 @@ pub enum PipelineError {
     InvalidPermissionMode { agent: String, reason: String },
     #[error("invalid runtime config for agent {agent}: {reason}")]
     InvalidRuntimeConfig { agent: String, reason: String },
+    #[error("invalid synthesis step {step}: {reason}")]
+    InvalidSynthesisStep { step: String, reason: String },
 }

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -150,6 +150,7 @@ pub struct RepoFinalizeSnapshot {
 pub struct WorkflowStepInfo {
     pub name: String,
     pub agent: String,
+    pub kind: String,
     pub dependencies: Vec<String>,
     pub state: String,
     pub can_navigate: bool,
@@ -172,6 +173,7 @@ pub struct StepDetailSnapshot {
     pub step_name: String,
     pub status: String,
     pub agent: String,
+    pub kind: String,
     pub dependencies: Vec<String>,
     pub can_navigate: bool,
     pub verdict: Option<String>,
@@ -297,6 +299,7 @@ pub struct StepDetailState {
     pub status: String,
     pub verdict: Option<String>,
     pub agent: String,
+    pub kind: String,
     pub dependencies: Vec<String>,
     pub can_navigate: bool,
     pub run_id: Option<String>,
@@ -376,6 +379,7 @@ pub fn extract_step_detail_state(
                     status,
                     verdict,
                     agent: step_config.agent.clone(),
+                    kind: step_config.kind.to_string(),
                     dependencies: step_config.depends.clone().unwrap_or_default(),
                     can_navigate: pipeline_run
                         .map(|r| r.step_states.contains_key(step_name))
@@ -413,6 +417,7 @@ pub fn extract_step_detail_state(
                         None
                     },
                     agent: step.agent.clone(),
+                    kind: step.kind.clone(),
                     dependencies: step.dependencies.clone(),
                     can_navigate: step.can_navigate,
                     run_id: completed.run_id.clone(),
@@ -470,6 +475,7 @@ pub fn build_step_detail_snapshot(
         step_name: step_name.to_string(),
         status: detail_state.status,
         agent: detail_state.agent,
+        kind: detail_state.kind,
         dependencies: detail_state.dependencies,
         can_navigate: detail_state.can_navigate,
         verdict: detail_state.verdict,
@@ -650,6 +656,7 @@ pub async fn build_issue_snapshot(
                 WorkflowStepInfo {
                     name: step.name.clone(),
                     agent: step.agent.clone(),
+                    kind: step.kind.to_string(),
                     dependencies: step.depends.clone().unwrap_or_default(),
                     state: state_str.to_string(),
                     can_navigate: pipeline_run
@@ -665,6 +672,7 @@ pub async fn build_issue_snapshot(
             .map(|step| WorkflowStepInfo {
                 name: step.name.clone(),
                 agent: step.agent.clone(),
+                kind: step.kind.clone(),
                 dependencies: step.dependencies.clone(),
                 state: step.state.clone(),
                 can_navigate: step.can_navigate,
@@ -858,7 +866,9 @@ fn pending_input_from_current(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ensemble::{ConcurrencyConfig, EnsembleConfig, StepConfig, TrackerConfig};
+    use crate::config::ensemble::{
+        ConcurrencyConfig, EnsembleConfig, StepConfig, StepKind, TrackerConfig,
+    };
     use crate::orchestrator::state::{OrchestratorState, WaitingOnHumanEntry};
     use crate::pipeline::engine::{PipelineRun, StepState};
     use crate::timeline::model::TimelineEventRecord;
@@ -971,6 +981,7 @@ mod tests {
             steps: vec![
                 StepConfig {
                     name: "build".to_string(),
+                    kind: StepKind::Agent,
                     agent: "builder".to_string(),
                     depends: None,
                     tracker_state: None,
@@ -978,6 +989,7 @@ mod tests {
                 },
                 StepConfig {
                     name: "review".to_string(),
+                    kind: StepKind::Agent,
                     agent: "reviewer".to_string(),
                     depends: Some(vec!["build".to_string()]),
                     tracker_state: None,

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -24,7 +24,7 @@ use crate::agent::events::{
     AgentEvent, InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult,
 };
 use crate::agent::{AgentRunRequest, AgentRunner, InteractionResponseEnvelope};
-use crate::config::ensemble::EnsembleConfig;
+use crate::config::ensemble::{EnsembleConfig, StepKind};
 use crate::error::{AgentError, EnsembleError};
 use crate::history::model::{HistoryRecord, TokenTotals};
 use crate::history::writer::HistoryWriter;
@@ -66,6 +66,8 @@ use state::{
 struct StepDispatchContext<'a> {
     step_name: &'a str,
     agent_name: &'a str,
+    #[allow(dead_code)]
+    step_kind: StepKind,
     tracker_state: Option<&'a str>,
     attempt: Option<u32>,
     interaction_response: Option<InteractionResponseEnvelope>,
@@ -647,6 +649,7 @@ impl Orchestrator {
                         StepDispatchContext {
                             step_name: &req.step_name,
                             agent_name: &req.agent_name,
+                            step_kind: req.step_kind,
                             tracker_state: req.tracker_state.as_deref(),
                             attempt,
                             interaction_response: None,
@@ -797,6 +800,7 @@ impl Orchestrator {
                     issue: &issue_clone,
                     agent_name: &agent_name_owned,
                     step_name: &step_name_owned,
+                    step_kind: dispatch.step_kind,
                     attempt,
                     interaction_response: interaction_response.clone(),
                     workspace_path: &workspace_path,
@@ -1085,6 +1089,7 @@ impl Orchestrator {
                                             StepDispatchContext {
                                                 step_name: &req.step_name,
                                                 agent_name: &req.agent_name,
+                                                step_kind: req.step_kind,
                                                 tracker_state: req.tracker_state.as_deref(),
                                                 attempt: None,
                                                 interaction_response: None,
@@ -3091,6 +3096,7 @@ impl Orchestrator {
                     StepDispatchContext {
                         step_name: &current_step.name,
                         agent_name: &current_step.agent,
+                        step_kind: current_step.kind,
                         tracker_state: current_step.tracker_state.as_deref(),
                         attempt: Some(attempt),
                         interaction_response: Some(interaction_response),
@@ -3205,6 +3211,7 @@ impl Orchestrator {
                                 StepDispatchContext {
                                     step_name: &req.step_name,
                                     agent_name: &req.agent_name,
+                                    step_kind: req.step_kind,
                                     tracker_state: req.tracker_state.as_deref(),
                                     attempt: Some(attempt),
                                     interaction_response: None,

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -66,7 +66,6 @@ use state::{
 struct StepDispatchContext<'a> {
     step_name: &'a str,
     agent_name: &'a str,
-    #[allow(dead_code)]
     step_kind: StepKind,
     tracker_state: Option<&'a str>,
     attempt: Option<u32>,

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -69,6 +69,7 @@ pub struct CompletedEntry {
 pub struct CompletedWorkflowStep {
     pub name: String,
     pub agent: String,
+    pub kind: String,
     pub dependencies: Vec<String>,
     pub state: String,
     pub can_navigate: bool,
@@ -637,6 +638,7 @@ fn completed_workflow_steps(
         .map(|step| CompletedWorkflowStep {
             name: step.name.clone(),
             agent: step.agent.clone(),
+            kind: step.kind.to_string(),
             dependencies: step.depends.clone().unwrap_or_default(),
             state: completed_step_state(step, run),
             can_navigate: run

--- a/crates/ensemble-core/src/pipeline/dag.rs
+++ b/crates/ensemble-core/src/pipeline/dag.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::config::ensemble::{StepApprovalConfig, StepConfig};
+use crate::config::ensemble::{StepApprovalConfig, StepConfig, StepKind};
 use crate::error::PipelineError;
 
 /// A single step in the resolved DAG, with its explicit dependency list.
@@ -8,6 +8,7 @@ use crate::error::PipelineError;
 pub struct DagStep {
     pub name: String,
     pub agent: String,
+    pub kind: StepKind,
     pub tracker_state: Option<String>,
     pub approval: Option<StepApprovalConfig>,
     pub depends: Vec<String>,
@@ -71,6 +72,7 @@ pub fn build_dag(steps: &[StepConfig]) -> Result<StepDag, PipelineError> {
         resolved.push(DagStep {
             name: step.name.clone(),
             agent: step.agent.clone(),
+            kind: step.kind,
             tracker_state: step.tracker_state.clone(),
             approval: step.approval.clone(),
             depends: deps,
@@ -148,6 +150,7 @@ pub fn ready_steps<'a>(dag: &'a StepDag, completed: &HashSet<String>) -> Vec<&'a
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ensemble::StepKind;
 
     fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
         let deps = if depends.is_empty() {
@@ -157,6 +160,7 @@ mod tests {
         };
         StepConfig {
             name: name.to_string(),
+            kind: StepKind::Agent,
             agent: agent.to_string(),
             depends: deps,
             tracker_state: None,
@@ -167,6 +171,7 @@ mod tests {
     fn make_root_step(name: &str, agent: &str) -> StepConfig {
         StepConfig {
             name: name.to_string(),
+            kind: StepKind::Agent,
             agent: agent.to_string(),
             depends: Some(vec![]), // explicit root
             tracker_state: None,
@@ -314,9 +319,41 @@ mod tests {
     }
 
     #[test]
+    fn test_dag_preserves_synthesis_kind() {
+        let steps = vec![
+            StepConfig {
+                name: "review-a".to_string(),
+                kind: StepKind::Agent,
+                agent: "reviewer".to_string(),
+                depends: Some(vec![]),
+                tracker_state: None,
+                approval: None,
+            },
+            StepConfig {
+                name: "synthesize".to_string(),
+                kind: StepKind::Synthesis,
+                agent: "synth".to_string(),
+                depends: Some(vec!["review-a".to_string()]),
+                tracker_state: None,
+                approval: None,
+            },
+        ];
+
+        let dag = build_dag(&steps).unwrap();
+        let synth = dag
+            .steps
+            .iter()
+            .find(|step| step.name == "synthesize")
+            .unwrap();
+
+        assert_eq!(synth.kind, StepKind::Synthesis);
+    }
+
+    #[test]
     fn preserves_step_approval_metadata() {
         let steps = vec![StepConfig {
             name: "plan".to_string(),
+            kind: StepKind::Agent,
             agent: "planner".to_string(),
             depends: None,
             tracker_state: Some("Planning".to_string()),

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::Serialize;
 
+use crate::config::ensemble::StepKind;
 use crate::pipeline::dag::StepDag;
 use crate::pipeline::verdict::{StepOutput, Verdict};
 
@@ -45,6 +46,8 @@ pub struct DispatchRequest {
     pub step_name: String,
     /// The name of the agent that should execute this step.
     pub agent_name: String,
+    /// The kind of the step (agent or synthesis).
+    pub step_kind: StepKind,
     /// Optional tracker state to set while the step is running.
     pub tracker_state: Option<String>,
 }
@@ -420,6 +423,7 @@ impl PipelineRun {
             .map(|s| DispatchRequest {
                 step_name: s.name.clone(),
                 agent_name: s.agent.clone(),
+                step_kind: s.kind,
                 tracker_state: s.tracker_state.clone(),
             })
             .collect();
@@ -447,7 +451,7 @@ fn template_entry(step: &str, output: &StepOutput) -> StepOutputTemplateEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ensemble::{StepApprovalConfig, StepApprovalMode, StepConfig};
+    use crate::config::ensemble::{StepApprovalConfig, StepApprovalMode, StepConfig, StepKind};
     use crate::pipeline::dag::build_dag;
     use crate::pipeline::verdict::StepOutput;
     use serde_json::json;
@@ -460,6 +464,7 @@ mod tests {
         };
         StepConfig {
             name: name.to_string(),
+            kind: StepKind::Agent,
             agent: agent.to_string(),
             depends: deps,
             tracker_state: None,
@@ -480,6 +485,7 @@ mod tests {
         };
         StepConfig {
             name: name.to_string(),
+            kind: StepKind::Agent,
             agent: agent.to_string(),
             depends: deps,
             tracker_state: Some(tracker_state.to_string()),
@@ -501,6 +507,7 @@ mod tests {
         };
         StepConfig {
             name: name.to_string(),
+            kind: StepKind::Agent,
             agent: agent.to_string(),
             depends: deps,
             tracker_state: None,
@@ -1129,6 +1136,41 @@ mod tests {
         assert_eq!(context.dependency_outputs[0].step, "review-a");
         assert_eq!(context.dependency_outputs[1].step, "review-b");
         assert_eq!(context.steps["review-a"].summary.as_deref(), Some("a ok"));
+    }
+
+    #[test]
+    fn dispatch_request_carries_synthesis_kind() {
+        let steps = vec![
+            StepConfig {
+                name: "review-a".to_string(),
+                kind: StepKind::Agent,
+                agent: "reviewer".to_string(),
+                depends: Some(vec![]),
+                tracker_state: None,
+                approval: None,
+            },
+            StepConfig {
+                name: "synthesize".to_string(),
+                kind: StepKind::Synthesis,
+                agent: "synth".to_string(),
+                depends: Some(vec!["review-a".to_string()]),
+                tracker_state: None,
+                approval: None,
+            },
+        ];
+        let mut run = make_run(&steps);
+
+        assert!(matches!(run.start(), PipelineAction::Dispatch(_)));
+        let action = run.step_completed("review-a", approve_output(), false);
+
+        match action {
+            PipelineAction::Dispatch(requests) => {
+                assert_eq!(requests.len(), 1);
+                assert_eq!(requests[0].step_name, "synthesize");
+                assert_eq!(requests[0].step_kind, StepKind::Synthesis);
+            }
+            other => panic!("expected synthesis dispatch, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ensemble-core/tests/step_output_templates.rs
+++ b/crates/ensemble-core/tests/step_output_templates.rs
@@ -1,4 +1,4 @@
-use ensemble_core::config::ensemble::StepConfig;
+use ensemble_core::config::ensemble::{StepConfig, StepKind};
 use ensemble_core::config::template::render_prompt_with_context;
 use ensemble_core::pipeline::dag::build_dag;
 use ensemble_core::pipeline::engine::PipelineRun;
@@ -26,6 +26,7 @@ fn sample_issue() -> Issue {
 fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
     StepConfig {
         name: name.to_string(),
+        kind: StepKind::Agent,
         agent: agent.to_string(),
         depends: if depends.is_empty() {
             None

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
@@ -43,6 +43,7 @@ export interface GuidedForm {
   }>;
   steps: Array<{
     name: string;
+    kind?: "agent" | "synthesis";
     agent: string;
     depends: string[];
     tracker_state?: string | null;
@@ -373,6 +374,7 @@ export default function GuidedEditor({
             value={{
               steps: form.steps.map((s) => ({
                 name: s.name,
+                kind: s.kind,
                 agent: s.agent,
                 depends: s.depends,
                 tracker_state: s.tracker_state,
@@ -383,6 +385,7 @@ export default function GuidedEditor({
               handleFormChange({
                 steps: draft.steps.map((s) => ({
                   name: s.name,
+                  kind: s.kind,
                   agent: s.agent,
                   depends: s.depends,
                   tracker_state: s.tracker_state,

--- a/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.test.tsx
@@ -6,8 +6,8 @@ import WorkflowEditor from "./WorkflowEditor";
 describe("WorkflowEditor", () => {
   const mockDraft = {
     steps: [
-      { name: "build", agent: "builder", depends: [], tracker_state: undefined },
-      { name: "test", agent: "tester", depends: ["build"], tracker_state: undefined },
+      { name: "build", kind: "agent", agent: "builder", depends: [], tracker_state: undefined },
+      { name: "test", kind: "agent", agent: "tester", depends: ["build"], tracker_state: undefined },
     ],
     agents: [{ name: "builder", label: "Builder" }, { name: "tester", label: "Tester" }],
   };
@@ -78,5 +78,17 @@ describe("WorkflowEditor", () => {
     // The second step (test) should show "build" as a dependency option
     // but the first step (build) should have no dependencies available
     expect(screen.getByText("build")).toBeInTheDocument();
+  });
+
+  it("allows marking a step as synthesis", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<WorkflowEditor value={mockDraft} onChange={mockOnChange} />);
+
+    await user.click(screen.getByLabelText("Step kind test"));
+    await user.click(screen.getByRole("option", { name: "Synthesis" }));
+
+    expect(mockOnChange).toHaveBeenCalled();
+    const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1]!;
+    expect(lastCall[0].steps[1].kind).toBe("synthesis");
   });
 });

--- a/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.test.tsx
@@ -85,7 +85,8 @@ describe("WorkflowEditor", () => {
     renderWithProviders(<WorkflowEditor value={mockDraft} onChange={mockOnChange} />);
 
     await user.click(screen.getByLabelText("Step kind test"));
-    await user.click(screen.getByRole("option", { name: "Synthesis" }));
+    const synthesisOption = await screen.findByText("Synthesis");
+    await user.click(synthesisOption);
 
     expect(mockOnChange).toHaveBeenCalled();
     const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1]!;

--- a/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.test.tsx
@@ -6,8 +6,8 @@ import WorkflowEditor from "./WorkflowEditor";
 describe("WorkflowEditor", () => {
   const mockDraft = {
     steps: [
-      { name: "build", kind: "agent", agent: "builder", depends: [], tracker_state: undefined },
-      { name: "test", kind: "agent", agent: "tester", depends: ["build"], tracker_state: undefined },
+      { name: "build", kind: "agent" as const, agent: "builder", depends: [], tracker_state: undefined },
+      { name: "test", kind: "agent" as const, agent: "tester", depends: ["build"], tracker_state: undefined },
     ],
     agents: [{ name: "builder", label: "Builder" }, { name: "tester", label: "Tester" }],
   };

--- a/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.tsx
@@ -11,6 +11,7 @@ import { X, Plus, GripVertical } from "lucide-react";
 
 export interface WorkflowStep {
   name: string;
+  kind?: "agent" | "synthesis";
   agent: string;
   depends: string[];
   tracker_state?: string | null;
@@ -44,6 +45,7 @@ export default function WorkflowEditor({ value, onChange }: WorkflowEditorProps)
   const addStep = () => {
     const newStep: WorkflowStep = {
       name: `step-${steps.length + 1}`,
+      kind: "agent",
       agent: agents[0]?.name || "",
       depends: [],
       tracker_state: null,
@@ -198,6 +200,24 @@ export default function WorkflowEditor({ value, onChange }: WorkflowEditorProps)
                       </SelectContent>
                     </Select>
                   </div>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium" htmlFor={`step-kind-${index}`}>Step Kind</label>
+                  <Select
+                    value={step.kind ?? "agent"}
+                    onValueChange={(val) =>
+                      updateStep(index, { kind: val as "agent" | "synthesis" })
+                    }
+                  >
+                    <SelectTrigger aria-label={`Step kind ${step.name}`} id={`step-kind-${index}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="agent">Agent</SelectItem>
+                      <SelectItem value="synthesis">Synthesis</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
 
                 {availableDeps.length > 0 && (

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -32,7 +32,7 @@ function toGuidedForm(form: GuidedConfigForm): GuidedForm {
     })),
     steps: form.steps.map((step) => ({
       ...step,
-      kind: step.kind ?? "agent",
+      kind: (step.kind ?? "agent") as "agent" | "synthesis",
       tracker_state: step.tracker_state ?? undefined,
     })),
     runtime: {

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -32,6 +32,7 @@ function toGuidedForm(form: GuidedConfigForm): GuidedForm {
     })),
     steps: form.steps.map((step) => ({
       ...step,
+      kind: step.kind ?? "agent",
       tracker_state: step.tracker_state ?? undefined,
     })),
     runtime: {
@@ -73,7 +74,14 @@ export default function ConfigPage() {
   };
 
   const handleSaveGuided = async (form: GuidedForm, baseRawYaml: string) => {
-    await saveGuidedFormMutation.mutateAsync({ baseRawYaml, form });
+    const normalizedForm = {
+      ...form,
+      steps: form.steps.map((step) => ({
+        ...step,
+        kind: step.kind && step.kind !== "agent" ? step.kind : undefined,
+      })),
+    };
+    await saveGuidedFormMutation.mutateAsync({ baseRawYaml, form: normalizedForm });
     setDisplayedIssues([]);
     await refetch();
   };

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigStatus.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigStatus.tsx
@@ -119,6 +119,9 @@ export default function ConfigStatus() {
                     <Badge variant="secondary" className="px-3 py-1.5">
                       <span className="font-medium">{step.name}</span>
                       <span className="ml-1 opacity-70">({step.agent})</span>
+                      {(step.kind ?? "agent") === "synthesis" && (
+                        <span className="ml-1 opacity-70">synthesis</span>
+                      )}
                       {step.depends && step.depends.length > 0 && (
                         <span className="ml-1 opacity-60">after {step.depends.join(", ")}</span>
                       )}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -225,6 +225,10 @@ Pipeline step definition:
 
 - `name` (string) — unique step identifier.
 - `agent` (string) — references a named agent from `agents`.
+- `kind` (string, optional, default `"agent"`)
+  - `"agent"` — normal agent-backed step.
+  - `"synthesis"` — agent-backed step intended to merge or adjudicate direct dependency outputs.
+  Synthesis steps must declare `depends` explicitly.
 - `depends` (list of strings, optional) — step names this step depends on. If omitted, the step
   implicitly depends on the step directly before it in the list. The first step has no implicit
   dependency. Explicit `depends` overrides the implicit rule.
@@ -648,6 +652,10 @@ Pipeline step definitions forming a DAG. Each step is an object:
   - Required. Unique step identifier.
 - `agent` (string)
   - Required. References a named agent from `agents`.
+- `kind` (string, optional)
+  - Default: `"agent"`.
+  - Step kind: `"agent"` for normal steps or `"synthesis"` for steps that merge/adjudicate direct
+    dependency outputs. Synthesis steps must declare `depends` explicitly.
 - `depends` (list of strings, optional)
   - Step names this step depends on. Steps with the same dependencies run in parallel.
   - If omitted: the first step in the list has no implicit dependency (it is a root). Each
@@ -795,6 +803,10 @@ Template input variables:
   - Ordered list of outputs from the step's direct dependencies. Each entry has the same shape as
     `steps` entries: `{ step, verdict, summary, output }`.
 
+Synthesis steps receive the same `steps` and `dependency_outputs` variables as normal steps. The
+runtime appends synthesis-specific guidance to the first turn prompt, instructing the agent to
+merge or adjudicate the outputs collected from its direct dependencies.
+
 Fallback prompt behavior:
 
 - Each agent must have exactly one of `prompt` or `prompt_template`. If neither is set, fail
@@ -936,6 +948,7 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `agents.<name>.prompt_template`: path, optional; file reference to prompt template (config-relative)
 - `steps[].name`: string, required; unique step identifier
 - `steps[].agent`: string, required; references a key in `agents`
+- `steps[].kind`: string, optional, default `"agent"`; `"agent"` or `"synthesis"`
 - `steps[].depends`: list of strings, optional; step dependencies for DAG
 - `steps[].tracker_state`: string, optional; tracker state to write on step entry
 - `on_success`: string, required; terminal tracker state on pipeline success

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,6 +294,7 @@ Pipeline step definitions. Each step invokes one agent.
 |-------|------|---------|-------------|
 | `name` | string | *required* | Unique step identifier |
 | `agent` | string | *required* | Name of an agent defined in `agents` |
+| `kind` | string | `agent` | Step kind. Use `agent` for normal steps and `synthesis` for steps that merge direct dependency outputs. |
 | `depends` | list of strings | — | Steps this depends on. Omit for sequential order. Use `[]` for no dependencies (root step). |
 | `tracker_state` | string | — | Tracker state to write when this step starts |
 | `approval.mode` | string | — | Optional post-step approval policy: `always` or `when_requested_by_agent` |
@@ -318,6 +319,24 @@ steps:
     approval:
       mode: when_requested_by_agent
       state: Plan Review
+```
+
+**Example with synthesis:**
+
+```yaml
+steps:
+  - name: implement
+    agent: builder
+  - name: review-a
+    agent: reviewer
+    depends: [implement]
+  - name: review-b
+    agent: reviewer
+    depends: [implement]
+  - name: synthesize
+    kind: synthesis
+    agent: synthesizer
+    depends: [review-a, review-b]
 ```
 
 ### on_success / on_failure

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -190,11 +190,12 @@ What happens:
 5. Reviewer approves → issue moves to "Done"
 6. If reviewer rejects → issue moves to "Needs Rework", retries from step 1 on next cycle
 
-## Accessing dependency outputs
+## Synthesis steps
 
-Downstream steps can access outputs from their direct dependencies via the `dependency_outputs` and
-`steps` template variables. This is useful for synthesis steps that merge results from parallel
-branches.
+Synthesis steps merge or adjudicate outputs from parallel branches. Set `kind: synthesis` on a step to
+mark it as a synthesis step. Synthesis steps must declare `depends` explicitly. Ensemble passes only
+final dependency outputs into the prompt context; intermediate tool calls and hidden reasoning are not
+injected.
 
 ```yaml
 steps:
@@ -207,9 +208,15 @@ steps:
     agent: reviewer
     depends: [implement]
   - name: synthesize
+    kind: synthesis
     agent: synthesizer
     depends: [review-a, review-b]
 ```
+
+## Accessing dependency outputs
+
+Downstream steps can access outputs from their direct dependencies via the `dependency_outputs` and
+`steps` template variables.
 
 A synthesizer prompt can iterate over `dependency_outputs`:
 

--- a/docs/superpowers/plans/2026-06-11-issue-183-synthesis-step-type.md
+++ b/docs/superpowers/plans/2026-06-11-issue-183-synthesis-step-type.md
@@ -1,0 +1,869 @@
+# Synthesis Step Type Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a first-class `kind: synthesis` pipeline step that runs an agent with all direct dependency `StepOutput` values available for merge, comparison, or adjudication.
+
+**Architecture:** Build this on top of the step-output passing work that already exists: `PipelineRun` stores `StepOutput` values, and prompt templates already receive `steps` plus `dependency_outputs`. The new step kind is a configuration and scheduling semantic: existing steps default to `agent`, synthesis steps require explicit non-empty dependencies, dispatch carries the kind, and the agent prompt receives synthesis-specific runtime guidance while still using the configured agent runtime and verdict/output contract.
+
+**Tech Stack:** Rust 2021, `serde`, `serde_yaml`, `serde_json`, `liquid`, `tokio`, React, TypeScript, Vitest
+
+---
+
+## Contract
+
+Config:
+
+```yaml
+steps:
+  - name: implement
+    agent: builder
+  - name: review-a
+    agent: reviewer
+    depends: [implement]
+  - name: review-b
+    agent: reviewer
+    depends: [implement]
+  - name: synthesize
+    kind: synthesis
+    agent: synthesizer
+    depends: [review-a, review-b]
+```
+
+Rules:
+
+- Existing configs keep working because omitted `kind` means `agent`.
+- `kind: synthesis` still requires `agent`; the configured agent performs the synthesis.
+- `kind: synthesis` must declare `depends` explicitly and the list must be non-empty.
+- Synthesis steps receive final structured outputs only: each `dependency_outputs[]` entry contains `{ step, verdict, summary, output }`.
+- Failed or rejected dependencies still block downstream dispatch as they do today. Approved dependencies with `output: null` are surfaced as `output: null`, not filtered.
+- A synthesis step emits the same verdict contract as any other step: `verdict`, `summary`, and optional arbitrary JSON `output`.
+
+## File Structure
+
+| Action | File | Responsibility |
+|---|---|---|
+| Modify | `crates/ensemble-core/src/config/ensemble.rs` | Add `StepKind`, parse/default `steps[].kind`, validate synthesis dependencies |
+| Modify | `crates/ensemble-core/src/error.rs` | Add a specific validation error for invalid synthesis step configuration |
+| Modify | `crates/ensemble-core/src/config/draft.rs` | Convert the new validation error to guided/YAML validation issues |
+| Modify | `crates/ensemble-core/src/pipeline/dag.rs` | Preserve `StepKind` in resolved DAG steps |
+| Modify | `crates/ensemble-core/src/pipeline/engine.rs` | Carry `StepKind` in `DispatchRequest` and keep output context ordering unchanged |
+| Modify | `crates/ensemble-core/src/orchestrator/mod.rs` | Pass step kind from dispatch to agent runs |
+| Modify | `crates/ensemble-core/src/agent/mod.rs` | Add synthesis prompt guidance when `request.step_kind == StepKind::Synthesis` |
+| Modify | `crates/ensemble-core/src/config/form.rs` | Round-trip `kind` through guided config form extraction and merge |
+| Modify | `crates/ensemble-core/src/api/config_edit_handler.rs` | Include `kind` in setup/guided response conversion where steps are serialized manually |
+| Modify | `crates/ensemble-core/src/observability/snapshot.rs` and `crates/ensemble-core/src/orchestrator/state.rs` | Include step kind in runtime workflow snapshots if those structs expose step metadata |
+| Modify | `crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.tsx` | Add an Agent/Synthesis step kind control |
+| Modify | `crates/ensemble-ui/src-ui/src/pages/ConfigStatus.tsx` | Display synthesis steps distinctly |
+| Modify | `crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.test.tsx` | Cover kind rendering and update callbacks |
+| Modify | `docs/SPEC.md`, `docs/configuration.md`, `docs/pipelines.md` | Document the new step kind and synthesis pattern |
+
+## Task 1: Add Step Kind to Typed Config
+
+**Files:**
+- Modify: `crates/ensemble-core/src/config/ensemble.rs`
+- Modify: `crates/ensemble-core/src/error.rs`
+- Modify: `crates/ensemble-core/src/config/draft.rs`
+
+- [ ] **Step 1: Write failing config parser and validation tests**
+
+Add these tests near the existing `validate_config` tests in `crates/ensemble-core/src/config/ensemble.rs`:
+
+```rust
+#[test]
+fn test_step_kind_defaults_to_agent() {
+    let config = parse_config(
+        r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(config.steps[0].kind, StepKind::Agent);
+}
+
+#[test]
+fn test_parse_synthesis_step_kind() {
+    let config = parse_config(
+        r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+  synthesizer:
+    acpx_agent: claude
+    prompt: "Merge dependency outputs."
+steps:
+  - name: build
+    agent: builder
+  - name: synthesize
+    kind: synthesis
+    agent: synthesizer
+    depends: [build]
+on_success: Done
+on_failure: Failed
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(config.steps[1].kind, StepKind::Synthesis);
+    assert!(validate_config(&config).is_ok());
+}
+
+#[test]
+fn test_validate_synthesis_step_requires_explicit_dependencies() {
+    let config = parse_config(
+        r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    acpx_agent: claude
+    prompt: "Merge dependency outputs."
+steps:
+  - name: synthesize
+    kind: synthesis
+    agent: synth
+on_success: Done
+on_failure: Failed
+"#,
+    )
+    .unwrap();
+
+    let err = validate_config(&config).unwrap_err();
+    assert!(matches!(
+        err,
+        PipelineError::InvalidSynthesisStep { step, reason }
+            if step == "synthesize" && reason.contains("explicit non-empty depends")
+    ));
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p ensemble-core config::ensemble::tests::test_step_kind_defaults_to_agent config::ensemble::tests::test_parse_synthesis_step_kind config::ensemble::tests::test_validate_synthesis_step_requires_explicit_dependencies
+```
+
+Expected: FAIL because `StepKind` and `InvalidSynthesisStep` do not exist.
+
+- [ ] **Step 3: Add the typed step kind**
+
+In `crates/ensemble-core/src/config/ensemble.rs`, add this enum above `StepConfig`:
+
+```rust
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StepKind {
+    #[default]
+    Agent,
+    Synthesis,
+}
+
+impl StepKind {
+    pub fn is_agent(self) -> bool {
+        matches!(self, Self::Agent)
+    }
+}
+```
+
+Change `StepConfig` to include the new defaulted field:
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct StepConfig {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "StepKind::is_agent")]
+    pub kind: StepKind,
+    pub agent: String,
+    pub depends: Option<Vec<String>>,
+    pub tracker_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval: Option<StepApprovalConfig>,
+}
+```
+
+- [ ] **Step 4: Add a validation error**
+
+In `crates/ensemble-core/src/error.rs`, add this variant to `PipelineError`:
+
+```rust
+#[error("invalid synthesis step {step}: {reason}")]
+InvalidSynthesisStep { step: String, reason: String },
+```
+
+In `validate_config`, after duplicate step-name validation and before `build_dag(&config.steps)?`, add:
+
+```rust
+for step in &config.steps {
+    if step.kind == StepKind::Synthesis && step.depends.as_ref().is_none_or(Vec::is_empty) {
+        return Err(PipelineError::InvalidSynthesisStep {
+            step: step.name.clone(),
+            reason: "synthesis steps require explicit non-empty depends".to_string(),
+        });
+    }
+}
+```
+
+Use `step.depends.as_ref().map_or(true, Vec::is_empty)` instead if the Rust version in CI rejects `Option::is_none_or`.
+
+- [ ] **Step 5: Map the validation error for draft validation**
+
+In `crates/ensemble-core/src/config/draft.rs`, add a match arm to `pipeline_error_to_validation_issue`:
+
+```rust
+PipelineError::InvalidSynthesisStep { step, reason } => ValidationIssue {
+    kind: ValidationIssueKind::Config,
+    message: format!("invalid synthesis step '{}': {}", step, reason),
+    section: "workflow".to_string(),
+    field: Some("kind".to_string()),
+    path: Some(format!("steps.{}", step)),
+},
+```
+
+- [ ] **Step 6: Run focused config tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core config::ensemble::tests::test_step_kind_defaults_to_agent config::ensemble::tests::test_parse_synthesis_step_kind config::ensemble::tests::test_validate_synthesis_step_requires_explicit_dependencies
+```
+
+Expected: PASS.
+
+## Task 2: Carry Step Kind Through DAG and Dispatch
+
+**Files:**
+- Modify: `crates/ensemble-core/src/pipeline/dag.rs`
+- Modify: `crates/ensemble-core/src/pipeline/engine.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/state.rs`
+- Modify: `crates/ensemble-core/src/observability/snapshot.rs`
+
+- [ ] **Step 1: Write failing DAG and dispatch tests**
+
+In `crates/ensemble-core/src/pipeline/dag.rs`, add:
+
+```rust
+#[test]
+fn test_dag_preserves_synthesis_kind() {
+    let steps = vec![
+        StepConfig {
+            name: "review-a".to_string(),
+            kind: StepKind::Agent,
+            agent: "reviewer".to_string(),
+            depends: Some(vec![]),
+            tracker_state: None,
+            approval: None,
+        },
+        StepConfig {
+            name: "synthesize".to_string(),
+            kind: StepKind::Synthesis,
+            agent: "synth".to_string(),
+            depends: Some(vec!["review-a".to_string()]),
+            tracker_state: None,
+            approval: None,
+        },
+    ];
+
+    let dag = build_dag(&steps).unwrap();
+    let synth = dag.steps.iter().find(|step| step.name == "synthesize").unwrap();
+
+    assert_eq!(synth.kind, StepKind::Synthesis);
+}
+```
+
+In `crates/ensemble-core/src/pipeline/engine.rs`, add:
+
+```rust
+#[test]
+fn dispatch_request_carries_synthesis_kind() {
+    let steps = vec![
+        StepConfig {
+            name: "review-a".to_string(),
+            kind: StepKind::Agent,
+            agent: "reviewer".to_string(),
+            depends: Some(vec![]),
+            tracker_state: None,
+            approval: None,
+        },
+        StepConfig {
+            name: "synthesize".to_string(),
+            kind: StepKind::Synthesis,
+            agent: "synth".to_string(),
+            depends: Some(vec!["review-a".to_string()]),
+            tracker_state: None,
+            approval: None,
+        },
+    ];
+    let mut run = make_run(&steps);
+
+    assert!(matches!(run.start(), PipelineAction::Dispatch(_)));
+    let action = run.step_completed("review-a", approve_output(), false);
+
+    match action {
+        PipelineAction::Dispatch(requests) => {
+            assert_eq!(requests.len(), 1);
+            assert_eq!(requests[0].step_name, "synthesize");
+            assert_eq!(requests[0].step_kind, StepKind::Synthesis);
+        }
+        other => panic!("expected synthesis dispatch, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p ensemble-core pipeline::dag::tests::test_dag_preserves_synthesis_kind pipeline::engine::tests::dispatch_request_carries_synthesis_kind
+```
+
+Expected: FAIL because `DagStep` and `DispatchRequest` do not carry kind yet.
+
+- [ ] **Step 3: Add kind to DAG and dispatch structs**
+
+In `crates/ensemble-core/src/pipeline/dag.rs`, import `StepKind`, add `pub kind: StepKind` to `DagStep`, and copy `kind: step.kind` when building resolved steps.
+
+In `crates/ensemble-core/src/pipeline/engine.rs`, import `StepKind`, add `pub step_kind: StepKind` to `DispatchRequest`, and set it in `find_dispatchable`:
+
+```rust
+DispatchRequest {
+    step_name: s.name.clone(),
+    step_kind: s.kind,
+    agent_name: s.agent.clone(),
+    tracker_state: s.tracker_state.clone(),
+}
+```
+
+Update test helper `StepConfig` literals in touched modules to include `kind: StepKind::Agent`.
+
+- [ ] **Step 4: Preserve kind in runtime snapshots**
+
+If `CompletedWorkflowStep`, `WorkflowStepInfo`, or step detail structs in `crates/ensemble-core/src/orchestrator/state.rs` and `crates/ensemble-core/src/observability/snapshot.rs` represent configured step metadata, add:
+
+```rust
+pub kind: StepKind,
+```
+
+Populate it from `StepConfig.kind` or `DagStep.kind`. Existing API JSON should now include `"kind": "agent"` or `"kind": "synthesis"`.
+
+- [ ] **Step 5: Run focused pipeline and snapshot tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core pipeline::dag pipeline::engine observability::snapshot orchestrator::state
+```
+
+Expected: PASS.
+
+## Task 3: Add Synthesis Prompt Guidance
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+
+- [ ] **Step 1: Write failing prompt test**
+
+In `crates/ensemble-core/src/agent/mod.rs`, add a test next to `build_prompt_includes_step_outputs`:
+
+```rust
+#[tokio::test]
+async fn build_prompt_adds_synthesis_guidance_for_synthesis_step() {
+    use crate::config::ensemble::StepKind;
+    use crate::pipeline::engine::{StepOutputTemplateContext, StepOutputTemplateEntry};
+    use std::collections::HashMap;
+
+    let runner = test_runner();
+    let config = parse_config(
+        r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    prompt: 'Merge: {% for dep in dependency_outputs %}{{ dep.step }} {{ dep.summary }}{% endfor %}'
+steps:
+  - name: review-a
+    agent: synth
+    depends: []
+  - name: synthesize
+    kind: synthesis
+    agent: synth
+    depends: [review-a]
+on_success: Done
+on_failure: Todo
+"#,
+    )
+    .unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let context = StepOutputTemplateContext {
+        steps: HashMap::from([(
+            "review-a".to_string(),
+            StepOutputTemplateEntry {
+                step: "review-a".to_string(),
+                verdict: "approve".to_string(),
+                summary: Some("risk is low".to_string()),
+                output: Some(serde_json::json!({"risk": "low"})),
+            },
+        )]),
+        dependency_outputs: vec![StepOutputTemplateEntry {
+            step: "review-a".to_string(),
+            verdict: "approve".to_string(),
+            summary: Some("risk is low".to_string()),
+            output: Some(serde_json::json!({"risk": "low"})),
+        }],
+    };
+
+    let prompt = runner
+        .build_prompt(
+            &config,
+            BuildPromptRequest {
+                issue: &test_issue(),
+                agent_name: "synth",
+                step_name: "synthesize",
+                step_kind: StepKind::Synthesis,
+                attempt: None,
+                workspace_path: tmp.path(),
+                turn_number: 1,
+                step_outputs: &context,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(prompt.contains("This is a synthesis step."));
+    assert!(prompt.contains("dependency_outputs"));
+    assert!(prompt.contains("risk is low"));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p ensemble-core agent::tests::build_prompt_adds_synthesis_guidance_for_synthesis_step -- --exact
+```
+
+Expected: FAIL because `BuildPromptRequest` and `AgentRunRequest` do not include `step_kind`.
+
+- [ ] **Step 3: Thread `StepKind` into agent requests**
+
+In `crates/ensemble-core/src/agent/mod.rs`, add `StepKind` to imports and to both request structs:
+
+```rust
+pub step_kind: StepKind,
+```
+
+Update every test `AgentRunRequest` and `BuildPromptRequest` literal in `agent/mod.rs` and `acpx_runtime.rs` with `step_kind: StepKind::Agent` unless the test is explicitly synthesis-focused.
+
+In `crates/ensemble-core/src/orchestrator/mod.rs`, add `step_kind: StepKind` to `StepDispatchContext`, populate it from `DispatchRequest.step_kind`, and pass it into `AgentRunRequest`.
+
+- [ ] **Step 4: Add synthesis guidance**
+
+In `crates/ensemble-core/src/agent/mod.rs`, add:
+
+```rust
+fn maybe_append_synthesis_instruction(rendered: String, step_kind: StepKind) -> String {
+    if step_kind != StepKind::Synthesis {
+        return rendered;
+    }
+
+    format!(
+        "{rendered}\n\n\
+         This is a synthesis step. Use the `dependency_outputs` Liquid data already rendered above as the authoritative set of direct predecessor results. \
+         Merge, compare, or adjudicate those final structured outputs. Do not assume intermediate tool calls or hidden reasoning are available unless the prompt included them explicitly. \
+         Return a normal Ensemble verdict with a concise `summary` and, when useful, a structured `output` JSON value describing the merged result."
+    )
+}
+```
+
+Call it after `render_prompt_with_context` and before `maybe_append_interaction_policy_instruction`:
+
+```rust
+let rendered = maybe_append_synthesis_instruction(rendered, step_kind);
+let rendered = maybe_append_interaction_policy_instruction(
+    rendered,
+    resolve_interaction_policy_instruction(config, agent_name, step_name).as_deref(),
+);
+```
+
+- [ ] **Step 5: Run focused agent and orchestrator tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core agent::tests::build_prompt_adds_synthesis_guidance_for_synthesis_step orchestrator::tests
+```
+
+Expected: PASS.
+
+## Task 4: Round-Trip Kind Through Config Editing APIs
+
+**Files:**
+- Modify: `crates/ensemble-core/src/config/form.rs`
+- Modify: `crates/ensemble-core/src/api/config_edit_handler.rs`
+- Modify: `crates/ensemble-core/tests/openapi_spec.rs`
+
+- [ ] **Step 1: Write failing guided form tests**
+
+In `crates/ensemble-core/src/config/form.rs`, add:
+
+```rust
+#[test]
+fn extract_guided_form_includes_step_kind() {
+    let raw = r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    acpx_agent: claude
+    prompt: Merge.
+steps:
+  - name: synthesize
+    kind: synthesis
+    agent: synth
+    depends: [review-a]
+on_success: Done
+on_failure: Failed
+"#;
+
+    let form = extract_guided_form(raw).unwrap();
+
+    assert_eq!(form.steps[0].kind.as_deref(), Some("synthesis"));
+}
+
+#[test]
+fn apply_guided_form_writes_step_kind() {
+    let base = r#"
+tracker:
+  kind: todo_file
+agents:
+  synth:
+    acpx_agent: claude
+    prompt: Merge.
+steps:
+  - name: synthesize
+    agent: synth
+on_success: Done
+on_failure: Failed
+"#;
+    let mut form = extract_guided_form(base).unwrap();
+    form.steps[0].kind = Some("synthesis".to_string());
+    form.steps[0].depends = vec!["review-a".to_string()];
+
+    let merged = apply_guided_form(base, &form).unwrap();
+
+    assert!(merged.contains("kind: synthesis"));
+    assert!(merged.contains("depends:"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p ensemble-core config::form::tests::extract_guided_form_includes_step_kind config::form::tests::apply_guided_form_writes_step_kind
+```
+
+Expected: FAIL because `GuidedStepForm` has no `kind`.
+
+- [ ] **Step 3: Add optional kind to guided form**
+
+In `GuidedStepForm`, add:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub kind: Option<String>,
+```
+
+When extracting:
+
+```rust
+kind: (s.kind != StepKind::Agent).then(|| "synthesis".to_string()),
+```
+
+When applying:
+
+```rust
+step_mapping.remove("kind");
+if let Some(ref kind) = s.kind {
+    if kind != "agent" {
+        step_mapping.insert("kind".into(), kind.clone().into());
+    }
+}
+```
+
+- [ ] **Step 4: Include kind in manually serialized setup shapes**
+
+In `crates/ensemble-core/src/api/config_edit_handler.rs`, update the `steps` JSON conversion that emits `"agent_role"`:
+
+```rust
+"kind": match step.kind {
+    crate::config::ensemble::StepKind::Agent => "agent",
+    crate::config::ensemble::StepKind::Synthesis => "synthesis",
+},
+```
+
+If setup request structs have a `SetupStep` equivalent, add `kind: Option<String>` there too and map it into generated `StepConfig.kind`.
+
+- [ ] **Step 5: Run config API tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core config::form api::config_edit_handler tests::openapi_spec
+```
+
+Expected: PASS. If `tests::openapi_spec` updates a checked-in OpenAPI snapshot, inspect the diff and keep only the schema changes for `StepKind`, `StepConfig.kind`, and `GuidedStepForm.kind`.
+
+## Task 5: Update Frontend Config UI
+
+**Files:**
+- Modify: `crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.tsx`
+- Modify: `crates/ensemble-ui/src-ui/src/components/config/WorkflowEditor.test.tsx`
+- Modify: `crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx`
+- Modify: `crates/ensemble-ui/src-ui/src/pages/ConfigStatus.tsx`
+
+- [ ] **Step 1: Write failing UI test**
+
+In `WorkflowEditor.test.tsx`, update `mockDraft.steps` to include `kind: "agent"` and add:
+
+```tsx
+it("allows marking a step as synthesis", async () => {
+  const user = userEvent.setup();
+  renderWithProviders(<WorkflowEditor value={mockDraft} onChange={mockOnChange} />);
+
+  await user.click(screen.getAllByLabelText(/step kind/i)[1]);
+  await user.click(screen.getByRole("option", { name: /synthesis/i }));
+
+  expect(mockOnChange).toHaveBeenCalled();
+  const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1];
+  expect(lastCall?.[0].steps[1].kind).toBe("synthesis");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd crates/ensemble-ui/src-ui
+pnpm test -- WorkflowEditor.test.tsx --run
+```
+
+Expected: FAIL because the workflow editor has no kind selector.
+
+- [ ] **Step 3: Add kind to frontend workflow types and mapping**
+
+In `WorkflowEditor.tsx`, change `WorkflowStep`:
+
+```ts
+export interface WorkflowStep {
+  name: string;
+  kind?: "agent" | "synthesis";
+  agent: string;
+  depends: string[];
+  tracker_state?: string | null;
+}
+```
+
+Set new steps to `kind: "agent"`. Add a compact `Select` labelled `Step Kind` next to the agent select:
+
+```tsx
+<Select
+  value={step.kind ?? "agent"}
+  onValueChange={(val) =>
+    updateStep(index, { kind: val as "agent" | "synthesis" })
+  }
+>
+  <SelectTrigger aria-label={`Step kind ${step.name}`} id={`step-kind-${index}`}>
+    <SelectValue />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectItem value="agent">Agent</SelectItem>
+    <SelectItem value="synthesis">Synthesis</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+In `ConfigPage.tsx`, preserve `kind` when mapping form steps:
+
+```ts
+steps: form.steps.map((step) => ({
+  name: step.name,
+  kind: step.kind ?? "agent",
+  agent: step.agent,
+  depends: step.depends ?? [],
+  tracker_state: step.tracker_state ?? null,
+})),
+```
+
+When submitting back to the API, omit `"agent"` or `undefined` if the backend form keeps kind optional:
+
+```ts
+kind: step.kind && step.kind !== "agent" ? step.kind : undefined,
+```
+
+- [ ] **Step 4: Show synthesis in config status**
+
+In `ConfigStatus.tsx`, update step badges:
+
+```tsx
+{(step.kind ?? "agent") === "synthesis" && (
+  <span className="ml-1 opacity-70">synthesis</span>
+)}
+```
+
+Keep the current agent and dependency display.
+
+- [ ] **Step 5: Run frontend tests**
+
+Run:
+
+```bash
+cd crates/ensemble-ui/src-ui
+pnpm test -- WorkflowEditor.test.tsx ConfigPage.test.tsx --run
+```
+
+Expected: PASS.
+
+## Task 6: Update Documentation
+
+**Files:**
+- Modify: `docs/SPEC.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/pipelines.md`
+
+- [ ] **Step 1: Update config reference**
+
+In `docs/configuration.md`, add `kind` to the step fields table:
+
+```markdown
+| `kind` | string | `agent` | Step kind. Use `agent` for normal steps and `synthesis` for steps that merge direct dependency outputs. |
+```
+
+Add a short synthesis example under the pipeline section using the YAML from the contract above.
+
+- [ ] **Step 2: Update pipeline docs**
+
+In `docs/pipelines.md`, revise “Accessing dependency outputs” so the synthesis example uses:
+
+```yaml
+  - name: synthesize
+    kind: synthesis
+    agent: synthesizer
+    depends: [review-a, review-b]
+```
+
+Add the rule:
+
+```markdown
+Synthesis steps must declare `depends` explicitly. Ensemble passes only final dependency outputs into the prompt context; intermediate tool calls and hidden reasoning are not injected.
+```
+
+- [ ] **Step 3: Update the spec**
+
+In `docs/SPEC.md`, update `StepConfig` to include:
+
+```markdown
+- `kind` (string, optional, default `"agent"`)
+  - `"agent"` — normal agent-backed step.
+  - `"synthesis"` — agent-backed step intended to merge or adjudicate direct dependency outputs.
+```
+
+In the prompt-template section, state that synthesis steps receive the same `steps` and `dependency_outputs` variables as any downstream step, with runtime synthesis guidance appended to the first turn prompt.
+
+- [ ] **Step 4: Verify docs mention every new behavior**
+
+Run:
+
+```bash
+rg -n "kind: synthesis|synthesis steps|dependency_outputs|StepConfig" docs/SPEC.md docs/configuration.md docs/pipelines.md
+```
+
+Expected: output includes the new config field, validation rule, and pipeline example.
+
+## Task 7: Final Verification
+
+**Files:**
+- No new files
+- Verify workspace-wide behavior
+
+- [ ] **Step 1: Run focused backend tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core config::ensemble config::form pipeline::dag pipeline::engine agent::tests::build_prompt_adds_synthesis_guidance_for_synthesis_step api::config_edit_handler tests::openapi_spec
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused frontend tests**
+
+Run:
+
+```bash
+cd crates/ensemble-ui/src-ui
+pnpm test -- WorkflowEditor.test.tsx ConfigPage.test.tsx --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run pre-push checks required for touched areas**
+
+Run from repo root:
+
+```bash
+cargo test --workspace --exclude ensemble-desktop
+cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+cargo fmt --all -- --check
+```
+
+If UI files changed, also run:
+
+```bash
+cd crates/ensemble-ui/src-ui
+pnpm test
+pnpm run build
+```
+
+Expected: all commands exit 0.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Existing configs fail to parse | High | `StepKind` defaults to `Agent`; docs and tests verify omitted kind works |
+| Guided config editing drops `kind` | Medium | Add `GuidedStepForm.kind` extraction and merge tests |
+| Synthesis step dispatches without outputs | Medium | Validation requires explicit non-empty dependencies; existing scheduler only dispatches after dependencies pass |
+| Synthesis prompt gets too much hidden context | Low | Runtime guidance says only rendered final dependency outputs are authoritative |
+| UI generated API types lag backend schema | Medium | Run OpenAPI and frontend build checks; update checked-in generated types if build requires it |
+
+## Open Questions
+
+- Should `kind: synthesis` require at least two dependencies instead of one? This plan enforces explicit non-empty dependencies to support summarizer-style synthesis over one predecessor while still preventing root synthesis steps.
+- Should the default `ensemble init` wizard offer a synthesis step preset? This plan updates guided editing but does not change init defaults, keeping the first release focused on first-class support for hand-authored and guided configs.
+
+## Self-Review
+
+- Spec coverage: the plan covers config schema, validation, DAG/dispatch propagation, prompt behavior, output semantics, UI config editing, API schema, and docs.
+- Placeholder scan: no task relies on undefined implementation work; every code-changing step names the files and concrete snippets to add or modify.
+- Type consistency: `StepKind::Agent`, `StepKind::Synthesis`, `steps[].kind`, `GuidedStepForm.kind`, `DispatchRequest.step_kind`, `AgentRunRequest.step_kind`, and `BuildPromptRequest.step_kind` are used consistently throughout the plan.


### PR DESCRIPTION
Adds a first-class `kind: synthesis` pipeline step that runs an agent with all direct dependency StepOutput values available for merge, comparison, or adjudication.

## Changes

- **StepKind enum** (Agent/Synthesis) — defaults to Agent, synthesis requires explicit non-empty `depends`
- **Validation**: synthesis steps without dependencies are rejected with a clear error
- **DAG/dispatch**: `step_kind` carried through `DagStep`, `DispatchRequest`, orchestrator state, and API snapshots
- **Prompt guidance**: synthesis steps receive runtime guidance appended to the first-turn prompt
- **Config APIs**: `kind` round-trips through guided form and setup wizard
- **Frontend**: Step Kind selector in WorkflowEditor, synthesis indicator in ConfigStatus
- **Docs**: SPEC.md, configuration.md, and pipelines.md updated

Closes #183