### PR TITLE
Add lockfile maintenance to Renovate automerge list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,11 @@
       "groupSlug": "codemirror"
     },
     {
+      "description": "Auto-merge lockfile maintenance",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true
+    },
+    {
       "description": "Auto-merge safe patch updates for Rust",
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
Lockfile maintenance PRs from Renovate should be auto-merged like patch/minor updates.