### PR TITLE
Implement step-level retry and results

### DIFF
--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -166,6 +166,13 @@ fn text_from_content(content: &ContentBlock) -> Option<String> {
     }
 }
 
+fn runtime_verdict_from_value(value: &serde_json::Value) -> Option<serde_json::Value> {
+    value
+        .get("result")
+        .cloned()
+        .or_else(|| value.get("verdict").cloned())
+}
+
 #[derive(Debug, Default)]
 struct ParsedSdkDispatch {
     output_text: Option<String>,
@@ -187,7 +194,7 @@ fn parse_session_notification(notification: SessionNotification) -> ParsedSdkDis
                     .and_then(|v| v.get("usage").cloned())
                     .or_else(|| value.clone())
                     .and_then(token_usage_from_value),
-                verdict: value.as_ref().and_then(|v| v.get("verdict").cloned()),
+                verdict: value.as_ref().and_then(runtime_verdict_from_value),
                 output_text: None,
             }
         }
@@ -876,6 +883,29 @@ mod tests {
         let parsed = parse_session_notification(notification);
 
         assert_eq!(parsed.usage.map(|usage| usage.total_tokens), Some(42));
+    }
+
+    #[test]
+    fn runtime_verdict_from_value_extracts_result() {
+        let value = serde_json::json!({
+            "result": {"result": "concern", "summary": "needs review"}
+        });
+        assert_eq!(
+            runtime_verdict_from_value(&value),
+            Some(serde_json::json!({"result":"concern","summary":"needs review"}))
+        );
+    }
+
+    #[test]
+    fn runtime_verdict_from_value_prefers_result_over_legacy_verdict() {
+        let value = serde_json::json!({
+            "result": {"result": "concern", "summary": "new"},
+            "verdict": {"verdict": "approve"}
+        });
+        assert_eq!(
+            runtime_verdict_from_value(&value),
+            Some(serde_json::json!({"result":"concern","summary":"new"}))
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -2192,7 +2192,7 @@ on_failure: Todo
             "review-a".to_string(),
             StepOutputTemplateEntry {
                 step: "review-a".to_string(),
-                verdict: "approve".to_string(),
+                result: "succeeded".to_string(),
                 summary: None,
                 output: Some(json!({"risk":"low"})),
             },
@@ -2256,14 +2256,14 @@ on_failure: Todo
                 "review-a".to_string(),
                 StepOutputTemplateEntry {
                     step: "review-a".to_string(),
-                    verdict: "approve".to_string(),
+                    result: "succeeded".to_string(),
                     summary: Some("risk is low".to_string()),
                     output: Some(serde_json::json!({"risk": "low"})),
                 },
             )]),
             dependency_outputs: vec![StepOutputTemplateEntry {
                 step: "review-a".to_string(),
-                verdict: "approve".to_string(),
+                result: "succeeded".to_string(),
                 summary: Some("risk is low".to_string()),
                 output: Some(serde_json::json!({"risk": "low"})),
             }],

--- a/crates/ensemble-core/src/agent/protocol.rs
+++ b/crates/ensemble-core/src/agent/protocol.rs
@@ -185,8 +185,10 @@ fn extract_verdict(
     update: Option<&serde_json::Value>,
 ) -> Option<serde_json::Value> {
     update
-        .and_then(|u| u.get("verdict"))
+        .and_then(|u| u.get("result"))
         .cloned()
+        .or_else(|| update.and_then(|u| u.get("verdict")).cloned())
+        .or_else(|| params.get("result").cloned())
         .or_else(|| params.get("verdict").cloned())
 }
 
@@ -301,6 +303,35 @@ mod tests {
 
         let parsed = parse_session_update(&params).unwrap();
         assert_eq!(parsed.verdict, Some(json!({"verdict":"approve"})));
+    }
+
+    #[test]
+    fn parse_session_update_extracts_result_from_params() {
+        let params = json!({
+            "sessionId": "s1",
+            "result": {"result": "concern", "summary": "needs review"}
+        });
+
+        let parsed = parse_session_update(&params).unwrap();
+        assert_eq!(
+            parsed.verdict,
+            Some(json!({"result":"concern","summary":"needs review"}))
+        );
+    }
+
+    #[test]
+    fn parse_session_update_prefers_result_over_legacy_verdict() {
+        let params = json!({
+            "sessionId": "s1",
+            "result": {"result": "concern", "summary": "new"},
+            "verdict": {"verdict": "approve"}
+        });
+
+        let parsed = parse_session_update(&params).unwrap();
+        assert_eq!(
+            parsed.verdict,
+            Some(json!({"result":"concern","summary":"new"}))
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -2,13 +2,14 @@ use crate::agent::cancellation::{cancel_issue, clear_issue_cancellation};
 use crate::api::handlers::{api_error, ApiError};
 use crate::api::router::AppState;
 use crate::interaction::{InteractionStatus, InteractionStore};
+use crate::orchestrator::retry::{next_attempt, schedule_failure_retry, FailureRetryRequest};
 use crate::orchestrator::state::{FinalizeStatus, OrchestratorState};
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use axum::Json;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq)]
 enum IssuePresence {
@@ -112,6 +113,12 @@ pub struct RetryResponse {
     pub retried: bool,
     pub issue_identifier: String,
     pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RetryQuery {
+    #[serde(default)]
+    pub step: Option<String>,
 }
 
 /// Response for a successful resume operation.
@@ -268,7 +275,10 @@ pub async fn post_stop(
     post,
     path = "/api/v1/{identifier}/retry",
     operation_id = "postRetry",
-    params(("identifier" = String, Path, description = "Issue identifier")),
+    params(
+        ("identifier" = String, Path, description = "Issue identifier"),
+        ("step" = Option<String>, Query, description = "Step name for step-level retry")
+    ),
     responses(
         (status = 200, description = "Retry queued", body = RetryResponse),
         (status = 404, description = "Not found", body = ApiError),
@@ -279,7 +289,24 @@ pub async fn post_stop(
 pub async fn post_retry(
     State(state): State<AppState>,
     Path(identifier): Path<String>,
+    Query(query): Query<RetryQuery>,
 ) -> impl IntoResponse {
+    let retry_settings = if query.step.is_some() {
+        let document_state = state.config_runtime.document_state.read().await;
+        match document_state.active_config.as_ref() {
+            Some(config) => Some((config.agent.max_retry_backoff_ms, config.max_cycles)),
+            None => {
+                return issue_error_response(
+                    StatusCode::CONFLICT,
+                    "no_active_config",
+                    "cannot schedule step-level retry without an active config",
+                );
+            }
+        }
+    } else {
+        None
+    };
+
     let mut lock = state.orchestrator_state.write().await;
 
     let issue_id = match find_issue_presence(&lock, &identifier) {
@@ -301,21 +328,86 @@ pub async fn post_retry(
                 format!("issue '{}' is finalizing, not retrying", identifier),
             );
         }
-        IssuePresence::Missing => {
+        IssuePresence::Missing => match lock.find_issue_id_by_identifier(&identifier) {
+            Some(id) => id,
+            None => {
+                return issue_error_response(
+                    StatusCode::NOT_FOUND,
+                    "issue_not_found",
+                    format!(
+                        "no running, retrying, waiting, or finalizing issue with identifier '{}'",
+                        identifier
+                    ),
+                );
+            }
+        },
+    };
+
+    if let Some(step_name) = query.step.as_ref() {
+        let Some(run) = lock.get_pipeline_run_mut(&issue_id) else {
+            return issue_error_response(
+                StatusCode::CONFLICT,
+                "no_pipeline_run",
+                format!("issue '{}' has no resumable pipeline run", identifier),
+            );
+        };
+        if !run.step_states.contains_key(step_name) {
             return issue_error_response(
                 StatusCode::NOT_FOUND,
-                "issue_not_found",
+                "step_not_found",
                 format!(
-                    "no running, retrying, or finalizing issue with identifier '{}'",
-                    identifier
+                    "issue '{}' has no pipeline step '{}'",
+                    identifier, step_name
                 ),
             );
         }
-    };
+        run.retry_from_step(step_name);
 
-    // Remove from retry queue and release claim (allows next poll to re-pick it up)
-    lock.remove_retry(&issue_id);
-    lock.remove_claimed(&issue_id);
+        let identifier_copy = lock
+            .retry_attempts
+            .get(&issue_id)
+            .map(|entry| entry.identifier.clone())
+            .or_else(|| {
+                lock.waiting_on_human
+                    .get(&issue_id)
+                    .map(|entry| entry.identifier.clone())
+            })
+            .unwrap_or_else(|| identifier.clone());
+        let attempt = lock
+            .retry_attempts
+            .get(&issue_id)
+            .map(|entry| entry.attempt + 1)
+            .or_else(|| {
+                lock.waiting_on_human
+                    .get(&issue_id)
+                    .map(|entry| next_attempt(entry.retry_attempt))
+            })
+            .unwrap_or(1);
+        let (max_backoff_ms, max_cycles) =
+            retry_settings.expect("retry settings loaded for step-level retry");
+
+        lock.remove_retry(&issue_id);
+        lock.remove_waiting_on_human(&issue_id);
+        schedule_failure_retry(
+            &mut lock,
+            FailureRetryRequest {
+                issue_id: &issue_id,
+                identifier: &identifier_copy,
+                attempt,
+                max_backoff_ms,
+                max_cycles,
+                error: "manual step-level retry",
+                retry_from_step: Some(step_name.clone()),
+                with_fixup: false,
+            },
+        );
+    } else {
+        // Whole-issue retry: release the claim so the next poll can pick it up fresh.
+        lock.remove_retry(&issue_id);
+        lock.remove_waiting_on_human(&issue_id);
+        lock.remove_claimed(&issue_id);
+        lock.remove_pipeline_run(&issue_id);
+    }
     drop(lock);
 
     // Signal the orchestrator to poll immediately so it picks up the now-unclaimed issue
@@ -326,7 +418,11 @@ pub async fn post_retry(
         Json(RetryResponse {
             retried: true,
             issue_identifier: identifier,
-            message: "removed from retry queue, will be re-dispatched on next poll".to_string(),
+            message: if query.step.is_some() {
+                "step-level retry queued".to_string()
+            } else {
+                "removed from retry queue, will be re-dispatched on next poll".to_string()
+            },
         }),
     )
         .into_response()
@@ -671,9 +767,11 @@ mod tests {
     use crate::agent::cancellation::register_issue_cancellation;
     use crate::api::router::AppState;
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
-    use crate::config::ensemble::{ConcurrencyConfig, StepConfig, StepKind};
+    use crate::config::ensemble::{ConcurrencyConfig, OnFailure, StepConfig, StepKind};
+    use crate::interaction::model::InteractionKind;
     use crate::orchestrator::state::{
         FinalizeStatus, IssueFinalizeState, OrchestratorState, RepoFinalizeState,
+        WaitingOnHumanEntry,
     };
     use crate::pipeline::dag::build_dag;
     use crate::pipeline::engine::PipelineRun;
@@ -693,6 +791,8 @@ mod tests {
             attempt: 2,
             due_at_ms: 999999,
             error: Some("timeout".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
         });
 
         match find_issue_presence(&state, "my-repo#42") {
@@ -771,6 +871,8 @@ mod tests {
             depends: None,
             tracker_state: None,
             approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
         }])
         .unwrap();
 
@@ -805,6 +907,8 @@ mod tests {
             attempt: 2,
             due_at_ms: 999999,
             error: Some("timeout".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
         });
 
         let mut app_state = app_state_with_document_state(parsed_document_state());
@@ -830,6 +934,36 @@ mod tests {
         );
 
         let mut app_state = app_state_with_document_state(parsed_document_state());
+        app_state.orchestrator_state = Arc::new(RwLock::new(state));
+        app_state
+    }
+
+    fn build_app_state_with_waiting_pipeline() -> AppState {
+        let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
+        let issue = test_issue();
+        state.add_waiting_on_human(WaitingOnHumanEntry {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            interaction_request_id: "halted:NODE_123:build".to_string(),
+            step_name: "build".to_string(),
+            kind: InteractionKind::Handoff,
+            prompt: "manual repair needed".to_string(),
+            agent_name: "build".to_string(),
+            retry_attempt: Some(1),
+            started_at: Some(chrono::Utc::now()),
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: chrono::Utc::now(),
+            run_id: Some("run-1".to_string()),
+            issue: Some(issue.clone()),
+        });
+
+        let document_state = parsed_document_state();
+        let active_config = document_state.active_config.clone().unwrap();
+        state.insert_pipeline_run("NODE_123", test_pipeline_run(), Arc::new(active_config));
+
+        let mut app_state = app_state_with_document_state(document_state);
         app_state.orchestrator_state = Arc::new(RwLock::new(state));
         app_state
     }
@@ -1023,7 +1157,12 @@ mod tests {
     #[tokio::test]
     async fn test_retry_retrying_issue() {
         let state = build_app_state_with_retry();
-        let response = post_retry(State(state.clone()), Path("my-repo#99".to_string())).await;
+        let response = post_retry(
+            State(state.clone()),
+            Path("my-repo#99".to_string()),
+            Query(RetryQuery { step: None }),
+        )
+        .await;
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::OK);
 
@@ -1034,9 +1173,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_retry_waiting_issue_with_step_queues_step_retry() {
+        let state = build_app_state_with_waiting_pipeline();
+        let response = post_retry(
+            State(state.clone()),
+            Path("my-repo#42".to_string()),
+            Query(RetryQuery {
+                step: Some("build".to_string()),
+            }),
+        )
+        .await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response_json(response).await;
+        assert_eq!(body["message"], "step-level retry queued");
+
+        let lock = state.orchestrator_state.read().await;
+        assert!(!lock.waiting_on_human.contains_key("NODE_123"));
+        assert!(lock.get_pipeline_run("NODE_123").is_some());
+        let retry = lock
+            .retry_attempts
+            .get("NODE_123")
+            .expect("step retry should be queued");
+        assert_eq!(retry.retry_from_step.as_deref(), Some("build"));
+        assert!(!retry.with_fixup);
+        assert_eq!(retry.attempt, 2);
+        assert!(lock.is_claimed("NODE_123"));
+    }
+
+    #[tokio::test]
     async fn test_retry_not_found() {
         let state = build_app_state_with_retry();
-        let response = post_retry(State(state), Path("nonexistent#999".to_string())).await;
+        let response = post_retry(
+            State(state),
+            Path("nonexistent#999".to_string()),
+            Query(RetryQuery { step: None }),
+        )
+        .await;
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
@@ -1044,7 +1218,12 @@ mod tests {
     #[tokio::test]
     async fn test_retry_running_issue_returns_conflict() {
         let state = build_app_state_with_running();
-        let response = post_retry(State(state), Path("my-repo#42".to_string())).await;
+        let response = post_retry(
+            State(state),
+            Path("my-repo#42".to_string()),
+            Query(RetryQuery { step: None }),
+        )
+        .await;
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::CONFLICT);
     }

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -452,6 +452,8 @@ mod tests {
             attempt: 3,
             due_at_ms: 1711641600000,
             error: Some("no available orchestrator slots".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
         }
     }
 

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -321,6 +321,13 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
             field: Some(step.clone()),
             path: Some(format!("steps.{}", step)),
         },
+        PipelineError::InvalidStepConfig { step, reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("invalid step config for '{}': {}", step, reason),
+            section: "workflow".to_string(),
+            field: Some(step.clone()),
+            path: Some(format!("steps.{}", step)),
+        },
         PipelineError::MaxCyclesExceeded { .. } => ValidationIssue {
             kind: ValidationIssueKind::Config,
             message: e.to_string(),

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -370,6 +370,22 @@ impl std::fmt::Display for StepKind {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OnFailure {
+    #[default]
+    RetryIssue,
+    RetryStep,
+    Fixup,
+    Halt,
+}
+
+impl OnFailure {
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::RetryIssue)
+    }
+}
+
 /// A single step in the pipeline DAG.
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct StepConfig {
@@ -383,6 +399,10 @@ pub struct StepConfig {
     pub tracker_state: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approval: Option<StepApprovalConfig>,
+    #[serde(default, skip_serializing_if = "OnFailure::is_default")]
+    pub on_failure: OnFailure,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixup_agent: Option<String>,
 }
 
 /// Concurrency limits for the pipeline orchestrator.
@@ -945,6 +965,19 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
                 name: step.agent.clone(),
             });
         }
+        if step.on_failure == OnFailure::Fixup {
+            let Some(fixup_agent) = step.fixup_agent.as_deref() else {
+                return Err(PipelineError::InvalidStepConfig {
+                    step: step.name.clone(),
+                    reason: "on_failure: fixup requires fixup_agent".to_string(),
+                });
+            };
+            if !config.agents.contains_key(fixup_agent) {
+                return Err(PipelineError::UnknownAgent {
+                    name: fixup_agent.to_string(),
+                });
+            }
+        }
     }
     // Synthesis steps must have explicit non-empty dependencies
     for step in &config.steps {
@@ -1441,6 +1474,63 @@ on_failure: Failed
     }
 
     #[test]
+    fn validate_fixup_on_failure_requires_fixup_agent() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: "Build it."
+steps:
+  - name: build
+    agent: build
+    on_failure: fixup
+on_success: Done
+on_failure: Failed
+"#;
+        let config = parse_config(yaml).unwrap();
+        let result = validate_config(&config);
+
+        assert!(
+            matches!(
+                result,
+                Err(PipelineError::InvalidStepConfig { ref step, ref reason })
+                    if step == "build" && reason == "on_failure: fixup requires fixup_agent"
+            ),
+            "expected InvalidStepConfig, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn validate_fixup_on_failure_rejects_unknown_fixup_agent() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: "Build it."
+steps:
+  - name: build
+    agent: build
+    on_failure: fixup
+    fixup_agent: fixer
+on_success: Done
+on_failure: Failed
+"#;
+        let config = parse_config(yaml).unwrap();
+        let result = validate_config(&config);
+
+        assert!(
+            matches!(result, Err(PipelineError::UnknownAgent { ref name }) if name == "fixer"),
+            "expected UnknownAgent, got {result:?}"
+        );
+    }
+
+    #[test]
     fn test_defaults_applied() {
         let config = parse_config(minimal_yaml()).unwrap();
 
@@ -1500,6 +1590,61 @@ on_failure: Failed
         assert_eq!(
             config.human_interaction.default_resume_mode,
             HumanResumeMode::Manual
+        );
+    }
+
+    #[test]
+    fn step_config_defaults_on_failure_to_retry_issue() {
+        let config = parse_config(minimal_yaml()).unwrap();
+        let step = config.steps.first().unwrap();
+
+        assert_eq!(step.on_failure, OnFailure::RetryIssue);
+        assert_eq!(step.fixup_agent, None);
+    }
+
+    #[test]
+    fn parses_on_failure_values_from_snake_case_yaml() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: "Build the thing."
+  fix:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: "Fix the thing."
+steps:
+  - name: retry-issue
+    agent: build
+    on_failure: retry_issue
+  - name: retry-step
+    agent: build
+    on_failure: retry_step
+  - name: fixup
+    agent: build
+    on_failure: fixup
+    fixup_agent: fix
+  - name: halt
+    agent: build
+    on_failure: halt
+on_success: Done
+on_failure: Failed
+"#;
+        let config = parse_config(yaml).unwrap();
+        let values: Vec<OnFailure> = config.steps.iter().map(|step| step.on_failure).collect();
+
+        assert_eq!(
+            values,
+            vec![
+                OnFailure::RetryIssue,
+                OnFailure::RetryStep,
+                OnFailure::Fixup,
+                OnFailure::Halt
+            ]
         );
     }
 

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -1,5 +1,5 @@
 use crate::config::ensemble::ModelDefinition;
-use crate::config::ensemble::{resolve_relative_to_base, StepConfig, StepKind};
+use crate::config::ensemble::{resolve_relative_to_base, OnFailure, StepConfig, StepKind};
 use crate::error::ConfigError;
 use crate::pipeline::dag::build_dag;
 use serde::{Deserialize, Serialize};
@@ -840,6 +840,8 @@ fn build_setup_dag(steps: &[SetupStep]) -> Result<crate::pipeline::dag::StepDag,
                 depends: Some(step.depends.clone()),
                 tracker_state: step.tracker_state.clone(),
                 approval: None,
+                on_failure: OnFailure::RetryIssue,
+                fixup_agent: None,
             })
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/ensemble-core/src/config/template.rs
+++ b/crates/ensemble-core/src/config/template.rs
@@ -30,7 +30,7 @@ pub fn render_prompt_with_interaction_response(
 /// This is the core rendering entry point used by [`render_prompt`] and
 /// [`render_prompt_with_interaction_response`]. When `step_outputs` is provided, each key from the
 /// serialized map is inserted directly into the Liquid globals so templates can reference fields
-/// like `steps["review-a"].summary` or `dependency_outputs[0].verdict`.
+/// like `steps["review-a"].summary` or `dependency_outputs[0].result`.
 pub fn render_prompt_with_context(
     template_str: &str,
     issue: &Issue,
@@ -245,7 +245,7 @@ mod tests {
             "review-a".to_string(),
             StepOutputTemplateEntry {
                 step: "review-a".to_string(),
-                verdict: "approve".to_string(),
+                result: "succeeded".to_string(),
                 summary: Some("looks good".to_string()),
                 output: Some(json!({"risk":"low"})),
             },

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -128,6 +128,8 @@ pub enum PipelineError {
     NoRootSteps,
     #[error("step {step} requires tracker writes but tracker does not support them")]
     WritesRequired { step: String },
+    #[error("invalid step config for {step}: {reason}")]
+    InvalidStepConfig { step: String, reason: String },
     #[error("max cycles ({max}) exceeded for issue {issue_id}")]
     MaxCyclesExceeded { issue_id: String, max: u32 },
     #[error("agent must have exactly one of 'prompt' or 'prompt_template', got neither or both: {agent}")]

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -360,17 +360,17 @@ pub fn extract_step_detail_state(
                         StepState::Running { .. } => "running",
                         StepState::Passed => "passed",
                         StepState::Failed { .. } => "failed",
+                        StepState::Errored { .. } => "failed",
                         StepState::BlockedOnHuman { .. } => "waiting",
                         StepState::AwaitingApproval { .. } => "waiting",
-                        StepState::Rejected { .. } => "rejected",
                     })
                     .unwrap_or("pending")
                     .to_string();
 
                 let verdict = step_state.and_then(|s| match s {
                     StepState::Passed => Some("success".to_string()),
-                    StepState::Failed { error, .. } => Some(error.clone()),
-                    StepState::Rejected { summary } => Some(summary.clone()),
+                    StepState::Failed { summary } => Some(summary.clone()),
+                    StepState::Errored { error } => Some(error.clone()),
                     _ => None,
                 });
 
@@ -648,9 +648,9 @@ pub async fn build_issue_snapshot(
                         StepState::Running { .. } => "running",
                         StepState::Passed => "passed",
                         StepState::Failed { .. } => "failed",
+                        StepState::Errored { .. } => "failed",
                         StepState::BlockedOnHuman { .. } => "waiting",
                         StepState::AwaitingApproval { .. } => "waiting",
-                        StepState::Rejected { .. } => "rejected",
                     })
                     .unwrap_or("pending");
                 WorkflowStepInfo {
@@ -867,7 +867,7 @@ fn pending_input_from_current(
 mod tests {
     use super::*;
     use crate::config::ensemble::{
-        ConcurrencyConfig, EnsembleConfig, StepConfig, StepKind, TrackerConfig,
+        ConcurrencyConfig, EnsembleConfig, OnFailure, StepConfig, StepKind, TrackerConfig,
     };
     use crate::orchestrator::state::{OrchestratorState, WaitingOnHumanEntry};
     use crate::pipeline::engine::{PipelineRun, StepState};
@@ -922,6 +922,8 @@ mod tests {
             attempt: 3,
             due_at_ms: 1711641600000,
             error: Some("no available orchestrator slots".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
         }
     }
 
@@ -986,6 +988,8 @@ mod tests {
                     depends: None,
                     tracker_state: None,
                     approval: None,
+                    on_failure: OnFailure::RetryIssue,
+                    fixup_agent: None,
                 },
                 StepConfig {
                     name: "review".to_string(),
@@ -994,6 +998,8 @@ mod tests {
                     depends: Some(vec!["build".to_string()]),
                     tracker_state: None,
                     approval: None,
+                    on_failure: OnFailure::RetryIssue,
+                    fixup_agent: None,
                 },
             ],
             on_success: "finalize".to_string(),
@@ -1440,6 +1446,8 @@ mod tests {
             attempt: 1,
             due_at_ms: 1711641600000,
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         };
 
         let row = retry_entry_to_row(&entry);

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1329,8 +1329,16 @@ impl Orchestrator {
                             let mut completed_identifier = None;
                             let mut rejection_comment = None;
                             let mut history_run_id = None;
+                            let runtime_step = state
+                                .get_pipeline_run(issue_id)
+                                .and_then(|run| run.step(&step))
+                                .cloned();
                             let step_config = config.steps.iter().find(|s| s.name == step);
-                            let on_failure = step_config.map(|s| s.on_failure).unwrap_or_default();
+                            let on_failure = runtime_step
+                                .as_ref()
+                                .map(|s| s.on_failure)
+                                .or_else(|| step_config.map(|s| s.on_failure))
+                                .unwrap_or_default();
                             match on_failure {
                                 OnFailure::RetryStep => {
                                     if let Some(run) = state.get_pipeline_run_mut(issue_id) {
@@ -1385,9 +1393,13 @@ impl Orchestrator {
                                     }
                                 }
                                 OnFailure::Fixup => {
-                                    let Some(fixup_agent) =
-                                        step_config.and_then(|s| s.fixup_agent.as_deref())
-                                    else {
+                                    let fixup_agent = runtime_step
+                                        .as_ref()
+                                        .and_then(|s| s.fixup_agent.as_deref())
+                                        .or_else(|| {
+                                            step_config.and_then(|s| s.fixup_agent.as_deref())
+                                        });
+                                    let Some(fixup_agent) = fixup_agent else {
                                         error!(
                                             issue_id = %issue_id,
                                             step = %step,
@@ -1460,8 +1472,10 @@ impl Orchestrator {
                                     );
                                     if let Some(entry) = state.remove_running(issue_id) {
                                         state.add_runtime_seconds(&entry);
-                                        let agent_name = step_config
+                                        let agent_name = runtime_step
+                                            .as_ref()
                                             .map(|s| s.agent.clone())
+                                            .or_else(|| step_config.map(|s| s.agent.clone()))
                                             .unwrap_or_default();
                                         state.add_waiting_on_human(WaitingOnHumanEntry {
                                             issue_id: issue_id.to_string(),
@@ -4472,6 +4486,50 @@ agent:
         parse_config(yaml).unwrap()
     }
 
+    fn make_fixup_config() -> EnsembleConfig {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress"]
+  terminal_states: ["Done", "Closed"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{ issue.identifier }}."
+  fixer:
+    executor: claude
+    model: opus
+    prompt: "Fix {{ issue.identifier }}."
+steps:
+  - name: build
+    agent: builder
+  - name: review
+    agent: builder
+    on_failure: fixup
+    fixup_agent: fixer
+max_cycles: 10
+on_success: Done
+on_failure: Todo
+concurrency:
+  max_concurrent_agents: 5
+polling:
+  interval_ms: 100
+workspace:
+  root: /tmp/ensemble-test
+agent:
+  max_turns: 3
+  command: "echo test"
+  session_mode: code
+  permission_request_policy: auto_approve_all
+  turn_timeout_ms: 30000
+  read_timeout_ms: 5000
+  max_retry_backoff_ms: 300000
+  stall_timeout_ms: 300000
+"#;
+        parse_config(yaml).unwrap()
+    }
+
     fn make_halt_config() -> EnsembleConfig {
         let yaml = r#"
 tracker:
@@ -4881,6 +4939,79 @@ agent:
             run.step_states.get("test"),
             Some(StepState::Pending)
         ));
+    }
+
+    #[tokio::test]
+    async fn synthetic_fixup_failure_halts_for_manual_intervention() {
+        let config = Arc::new(RwLock::new(make_fixup_config()));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.step_completed(
+                "build",
+                StepOutput {
+                    result: StepResult::Succeeded,
+                    summary: None,
+                    output: None,
+                },
+                false,
+            );
+            pipeline_run.retry_from_step_with_fixup("review", "fixer");
+            pipeline_run.mark_running("fixup-review", "session-fixup".to_string());
+
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), Some(2));
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "fixup-review",
+                WorkerResult::Success {
+                    runtime_verdict: Some(serde_json::json!({
+                        "result": "failed",
+                        "summary": "fixup could not repair"
+                    })),
+                    approval_request: None,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.get_pipeline_run("1").is_some());
+        assert!(!state.retry_attempts.contains_key("1"));
+        assert!(!state.running.contains_key("1"));
+        assert!(state.waiting_on_human.contains_key("1"));
+        assert!(state.is_claimed("1"));
+
+        let waiting = state.waiting_on_human.get("1").unwrap();
+        assert_eq!(waiting.step_name, "fixup-review");
+        assert_eq!(waiting.agent_name, "fixer");
+        assert_eq!(waiting.prompt, "fixup could not repair");
+        assert!(matches!(waiting.kind, InteractionKind::Handoff));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -14,7 +14,7 @@ use chrono::Utc;
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 use tokio::time::{sleep, timeout};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::agent::cancellation::{
     cancel_all, clear_issue_cancellation, new_cancellation_registry, register_issue_cancellation,
@@ -24,7 +24,7 @@ use crate::agent::events::{
     AgentEvent, InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult,
 };
 use crate::agent::{AgentRunRequest, AgentRunner, InteractionResponseEnvelope};
-use crate::config::ensemble::{EnsembleConfig, StepKind};
+use crate::config::ensemble::{EnsembleConfig, OnFailure, StepKind};
 use crate::error::{AgentError, EnsembleError};
 use crate::history::model::{HistoryRecord, TokenTotals};
 use crate::history::writer::HistoryWriter;
@@ -46,7 +46,7 @@ use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{
     DispatchRequest, PipelineAction, PipelineRun, StepOutputTemplateContext, StepState,
 };
-use crate::pipeline::verdict::{resolve_verdict_with_source, Verdict, VerdictSource};
+use crate::pipeline::verdict::{resolve_verdict_with_source, StepResult, VerdictSource};
 use crate::timeline::persistence::TimelinePersistence;
 use crate::tracker::model::Issue;
 use crate::tracker::IssueTracker;
@@ -55,7 +55,9 @@ use crate::workspace::manager::WorkspaceManager;
 
 use futures_util::FutureExt;
 use reconciler::{reconcile_stalled_runs, reconcile_tracker_states, startup_terminal_cleanup};
-use retry::{current_time_ms, get_due_retries, next_attempt, schedule_failure_retry};
+use retry::{
+    current_time_ms, get_due_retries, next_attempt, schedule_failure_retry, FailureRetryRequest,
+};
 use scheduler::{
     has_available_slots, is_dispatch_eligible, is_resume_dispatch_eligible, sort_for_dispatch,
 };
@@ -372,12 +374,16 @@ impl Orchestrator {
                         state.add_runtime_seconds(&entry);
                         schedule_failure_retry(
                             &mut state,
-                            issue_id,
-                            &entry.identifier,
-                            next_attempt(entry.retry_attempt),
-                            config.agent.max_retry_backoff_ms,
-                            config.max_cycles,
-                            "stall timeout",
+                            FailureRetryRequest {
+                                issue_id,
+                                identifier: &entry.identifier,
+                                attempt: next_attempt(entry.retry_attempt),
+                                max_backoff_ms: config.agent.max_retry_backoff_ms,
+                                max_cycles: config.max_cycles,
+                                error: "stall timeout",
+                                retry_from_step: None,
+                                with_fixup: false,
+                            },
                         );
                     }
                 }
@@ -578,6 +584,121 @@ impl Orchestrator {
 
     /// Dispatch a single issue: build DAG, create PipelineRun, dispatch initial steps.
     async fn dispatch_issue(&self, issue: &Issue, attempt: Option<u32>) {
+        let cycle = attempt.unwrap_or(1);
+
+        {
+            let state = self.state.read().await;
+            if state.get_pipeline_run(&issue.id).is_some() {
+                drop(state);
+
+                let (config_snapshot, action) = {
+                    let mut state = self.state.write().await;
+                    state.add_running(issue, attempt);
+                    let config = state.get_pipeline_config(&issue.id).cloned();
+                    let action = state
+                        .get_pipeline_run_mut(&issue.id)
+                        .map(|run| {
+                            run.cycle = cycle;
+                            run.start()
+                        })
+                        .unwrap_or(PipelineAction::Waiting);
+                    (config, action)
+                };
+
+                let Some(config_snapshot) = config_snapshot else {
+                    warn!(
+                        issue_id = %issue.id,
+                        identifier = %issue.identifier,
+                        "existing pipeline run has no config snapshot, skipping dispatch"
+                    );
+                    return;
+                };
+
+                info!(
+                    event = ISSUE_DISPATCH_STARTED,
+                    issue_id = %issue.id,
+                    identifier = %issue.identifier,
+                    cycle = cycle,
+                    "resuming with existing pipeline"
+                );
+
+                if let PipelineAction::Dispatch(requests) = action {
+                    for req in requests {
+                        let workspace_path =
+                            match self.prepare_step_workspace(issue, &config_snapshot).await {
+                                Ok(path) => path,
+                                Err(error) => {
+                                    warn!(
+                                        issue_id = %issue.id,
+                                        step = %req.step_name,
+                                        error = %error,
+                                        "failed to prepare step workspace"
+                                    );
+                                    let mut state = self.state.write().await;
+                                    if let Some(run) = state.get_pipeline_run_mut(&issue.id) {
+                                        run.step_failed(&req.step_name, error.to_string());
+                                    }
+                                    if let Some(entry) = state.remove_running(&issue.id) {
+                                        state.add_runtime_seconds(&entry);
+                                        schedule_failure_retry(
+                                            &mut state,
+                                            FailureRetryRequest {
+                                                issue_id: &issue.id,
+                                                identifier: &entry.identifier,
+                                                attempt: next_attempt(entry.retry_attempt),
+                                                max_backoff_ms: config_snapshot
+                                                    .agent
+                                                    .max_retry_backoff_ms,
+                                                max_cycles: config_snapshot.max_cycles,
+                                                error: &error.to_string(),
+                                                retry_from_step: None,
+                                                with_fixup: false,
+                                            },
+                                        );
+                                    }
+                                    state.remove_pipeline_run(&issue.id);
+                                    return;
+                                }
+                            };
+
+                        let step_outputs = {
+                            let state = self.state.read().await;
+                            state
+                                .get_pipeline_run(&issue.id)
+                                .and_then(|run| run.output_context_for(&req.step_name))
+                                .unwrap_or_default()
+                        };
+
+                        let _ = self
+                            .dispatch_step(
+                                issue,
+                                Arc::clone(&config_snapshot),
+                                StepDispatchContext {
+                                    step_name: &req.step_name,
+                                    agent_name: &req.agent_name,
+                                    step_kind: req.step_kind,
+                                    tracker_state: req.tracker_state.as_deref(),
+                                    attempt,
+                                    interaction_response: None,
+                                    workspace_path,
+                                    step_outputs,
+                                },
+                            )
+                            .await;
+                    }
+                }
+
+                info!(
+                    event = ISSUE_DISPATCH_COMPLETED,
+                    issue_id = %issue.id,
+                    identifier = %issue.identifier,
+                    cycle = cycle,
+                    "existing pipeline dispatch setup completed"
+                );
+                return;
+            }
+        }
+
         let (dag, config_snapshot) = {
             let config = self.config.read().await;
             match build_dag(&config.steps) {
@@ -589,7 +710,6 @@ impl Orchestrator {
             }
         };
 
-        let cycle = attempt.unwrap_or(1);
         let pipeline_run = PipelineRun::new(issue.id.clone(), cycle, dag);
         let action = pipeline_run.start();
 
@@ -628,12 +748,16 @@ impl Orchestrator {
                                 state.add_runtime_seconds(&entry);
                                 schedule_failure_retry(
                                     &mut state,
-                                    &issue.id,
-                                    &entry.identifier,
-                                    next_attempt(entry.retry_attempt),
-                                    config_snapshot.agent.max_retry_backoff_ms,
-                                    config_snapshot.max_cycles,
-                                    &error.to_string(),
+                                    FailureRetryRequest {
+                                        issue_id: &issue.id,
+                                        identifier: &entry.identifier,
+                                        attempt: next_attempt(entry.retry_attempt),
+                                        max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
+                                        max_cycles: config_snapshot.max_cycles,
+                                        error: &error.to_string(),
+                                        retry_from_step: None,
+                                        with_fixup: false,
+                                    },
                                 );
                             }
                             state.remove_pipeline_run(&issue.id);
@@ -979,19 +1103,20 @@ impl Orchestrator {
                     Some(wp) => {
                         resolve_verdict_with_source(runtime_verdict.as_ref(), &wp, step_name).await
                     }
-                    None => crate::pipeline::verdict::ResolvedVerdict {
-                        verdict: Verdict::Approve,
+                    None => crate::pipeline::verdict::ResolvedResult {
+                        result: StepResult::Succeeded,
                         output: crate::pipeline::verdict::StepOutput {
-                            verdict: Verdict::Approve,
+                            result: StepResult::Succeeded,
                             summary: None,
                             output: None,
                         },
                         source: VerdictSource::Default,
                     },
                 };
-                let verdict_value = match &resolved.verdict {
-                    Verdict::Approve => "approve",
-                    Verdict::Reject { .. } => "reject",
+                let verdict_value = match &resolved.result {
+                    StepResult::Succeeded => "succeeded",
+                    StepResult::Failed { .. } => "failed",
+                    StepResult::Concern { .. } => "concern",
                 };
                 info!(
                     issue_id = %issue_id,
@@ -1068,12 +1193,18 @@ impl Orchestrator {
                                                 state.add_runtime_seconds(&entry);
                                                 schedule_failure_retry(
                                                     &mut state,
-                                                    issue_id,
-                                                    &entry.identifier,
-                                                    next_attempt(entry.retry_attempt),
-                                                    config_snapshot.agent.max_retry_backoff_ms,
-                                                    config_snapshot.max_cycles,
-                                                    &error.to_string(),
+                                                    FailureRetryRequest {
+                                                        issue_id,
+                                                        identifier: &entry.identifier,
+                                                        attempt: next_attempt(entry.retry_attempt),
+                                                        max_backoff_ms: config_snapshot
+                                                            .agent
+                                                            .max_retry_backoff_ms,
+                                                        max_cycles: config_snapshot.max_cycles,
+                                                        error: &error.to_string(),
+                                                        retry_from_step: None,
+                                                        with_fixup: false,
+                                                    },
                                                 );
                                             }
                                             state.remove_pipeline_run(issue_id);
@@ -1198,45 +1329,212 @@ impl Orchestrator {
                             let mut completed_identifier = None;
                             let mut rejection_comment = None;
                             let mut history_run_id = None;
-                            if let Some(entry) = state.remove_running(issue_id) {
-                                state.add_runtime_seconds(&entry);
-                                completed_identifier = Some(entry.identifier.clone());
-                                history_run_id = entry.run_id.clone();
-                                let retry_scheduled = schedule_failure_retry(
-                                    &mut state,
-                                    issue_id,
-                                    &entry.identifier,
-                                    next_attempt(entry.retry_attempt),
-                                    config.agent.max_retry_backoff_ms,
-                                    config.max_cycles,
-                                    &reason,
-                                );
-                                final_failure = retry_scheduled.is_none();
-                                if final_failure {
-                                    history_record = state.get_pipeline_run(issue_id).map(|run| {
-                                        rejection_comment =
-                                            Self::rejection_comment_for_step(run, &step);
-                                        self.build_history_record(
-                                            issue_id,
-                                            HISTORY_OUTCOME_FAILED,
-                                            Some(reason.clone()),
-                                            &entry,
-                                            run,
-                                            completed_at,
-                                        )
-                                    });
-                                }
-                                if retry_scheduled.is_none() && self.tracker.supports_writes() {
-                                    if let Err(e) = self
-                                        .tracker
-                                        .set_issue_state(issue_id, &config.on_failure)
-                                        .await
-                                    {
-                                        warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
+                            let step_config = config.steps.iter().find(|s| s.name == step);
+                            let on_failure = step_config.map(|s| s.on_failure).unwrap_or_default();
+                            match on_failure {
+                                OnFailure::RetryStep => {
+                                    if let Some(run) = state.get_pipeline_run_mut(issue_id) {
+                                        run.retry_from_step(&step);
+                                    }
+                                    if let Some(entry) = state.remove_running(issue_id) {
+                                        state.add_runtime_seconds(&entry);
+                                        completed_identifier = Some(entry.identifier.clone());
+                                        history_run_id = entry.run_id.clone();
+                                        let retry_scheduled = schedule_failure_retry(
+                                            &mut state,
+                                            FailureRetryRequest {
+                                                issue_id,
+                                                identifier: &entry.identifier,
+                                                attempt: next_attempt(entry.retry_attempt),
+                                                max_backoff_ms: config.agent.max_retry_backoff_ms,
+                                                max_cycles: config.max_cycles,
+                                                error: &reason,
+                                                retry_from_step: Some(step.clone()),
+                                                with_fixup: false,
+                                            },
+                                        );
+                                        final_failure = retry_scheduled.is_none();
+                                        if final_failure {
+                                            history_record =
+                                                state.get_pipeline_run(issue_id).map(|run| {
+                                                    rejection_comment =
+                                                        Self::rejection_comment_for_step(
+                                                            run, &step,
+                                                        );
+                                                    self.build_history_record(
+                                                        issue_id,
+                                                        HISTORY_OUTCOME_FAILED,
+                                                        Some(reason.clone()),
+                                                        &entry,
+                                                        run,
+                                                        completed_at,
+                                                    )
+                                                });
+                                        }
+                                        if retry_scheduled.is_none()
+                                            && self.tracker.supports_writes()
+                                        {
+                                            if let Err(e) = self
+                                                .tracker
+                                                .set_issue_state(issue_id, &config.on_failure)
+                                                .await
+                                            {
+                                                warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
+                                            }
+                                        }
                                     }
                                 }
+                                OnFailure::Fixup => {
+                                    let Some(fixup_agent) =
+                                        step_config.and_then(|s| s.fixup_agent.as_deref())
+                                    else {
+                                        error!(
+                                            issue_id = %issue_id,
+                                            step = %step,
+                                            "fixup step missing fixup_agent after config validation"
+                                        );
+                                        if let Some(entry) = state.remove_running(issue_id) {
+                                            state.add_runtime_seconds(&entry);
+                                        }
+                                        state.remove_pipeline_run(issue_id);
+                                        return;
+                                    };
+
+                                    if let Some(run) = state.get_pipeline_run_mut(issue_id) {
+                                        run.retry_from_step_with_fixup(&step, fixup_agent);
+                                    }
+                                    if let Some(entry) = state.remove_running(issue_id) {
+                                        state.add_runtime_seconds(&entry);
+                                        completed_identifier = Some(entry.identifier.clone());
+                                        history_run_id = entry.run_id.clone();
+                                        let retry_scheduled = schedule_failure_retry(
+                                            &mut state,
+                                            FailureRetryRequest {
+                                                issue_id,
+                                                identifier: &entry.identifier,
+                                                attempt: next_attempt(entry.retry_attempt),
+                                                max_backoff_ms: config.agent.max_retry_backoff_ms,
+                                                max_cycles: config.max_cycles,
+                                                error: &reason,
+                                                retry_from_step: Some(step.clone()),
+                                                with_fixup: true,
+                                            },
+                                        );
+                                        final_failure = retry_scheduled.is_none();
+                                        if final_failure {
+                                            history_record =
+                                                state.get_pipeline_run(issue_id).map(|run| {
+                                                    rejection_comment =
+                                                        Self::rejection_comment_for_step(
+                                                            run, &step,
+                                                        );
+                                                    self.build_history_record(
+                                                        issue_id,
+                                                        HISTORY_OUTCOME_FAILED,
+                                                        Some(reason.clone()),
+                                                        &entry,
+                                                        run,
+                                                        completed_at,
+                                                    )
+                                                });
+                                        }
+                                        if retry_scheduled.is_none()
+                                            && self.tracker.supports_writes()
+                                        {
+                                            if let Err(e) = self
+                                                .tracker
+                                                .set_issue_state(issue_id, &config.on_failure)
+                                                .await
+                                            {
+                                                warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
+                                            }
+                                        }
+                                    }
+                                }
+                                OnFailure::Halt => {
+                                    warn!(
+                                        issue_id = %issue_id,
+                                        step = %step,
+                                        reason = %reason,
+                                        "pipeline halted, waiting for manual intervention"
+                                    );
+                                    if let Some(entry) = state.remove_running(issue_id) {
+                                        state.add_runtime_seconds(&entry);
+                                        let agent_name = step_config
+                                            .map(|s| s.agent.clone())
+                                            .unwrap_or_default();
+                                        state.add_waiting_on_human(WaitingOnHumanEntry {
+                                            issue_id: issue_id.to_string(),
+                                            identifier: entry.identifier.clone(),
+                                            interaction_request_id: format!(
+                                                "halted:{issue_id}:{step}"
+                                            ),
+                                            step_name: step.clone(),
+                                            kind: InteractionKind::Handoff,
+                                            prompt: reason.clone(),
+                                            agent_name,
+                                            retry_attempt: entry.retry_attempt,
+                                            started_at: Some(entry.started_at),
+                                            agent_input_tokens: entry.agent_input_tokens,
+                                            agent_output_tokens: entry.agent_output_tokens,
+                                            agent_total_tokens: entry.agent_total_tokens,
+                                            requested_at: Utc::now(),
+                                            run_id: entry.run_id.clone(),
+                                            issue: Some(entry.issue.clone()),
+                                        });
+                                    }
+                                }
+                                OnFailure::RetryIssue => {
+                                    if let Some(entry) = state.remove_running(issue_id) {
+                                        state.add_runtime_seconds(&entry);
+                                        completed_identifier = Some(entry.identifier.clone());
+                                        history_run_id = entry.run_id.clone();
+                                        let retry_scheduled = schedule_failure_retry(
+                                            &mut state,
+                                            FailureRetryRequest {
+                                                issue_id,
+                                                identifier: &entry.identifier,
+                                                attempt: next_attempt(entry.retry_attempt),
+                                                max_backoff_ms: config.agent.max_retry_backoff_ms,
+                                                max_cycles: config.max_cycles,
+                                                error: &reason,
+                                                retry_from_step: None,
+                                                with_fixup: false,
+                                            },
+                                        );
+                                        final_failure = retry_scheduled.is_none();
+                                        if final_failure {
+                                            history_record =
+                                                state.get_pipeline_run(issue_id).map(|run| {
+                                                    rejection_comment =
+                                                        Self::rejection_comment_for_step(
+                                                            run, &step,
+                                                        );
+                                                    self.build_history_record(
+                                                        issue_id,
+                                                        HISTORY_OUTCOME_FAILED,
+                                                        Some(reason.clone()),
+                                                        &entry,
+                                                        run,
+                                                        completed_at,
+                                                    )
+                                                });
+                                        }
+                                        if retry_scheduled.is_none()
+                                            && self.tracker.supports_writes()
+                                        {
+                                            if let Err(e) = self
+                                                .tracker
+                                                .set_issue_state(issue_id, &config.on_failure)
+                                                .await
+                                            {
+                                                warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
+                                            }
+                                        }
+                                    }
+                                    state.remove_pipeline_run(issue_id);
+                                }
                             }
-                            state.remove_pipeline_run(issue_id);
                             if final_failure {
                                 if let Some(identifier) = completed_identifier {
                                     state.add_completed(
@@ -1292,12 +1590,16 @@ impl Orchestrator {
                                     state.add_runtime_seconds(&entry);
                                     schedule_failure_retry(
                                         &mut state,
-                                        issue_id,
-                                        &entry.identifier,
-                                        next_attempt(entry.retry_attempt),
-                                        config.agent.max_retry_backoff_ms,
-                                        config.max_cycles,
-                                        &error.to_string(),
+                                        FailureRetryRequest {
+                                            issue_id,
+                                            identifier: &entry.identifier,
+                                            attempt: next_attempt(entry.retry_attempt),
+                                            max_backoff_ms: config.agent.max_retry_backoff_ms,
+                                            max_cycles: config.max_cycles,
+                                            error: &error.to_string(),
+                                            retry_from_step: None,
+                                            with_fixup: false,
+                                        },
                                     );
                                 }
                                 state.remove_pipeline_run(issue_id);
@@ -1341,12 +1643,16 @@ impl Orchestrator {
                         state.add_runtime_seconds(&entry);
                         schedule_failure_retry(
                             &mut state,
-                            issue_id,
-                            &entry.identifier,
-                            next_attempt(entry.retry_attempt),
-                            config.agent.max_retry_backoff_ms,
-                            config.max_cycles,
-                            &error.to_string(),
+                            FailureRetryRequest {
+                                issue_id,
+                                identifier: &entry.identifier,
+                                attempt: next_attempt(entry.retry_attempt),
+                                max_backoff_ms: config.agent.max_retry_backoff_ms,
+                                max_cycles: config.max_cycles,
+                                error: &error.to_string(),
+                                retry_from_step: None,
+                                with_fixup: false,
+                            },
                         );
                     }
                     state.remove_pipeline_run(issue_id);
@@ -1378,12 +1684,16 @@ impl Orchestrator {
                     state.add_runtime_seconds(&entry);
                     let retry_scheduled = schedule_failure_retry(
                         &mut state,
-                        issue_id,
-                        &entry.identifier,
-                        next_attempt(entry.retry_attempt),
-                        config.agent.max_retry_backoff_ms,
-                        config.max_cycles,
-                        &error,
+                        FailureRetryRequest {
+                            issue_id,
+                            identifier: &entry.identifier,
+                            attempt: next_attempt(entry.retry_attempt),
+                            max_backoff_ms: config.agent.max_retry_backoff_ms,
+                            max_cycles: config.max_cycles,
+                            error: &error,
+                            retry_from_step: None,
+                            with_fixup: false,
+                        },
                     );
                     final_failure = retry_scheduled.is_none();
                     if final_failure {
@@ -1432,7 +1742,7 @@ impl Orchestrator {
 
     fn rejection_comment_for_step(run: &PipelineRun, step_name: &str) -> Option<(String, String)> {
         match run.step_states.get(step_name) {
-            Some(StepState::Rejected { summary }) if !summary.trim().is_empty() => {
+            Some(StepState::Failed { summary }) if !summary.trim().is_empty() => {
                 Some((step_name.to_string(), summary.trim().to_string()))
             }
             _ => None,
@@ -2734,7 +3044,7 @@ impl Orchestrator {
         if run
             .step_states
             .values()
-            .any(|state| matches!(state, StepState::Rejected { .. }))
+            .any(|state| matches!(state, StepState::Failed { .. }))
         {
             return Some(HISTORY_VERDICT_REJECTED.to_string());
         }
@@ -2742,7 +3052,7 @@ impl Orchestrator {
         if run
             .step_states
             .values()
-            .any(|state| matches!(state, StepState::Failed { .. }))
+            .any(|state| matches!(state, StepState::Errored { .. }))
         {
             return Some(HISTORY_VERDICT_FAILED.to_string());
         }
@@ -3431,12 +3741,16 @@ impl Orchestrator {
                 let config = self.config.read().await;
                 schedule_failure_retry(
                     &mut state,
-                    issue_id,
-                    &retry_entry.identifier,
-                    retry_entry.attempt + 1,
-                    config.agent.max_retry_backoff_ms,
-                    config.max_cycles,
-                    "retry poll failed",
+                    FailureRetryRequest {
+                        issue_id,
+                        identifier: &retry_entry.identifier,
+                        attempt: retry_entry.attempt + 1,
+                        max_backoff_ms: config.agent.max_retry_backoff_ms,
+                        max_cycles: config.max_cycles,
+                        error: "retry poll failed",
+                        retry_from_step: retry_entry.retry_from_step.clone(),
+                        with_fixup: retry_entry.with_fixup,
+                    },
                 );
                 return;
             }
@@ -3476,12 +3790,16 @@ impl Orchestrator {
                     let config = self.config.read().await;
                     schedule_failure_retry(
                         &mut state,
-                        issue_id,
-                        &retry_entry.identifier,
-                        retry_entry.attempt + 1,
-                        config.agent.max_retry_backoff_ms,
-                        config.max_cycles,
-                        "no available orchestrator slots",
+                        FailureRetryRequest {
+                            issue_id,
+                            identifier: &retry_entry.identifier,
+                            attempt: retry_entry.attempt + 1,
+                            max_backoff_ms: config.agent.max_retry_backoff_ms,
+                            max_cycles: config.max_cycles,
+                            error: "no available orchestrator slots",
+                            retry_from_step: retry_entry.retry_from_step.clone(),
+                            with_fixup: retry_entry.with_fixup,
+                        },
                     );
                 }
             }
@@ -3758,7 +4076,7 @@ mod tests {
         InteractionKind, InteractionResponse, InteractionResumeStrategy, InteractionStatus,
         InteractionStore,
     };
-    use crate::pipeline::verdict::{StepOutput, Verdict};
+    use crate::pipeline::verdict::{StepOutput, StepResult};
     use crate::tracker::TrackerError;
     use async_trait::async_trait;
 
@@ -4115,6 +4433,82 @@ agent:
         parse_config(yaml).unwrap()
     }
 
+    fn make_retry_step_config() -> EnsembleConfig {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress"]
+  terminal_states: ["Done", "Closed"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{ issue.identifier }}."
+steps:
+  - name: build
+    agent: builder
+    on_failure: retry_step
+  - name: test
+    agent: builder
+max_cycles: 10
+on_success: Done
+on_failure: Todo
+concurrency:
+  max_concurrent_agents: 5
+polling:
+  interval_ms: 100
+workspace:
+  root: /tmp/ensemble-test
+agent:
+  max_turns: 3
+  command: "echo test"
+  session_mode: code
+  permission_request_policy: auto_approve_all
+  turn_timeout_ms: 30000
+  read_timeout_ms: 5000
+  max_retry_backoff_ms: 300000
+  stall_timeout_ms: 300000
+"#;
+        parse_config(yaml).unwrap()
+    }
+
+    fn make_halt_config() -> EnsembleConfig {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress"]
+  terminal_states: ["Done", "Closed"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{ issue.identifier }}."
+steps:
+  - name: build
+    agent: builder
+    on_failure: halt
+max_cycles: 10
+on_success: Done
+on_failure: Todo
+concurrency:
+  max_concurrent_agents: 5
+polling:
+  interval_ms: 100
+workspace:
+  root: /tmp/ensemble-test
+agent:
+  max_turns: 3
+  command: "echo test"
+  session_mode: code
+  permission_request_policy: auto_approve_all
+  turn_timeout_ms: 30000
+  read_timeout_ms: 5000
+  max_retry_backoff_ms: 300000
+  stall_timeout_ms: 300000
+"#;
+        parse_config(yaml).unwrap()
+    }
+
     fn make_parallel_resume_config() -> EnsembleConfig {
         let yaml = r#"
 tracker:
@@ -4416,6 +4810,139 @@ agent:
             state.completed.contains_key("1") || state.retry_attempts.contains_key("1"),
             "should be completed or retrying"
         );
+    }
+
+    #[tokio::test]
+    async fn pipeline_failure_retry_step_preserves_run_and_schedules_step_retry() {
+        let config = Arc::new(RwLock::new(make_retry_step_config()));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    runtime_verdict: Some(serde_json::json!({
+                        "result": "failed",
+                        "summary": "tests failed"
+                    })),
+                    approval_request: None,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        let retry = state
+            .retry_attempts
+            .get("1")
+            .expect("retry should be queued");
+        assert_eq!(retry.retry_from_step.as_deref(), Some("build"));
+        assert!(!retry.with_fixup);
+        assert!(state.get_pipeline_run("1").is_some());
+        assert!(!state.running.contains_key("1"));
+        assert!(!state.completed.contains_key("1"));
+
+        let run = state.get_pipeline_run("1").unwrap();
+        assert!(matches!(
+            run.step_states.get("build"),
+            Some(StepState::Pending)
+        ));
+        assert!(matches!(
+            run.step_states.get("test"),
+            Some(StepState::Pending)
+        ));
+    }
+
+    #[tokio::test]
+    async fn pipeline_failure_halt_preserves_run_and_waits_on_human() {
+        let config = Arc::new(RwLock::new(make_halt_config()));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    runtime_verdict: Some(serde_json::json!({
+                        "result": "failed",
+                        "summary": "needs manual repair"
+                    })),
+                    approval_request: None,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.get_pipeline_run("1").is_some());
+        assert!(!state.retry_attempts.contains_key("1"));
+        assert!(!state.running.contains_key("1"));
+        assert!(state.waiting_on_human.contains_key("1"));
+        assert!(state.is_claimed("1"));
+
+        let waiting = state.waiting_on_human.get("1").unwrap();
+        assert_eq!(waiting.step_name, "build");
+        assert_eq!(waiting.prompt, "needs manual repair");
+        assert!(matches!(waiting.kind, InteractionKind::Handoff));
     }
 
     #[tokio::test]
@@ -5040,6 +5567,8 @@ agent:
                 attempt: 1,
                 due_at_ms: 0,
                 error: None,
+                retry_from_step: None,
+                with_fixup: false,
             });
         }
 
@@ -5050,6 +5579,8 @@ agent:
             attempt: 1,
             due_at_ms: 0,
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         };
         orchestrator.handle_single_retry(&retry_entry).await;
 
@@ -5323,6 +5854,67 @@ agent:
 
         let commands = observed_commands.read().await;
         assert_eq!(commands.as_slice(), &["echo test".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn dispatch_issue_reuses_existing_pipeline_run_for_step_retry() {
+        let config = Arc::new(RwLock::new(make_retry_step_config()));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 1000,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let issue = test_issue("1", "Todo");
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+            pipeline_run.step_completed(
+                "build",
+                StepOutput {
+                    result: StepResult::Succeeded,
+                    summary: None,
+                    output: None,
+                },
+                false,
+            );
+            pipeline_run.retry_from_step("test");
+
+            let mut state = orchestrator.state.write().await;
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        orchestrator.dispatch_issue(&issue, Some(2)).await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.running.contains_key("1"));
+        let run = state.get_pipeline_run("1").expect("pipeline run");
+        assert_eq!(run.cycle, 2);
+        assert!(matches!(
+            run.step_states.get("build"),
+            Some(StepState::Passed)
+        ));
+        assert!(matches!(
+            run.step_states.get("test"),
+            Some(StepState::Running { .. })
+        ));
     }
 
     #[tokio::test]
@@ -6135,7 +6727,7 @@ agent:
             pipeline_run.step_completed(
                 "build",
                 StepOutput {
-                    verdict: Verdict::Approve,
+                    result: StepResult::Succeeded,
                     summary: None,
                     output: None,
                 },

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -11,6 +11,17 @@ pub const CONTINUATION_RETRY_DELAY_MS: u64 = 1000;
 /// Base delay for failure-driven exponential backoff.
 pub const FAILURE_BASE_DELAY_MS: u64 = 10000;
 
+pub struct FailureRetryRequest<'a> {
+    pub issue_id: &'a str,
+    pub identifier: &'a str,
+    pub attempt: u32,
+    pub max_backoff_ms: u64,
+    pub max_cycles: u32,
+    pub error: &'a str,
+    pub retry_from_step: Option<String>,
+    pub with_fixup: bool,
+}
+
 /// Calculate exponential backoff delay for a failure retry.
 /// Formula: min(10000 * 2^(attempt - 1), max_backoff_ms)
 pub fn calculate_backoff(attempt: u32, max_backoff_ms: u64) -> u64 {
@@ -37,6 +48,8 @@ pub fn schedule_continuation_retry(
         attempt: 1,
         due_at_ms,
         error: None,
+        retry_from_step: None,
+        with_fixup: false,
     };
 
     info!(
@@ -57,13 +70,19 @@ pub fn schedule_continuation_retry(
 /// has been reached and the issue should not be retried.
 pub fn schedule_failure_retry(
     state: &mut OrchestratorState,
-    issue_id: &str,
-    identifier: &str,
-    attempt: u32,
-    max_backoff_ms: u64,
-    max_cycles: u32,
-    error: &str,
+    request: FailureRetryRequest<'_>,
 ) -> Option<u64> {
+    let FailureRetryRequest {
+        issue_id,
+        identifier,
+        attempt,
+        max_backoff_ms,
+        max_cycles,
+        error,
+        retry_from_step,
+        with_fixup,
+    } = request;
+
     if attempt >= max_cycles {
         warn!(
             event = ISSUE_RETRY_CANCELLED,
@@ -86,6 +105,8 @@ pub fn schedule_failure_retry(
         attempt,
         due_at_ms,
         error: Some(error.to_string()),
+        retry_from_step,
+        with_fixup,
     };
 
     info!(
@@ -223,12 +244,16 @@ mod tests {
 
         let due = schedule_failure_retry(
             &mut state,
-            "issue-1",
-            "repo#1",
-            2,
-            300_000,
-            5,
-            "agent crashed",
+            FailureRetryRequest {
+                issue_id: "issue-1",
+                identifier: "repo#1",
+                attempt: 2,
+                max_backoff_ms: 300_000,
+                max_cycles: 5,
+                error: "agent crashed",
+                retry_from_step: None,
+                with_fixup: false,
+            },
         );
 
         assert!(due.is_some());
@@ -237,6 +262,8 @@ mod tests {
         let entry = state.retry_attempts.get("issue-1").unwrap();
         assert_eq!(entry.attempt, 2);
         assert_eq!(entry.error.as_deref(), Some("agent crashed"));
+        assert_eq!(entry.retry_from_step, None);
+        assert!(!entry.with_fixup);
     }
 
     #[test]
@@ -246,12 +273,16 @@ mod tests {
         // attempt 3, max_cycles 3 → should NOT schedule
         let due = schedule_failure_retry(
             &mut state,
-            "issue-1",
-            "repo#1",
-            3,
-            300_000,
-            3,
-            "agent crashed",
+            FailureRetryRequest {
+                issue_id: "issue-1",
+                identifier: "repo#1",
+                attempt: 3,
+                max_backoff_ms: 300_000,
+                max_cycles: 3,
+                error: "agent crashed",
+                retry_from_step: None,
+                with_fixup: false,
+            },
         );
         assert!(due.is_none());
         assert!(!state.retry_attempts.contains_key("issue-1"));
@@ -259,12 +290,16 @@ mod tests {
         // attempt 2, max_cycles 3 → should schedule
         let due = schedule_failure_retry(
             &mut state,
-            "issue-2",
-            "repo#2",
-            2,
-            300_000,
-            3,
-            "agent crashed",
+            FailureRetryRequest {
+                issue_id: "issue-2",
+                identifier: "repo#2",
+                attempt: 2,
+                max_backoff_ms: 300_000,
+                max_cycles: 3,
+                error: "agent crashed",
+                retry_from_step: None,
+                with_fixup: false,
+            },
         );
         assert!(due.is_some());
         assert!(state.retry_attempts.contains_key("issue-2"));
@@ -285,6 +320,8 @@ mod tests {
             attempt: 1,
             due_at_ms: 0, // in the past
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         };
         assert!(is_retry_due(&past_entry));
 
@@ -294,6 +331,8 @@ mod tests {
             attempt: 1,
             due_at_ms: current_time_ms() + 999_999_999,
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         };
         assert!(!is_retry_due(&future_entry));
     }
@@ -309,6 +348,8 @@ mod tests {
             attempt: 1,
             due_at_ms: 0,
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         });
 
         // One future retry
@@ -318,6 +359,8 @@ mod tests {
             attempt: 1,
             due_at_ms: current_time_ms() + 999_999_999,
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         });
 
         let due = get_due_retries(&state);
@@ -336,6 +379,8 @@ mod tests {
             attempt: 1,
             due_at_ms: 5000,
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         });
         state.add_retry(RetryEntry {
             issue_id: "2".to_string(),
@@ -343,6 +388,8 @@ mod tests {
             attempt: 1,
             due_at_ms: 3000,
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         });
 
         assert_eq!(next_retry_time(&state), Some(3000));

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -279,6 +279,26 @@ impl OrchestratorState {
         self.running.contains_key(issue_id)
     }
 
+    /// Find the issue ID for a tracker identifier across active control states.
+    pub fn find_issue_id_by_identifier(&self, identifier: &str) -> Option<String> {
+        for (id, entry) in &self.running {
+            if entry.identifier == identifier {
+                return Some(id.clone());
+            }
+        }
+        for (id, entry) in &self.retry_attempts {
+            if entry.identifier == identifier {
+                return Some(id.clone());
+            }
+        }
+        for (id, entry) in &self.waiting_on_human {
+            if entry.identifier == identifier {
+                return Some(id.clone());
+            }
+        }
+        None
+    }
+
     /// Add a retry entry.
     pub fn add_retry(&mut self, entry: RetryEntry) {
         self.claimed.insert(entry.issue_id.clone());
@@ -657,7 +677,7 @@ fn completed_step_state(step: &StepConfig, run: Option<&PipelineRun>) -> String 
             crate::pipeline::engine::StepState::Failed { .. } => "failed",
             crate::pipeline::engine::StepState::BlockedOnHuman { .. } => "waiting",
             crate::pipeline::engine::StepState::AwaitingApproval { .. } => "waiting",
-            crate::pipeline::engine::StepState::Rejected { .. } => "rejected",
+            crate::pipeline::engine::StepState::Errored { .. } => "failed",
         })
         .unwrap_or("pending")
         .to_string()
@@ -735,6 +755,8 @@ mod tests {
             attempt: 1,
             due_at_ms: 5000,
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         };
 
         state.add_retry(retry);
@@ -753,6 +775,8 @@ mod tests {
             attempt: 1,
             due_at_ms: 5000,
             error: None,
+            retry_from_step: None,
+            with_fixup: false,
         };
 
         state.add_retry(retry);
@@ -786,6 +810,52 @@ mod tests {
 
         assert!(state.is_claimed("1"));
         assert!(state.is_waiting_on_human("1"));
+    }
+
+    #[test]
+    fn test_find_issue_id_by_identifier_checks_active_control_states() {
+        let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
+        state.add_running(&test_issue("running", "Todo"), None);
+        state.add_retry(RetryEntry {
+            issue_id: "retrying".to_string(),
+            identifier: "repo#retrying".to_string(),
+            attempt: 1,
+            due_at_ms: 5000,
+            error: None,
+            retry_from_step: None,
+            with_fixup: false,
+        });
+        state.add_waiting_on_human(WaitingOnHumanEntry {
+            issue_id: "waiting".to_string(),
+            identifier: "repo#waiting".to_string(),
+            interaction_request_id: "interaction-1".to_string(),
+            step_name: "build".to_string(),
+            kind: InteractionKind::Question,
+            prompt: "Need input".to_string(),
+            agent_name: "builder".to_string(),
+            retry_attempt: None,
+            started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: Utc::now(),
+            run_id: None,
+            issue: None,
+        });
+
+        assert_eq!(
+            state.find_issue_id_by_identifier("repo#running"),
+            Some("running".to_string())
+        );
+        assert_eq!(
+            state.find_issue_id_by_identifier("repo#retrying"),
+            Some("retrying".to_string())
+        );
+        assert_eq!(
+            state.find_issue_id_by_identifier("repo#waiting"),
+            Some("waiting".to_string())
+        );
+        assert_eq!(state.find_issue_id_by_identifier("repo#missing"), None);
     }
 
     #[test]
@@ -926,6 +996,8 @@ mod tests {
             attempt: 2,
             due_at_ms: 5000,
             error: Some("previous error".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
         };
         state.add_retry(retry);
         assert!(state.retry_attempts.contains_key("1"));
@@ -955,6 +1027,8 @@ mod tests {
             attempt: 2,
             due_at_ms: 5000,
             error: Some("retry".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
         });
         state.add_running(&issue, Some(2));
 

--- a/crates/ensemble-core/src/pipeline/dag.rs
+++ b/crates/ensemble-core/src/pipeline/dag.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::config::ensemble::{StepApprovalConfig, StepConfig, StepKind};
+use crate::config::ensemble::{OnFailure, StepApprovalConfig, StepConfig, StepKind};
 use crate::error::PipelineError;
 
 /// A single step in the resolved DAG, with its explicit dependency list.
@@ -11,6 +11,8 @@ pub struct DagStep {
     pub kind: StepKind,
     pub tracker_state: Option<String>,
     pub approval: Option<StepApprovalConfig>,
+    pub on_failure: OnFailure,
+    pub fixup_agent: Option<String>,
     pub depends: Vec<String>,
 }
 
@@ -22,6 +24,38 @@ pub struct DagStep {
 #[derive(Debug, Clone)]
 pub struct StepDag {
     pub steps: Vec<DagStep>,
+}
+
+impl StepDag {
+    /// Return `step_name` and every step that transitively depends on it.
+    pub fn downstream_steps(&self, step_name: &str) -> HashSet<String> {
+        let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
+        for step in &self.steps {
+            for dep in &step.depends {
+                dependents
+                    .entry(dep.as_str())
+                    .or_default()
+                    .push(step.name.as_str());
+            }
+        }
+
+        let mut downstream = HashSet::new();
+        let mut queue = VecDeque::from([step_name.to_string()]);
+
+        while let Some(current) = queue.pop_front() {
+            if !downstream.insert(current.clone()) {
+                continue;
+            }
+
+            if let Some(next_steps) = dependents.get(current.as_str()) {
+                for next in next_steps {
+                    queue.push_back((*next).to_string());
+                }
+            }
+        }
+
+        downstream
+    }
 }
 
 /// Build a [`StepDag`] from a slice of [`StepConfig`] entries.
@@ -75,6 +109,8 @@ pub fn build_dag(steps: &[StepConfig]) -> Result<StepDag, PipelineError> {
             kind: step.kind,
             tracker_state: step.tracker_state.clone(),
             approval: step.approval.clone(),
+            on_failure: step.on_failure,
+            fixup_agent: step.fixup_agent.clone(),
             depends: deps,
         });
     }
@@ -165,6 +201,8 @@ mod tests {
             depends: deps,
             tracker_state: None,
             approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
         }
     }
 
@@ -176,6 +214,8 @@ mod tests {
             depends: Some(vec![]), // explicit root
             tracker_state: None,
             approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
         }
     }
 
@@ -328,6 +368,8 @@ mod tests {
                 depends: Some(vec![]),
                 tracker_state: None,
                 approval: None,
+                on_failure: OnFailure::RetryIssue,
+                fixup_agent: None,
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -336,6 +378,8 @@ mod tests {
                 depends: Some(vec!["review-a".to_string()]),
                 tracker_state: None,
                 approval: None,
+                on_failure: OnFailure::RetryIssue,
+                fixup_agent: None,
             },
         ];
 
@@ -361,6 +405,8 @@ mod tests {
                 mode: crate::config::ensemble::StepApprovalMode::WhenRequestedByAgent,
                 state: Some("Plan Review".to_string()),
             }),
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
         }];
 
         let dag = build_dag(&steps).unwrap();
@@ -375,5 +421,95 @@ mod tests {
             crate::config::ensemble::StepApprovalMode::WhenRequestedByAgent
         );
         assert_eq!(approval.state.as_deref(), Some("Plan Review"));
+    }
+
+    #[test]
+    fn preserves_on_failure_metadata() {
+        let steps = vec![StepConfig {
+            name: "build".to_string(),
+            kind: StepKind::Agent,
+            agent: "builder".to_string(),
+            depends: None,
+            tracker_state: None,
+            approval: None,
+            on_failure: OnFailure::Fixup,
+            fixup_agent: Some("fixer".to_string()),
+        }];
+
+        let dag = build_dag(&steps).unwrap();
+        let build = dag.steps.iter().find(|s| s.name == "build").unwrap();
+
+        assert_eq!(build.on_failure, OnFailure::Fixup);
+        assert_eq!(build.fixup_agent.as_deref(), Some("fixer"));
+    }
+
+    #[test]
+    fn downstream_steps_for_linear_chain_includes_middle_and_tail() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("test", "tester", &[]),
+            make_step("review", "reviewer", &[]),
+        ];
+        let dag = build_dag(&steps).unwrap();
+
+        let downstream = dag.downstream_steps("test");
+
+        assert_eq!(
+            downstream,
+            HashSet::from(["test".to_string(), "review".to_string()])
+        );
+    }
+
+    #[test]
+    fn downstream_steps_for_diamond_excludes_sibling_branch() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("review-a", "reviewer", &["build"]),
+            make_step("review-b", "reviewer", &["build"]),
+            make_step("synth", "synthesizer", &["review-a", "review-b"]),
+        ];
+        let dag = build_dag(&steps).unwrap();
+
+        let downstream = dag.downstream_steps("review-a");
+
+        assert_eq!(
+            downstream,
+            HashSet::from(["review-a".to_string(), "synth".to_string()])
+        );
+    }
+
+    #[test]
+    fn downstream_steps_for_root_in_sequential_graph_includes_all_steps() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("test", "tester", &[]),
+            make_step("review", "reviewer", &[]),
+        ];
+        let dag = build_dag(&steps).unwrap();
+
+        let downstream = dag.downstream_steps("build");
+
+        assert_eq!(
+            downstream,
+            HashSet::from([
+                "build".to_string(),
+                "test".to_string(),
+                "review".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn downstream_steps_for_leaf_returns_only_itself() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("test", "tester", &[]),
+            make_step("review", "reviewer", &[]),
+        ];
+        let dag = build_dag(&steps).unwrap();
+
+        let downstream = dag.downstream_steps("review");
+
+        assert_eq!(downstream, HashSet::from(["review".to_string()]));
     }
 }

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -332,6 +332,11 @@ impl PipelineRun {
         }
     }
 
+    /// Return runtime DAG metadata for a step, including synthetic steps.
+    pub fn step(&self, step_name: &str) -> Option<&DagStep> {
+        self.dag.steps.iter().find(|step| step.name == step_name)
+    }
+
     /// Reset `step_name` and every step that transitively depends on it back
     /// to pending, clearing any stored outputs for those steps.
     pub fn retry_from_step(&mut self, step_name: &str) -> HashSet<String> {
@@ -388,7 +393,7 @@ impl PipelineRun {
                         kind: StepKind::Agent,
                         tracker_state: None,
                         approval: None,
-                        on_failure: OnFailure::RetryStep,
+                        on_failure: OnFailure::Halt,
                         fixup_agent: None,
                         depends: original_deps,
                     },

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -2,9 +2,9 @@ use std::collections::{HashMap, HashSet};
 
 use serde::Serialize;
 
-use crate::config::ensemble::StepKind;
-use crate::pipeline::dag::StepDag;
-use crate::pipeline::verdict::{StepOutput, Verdict};
+use crate::config::ensemble::{OnFailure, StepKind};
+use crate::pipeline::dag::{DagStep, StepDag};
+use crate::pipeline::verdict::{StepOutput, StepResult};
 
 /// The execution state of a single pipeline step.
 #[derive(Debug, Clone, PartialEq)]
@@ -22,10 +22,10 @@ pub enum StepState {
     },
     /// Step completed and was approved.
     Passed,
-    /// Step completed but was rejected by a review agent.
-    Rejected { summary: String },
+    /// Step completed with a failed result.
+    Failed { summary: String },
     /// Step failed due to an agent crash or runtime error.
-    Failed { error: String },
+    Errored { error: String },
 }
 
 impl StepState {
@@ -34,7 +34,7 @@ impl StepState {
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,
-            Self::Passed | Self::Rejected { .. } | Self::Failed { .. }
+            Self::Passed | Self::Failed { .. } | Self::Errored { .. }
         )
     }
 }
@@ -70,7 +70,7 @@ pub enum PipelineAction {
     },
     /// All steps have passed — pipeline completed successfully.
     Succeeded,
-    /// A step failed or was rejected — pipeline halted.
+    /// A step failed or errored — pipeline halted.
     Failed { step: String, reason: String },
     /// No steps are ready right now; waiting for running steps to finish.
     Waiting,
@@ -91,7 +91,7 @@ pub enum ApprovalGateCheck {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct StepOutputTemplateEntry {
     pub step: String,
-    pub verdict: String,
+    pub result: String,
     pub summary: Option<String>,
     pub output: Option<serde_json::Value>,
 }
@@ -118,6 +118,8 @@ pub struct PipelineRun {
     pub step_outputs: HashMap<String, StepOutput>,
     /// The resolved, validated step DAG.
     dag: StepDag,
+    /// Synthetic fixup steps generated for step-level retries.
+    synthetic_fixup_steps: HashSet<String>,
 }
 
 impl PipelineRun {
@@ -135,6 +137,7 @@ impl PipelineRun {
             step_states,
             step_outputs: HashMap::new(),
             dag,
+            synthetic_fixup_steps: HashSet::new(),
         }
     }
 
@@ -151,13 +154,13 @@ impl PipelineRun {
             .insert(step_name.to_string(), StepState::Running { session_id });
     }
 
-    /// Handle a completed step verdict.
+    /// Handle a completed step result.
     ///
-    /// - [`Verdict::Approve`] → either transitions to
+    /// - [`StepResult::Succeeded`] → either transitions to
     ///   [`PipelineAction::AwaitingApproval`] for approval-gated steps, or
     ///   marks the step as [`StepState::Passed`] and checks whether all steps
     ///   are done or if new steps can be dispatched.
-    /// - [`Verdict::Reject`] → marks the step as [`StepState::Rejected`] and
+    /// - [`StepResult::Failed`] → marks the step as [`StepState::Failed`] and
     ///   returns [`PipelineAction::Failed`].
     pub fn step_completed(
         &mut self,
@@ -165,10 +168,10 @@ impl PipelineRun {
         output: StepOutput,
         approval_requested: bool,
     ) -> PipelineAction {
-        let verdict = output.verdict.clone();
+        let result = output.result.clone();
         self.step_outputs.insert(step_name.to_string(), output);
-        match verdict {
-            Verdict::Approve => match self.gate_check(step_name, approval_requested) {
+        match result {
+            StepResult::Succeeded => match self.gate_check(step_name, approval_requested) {
                 ApprovalGateCheck::EligibleGating => {
                     let approval_state = self.approval_state_for(step_name);
                     self.step_states.insert(
@@ -184,19 +187,19 @@ impl PipelineRun {
                 }
                 ApprovalGateCheck::UnconfiguredButRequested => {
                     self.step_states.insert(
-                            step_name.to_string(),
-                            StepState::Failed {
-                                error: format!(
-                                    "worker requested approval for step '{step_name}' but it has no approval configuration"
-                                ),
-                            },
-                        );
-                    PipelineAction::Failed {
-                            step: step_name.to_string(),
-                            reason: format!(
-                                "step '{step_name}' has no approval configuration but the worker requested one"
+                        step_name.to_string(),
+                        StepState::Errored {
+                            error: format!(
+                                "worker requested approval for step '{step_name}' but it has no approval configuration"
                             ),
-                        }
+                        },
+                    );
+                    PipelineAction::Failed {
+                        step: step_name.to_string(),
+                        reason: format!(
+                            "step '{step_name}' has no approval configuration but the worker requested one"
+                        ),
+                    }
                 }
                 ApprovalGateCheck::NotRequested => {
                     self.step_states
@@ -208,10 +211,23 @@ impl PipelineRun {
                     }
                 }
             },
-            Verdict::Reject { summary } => {
+            StepResult::Concern { .. } => {
+                // Concern is a non-terminal-review signal for humans and
+                // downstream steps. It intentionally continues like success
+                // without applying approval gates or unconfigured approval
+                // request errors.
+                self.step_states
+                    .insert(step_name.to_string(), StepState::Passed);
+                if self.all_passed() {
+                    PipelineAction::Succeeded
+                } else {
+                    self.find_dispatchable()
+                }
+            }
+            StepResult::Failed { summary } => {
                 self.step_states.insert(
                     step_name.to_string(),
-                    StepState::Rejected {
+                    StepState::Failed {
                         summary: summary.clone(),
                     },
                 );
@@ -260,7 +276,7 @@ impl PipelineRun {
         }
     }
 
-    /// Mark an approval gate as rejected, halting the pipeline.
+    /// Mark an approval gate as failed, halting the pipeline.
     pub fn reject_gate(&mut self, step_name: &str, reason: String) -> PipelineAction {
         if !matches!(
             self.step_states.get(step_name),
@@ -271,7 +287,7 @@ impl PipelineRun {
 
         self.step_states.insert(
             step_name.to_string(),
-            StepState::Rejected {
+            StepState::Failed {
                 summary: reason.clone(),
             },
         );
@@ -301,12 +317,12 @@ impl PipelineRun {
 
     /// Handle a step that failed due to a runtime error.
     ///
-    /// Marks the step as [`StepState::Failed`] and returns
+    /// Marks the step as [`StepState::Errored`] and returns
     /// [`PipelineAction::Failed`].
     pub fn step_failed(&mut self, step_name: &str, error: String) -> PipelineAction {
         self.step_states.insert(
             step_name.to_string(),
-            StepState::Failed {
+            StepState::Errored {
                 error: error.clone(),
             },
         );
@@ -314,6 +330,105 @@ impl PipelineRun {
             step: step_name.to_string(),
             reason: error,
         }
+    }
+
+    /// Reset `step_name` and every step that transitively depends on it back
+    /// to pending, clearing any stored outputs for those steps.
+    pub fn retry_from_step(&mut self, step_name: &str) -> HashSet<String> {
+        let reset_steps = self.dag.downstream_steps(step_name);
+        for step in &reset_steps {
+            self.step_states.insert(step.clone(), StepState::Pending);
+            self.step_outputs.remove(step);
+        }
+        reset_steps
+    }
+
+    /// Reset from `step_name` and insert a synthetic fixup step immediately
+    /// before it, rewiring the failed step to depend on the fixup.
+    pub fn retry_from_step_with_fixup(
+        &mut self,
+        step_name: &str,
+        fixup_agent: &str,
+    ) -> HashSet<String> {
+        let Some(step_index) = self
+            .dag
+            .steps
+            .iter()
+            .position(|step| step.name == step_name)
+        else {
+            return HashSet::new();
+        };
+        let current_deps = self.dag.steps[step_index].depends.clone();
+        let original_deps =
+            if current_deps.len() == 1 && self.synthetic_fixup_steps.contains(&current_deps[0]) {
+                self.dag
+                    .steps
+                    .iter()
+                    .find(|step| step.name == current_deps[0])
+                    .map(|step| step.depends.clone())
+                    .unwrap_or_default()
+            } else {
+                current_deps
+            };
+        let reset_steps = self.retry_from_step(step_name);
+        let fixup_name = self.fixup_step_name_for(step_name);
+
+        if !self.synthetic_fixup_steps.contains(&fixup_name) {
+            if let Some(step_index) = self
+                .dag
+                .steps
+                .iter()
+                .position(|step| step.name == step_name)
+            {
+                self.dag.steps.insert(
+                    step_index,
+                    DagStep {
+                        name: fixup_name.clone(),
+                        agent: fixup_agent.to_string(),
+                        kind: StepKind::Agent,
+                        tracker_state: None,
+                        approval: None,
+                        on_failure: OnFailure::RetryStep,
+                        fixup_agent: None,
+                        depends: original_deps,
+                    },
+                );
+                self.synthetic_fixup_steps.insert(fixup_name.clone());
+            }
+        }
+
+        if let Some(step) = self
+            .dag
+            .steps
+            .iter_mut()
+            .find(|step| step.name == step_name)
+        {
+            step.depends = vec![fixup_name.clone()];
+        }
+        self.step_states
+            .insert(fixup_name.clone(), StepState::Pending);
+        self.step_outputs.remove(&fixup_name);
+
+        reset_steps
+    }
+
+    fn fixup_step_name_for(&self, step_name: &str) -> String {
+        let base_name = format!("fixup-{step_name}");
+        if !self.dag.steps.iter().any(|step| step.name == base_name)
+            || self.synthetic_fixup_steps.contains(&base_name)
+        {
+            return base_name;
+        }
+
+        for suffix in 1.. {
+            let candidate = format!("{base_name}-{suffix}");
+            if !self.dag.steps.iter().any(|step| step.name == candidate)
+                || self.synthetic_fixup_steps.contains(&candidate)
+            {
+                return candidate;
+            }
+        }
+        unreachable!("unbounded suffix search should always find a fixup step name")
     }
 
     /// Step names in configured DAG order, excluding steps that never started.
@@ -439,9 +554,10 @@ impl PipelineRun {
 fn template_entry(step: &str, output: &StepOutput) -> StepOutputTemplateEntry {
     StepOutputTemplateEntry {
         step: step.to_string(),
-        verdict: match &output.verdict {
-            Verdict::Approve => "approve".to_string(),
-            Verdict::Reject { .. } => "reject".to_string(),
+        result: match &output.result {
+            StepResult::Succeeded => "succeeded".to_string(),
+            StepResult::Concern { .. } => "concern".to_string(),
+            StepResult::Failed { .. } => "failed".to_string(),
         },
         summary: output.summary.clone(),
         output: output.output.clone(),
@@ -451,7 +567,9 @@ fn template_entry(step: &str, output: &StepOutput) -> StepOutputTemplateEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ensemble::{StepApprovalConfig, StepApprovalMode, StepConfig, StepKind};
+    use crate::config::ensemble::{
+        OnFailure, StepApprovalConfig, StepApprovalMode, StepConfig, StepKind,
+    };
     use crate::pipeline::dag::build_dag;
     use crate::pipeline::verdict::StepOutput;
     use serde_json::json;
@@ -469,6 +587,8 @@ mod tests {
             depends: deps,
             tracker_state: None,
             approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
         }
     }
 
@@ -490,6 +610,8 @@ mod tests {
             depends: deps,
             tracker_state: Some(tracker_state.to_string()),
             approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
         }
     }
 
@@ -515,6 +637,8 @@ mod tests {
                 mode,
                 state: state.map(|value| value.to_string()),
             }),
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
         }
     }
 
@@ -526,15 +650,23 @@ mod tests {
 
     fn approve_output() -> StepOutput {
         StepOutput {
-            verdict: Verdict::Approve,
+            result: StepResult::Succeeded,
             summary: None,
             output: None,
         }
     }
 
-    fn reject_output(summary: &str) -> StepOutput {
+    fn approve_output_with_summary(summary: &str) -> StepOutput {
         StepOutput {
-            verdict: Verdict::Reject {
+            result: StepResult::Succeeded,
+            summary: Some(summary.to_string()),
+            output: None,
+        }
+    }
+
+    fn failed_output(summary: &str) -> StepOutput {
+        StepOutput {
+            result: StepResult::Failed {
                 summary: summary.to_string(),
             },
             summary: Some(summary.to_string()),
@@ -829,12 +961,8 @@ mod tests {
         assert_eq!(run.step_states["implement"], StepState::Passed);
     }
 
-    // -------------------------------------------------------------------------
-    // test_rejection_halts_pipeline
-    // -------------------------------------------------------------------------
-
     #[test]
-    fn test_rejection_halts_pipeline() {
+    fn failed_result_halts_pipeline() {
         let steps = vec![
             make_step("build", "builder", &[]),
             make_step("review", "reviewer", &[]),
@@ -845,7 +973,7 @@ mod tests {
         run.step_completed("build", approve_output(), false);
         run.mark_running("review", "s-r".to_string());
 
-        let action = run.step_completed("review", reject_output("code quality is too low"), false);
+        let action = run.step_completed("review", failed_output("code quality is too low"), false);
 
         assert!(
             matches!(
@@ -853,13 +981,13 @@ mod tests {
                 PipelineAction::Failed { step, reason }
                     if step == "review" && reason == "code quality is too low"
             ),
-            "expected Failed for rejected review, got {action:?}"
+            "expected Failed for failed review result, got {action:?}"
         );
 
-        // Step state should reflect rejection.
+        // Step state should reflect failed result.
         assert!(matches!(
             &run.step_states["review"],
-            StepState::Rejected { summary } if summary == "code quality is too low"
+            StepState::Failed { summary } if summary == "code quality is too low"
         ));
     }
 
@@ -887,7 +1015,7 @@ mod tests {
 
         assert!(matches!(
             &run.step_states["build"],
-            StepState::Failed { error } if error == "agent crashed with exit code 1"
+            StepState::Errored { error } if error == "agent crashed with exit code 1"
         ));
     }
 
@@ -947,11 +1075,11 @@ mod tests {
         }
         .is_terminal());
         assert!(StepState::Passed.is_terminal());
-        assert!(StepState::Rejected {
+        assert!(StepState::Failed {
             summary: "nope".to_string()
         }
         .is_terminal());
-        assert!(StepState::Failed {
+        assert!(StepState::Errored {
             error: "boom".to_string()
         }
         .is_terminal());
@@ -975,7 +1103,7 @@ mod tests {
     }
 
     #[test]
-    fn reject_gate_rejects_and_halts_from_approval_state() {
+    fn reject_gate_marks_step_failed_and_halts_from_approval_state() {
         let steps = vec![make_step_with_approval(
             "review",
             "reviewer",
@@ -1001,7 +1129,7 @@ mod tests {
         );
         assert_eq!(
             run.step_states["review"],
-            StepState::Rejected {
+            StepState::Failed {
                 summary: "needs more work".to_string()
             }
         );
@@ -1105,7 +1233,7 @@ mod tests {
         run.step_completed(
             "build",
             StepOutput {
-                verdict: Verdict::Approve,
+                result: StepResult::Succeeded,
                 summary: Some("built".to_string()),
                 output: Some(json!({"artifact":"branch"})),
             },
@@ -1114,7 +1242,7 @@ mod tests {
         run.step_completed(
             "review-a",
             StepOutput {
-                verdict: Verdict::Approve,
+                result: StepResult::Succeeded,
                 summary: Some("a ok".to_string()),
                 output: Some(json!({"risk":"low"})),
             },
@@ -1123,7 +1251,7 @@ mod tests {
         run.step_completed(
             "review-b",
             StepOutput {
-                verdict: Verdict::Approve,
+                result: StepResult::Succeeded,
                 summary: Some("b ok".to_string()),
                 output: Some(json!({"risk":"medium"})),
             },
@@ -1139,6 +1267,110 @@ mod tests {
     }
 
     #[test]
+    fn concern_with_unconfigured_approval_request_continues_and_enters_context() {
+        let steps = vec![
+            make_step("review", "reviewer", &[]),
+            make_step("synth", "synthesizer", &["review"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.mark_running("review", "session-review".to_string());
+        let action = run.step_completed(
+            "review",
+            StepOutput {
+                result: StepResult::Concern {
+                    summary: "minor issue found".to_string(),
+                },
+                summary: Some("minor issue found".to_string()),
+                output: Some(json!({"risk":"medium"})),
+            },
+            true,
+        );
+
+        assert!(
+            matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "synth"),
+            "expected concern to continue and dispatch synth, got {action:?}"
+        );
+        assert_eq!(run.step_states["review"], StepState::Passed);
+
+        let context = run.output_context_for("synth").unwrap();
+        assert_eq!(context.dependency_outputs.len(), 1);
+        assert_eq!(context.dependency_outputs[0].step, "review");
+        assert_eq!(context.dependency_outputs[0].result, "concern");
+        assert_eq!(
+            context.dependency_outputs[0].summary.as_deref(),
+            Some("minor issue found")
+        );
+        assert_eq!(context.steps["review"].result, "concern");
+    }
+
+    #[test]
+    fn concern_result_on_always_approval_step_bypasses_gate_and_dispatches_downstream() {
+        let steps = vec![
+            make_step_with_approval(
+                "review",
+                "reviewer",
+                &[],
+                StepApprovalMode::Always,
+                Some("Review gate"),
+            ),
+            make_step("synth", "synthesizer", &["review"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.mark_running("review", "session-review".to_string());
+        let action = run.step_completed(
+            "review",
+            StepOutput {
+                result: StepResult::Concern {
+                    summary: "minor issue found".to_string(),
+                },
+                summary: Some("minor issue found".to_string()),
+                output: None,
+            },
+            false,
+        );
+
+        assert!(
+            matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "synth"),
+            "expected concern on approval-gated step to dispatch synth without gating, got {action:?}"
+        );
+        assert_eq!(run.step_states["review"], StepState::Passed);
+        assert!(!matches!(
+            run.step_states["review"],
+            StepState::AwaitingApproval { .. }
+        ));
+    }
+
+    #[test]
+    fn concern_result_on_terminal_always_approval_step_bypasses_gate_and_succeeds() {
+        let steps = vec![make_step_with_approval(
+            "review",
+            "reviewer",
+            &[],
+            StepApprovalMode::Always,
+            Some("Review gate"),
+        )];
+        let mut run = make_run(&steps);
+
+        run.mark_running("review", "session-review".to_string());
+        let action = run.step_completed(
+            "review",
+            StepOutput {
+                result: StepResult::Concern {
+                    summary: "minor issue found".to_string(),
+                },
+                summary: Some("minor issue found".to_string()),
+                output: None,
+            },
+            false,
+        );
+
+        assert_eq!(action, PipelineAction::Succeeded);
+        assert_eq!(run.step_states["review"], StepState::Passed);
+    }
+
+    #[test]
     fn dispatch_request_carries_synthesis_kind() {
         let steps = vec![
             StepConfig {
@@ -1148,6 +1380,8 @@ mod tests {
                 depends: Some(vec![]),
                 tracker_state: None,
                 approval: None,
+                on_failure: OnFailure::RetryIssue,
+                fixup_agent: None,
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -1156,6 +1390,8 @@ mod tests {
                 depends: Some(vec!["review-a".to_string()]),
                 tracker_state: None,
                 approval: None,
+                on_failure: OnFailure::RetryIssue,
+                fixup_agent: None,
             },
         ];
         let mut run = make_run(&steps);
@@ -1191,7 +1427,243 @@ mod tests {
         );
         assert!(matches!(
             &run.step_states["build"],
-            StepState::Failed { error } if error.contains("no approval configuration")
+            StepState::Errored { error } if error.contains("no approval configuration")
         ));
+    }
+
+    #[test]
+    fn retry_from_mid_dag_resets_failed_step_and_downstream_only() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("test", "tester", &["build"]),
+            make_step("docs", "writer", &["build"]),
+            make_step("deploy", "deployer", &["test"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.step_completed("build", approve_output(), false);
+        run.step_completed("docs", approve_output(), false);
+        run.step_completed("deploy", approve_output(), false);
+        run.step_completed("test", failed_output("tests failed"), false);
+
+        let reset = run.retry_from_step("test");
+
+        assert_eq!(
+            reset,
+            HashSet::from(["test".to_string(), "deploy".to_string()])
+        );
+        assert_eq!(run.step_states["build"], StepState::Passed);
+        assert_eq!(run.step_states["docs"], StepState::Passed);
+        assert_eq!(run.step_states["test"], StepState::Pending);
+        assert_eq!(run.step_states["deploy"], StepState::Pending);
+        assert!(run.step_outputs.contains_key("build"));
+        assert!(run.step_outputs.contains_key("docs"));
+        assert!(!run.step_outputs.contains_key("test"));
+        assert!(!run.step_outputs.contains_key("deploy"));
+    }
+
+    #[test]
+    fn retry_from_leaf_resets_only_leaf() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("test", "tester", &["build"]),
+            make_step("deploy", "deployer", &["test"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.step_completed("build", approve_output(), false);
+        run.step_completed("test", approve_output(), false);
+        run.step_completed("deploy", failed_output("deploy failed"), false);
+
+        let reset = run.retry_from_step("deploy");
+
+        assert_eq!(reset, HashSet::from(["deploy".to_string()]));
+        assert_eq!(run.step_states["build"], StepState::Passed);
+        assert_eq!(run.step_states["test"], StepState::Passed);
+        assert_eq!(run.step_states["deploy"], StepState::Pending);
+        assert!(run.step_outputs.contains_key("build"));
+        assert!(run.step_outputs.contains_key("test"));
+        assert!(!run.step_outputs.contains_key("deploy"));
+    }
+
+    #[test]
+    fn retry_from_root_resets_all_downstream_steps() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("test", "tester", &["build"]),
+            make_step("docs", "writer", &["build"]),
+            make_step("deploy", "deployer", &["test", "docs"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.step_completed("build", approve_output(), false);
+        run.step_completed("test", approve_output(), false);
+        run.step_completed("docs", approve_output(), false);
+        run.step_completed("deploy", approve_output(), false);
+
+        let reset = run.retry_from_step("build");
+
+        assert_eq!(
+            reset,
+            HashSet::from([
+                "build".to_string(),
+                "test".to_string(),
+                "docs".to_string(),
+                "deploy".to_string()
+            ])
+        );
+        assert!(reset
+            .iter()
+            .all(|step| run.step_states[step] == StepState::Pending));
+        assert!(reset
+            .iter()
+            .all(|step| !run.step_outputs.contains_key(step)));
+    }
+
+    #[test]
+    fn retry_from_step_with_fixup_injects_fixup_before_failed_step() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("review", "reviewer", &["build"]),
+            make_step("deploy", "deployer", &["review"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.step_completed("build", approve_output(), false);
+        run.step_completed("review", failed_output("needs fixes"), false);
+
+        let reset = run.retry_from_step_with_fixup("review", "fixer");
+
+        assert_eq!(
+            reset,
+            HashSet::from(["review".to_string(), "deploy".to_string()])
+        );
+        let fixup = run
+            .dag
+            .steps
+            .iter()
+            .find(|step| step.name == "fixup-review")
+            .unwrap();
+        assert_eq!(fixup.agent, "fixer");
+        assert_eq!(fixup.kind, StepKind::Agent);
+        assert_eq!(fixup.tracker_state, None);
+        assert_eq!(fixup.approval, None);
+        assert_eq!(fixup.depends, vec!["build".to_string()]);
+
+        let review = run
+            .dag
+            .steps
+            .iter()
+            .find(|step| step.name == "review")
+            .unwrap();
+        assert_eq!(review.depends, vec!["fixup-review".to_string()]);
+        assert_eq!(run.step_states["fixup-review"], StepState::Pending);
+        assert_eq!(run.step_states["review"], StepState::Pending);
+    }
+
+    #[test]
+    fn repeated_fixup_retry_does_not_duplicate_fixup_step() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("review", "reviewer", &["build"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.retry_from_step_with_fixup("review", "fixer");
+        run.retry_from_step_with_fixup("review", "fixer");
+
+        let fixup_count = run
+            .dag
+            .steps
+            .iter()
+            .filter(|step| step.name == "fixup-review")
+            .count();
+        assert_eq!(fixup_count, 1);
+        let review = run
+            .dag
+            .steps
+            .iter()
+            .find(|step| step.name == "review")
+            .unwrap();
+        assert_eq!(review.depends, vec!["fixup-review".to_string()]);
+    }
+
+    #[test]
+    fn repeated_fixup_retry_clears_stale_fixup_output() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("review", "reviewer", &["build"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.retry_from_step_with_fixup("review", "fixer");
+        run.step_completed(
+            "fixup-review",
+            approve_output_with_summary("old fixup output"),
+            false,
+        );
+
+        run.retry_from_step_with_fixup("review", "fixer");
+
+        assert_eq!(run.step_states["fixup-review"], StepState::Pending);
+        assert!(!run.step_outputs.contains_key("fixup-review"));
+        let context = run.output_context_for("review").unwrap();
+        assert!(context.dependency_outputs.is_empty());
+    }
+
+    #[test]
+    fn configured_fixup_name_collision_uses_unique_synthetic_fixup_name() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("fixup-review", "configured-fixer", &["build"]),
+            make_step("review", "reviewer", &["build"]),
+        ];
+        let mut run = make_run(&steps);
+
+        run.retry_from_step_with_fixup("review", "synthetic-fixer");
+
+        let configured_fixup = run
+            .dag
+            .steps
+            .iter()
+            .find(|step| step.name == "fixup-review")
+            .unwrap();
+        assert_eq!(configured_fixup.agent, "configured-fixer");
+        assert_eq!(configured_fixup.depends, vec!["build".to_string()]);
+
+        let synthetic_fixup = run
+            .dag
+            .steps
+            .iter()
+            .find(|step| step.name == "fixup-review-1")
+            .unwrap();
+        assert_eq!(synthetic_fixup.agent, "synthetic-fixer");
+        assert_eq!(synthetic_fixup.depends, vec!["build".to_string()]);
+
+        let review = run
+            .dag
+            .steps
+            .iter()
+            .find(|step| step.name == "review")
+            .unwrap();
+        assert_eq!(review.depends, vec!["fixup-review-1".to_string()]);
+    }
+
+    #[test]
+    fn retry_from_step_with_fixup_for_unknown_step_is_no_op() {
+        let steps = vec![
+            make_step("build", "builder", &[]),
+            make_step("review", "reviewer", &["build"]),
+        ];
+        let mut run = make_run(&steps);
+        let original_steps = run.dag.steps.clone();
+        let original_states = run.step_states.clone();
+
+        let reset = run.retry_from_step_with_fixup("unknown", "fixer");
+
+        assert!(reset.is_empty());
+        assert_eq!(run.dag.steps, original_steps);
+        assert_eq!(run.step_states, original_states);
+        assert!(!run.step_states.contains_key("fixup-unknown"));
     }
 }

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -3,13 +3,15 @@ use std::path::Path;
 use serde::Deserialize;
 use tracing::warn;
 
-/// The verdict returned by a review agent at the end of a pipeline step.
+/// The result returned by an agent at the end of a pipeline step.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Verdict {
-    /// The step output is accepted; continue to the next step or mark success.
-    Approve,
-    /// The step output is rejected; retry or mark failure.
-    Reject { summary: String },
+pub enum StepResult {
+    /// The step output succeeded; continue to the next step or mark success.
+    Succeeded,
+    /// The step output failed; retry or mark failure.
+    Failed { summary: String },
+    /// The step output raised a concern; continue according to pipeline policy.
+    Concern { summary: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -21,14 +23,14 @@ pub enum VerdictSource {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StepOutput {
-    pub verdict: Verdict,
+    pub result: StepResult,
     pub summary: Option<String>,
     pub output: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ResolvedVerdict {
-    pub verdict: Verdict,
+pub struct ResolvedResult {
+    pub result: StepResult,
     pub output: StepOutput,
     pub source: VerdictSource,
 }
@@ -36,21 +38,23 @@ pub struct ResolvedVerdict {
 /// Internal deserialization type for both ACP JSON values and verdict files.
 #[derive(Debug, Deserialize)]
 struct VerdictPayload {
+    result: Option<String>,
     verdict: Option<String>,
     summary: Option<String>,
     #[serde(default)]
     output: Option<serde_json::Value>,
 }
 
-/// Parse a [`Verdict`] from an arbitrary JSON value (e.g. an ACP event body).
+/// Parse a [`StepResult`] from an arbitrary JSON value (e.g. an ACP event body).
 ///
-/// Recognises `"approve"` (case-insensitive) → [`Verdict::Approve`] and
-/// `"reject"` (case-insensitive) → [`Verdict::Reject`] with an optional
-/// `summary` field. Any other value or an absent/null `verdict` field returns
-/// `None`.
-pub fn parse_verdict_from_value(value: &serde_json::Value) -> Option<Verdict> {
+/// Recognises `"approve"`/`"succeeded"` (case-insensitive) →
+/// [`StepResult::Succeeded`], `"reject"`/`"failed"` (case-insensitive) →
+/// [`StepResult::Failed`], and `"concern"` (case-insensitive) →
+/// [`StepResult::Concern`] with an optional `summary` field. Any other value or
+/// an absent/null `result`/`verdict` field returns `None`.
+pub fn parse_verdict_from_value(value: &serde_json::Value) -> Option<StepResult> {
     let payload: VerdictPayload = serde_json::from_value(value.clone()).ok()?;
-    verdict_from_payload(&payload)
+    result_from_payload(&payload)
 }
 
 pub fn parse_step_output_from_value(value: &serde_json::Value) -> Option<StepOutput> {
@@ -66,10 +70,10 @@ pub fn parse_step_output_from_value(value: &serde_json::Value) -> Option<StepOut
 pub async fn read_verdict_file(
     workspace: &Path,
     step_name: &str,
-) -> Result<Option<Verdict>, std::io::Error> {
+) -> Result<Option<StepResult>, std::io::Error> {
     read_step_output_file(workspace, step_name)
         .await
-        .map(|value| value.map(|output| output.verdict))
+        .map(|value| value.map(|output| output.result))
 }
 
 pub async fn read_step_output_file(
@@ -102,15 +106,15 @@ pub async fn read_step_output_file(
 /// 1. ACP event value (`acp_verdict`) — checked first.
 /// 2. `.ensemble/verdict-{step_name}.json` in the workspace — checked if ACP yields nothing.
 /// 3. `.ensemble/verdict.json` (legacy fallback) — checked if step-scoped file is absent.
-/// 4. Default to [`Verdict::Approve`] if no source provides a verdict.
+/// 4. Default to [`StepResult::Succeeded`] if no source provides a verdict.
 pub async fn resolve_verdict(
     acp_verdict: Option<&serde_json::Value>,
     workspace: &Path,
     step_name: &str,
-) -> Verdict {
+) -> StepResult {
     resolve_verdict_with_source(acp_verdict, workspace, step_name)
         .await
-        .verdict
+        .result
 }
 
 /// Resolve the final verdict for a completed step, including the source.
@@ -118,12 +122,12 @@ pub async fn resolve_verdict_with_source(
     acp_verdict: Option<&serde_json::Value>,
     workspace: &Path,
     step_name: &str,
-) -> ResolvedVerdict {
+) -> ResolvedResult {
     // 1. Try ACP event.
     if let Some(value) = acp_verdict {
         if let Some(output) = parse_step_output_from_value(value) {
-            return ResolvedVerdict {
-                verdict: output.verdict.clone(),
+            return ResolvedResult {
+                result: output.result.clone(),
                 output,
                 source: VerdictSource::Runtime,
             };
@@ -133,8 +137,8 @@ pub async fn resolve_verdict_with_source(
     // 2. Try file.
     match read_step_output_file(workspace, step_name).await {
         Ok(Some(output)) => {
-            return ResolvedVerdict {
-                verdict: output.verdict.clone(),
+            return ResolvedResult {
+                result: output.result.clone(),
                 output,
                 source: VerdictSource::File,
             };
@@ -143,16 +147,16 @@ pub async fn resolve_verdict_with_source(
         Err(e) => {
             // Malformed verdict file — treat as rejection, not silent approval.
             let msg = format!("failed to parse .ensemble/verdict-{step_name}.json: {e}");
-            let reject = Verdict::Reject {
+            let failed = StepResult::Failed {
                 summary: msg.clone(),
             };
             let output = StepOutput {
-                verdict: reject.clone(),
+                result: failed.clone(),
                 summary: Some(msg),
                 output: None,
             };
-            return ResolvedVerdict {
-                verdict: reject,
+            return ResolvedResult {
+                result: failed,
                 output,
                 source: VerdictSource::File,
             };
@@ -160,35 +164,43 @@ pub async fn resolve_verdict_with_source(
     }
 
     // 3. Default (no ACP verdict, no file).
-    warn!("no verdict source found for step, defaulting to Approve");
+    warn!("no verdict source found for step, defaulting to Succeeded");
     let output = StepOutput {
-        verdict: Verdict::Approve,
+        result: StepResult::Succeeded,
         summary: None,
         output: None,
     };
-    ResolvedVerdict {
-        verdict: output.verdict.clone(),
+    ResolvedResult {
+        result: output.result.clone(),
         output,
         source: VerdictSource::Default,
     }
 }
 
-/// Convert a [`VerdictPayload`] into an `Option<Verdict>`.
-fn verdict_from_payload(payload: &VerdictPayload) -> Option<Verdict> {
-    step_output_from_payload(payload).map(|output| output.verdict)
+/// Convert a [`VerdictPayload`] into an `Option<StepResult>`.
+fn result_from_payload(payload: &VerdictPayload) -> Option<StepResult> {
+    step_output_from_payload(payload).map(|output| output.result)
 }
 
 fn step_output_from_payload(payload: &VerdictPayload) -> Option<StepOutput> {
-    let verdict = match payload.verdict.as_deref() {
-        Some(v) if v.eq_ignore_ascii_case("approve") => Verdict::Approve,
-        Some(v) if v.eq_ignore_ascii_case("reject") => Verdict::Reject {
+    let result_value = payload.result.as_deref().or(payload.verdict.as_deref());
+    let result = match result_value {
+        Some(v) if v.eq_ignore_ascii_case("approve") || v.eq_ignore_ascii_case("succeeded") => {
+            StepResult::Succeeded
+        }
+        Some(v) if v.eq_ignore_ascii_case("reject") || v.eq_ignore_ascii_case("failed") => {
+            StepResult::Failed {
+                summary: payload.summary.clone().unwrap_or_default(),
+            }
+        }
+        Some(v) if v.eq_ignore_ascii_case("concern") => StepResult::Concern {
             summary: payload.summary.clone().unwrap_or_default(),
         },
         _ => return None,
     };
 
     Some(StepOutput {
-        verdict,
+        result,
         summary: payload.summary.clone(),
         output: payload.output.clone(),
     })
@@ -205,19 +217,66 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
-    fn test_parse_approve() {
-        let value = json!({ "verdict": "approve" });
-        assert_eq!(parse_verdict_from_value(&value), Some(Verdict::Approve));
+    fn test_parse_succeeded_result() {
+        let value = json!({ "result": "succeeded" });
+        assert_eq!(
+            parse_verdict_from_value(&value),
+            Some(StepResult::Succeeded)
+        );
     }
 
     #[test]
-    fn test_parse_reject() {
+    fn test_parse_legacy_approve_verdict() {
+        let value = json!({ "verdict": "approve" });
+        assert_eq!(
+            parse_verdict_from_value(&value),
+            Some(StepResult::Succeeded)
+        );
+    }
+
+    #[test]
+    fn test_parse_failed_result() {
+        let value = json!({ "result": "failed", "summary": "tests failed" });
+        assert_eq!(
+            parse_verdict_from_value(&value),
+            Some(StepResult::Failed {
+                summary: "tests failed".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_legacy_reject_verdict() {
         let value = json!({ "verdict": "reject", "summary": "tests failed" });
         assert_eq!(
             parse_verdict_from_value(&value),
-            Some(Verdict::Reject {
+            Some(StepResult::Failed {
                 summary: "tests failed".to_string()
             })
+        );
+    }
+
+    #[test]
+    fn test_parse_concern() {
+        let value = json!({ "result": "concern", "summary": "needs review" });
+        assert_eq!(
+            parse_verdict_from_value(&value),
+            Some(StepResult::Concern {
+                summary: "needs review".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_result_preferred_over_legacy_verdict() {
+        let value = json!({
+            "result": "succeeded",
+            "verdict": "reject",
+            "summary": "legacy value should be ignored"
+        });
+        assert_eq!(
+            parse_verdict_from_value(&value),
+            Some(StepResult::Succeeded)
         );
     }
 
@@ -255,7 +314,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, r#"{"verdict":"approve"}"#).await;
         let result = read_verdict_file(dir.path(), "build").await.unwrap();
-        assert_eq!(result, Some(Verdict::Approve));
+        assert_eq!(result, Some(StepResult::Succeeded));
     }
 
     #[tokio::test]
@@ -265,7 +324,7 @@ mod tests {
         let result = read_verdict_file(dir.path(), "build").await.unwrap();
         assert_eq!(
             result,
-            Some(Verdict::Reject {
+            Some(StepResult::Failed {
                 summary: "lint errors".to_string()
             })
         );
@@ -288,9 +347,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, r#"{"verdict":"reject","summary":"broken"}"#).await;
 
-        let acp = json!({ "verdict": "approve" });
+        let acp = json!({ "result": "succeeded" });
         let result = resolve_verdict(Some(&acp), dir.path(), "build").await;
-        assert_eq!(result, Verdict::Approve);
+        assert_eq!(result, StepResult::Succeeded);
     }
 
     #[tokio::test]
@@ -298,9 +357,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, r#"{"verdict":"reject","summary":"broken"}"#).await;
 
-        let acp = json!({ "verdict": "approve" });
+        let acp = json!({ "result": "succeeded" });
         let result = resolve_verdict_with_source(Some(&acp), dir.path(), "build").await;
-        assert_eq!(result.verdict, Verdict::Approve);
+        assert_eq!(result.result, StepResult::Succeeded);
         assert_eq!(result.source, VerdictSource::Runtime);
     }
 
@@ -313,7 +372,7 @@ mod tests {
         let result = resolve_verdict(None, dir.path(), "build").await;
         assert_eq!(
             result,
-            Verdict::Reject {
+            StepResult::Failed {
                 summary: "compile error".to_string()
             }
         );
@@ -326,8 +385,8 @@ mod tests {
 
         let result = resolve_verdict_with_source(None, dir.path(), "build").await;
         assert_eq!(
-            result.verdict,
-            Verdict::Reject {
+            result.result,
+            StepResult::Failed {
                 summary: "compile error".to_string()
             }
         );
@@ -339,14 +398,14 @@ mod tests {
         // No ACP, no file — defaults to Approve.
         let dir = TempDir::new().unwrap();
         let result = resolve_verdict(None, dir.path(), "build").await;
-        assert_eq!(result, Verdict::Approve);
+        assert_eq!(result, StepResult::Succeeded);
     }
 
     #[tokio::test]
     async fn test_resolve_verdict_with_source_no_source_is_default_approve() {
         let dir = TempDir::new().unwrap();
         let result = resolve_verdict_with_source(None, dir.path(), "build").await;
-        assert_eq!(result.verdict, Verdict::Approve);
+        assert_eq!(result.result, StepResult::Succeeded);
         assert_eq!(result.source, VerdictSource::Default);
     }
 
@@ -364,7 +423,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write_verdict_file(&dir, "not valid json").await;
         let result = resolve_verdict(None, dir.path(), "build").await;
-        assert!(matches!(result, Verdict::Reject { .. }));
+        assert!(matches!(result, StepResult::Failed { .. }));
     }
 
     // -------------------------------------------------------------------------
@@ -374,14 +433,14 @@ mod tests {
     #[test]
     fn test_parse_step_output_from_runtime_value() {
         let value = json!({
-            "verdict": "approve",
+            "result": "succeeded",
             "summary": "review passed",
             "output": {"risk": "low", "findings": []}
         });
 
         let output = parse_step_output_from_value(&value).unwrap();
 
-        assert_eq!(output.verdict, Verdict::Approve);
+        assert_eq!(output.result, StepResult::Succeeded);
         assert_eq!(output.summary.as_deref(), Some("review passed"));
         assert_eq!(output.output, Some(json!({"risk":"low","findings":[]})));
     }
@@ -400,7 +459,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(output.verdict, Verdict::Approve);
+        assert_eq!(output.result, StepResult::Succeeded);
         assert_eq!(output.summary.as_deref(), Some("ok"));
         assert_eq!(output.output, Some(json!({"files":["src/lib.rs"]})));
     }

--- a/crates/ensemble-core/src/tracker/model.rs
+++ b/crates/ensemble-core/src/tracker/model.rs
@@ -75,6 +75,12 @@ pub struct RetryEntry {
     pub attempt: u32,
     pub due_at_ms: u64,
     pub error: Option<String>,
+    /// If set, retry from this step. None means retry the whole issue.
+    #[serde(default)]
+    pub retry_from_step: Option<String>,
+    /// Whether to inject a fixup agent before retrying.
+    #[serde(default)]
+    pub with_fixup: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -112,6 +112,8 @@ fn build_populated_app_state() -> (AppState, TempDir) {
         attempt: 3,
         due_at_ms: 1711641600000,
         error: Some("no available orchestrator slots".to_string()),
+        retry_from_step: None,
+        with_fixup: false,
     };
 
     let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());

--- a/crates/ensemble-core/tests/step_output_templates.rs
+++ b/crates/ensemble-core/tests/step_output_templates.rs
@@ -1,8 +1,8 @@
-use ensemble_core::config::ensemble::{StepConfig, StepKind};
+use ensemble_core::config::ensemble::{OnFailure, StepConfig, StepKind};
 use ensemble_core::config::template::render_prompt_with_context;
 use ensemble_core::pipeline::dag::build_dag;
 use ensemble_core::pipeline::engine::PipelineRun;
-use ensemble_core::pipeline::verdict::{StepOutput, Verdict};
+use ensemble_core::pipeline::verdict::{StepOutput, StepResult};
 use ensemble_core::tracker::model::Issue;
 use serde_json::json;
 
@@ -35,6 +35,8 @@ fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
         },
         tracker_state: None,
         approval: None,
+        on_failure: OnFailure::RetryIssue,
+        fixup_agent: None,
     }
 }
 
@@ -54,7 +56,7 @@ fn render_prompt_with_dependency_outputs() {
     run.step_completed(
         "build",
         StepOutput {
-            verdict: Verdict::Approve,
+            result: StepResult::Succeeded,
             summary: Some("built ok".to_string()),
             output: Some(json!({"artifact": "branch"})),
         },
@@ -65,7 +67,7 @@ fn render_prompt_with_dependency_outputs() {
     run.step_completed(
         "review-a",
         StepOutput {
-            verdict: Verdict::Approve,
+            result: StepResult::Succeeded,
             summary: Some("review a passed".to_string()),
             output: Some(json!({"risk": "low", "findings": ["minor nit"]})),
         },
@@ -76,7 +78,7 @@ fn render_prompt_with_dependency_outputs() {
     run.step_completed(
         "review-b",
         StepOutput {
-            verdict: Verdict::Approve,
+            result: StepResult::Succeeded,
             summary: Some("review b passed".to_string()),
             output: Some(json!({"risk": "medium", "findings": ["missing tests"]})),
         },
@@ -167,7 +169,7 @@ fn dependency_outputs_only_include_direct_deps() {
     run.step_completed(
         "a",
         StepOutput {
-            verdict: Verdict::Approve,
+            result: StepResult::Succeeded,
             summary: Some("a done".to_string()),
             output: Some(json!({"step": "a"})),
         },
@@ -176,7 +178,7 @@ fn dependency_outputs_only_include_direct_deps() {
     run.step_completed(
         "b",
         StepOutput {
-            verdict: Verdict::Approve,
+            result: StepResult::Succeeded,
             summary: Some("b done".to_string()),
             output: Some(json!({"step": "b"})),
         },

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,6 +1,6 @@
 # Pipeline Guide
 
-A pipeline is a directed acyclic graph (DAG) of steps that Ensemble runs for each issue. Each step invokes a named agent, collects a verdict, and decides what happens next.
+A pipeline is a directed acyclic graph (DAG) of steps that Ensemble runs for each issue. Each step invokes a named agent, collects a result, and decides what happens next.
 
 ## Steps and agents
 
@@ -23,7 +23,7 @@ When a step runs, Ensemble:
 1. Renders the agent's prompt template with the issue context
 2. Launches the agent in the issue's workspace directory
 3. Waits for the agent to finish
-4. Collects a verdict (approve or reject)
+4. Collects a result (`succeeded`, `failed`, or `concern`)
 
 ## Clarification request style (batched by default)
 
@@ -105,16 +105,16 @@ Todo → Building → In Review → Done
                             → Failed
 ```
 
-## Verdicts
+## Results
 
-After an agent finishes, Ensemble resolves verdicts with this strict precedence:
+After an agent finishes, Ensemble resolves results with this strict precedence:
 
-1. **Runtime verdict (primary)** — if the runtime reports a parseable structured verdict, Ensemble uses it.
-2. **File fallback** — only when no runtime verdict is available, Ensemble checks `.ensemble/verdict.json`:
+1. **Runtime result (primary)** — if the runtime reports a parseable structured result, Ensemble uses it.
+2. **File fallback** — only when no runtime result is available, Ensemble checks `.ensemble/verdict-{step}.json`:
 
 ```json
 {
-  "verdict": "approve"
+  "result": "succeeded"
 }
 ```
 
@@ -122,24 +122,37 @@ or:
 
 ```json
 {
-  "verdict": "reject",
-  "summary": "Tests are failing — 3 test cases need fixes"
+  "result": "failed",
+  "summary": "Tests are failing - 3 test cases need fixes"
 }
 ```
 
-3. **Default approve** — if neither source provides a verdict, the step is treated as approved.
+or:
 
-If both runtime and file verdicts exist, runtime verdict takes precedence and file verdict is ignored.
+```json
+{
+  "result": "concern",
+  "summary": "Naming is inconsistent, but the implementation is usable"
+}
+```
 
-By default, Ensemble appends fallback verdict instructions to rendered prompts (`agent.inject_verdict_fallback_instructions: true`, alias `agent.inject_verdict_instructions`), so users do not need to manually add `.ensemble/verdict.json` instructions in their templates.
+3. **Default success** — if neither source provides a result, the step is treated as succeeded.
 
-**Approve** means the step passed. The pipeline moves to the next step (or completes).
+If both runtime and file results exist, the runtime result takes precedence and the file result is ignored.
 
-**Reject** means the step failed. The `summary` field explains why. Ensemble transitions the issue to `on_failure` state, or retries if cycles remain.
+By default, Ensemble appends fallback result instructions to rendered prompts (`agent.inject_verdict_fallback_instructions: true`, alias `agent.inject_verdict_instructions`), so users do not need to manually add `.ensemble/verdict-{step}.json` instructions in their templates.
+
+For compatibility with older agent outputs, payloads that use `"verdict": "approve"` or `"verdict": "reject"` are still parsed. New templates and runtime payloads should use `result`.
+
+**Succeeded** means the step passed. The pipeline moves to the next step or completes.
+
+**Concern** means the step raised a non-blocking concern. The step is treated as passed, and downstream steps can inspect the summary and output.
+
+**Failed** means the step failed. The `summary` field explains why. Ensemble applies the step's `on_failure` behavior.
 
 ## Retries and cycles
 
-When a step rejects or an agent errors out, Ensemble can retry the entire pipeline. The `max_cycles` setting controls how many times:
+When a step fails or an agent errors out, Ensemble can retry. The `max_cycles` setting controls how many times:
 
 ```yaml
 max_cycles: 3  # default
@@ -153,6 +166,41 @@ max_cycles: 3  # default
 Retries use exponential backoff: 10s, 20s, 40s, ... capped at `agent.max_retry_backoff_ms` (default 5 minutes).
 
 The workspace persists across retries, so agents can see previous work and build on it. The `attempt` variable is available in prompt templates for retry-aware prompts.
+
+By default, step failures use whole-issue retry behavior: Ensemble removes the current `PipelineRun`, queues a retry, and starts again from the first step on the next cycle.
+
+## Step-level retry
+
+Each step can choose what happens when it returns `failed`:
+
+```yaml
+steps:
+  - name: implement
+    agent: builder
+    on_failure: retry_step
+  - name: review
+    agent: reviewer
+    on_failure: fixup
+    fixup_agent: fixer
+  - name: release
+    agent: releaser
+    on_failure: halt
+```
+
+`on_failure` values:
+
+- `retry_issue` (default): retry the whole issue from the first step.
+- `retry_step`: preserve passed upstream steps and retry the failed step plus downstream dependents.
+- `fixup`: inject a synthetic fixup step before retrying the failed step. This requires `fixup_agent`.
+- `halt`: stop automatic retry and keep the issue claimed while it waits for manual intervention.
+
+Manual step retry is also available from the API:
+
+```http
+POST /api/v1/{identifier}/retry?step=review
+```
+
+Without `step`, the retry endpoint keeps its whole-issue behavior: it releases the retry claim so the next poll can pick the issue up fresh.
 
 ## Example: build + review pipeline
 
@@ -186,9 +234,9 @@ What happens:
 1. Ensemble polls the tracker and finds an issue in "Todo" state
 2. Creates a workspace directory for the issue
 3. Runs the `implement` step — builder agent gets the issue context, writes code
-4. Builder approves → runs the `review` step — reviewer agent checks the work
-5. Reviewer approves → issue moves to "Done"
-6. If reviewer rejects → issue moves to "Needs Rework", retries from step 1 on next cycle
+4. Builder succeeds -> runs the `review` step; reviewer agent checks the work
+5. Reviewer succeeds -> issue moves to "Done"
+6. If reviewer fails -> the configured `on_failure` behavior decides whether to retry the issue, retry from `review`, run a fixup agent, or halt
 
 ## Synthesis steps
 
@@ -235,12 +283,12 @@ Review A risk: {{ steps["review-a"].output.risk }}
 Review B risk: {{ steps["review-b"].output.risk }}
 ```
 
-Steps can produce structured `output` data alongside their verdict. Set the `output` field in
-`.ensemble/verdict.json` or in the ACP runtime verdict:
+Steps can produce structured `output` data alongside their result. Set the `output` field in
+`.ensemble/verdict-{step}.json` or in the ACP runtime result:
 
 ```json
 {
-  "verdict": "approve",
+  "result": "succeeded",
   "summary": "Looks good, low risk",
   "output": {
     "risk": "low",

--- a/docs/superpowers/plans/2026-06-11-step-retry-and-results.md
+++ b/docs/superpowers/plans/2026-06-11-step-retry-and-results.md
@@ -82,13 +82,16 @@ pub struct ResolvedResult {
 }
 ```
 
-- [ ] **Step 4: Update verdict_from_payload to parse concern**
+- [ ] **Step 4: Update VerdictPayload and verdict_from_payload to parse result/concern**
 
-In `step_output_from_payload` (lines 181-195), add `"concern"` parsing:
+Add a `result: Option<String>` field to `VerdictPayload`, keeping `verdict` as the legacy alias. In `step_output_from_payload` (lines 181-195), prefer `result`, fall back to `verdict`, and add `"concern"` parsing:
 
 ```rust
 fn step_output_from_payload(payload: &VerdictPayload) -> Option<StepOutput> {
-    let result = match payload.verdict.as_deref() {
+    // Prefer the new `result` field, but keep `verdict` as a legacy alias
+    // for existing ACP/file payloads.
+    let raw_result = payload.result.as_deref().or(payload.verdict.as_deref());
+    let result = match raw_result {
         Some(v) if v.eq_ignore_ascii_case("approve") => StepResult::Succeeded,
         Some(v) if v.eq_ignore_ascii_case("succeeded") => StepResult::Succeeded,
         Some(v) if v.eq_ignore_ascii_case("concern") => StepResult::Concern {
@@ -217,6 +220,18 @@ fn test_parse_legacy_approve_reject() {
     );
     assert_eq!(
         parse_verdict_from_value(&json!({ "verdict": "reject", "summary": "nope" })),
+        Some(StepResult::Failed { summary: "nope".to_string() })
+    );
+}
+```
+
+Add a forward-format test for the new `result` field:
+
+```rust
+#[test]
+fn test_parse_result_field() {
+    assert_eq!(
+        parse_verdict_from_value(&json!({ "result": "failed", "summary": "nope" })),
         Some(StepResult::Failed { summary: "nope".to_string() })
     );
 }
@@ -417,15 +432,15 @@ pub fn step_failed(&mut self, step_name: &str, error: String) -> PipelineAction 
 }
 ```
 
-- [ ] **Step 7: Update template_entry to use StepResult**
+- [ ] **Step 7: Update template_entry to use StepResult and result terminology**
 
-Lines 439-449: `Verdict::Approve` → `StepResult::Succeeded`, `Verdict::Reject` → `StepResult::Failed`:
+Rename `StepOutputTemplateEntry.verdict` to `result`. Lines 439-449: `Verdict::Approve` → `StepResult::Succeeded`, `Verdict::Reject` → `StepResult::Failed`, and emit result values:
 
 ```rust
 fn template_entry(step: &str, output: &StepOutput) -> StepOutputTemplateEntry {
     StepOutputTemplateEntry {
         step: step.to_string(),
-        verdict: match &output.result {
+        result: match &output.result {
             StepResult::Succeeded => "succeeded".to_string(),
             StepResult::Concern { .. } => "concern".to_string(),
             StepResult::Failed { .. } => "failed".to_string(),
@@ -664,12 +679,12 @@ git add crates/ensemble-core/src/pipeline/dag.rs
 git commit -m "feat: add StepDag::downstream_steps for transitive dependency computation"
 ```
 
-### Task 5: Add PipelineRun::retry_from_step
+### Task 5: Add PipelineRun step-level retry primitives
 
 **Files:**
 - Modify: `crates/ensemble-core/src/pipeline/engine.rs`
 
-- [ ] **Step 1: Write failing test**
+- [ ] **Step 1: Write failing tests**
 
 Add to `mod tests` in engine.rs (before the closing `}` of mod tests):
 
@@ -749,14 +764,35 @@ fn test_retry_from_step_root_resets_all() {
     assert_eq!(run.step_states["build"], StepState::Pending);
     assert_eq!(run.step_states["review"], StepState::Pending);
 }
+
+#[test]
+fn test_retry_from_step_with_fixup_injects_fixup_before_failed_step() {
+    let steps = vec![
+        make_step("build", "builder", &[]),
+        make_step("synth", "synth", &["build"]),
+    ];
+    let mut run = make_run(&steps);
+    run.step_states.insert("build".to_string(), StepState::Passed);
+    run.step_states.insert("synth".to_string(), StepState::Failed {
+        summary: "synthesis conflict".to_string(),
+    });
+    let reset = run.retry_from_step_with_fixup("synth", "fixer");
+    assert!(reset.contains("synth"));
+    assert!(run.step_states.contains_key("fixup-synth"));
+    assert_eq!(run.step_states["fixup-synth"], StepState::Pending);
+    let synth = run.dag.steps.iter().find(|s| s.name == "synth").unwrap();
+    assert_eq!(synth.depends, vec!["fixup-synth"]);
+    let fixup = run.dag.steps.iter().find(|s| s.name == "fixup-synth").unwrap();
+    assert_eq!(fixup.depends, vec!["build"]);
+}
 ```
 
 - [ ] **Step 2: Run test to verify failure**
 
 Run: `cargo test -p ensemble-core -- pipeline::engine::tests::test_retry_from_step_resets_failed_and_downstream`
-Expected: FAIL — `retry_from_step` method doesn't exist.
+Expected: FAIL — `retry_from_step` and `retry_from_step_with_fixup` do not exist.
 
-- [ ] **Step 3: Implement retry_from_step**
+- [ ] **Step 3: Implement retry_from_step and retry_from_step_with_fixup**
 
 Add to `impl PipelineRun` (after `step_failed`, around line 317):
 
@@ -774,6 +810,41 @@ pub fn retry_from_step(&mut self, step_name: &str) -> HashSet<String> {
 
     downstream
 }
+
+/// Same as retry_from_step, but injects a synthetic fixup step between the
+/// reset step's dependencies and the reset step itself.
+pub fn retry_from_step_with_fixup(
+    &mut self,
+    step_name: &str,
+    fixup_agent: &str,
+) -> HashSet<String> {
+    let fixup_name = format!("fixup-{step_name}");
+    let original_deps: Vec<String> = self.dag.steps
+        .iter()
+        .find(|s| s.name == step_name)
+        .map(|s| s.depends.clone())
+        .unwrap_or_default();
+    let reset = self.retry_from_step(step_name);
+    let fixup_step = crate::pipeline::dag::DagStep {
+        name: fixup_name.clone(),
+        agent: fixup_agent.to_string(),
+        kind: crate::config::ensemble::StepKind::Agent,
+        tracker_state: None,
+        approval: None,
+        depends: original_deps.clone(),
+        on_failure: crate::config::ensemble::OnFailure::RetryStep,
+        fixup_agent: None,
+    };
+    let failed_idx = self.dag.steps.iter()
+        .position(|s| s.name == step_name)
+        .unwrap_or(self.dag.steps.len());
+    self.dag.steps.insert(failed_idx, fixup_step);
+    if let Some(step) = self.dag.steps.iter_mut().find(|s| s.name == step_name) {
+        step.depends = vec![fixup_name.clone()];
+    }
+    self.step_states.insert(fixup_name, StepState::Pending);
+    reset
+}
 ```
 
 - [ ] **Step 4: Run tests**
@@ -785,7 +856,7 @@ Expected: All tests pass including the new retry tests.
 
 ```bash
 git add crates/ensemble-core/src/pipeline/engine.rs
-git commit -m "feat: add PipelineRun::retry_from_step for step-level retry"
+git commit -m "feat: add PipelineRun step-level retry primitives"
 ```
 
 ---
@@ -795,9 +866,19 @@ git commit -m "feat: add PipelineRun::retry_from_step for step-level retry"
 ### Task 6: Add OnFailure enum and StepConfig fields
 
 **Files:**
+- Modify: `crates/ensemble-core/src/error.rs`
 - Modify: `crates/ensemble-core/src/config/ensemble.rs`
 
-- [ ] **Step 1: Add OnFailure enum**
+- [ ] **Step 1: Add a generic invalid-step config error**
+
+In `PipelineError`, add:
+
+```rust
+#[error("invalid step config for {step}: {reason}")]
+InvalidStepConfig { step: String, reason: String },
+```
+
+- [ ] **Step 2: Add OnFailure enum**
 
 After `StepKind` impl (around line 371), add:
 
@@ -818,7 +899,7 @@ pub enum OnFailure {
 }
 ```
 
-- [ ] **Step 2: Add on_failure and fixup_agent to StepConfig**
+- [ ] **Step 3: Add on_failure and fixup_agent to StepConfig**
 
 Modify `StepConfig` (lines 374-386):
 
@@ -852,7 +933,7 @@ impl OnFailure {
 }
 ```
 
-- [ ] **Step 3: Update DagStep to carry on_failure and fixup_agent**
+- [ ] **Step 4: Update DagStep to carry on_failure and fixup_agent**
 
 In `dag.rs`, update `DagStep`:
 
@@ -884,12 +965,32 @@ resolved.push(DagStep {
 });
 ```
 
-- [ ] **Step 4: Compile and fix cascading changes**
+- [ ] **Step 5: Compile and fix cascading changes**
 
 Run: `cargo build -p ensemble-core 2>&1 | head -40`
 Expected: May have compilation errors in dag.rs if `OnFailure` isn't imported. Add `use crate::config::ensemble::OnFailure;` to dag.rs if needed.
 
-- [ ] **Step 5: Write config test**
+- [ ] **Step 6: Write config validation tests**
+
+Update `validate_config` so `on_failure: fixup` requires a configured `fixup_agent`, and the named fixup agent exists in `config.agents`:
+
+```rust
+for step in &config.steps {
+    if step.on_failure == OnFailure::Fixup {
+        let Some(fixup_agent) = step.fixup_agent.as_ref() else {
+            return Err(PipelineError::InvalidStepConfig {
+                step: step.name.clone(),
+                reason: "on_failure: fixup requires fixup_agent".to_string(),
+            });
+        };
+        if !config.agents.contains_key(fixup_agent) {
+            return Err(PipelineError::UnknownAgent {
+                name: fixup_agent.clone(),
+            });
+        }
+    }
+}
+```
 
 Add to `mod tests` in ensemble.rs (or dag.rs):
 
@@ -906,15 +1007,17 @@ agent: builder
 }
 ```
 
-- [ ] **Step 6: Run tests**
+Add validation tests for `on_failure: fixup` without `fixup_agent` and with an unknown `fixup_agent`.
+
+- [ ] **Step 7: Run tests**
 
 Run: `cargo test -p ensemble-core -- config`
 Expected: All tests pass.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add crates/ensemble-core/src/config/ensemble.rs crates/ensemble-core/src/pipeline/dag.rs
+git add crates/ensemble-core/src/error.rs crates/ensemble-core/src/config/ensemble.rs crates/ensemble-core/src/pipeline/dag.rs
 git commit -m "feat: add OnFailure enum and on_failure/fixup_agent fields to StepConfig"
 ```
 
@@ -1081,11 +1184,14 @@ match on_failure {
     }
     OnFailure::Fixup => {
         // Fixup: inject fixup agent, then retry
-        let fixup_agent = config.steps
+        let Some(fixup_agent) = config.steps
             .iter()
             .find(|s| s.name == step)
-            .and_then(|s| s.fixup_agent.clone())
-            .unwrap_or_else(|| "fixer".to_string());
+            .and_then(|s| s.fixup_agent.clone()) else {
+            error!(issue_id = %issue_id, step = %step, "fixup step missing fixup_agent after config validation");
+            state.remove_pipeline_run(issue_id);
+            return;
+        };
 
         if let Some(run) = state.get_pipeline_run_mut(issue_id) {
             run.retry_from_step_with_fixup(&step, &fixup_agent);
@@ -1141,6 +1247,28 @@ match on_failure {
         );
         if let Some(entry) = state.remove_running(issue_id) {
             state.add_runtime_seconds(&entry);
+            let agent_name = config.steps
+                .iter()
+                .find(|s| s.name == step)
+                .map(|s| s.agent.clone())
+                .unwrap_or_default();
+            state.add_waiting_on_human(crate::orchestrator::state::WaitingOnHumanEntry {
+                issue_id: issue_id.to_string(),
+                identifier: entry.identifier.clone(),
+                interaction_request_id: format!("halted:{issue_id}:{step}"),
+                step_name: step.clone(),
+                kind: crate::interaction::model::InteractionKind::Handoff,
+                prompt: reason.clone(),
+                agent_name,
+                retry_attempt: entry.retry_attempt,
+                started_at: Some(entry.started_at),
+                agent_input_tokens: entry.agent_input_tokens,
+                agent_output_tokens: entry.agent_output_tokens,
+                agent_total_tokens: entry.agent_total_tokens,
+                requested_at: chrono::Utc::now(),
+                run_id: entry.run_id.clone(),
+                issue: Some(entry.issue.clone()),
+            });
         }
         // Do NOT remove_pipeline_run, do NOT schedule retry
         // Do NOT call remove_claimed — issue stays claimed
@@ -1269,97 +1397,7 @@ git add crates/ensemble-core/src/orchestrator/mod.rs
 git commit -m "feat: wire on_failure routing and step-level retry dispatch in orchestrator"
 ```
 
-### Task 9: Add retry_from_step_with_fixup to PipelineRun
-
-**Files:**
-- Modify: `crates/ensemble-core/src/pipeline/engine.rs`
-
-- [ ] **Step 1: Write failing test**
-
-Add to `mod tests` in engine.rs:
-
-```rust
-#[test]
-fn test_retry_from_step_with_fixup_injects_fixup_before_failed_step() {
-    let steps = vec![
-        make_step("build", "builder", &[]),
-        make_step("synth", "synth", &["build"]),
-    ];
-    let mut run = make_run(&steps);
-    run.step_states.insert("build".to_string(), StepState::Passed);
-    run.step_states.insert("synth".to_string(), StepState::Failed {
-        summary: "synthesis conflict".to_string(),
-    });
-    let reset = run.retry_from_step_with_fixup("synth", "fixer");
-    assert!(reset.contains("synth"));
-    assert!(run.step_states.contains_key("fixup-synth"));
-    assert_eq!(run.step_states["fixup-synth"], StepState::Pending);
-    let synth = run.dag.steps.iter().find(|s| s.name == "synth").unwrap();
-    assert_eq!(synth.depends, vec!["fixup-synth"]);
-    let fixup = run.dag.steps.iter().find(|s| s.name == "fixup-synth").unwrap();
-    assert_eq!(fixup.depends, vec!["build"]);
-}
-```
-
-- [ ] **Step 2: Run test to verify failure**
-
-Run: `cargo test -p ensemble-core -- pipeline::engine::tests::test_retry_from_step_with_fixup`
-Expected: FAIL — method does not exist.
-
-- [ ] **Step 3: Implement retry_from_step_with_fixup**
-
-After `retry_from_step` in engine.rs, add:
-
-```rust
-/// Same as retry_from_step, but injects a synthetic fixup step between the
-/// reset step's dependencies and the reset step itself.
-pub fn retry_from_step_with_fixup(
-    &mut self,
-    step_name: &str,
-    fixup_agent: &str,
-) -> HashSet<String> {
-    let fixup_name = format!("fixup-{step_name}");
-    let original_deps: Vec<String> = self.dag.steps
-        .iter()
-        .find(|s| s.name == step_name)
-        .map(|s| s.depends.clone())
-        .unwrap_or_default();
-    let reset = self.retry_from_step(step_name);
-    let fixup_step = crate::pipeline::dag::DagStep {
-        name: fixup_name.clone(),
-        agent: fixup_agent.to_string(),
-        kind: crate::config::ensemble::StepKind::Agent,
-        tracker_state: None,
-        approval: None,
-        depends: original_deps.clone(),
-        on_failure: crate::config::ensemble::OnFailure::RetryStep,
-        fixup_agent: None,
-    };
-    let failed_idx = self.dag.steps.iter()
-        .position(|s| s.name == step_name)
-        .unwrap_or(self.dag.steps.len());
-    self.dag.steps.insert(failed_idx, fixup_step);
-    if let Some(step) = self.dag.steps.iter_mut().find(|s| s.name == step_name) {
-        step.depends = vec![fixup_name.clone()];
-    }
-    self.step_states.insert(fixup_name, StepState::Pending);
-    reset
-}
-```
-
-- [ ] **Step 4: Run tests**
-
-Run: `cargo test -p ensemble-core -- pipeline::engine`
-Expected: All tests pass including fixup test.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add crates/ensemble-core/src/pipeline/engine.rs
-git commit -m "feat: add retry_from_step_with_fixup for fixup agent injection"
-```
-
-### Task 10: Update API retry endpoint for step-level retry
+### Task 9: Update API retry endpoint for step-level retry
 
 **Files:**
 - Modify: `crates/ensemble-core/src/api/controls.rs`
@@ -1370,9 +1408,12 @@ git commit -m "feat: add retry_from_step_with_fixup for fixup agent injection"
 In state.rs, add:
 
 ```rust
-/// Find the issue_id for a given identifier across running or waiting states.
+/// Find the issue_id for a given identifier across active control states.
 pub fn find_issue_id_by_identifier(&self, identifier: &str) -> Option<String> {
     for (id, entry) in &self.running {
+        if entry.identifier == identifier { return Some(id.clone()); }
+    }
+    for (id, entry) in &self.retry_attempts {
         if entry.identifier == identifier { return Some(id.clone()); }
     }
     for (id, entry) in &self.waiting_on_human {
@@ -1432,9 +1473,11 @@ pub async fn post_retry(
 
     if let Some(step_name) = &query.step {
         // Step-level retry: apply retry_from_step on PipelineRun, schedule retry
-        if let Some(run) = lock.get_pipeline_run_mut(&issue_id) {
-            run.retry_from_step(step_name);
-        }
+        let Some(run) = lock.get_pipeline_run_mut(&issue_id) else {
+            return issue_error_response(StatusCode::CONFLICT, "no_pipeline_run",
+                format!("issue '{}' has no resumable pipeline run", identifier));
+        };
+        run.retry_from_step(step_name);
         // Schedule retry with step info
         let identifier_copy = lock.running.get(&issue_id)
             .map(|e| e.identifier.clone())
@@ -1446,14 +1489,15 @@ pub async fn post_retry(
             .map(|a| a + 1)
             .unwrap_or(1);
         let config = state.config.read().await;
+        // Remove any existing retry entry before replacing it with the manual step retry.
+        lock.remove_retry(&issue_id);
+        lock.remove_waiting_on_human(&issue_id);
         schedule_failure_retry(
             &mut lock, &issue_id, &identifier_copy, attempt,
             config.agent.max_retry_backoff_ms, config.max_cycles,
             "manual step-level retry",
             Some(step_name.clone()), false,
         );
-        // Remove any existing retry entry
-        lock.remove_retry(&issue_id);
     } else {
         // Whole-issue retry (existing behavior)
         lock.remove_retry(&issue_id);
@@ -1493,7 +1537,7 @@ git add crates/ensemble-core/src/api/controls.rs crates/ensemble-core/src/orches
 git commit -m "feat: add step-level retry to API with ?step= query parameter"
 ```
 
-### Task 11: Update documentation
+### Task 10: Update documentation
 
 **Files:**
 - Modify: `docs/pipelines.md`
@@ -1557,9 +1601,3 @@ cargo test --workspace --exclude ensemble-desktop
 cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
 cargo fmt --all -- --check
 ```
-
-<｜end▁of▁thinking｜>Let me continue writing the remaining tasks for the plan:
-
-<｜｜DSML｜｜tool_calls>
-<｜｜DSML｜｜invoke name="read">
-<｜｜DSML｜｜parameter name="filePath" string="true">/Users/chris/.paseo/worktrees/0mixpvkw/furry-snake/docs/superpowers/plans/2026-06-11-step-retry-and-results.md

--- a/docs/superpowers/plans/2026-06-11-step-retry-and-results.md
+++ b/docs/superpowers/plans/2026-06-11-step-retry-and-results.md
@@ -1,0 +1,1565 @@
+# Step-level retry and agent results — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename Verdict → Result (add `Concern`), add step-level retry with per-step `on_failure` config, and support fixup agent injection on retry.
+
+**Architecture:** Three sequential phases. Phase 1 renames `Verdict` to `Result` and adds `Concern` — a pure refactor with no behavior change. Phase 2 adds `StepDag::downstream_steps` and `PipelineRun::retry_from_step` — core step-level retry primitives. Phase 3 wires `on_failure` config into the orchestrator, conditionally preserving PipelineRun state, and adds the fixup step injection.
+
+**Tech Stack:** Rust, tokio, serde, petgraph (if needed for downstream computation)
+
+**Spec:** `docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `crates/ensemble-core/src/pipeline/verdict.rs` | `StepResult` enum + parser rename, add `Concern` |
+| `crates/ensemble-core/src/pipeline/engine.rs` | `StepState` rename, `retry_from_step`, `retry_from_step_with_fixup`, `Concern` handling |
+| `crates/ensemble-core/src/pipeline/dag.rs` | `StepDag::downstream_steps()` |
+| `crates/ensemble-core/src/config/ensemble.rs` | `OnFailure` enum, `on_failure` + `fixup_agent` on `StepConfig` |
+| `crates/ensemble-core/src/orchestrator/mod.rs` | Route failures through `on_failure`, preserve PipelineRun, fixup dispatch |
+| `crates/ensemble-core/src/orchestrator/retry.rs` | `retry_from_step` + `with_fixup` on `RetryEntry`, `schedule_failure_retry` signature |
+| `crates/ensemble-core/src/orchestrator/state.rs` | `retry_issue` route still calls `remove_pipeline_run` |
+| `crates/ensemble-core/src/tracker/model.rs` | `RetryEntry` new fields |
+| `crates/ensemble-core/src/api/controls.rs` | `?step=` query param on retry endpoint |
+| `crates/ensemble-core/src/agent/mod.rs` | Propagate `Concern` to `WorkerResult::Success` |
+| `crates/ensemble-core/src/agent/events.rs` | Rename `verdict` references to `result` |
+| `docs/pipelines.md` | Document results, `on_failure`, step-level retry |
+
+---
+
+## Phase 1: Rename Verdict → Result + add Concern
+
+### Task 1: Rename Verdict enum to StepResult in verdict.rs
+
+**Files:**
+- Modify: `crates/ensemble-core/src/pipeline/verdict.rs`
+
+- [ ] **Step 1: Rename Verdict to StepResult, rename variants, add Concern**
+
+Open `crates/ensemble-core/src/pipeline/verdict.rs`. Replace lines 6-13:
+
+```rust
+/// The result returned by an agent at the end of a pipeline step.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StepResult {
+    /// The step completed successfully; continue to the next step or mark success.
+    Succeeded,
+    /// The step raised concerns but did not fail. Pipeline continues.
+    /// Downstream steps (especially synthesis) should review the flagged output.
+    Concern { summary: String },
+    /// The step failed; retry or mark failure.
+    Failed { summary: String },
+}
+```
+
+- [ ] **Step 2: Rename StepOutput.verdict field to result**
+
+On `StepOutput` struct (lines 22-27), rename `verdict: Verdict` to `result: StepResult`:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct StepOutput {
+    pub result: StepResult,
+    pub summary: Option<String>,
+    pub output: Option<serde_json::Value>,
+}
+```
+
+- [ ] **Step 3: Rename ResolvedVerdict to ResolvedResult**
+
+On `ResolvedVerdict` struct (lines 29-33), rename and update field:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedResult {
+    pub result: StepResult,
+    pub output: StepOutput,
+    pub source: VerdictSource,
+}
+```
+
+- [ ] **Step 4: Update verdict_from_payload to parse concern**
+
+In `step_output_from_payload` (lines 181-195), add `"concern"` parsing:
+
+```rust
+fn step_output_from_payload(payload: &VerdictPayload) -> Option<StepOutput> {
+    let result = match payload.verdict.as_deref() {
+        Some(v) if v.eq_ignore_ascii_case("approve") => StepResult::Succeeded,
+        Some(v) if v.eq_ignore_ascii_case("succeeded") => StepResult::Succeeded,
+        Some(v) if v.eq_ignore_ascii_case("concern") => StepResult::Concern {
+            summary: payload.summary.clone().unwrap_or_default(),
+        },
+        Some(v) if v.eq_ignore_ascii_case("reject") => StepResult::Failed {
+            summary: payload.summary.clone().unwrap_or_default(),
+        },
+        Some(v) if v.eq_ignore_ascii_case("failed") => StepResult::Failed {
+            summary: payload.summary.clone().unwrap_or_default(),
+        },
+        _ => return None,
+    };
+
+    Some(StepOutput {
+        result,
+        summary: payload.summary.clone(),
+        output: payload.output.clone(),
+    })
+}
+```
+
+- [ ] **Step 5: Update resolve_verdict_with_source return type and all verdict references**
+
+In `resolve_verdict_with_source` (lines 117-174), rename `verdict` field accesses to `result`:
+
+```rust
+pub async fn resolve_verdict_with_source(
+    acp_verdict: Option<&serde_json::Value>,
+    workspace: &Path,
+    step_name: &str,
+) -> ResolvedResult {
+    // 1. Try ACP event.
+    if let Some(value) = acp_verdict {
+        if let Some(output) = parse_step_output_from_value(value) {
+            return ResolvedResult {
+                result: output.result.clone(),
+                output,
+                source: VerdictSource::Runtime,
+            };
+        }
+    }
+
+    // 2. Try file.
+    match read_step_output_file(workspace, step_name).await {
+        Ok(Some(output)) => {
+            return ResolvedResult {
+                result: output.result.clone(),
+                output,
+                source: VerdictSource::File,
+            };
+        }
+        Ok(None) => {}
+        Err(e) => {
+            let msg = format!("failed to parse .ensemble/verdict-{step_name}.json: {e}");
+            let failed = StepResult::Failed {
+                summary: msg.clone(),
+            };
+            let output = StepOutput {
+                result: failed.clone(),
+                summary: Some(msg),
+                output: None,
+            };
+            return ResolvedResult {
+                result: failed,
+                output,
+                source: VerdictSource::File,
+            };
+        }
+    }
+
+    // 3. Default.
+    warn!("no result source found for step, defaulting to Succeeded");
+    let output = StepOutput {
+        result: StepResult::Succeeded,
+        summary: None,
+        output: None,
+    };
+    ResolvedResult {
+        result: output.result.clone(),
+        output,
+        source: VerdictSource::Default,
+    }
+}
+```
+
+- [ ] **Step 6: Update resolve_verdict to use ResolvedResult**
+
+```rust
+pub async fn resolve_verdict(
+    acp_verdict: Option<&serde_json::Value>,
+    workspace: &Path,
+    step_name: &str,
+) -> StepResult {
+    resolve_verdict_with_source(acp_verdict, workspace, step_name)
+        .await
+        .result
+}
+```
+
+- [ ] **Step 7: Update tests**
+
+In `mod tests` (lines 197-407), replace all `Verdict::Approve` with `StepResult::Succeeded`, `Verdict::Reject { summary }` with `StepResult::Failed { summary }`, and update field accesses from `.verdict` to `.result`. Add a `Concern` parsing test:
+
+```rust
+#[test]
+fn test_parse_concern() {
+    let value = json!({ "verdict": "concern", "summary": "naming issues found" });
+    assert_eq!(
+        parse_verdict_from_value(&value),
+        Some(StepResult::Concern {
+            summary: "naming issues found".to_string()
+        })
+    );
+}
+```
+
+And add a backward-compat test for old `"approve"` / `"reject"` strings:
+
+```rust
+#[test]
+fn test_parse_legacy_approve_reject() {
+    assert_eq!(
+        parse_verdict_from_value(&json!({ "verdict": "approve" })),
+        Some(StepResult::Succeeded)
+    );
+    assert_eq!(
+        parse_verdict_from_value(&json!({ "verdict": "reject", "summary": "nope" })),
+        Some(StepResult::Failed { summary: "nope".to_string() })
+    );
+}
+```
+
+- [ ] **Step 8: Run tests, fix compilation**
+
+Run: `cargo test -p ensemble-core -- pipeline::verdict`
+Expected: All tests pass with renamed types.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/ensemble-core/src/pipeline/verdict.rs
+git commit -m "refactor: rename Verdict to StepResult, add Concern variant"
+```
+
+### Task 2: Propagate rename through pipeline/engine.rs
+
+**Files:**
+- Modify: `crates/ensemble-core/src/pipeline/engine.rs`
+
+- [ ] **Step 1: Update import**
+
+Line 7: change `use crate::pipeline::verdict::{StepOutput, Verdict};` to `use crate::pipeline::verdict::{StepOutput, StepResult};`.
+
+- [ ] **Step 2: Rename StepState variants**
+
+Lines 23-28: rename `Rejected { summary }` to `Failed { summary: String }`:
+
+```rust
+pub enum StepState {
+    Pending,
+    Running { session_id: String },
+    BlockedOnHuman { interaction_request_id: String },
+    AwaitingApproval { interaction_request_id: Option<String> },
+    Passed,
+    Failed { summary: String },
+    /// Step failed due to an agent crash or runtime error.
+    Errored { error: String },
+}
+```
+
+Wait — we need to distinguish between an agent returning `Failed` (semantic failure: "I tried and it didn't work") vs the agent crashing (runtime error: "I died"). Let me check the current usage. Currently `Failed` is for runtime errors (line 28) and `Rejected` is for agent rejections. After rename: `Failed` for semantic failure from agent, `Errored` for runtime crashes.
+
+Actually, looking at the spec more carefully — the spec says `Failed` is the rename of `Reject`. The runtime error state should stay separate. So:
+
+```rust
+pub enum StepState {
+    Pending,
+    Running { session_id: String },
+    BlockedOnHuman { interaction_request_id: String },
+    AwaitingApproval { interaction_request_id: Option<String> },
+    Passed,
+    /// Step returned a Failed result from the agent.
+    Failed { summary: String },
+    /// Step errored due to an agent crash or runtime failure.
+    Errored { error: String },
+}
+```
+
+- [ ] **Step 3: Update StepState::is_terminal**
+
+Line 34-39: `Rejected` → `Failed`, keep `Errored`:
+
+```rust
+pub fn is_terminal(&self) -> bool {
+    matches!(
+        self,
+        Self::Passed | Self::Failed { .. } | Self::Errored { .. }
+    )
+}
+```
+
+- [ ] **Step 4: Update step_completed to handle Verdict→Result and add Concern**
+
+Lines 162-224: Replace `verdict` with `result`, handle `StepResult::Concern`:
+
+```rust
+pub fn step_completed(
+    &mut self,
+    step_name: &str,
+    output: StepOutput,
+    approval_requested: bool,
+) -> PipelineAction {
+    let result = output.result.clone();
+    self.step_outputs.insert(step_name.to_string(), output);
+    match result {
+        StepResult::Succeeded => match self.gate_check(step_name, approval_requested) {
+            ApprovalGateCheck::EligibleGating => {
+                let approval_state = self.approval_state_for(step_name);
+                self.step_states.insert(
+                    step_name.to_string(),
+                    StepState::AwaitingApproval {
+                        interaction_request_id: None,
+                    },
+                );
+                PipelineAction::AwaitingApproval {
+                    step: step_name.to_string(),
+                    approval_state,
+                }
+            }
+            ApprovalGateCheck::UnconfiguredButRequested => {
+                self.step_states.insert(
+                    step_name.to_string(),
+                    StepState::Errored {
+                        error: format!(
+                            "worker requested approval for step '{step_name}' but it has no approval configuration"
+                        ),
+                    },
+                );
+                PipelineAction::Failed {
+                    step: step_name.to_string(),
+                    reason: format!(
+                        "step '{step_name}' has no approval configuration but the worker requested one"
+                    ),
+                }
+            }
+            ApprovalGateCheck::NotRequested => {
+                self.step_states
+                    .insert(step_name.to_string(), StepState::Passed);
+                if self.all_passed() {
+                    PipelineAction::Succeeded
+                } else {
+                    self.find_dispatchable()
+                }
+            }
+        },
+        StepResult::Concern { summary: _ } => {
+            // Concern does not halt the pipeline. Treat like Succeeded
+            // but flag output so downstream steps can see the concern.
+            self.step_states
+                .insert(step_name.to_string(), StepState::Passed);
+            if self.all_passed() {
+                PipelineAction::Succeeded
+            } else {
+                self.find_dispatchable()
+            }
+        }
+        StepResult::Failed { summary } => {
+            self.step_states.insert(
+                step_name.to_string(),
+                StepState::Failed {
+                    summary: summary.clone(),
+                },
+            );
+            PipelineAction::Failed {
+                step: step_name.to_string(),
+                reason: summary,
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Update reject_gate to use Failed**
+
+Lines 264-281: `StepState::Rejected` → `StepState::Failed`:
+
+```rust
+pub fn reject_gate(&mut self, step_name: &str, reason: String) -> PipelineAction {
+    if !matches!(
+        self.step_states.get(step_name),
+        Some(StepState::AwaitingApproval { .. })
+    ) {
+        return PipelineAction::Waiting;
+    }
+
+    self.step_states.insert(
+        step_name.to_string(),
+        StepState::Failed {
+            summary: reason.clone(),
+        },
+    );
+    PipelineAction::Failed {
+        step: step_name.to_string(),
+        reason,
+    }
+}
+```
+
+- [ ] **Step 6: Update step_failed to use Errored**
+
+Lines 306-317: `StepState::Failed` → `StepState::Errored` for runtime crashes:
+
+```rust
+pub fn step_failed(&mut self, step_name: &str, error: String) -> PipelineAction {
+    self.step_states.insert(
+        step_name.to_string(),
+        StepState::Errored {
+            error: error.clone(),
+        },
+    );
+    PipelineAction::Failed {
+        step: step_name.to_string(),
+        reason: error,
+    }
+}
+```
+
+- [ ] **Step 7: Update template_entry to use StepResult**
+
+Lines 439-449: `Verdict::Approve` → `StepResult::Succeeded`, `Verdict::Reject` → `StepResult::Failed`:
+
+```rust
+fn template_entry(step: &str, output: &StepOutput) -> StepOutputTemplateEntry {
+    StepOutputTemplateEntry {
+        step: step.to_string(),
+        verdict: match &output.result {
+            StepResult::Succeeded => "succeeded".to_string(),
+            StepResult::Concern { .. } => "concern".to_string(),
+            StepResult::Failed { .. } => "failed".to_string(),
+        },
+        summary: output.summary.clone(),
+        output: output.output.clone(),
+    }
+}
+```
+
+- [ ] **Step 8: Update all tests in engine.rs**
+
+In `mod tests` (lines 452-1197), update all `Verdict::Approve` to `StepResult::Succeeded`, `Verdict::Reject { summary }` to `StepResult::Failed { summary }`, and `StepState::Rejected { summary }` to `StepState::Failed { summary }`. Update `StepState::Failed { error }` to `StepState::Errored { error }`.
+
+Update `approve_output()`:
+```rust
+fn approve_output() -> StepOutput {
+    StepOutput {
+        result: StepResult::Succeeded,
+        summary: None,
+        output: None,
+    }
+}
+```
+
+Update `reject_output()`:
+```rust
+fn reject_output(summary: &str) -> StepOutput {
+    StepOutput {
+        result: StepResult::Failed {
+            summary: summary.to_string(),
+        },
+        summary: Some(summary.to_string()),
+        output: None,
+    }
+}
+```
+
+- [ ] **Step 9: Run tests**
+
+Run: `cargo test -p ensemble-core -- pipeline::engine`
+Expected: All tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/ensemble-core/src/pipeline/engine.rs
+git commit -m "refactor: propagate StepResult rename through pipeline engine, add Concern handling"
+```
+
+### Task 3: Propagate rename through orchestrator and remaining crates
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/state.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Modify: `crates/ensemble-core/src/agent/events.rs`
+- Modify: `crates/ensemble-core/src/api/handlers.rs`
+
+- [ ] **Step 1: Update all Verdict references in orchestrator/mod.rs**
+
+Search for `Verdict::` in mod.rs and replace:
+- `Verdict::Approve` → `StepResult::Succeeded`
+- `Verdict::Reject { summary }` → `StepResult::Failed { summary }`
+- `verdict_value = "approve"` → `result_value = "succeeded"`
+- `verdict_value = "reject"` → `result_value = "failed"`
+
+Key locations to update (search for `Verdict::` and `ResolvedVerdict`):
+- Import line 49: `use crate::pipeline::verdict::{resolve_verdict_with_source, Verdict, VerdictSource};` → `resolve_verdict_with_source, StepResult, VerdictSource`
+- Lines 992-1001 (resolve_verdict_with_source usage): update `.verdict` to `.result`
+- History constants (lines 89-91): update verdict values
+- `rejection_comment_for_step` (line 1433): `StepState::Rejected` → `StepState::Failed`
+
+- [ ] **Step 2: Update state.rs**
+
+Line 658: `crate::pipeline::engine::StepState::Rejected { .. }` → `crate::pipeline::engine::StepState::Failed { .. }`
+
+- [ ] **Step 3: Update all Verdict references in agent/**
+
+In `agent/mod.rs` and `agent/events.rs`: update all `Verdict::` references to `StepResult::`.
+
+- [ ] **Step 4: Update API handlers**
+
+In `api/handlers.rs`: update any `Verdict` or `Rejected` references.
+
+- [ ] **Step 5: Run full workspace build and test**
+
+Run: `cargo build --workspace --exclude ensemble-desktop 2>&1 | head -80`
+Expected: Compilation succeeds (or lists remaining rename targets).
+
+Fix any remaining compilation errors by searching for `Verdict::` across the workspace:
+Run: `rg "Verdict::" --type rust crates/`
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cargo test --workspace --exclude ensemble-desktop`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/
+git commit -m "refactor: propagate StepResult rename through orchestrator, agent, and API layers"
+```
+
+---
+
+## Phase 2: Step-level retry core
+
+### Task 4: Add StepDag::downstream_steps
+
+**Files:**
+- Modify: `crates/ensemble-core/src/pipeline/dag.rs`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `mod tests` in dag.rs:
+
+```rust
+#[test]
+fn test_downstream_steps_linear() {
+    let steps = vec![
+        make_step("a", "agent1", &[]),
+        make_step("b", "agent1", &[]),
+        make_step("c", "agent1", &[]),
+    ];
+    let dag = build_dag(&steps).unwrap();
+
+    let ds = dag.downstream_steps("b");
+    let mut names: Vec<&str> = ds.iter().map(|s| s.as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["b", "c"]);
+}
+
+#[test]
+fn test_downstream_steps_parallel() {
+    let steps = vec![
+        make_step("build", "builder", &[]),
+        make_step("review-a", "reviewer", &["build"]),
+        make_step("review-b", "reviewer", &["build"]),
+        make_step("synth", "synth", &["review-a", "review-b"]),
+    ];
+    let dag = build_dag(&steps).unwrap();
+
+    let ds = dag.downstream_steps("review-a");
+    let mut names: Vec<&str> = ds.iter().map(|s| s.as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["review-a", "synth"]);
+    // review-b is NOT downstream of review-a
+}
+
+#[test]
+fn test_downstream_steps_root() {
+    let steps = vec![
+        make_step("a", "agent1", &[]),
+        make_step("b", "agent1", &[]),
+    ];
+    let dag = build_dag(&steps).unwrap();
+
+    let ds = dag.downstream_steps("a");
+    let mut names: Vec<&str> = ds.iter().map(|s| s.as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["a", "b"]);
+}
+
+#[test]
+fn test_downstream_steps_leaf() {
+    let steps = vec![
+        make_step("a", "agent1", &[]),
+        make_step("b", "agent1", &[]),
+    ];
+    let dag = build_dag(&steps).unwrap();
+
+    let ds = dag.downstream_steps("b");
+    let mut names: Vec<&str> = ds.iter().map(|s| s.as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["b"]);
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cargo test -p ensemble-core -- pipeline::dag::tests::test_downstream_steps_linear`
+Expected: FAIL — `downstream_steps` method doesn't exist.
+
+- [ ] **Step 3: Implement downstream_steps**
+
+Add method to `impl StepDag` (after line 25):
+
+```rust
+impl StepDag {
+    // ... existing methods later
+
+    /// Return the set of step names that transitively depend on `step_name`,
+    /// including `step_name` itself. Uses BFS through the dependency graph.
+    pub fn downstream_steps(&self, step_name: &str) -> HashSet<String> {
+        let mut result = HashSet::new();
+        let mut queue = VecDeque::new();
+        queue.push_back(step_name.to_string());
+
+        // Build an adjacency map: dep_name -> Vec<step_name> (reverse edges)
+        let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
+        for step in &self.steps {
+            for dep in &step.depends {
+                dependents.entry(dep.as_str()).or_default().push(step.name.as_str());
+            }
+        }
+
+        while let Some(current) = queue.pop_front() {
+            if !result.insert(current.clone()) {
+                continue; // already visited
+            }
+            if let Some(deps) = dependents.get(current.as_str()) {
+                for dependent in deps {
+                    queue.push_back(dependent.to_string());
+                }
+            }
+        }
+
+        result
+    }
+}
+```
+
+Add the import at the top of dag.rs: `use std::collections::{HashMap, HashSet, VecDeque};` (already has HashMap, HashSet, VecDeque imported).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p ensemble-core -- pipeline::dag`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/pipeline/dag.rs
+git commit -m "feat: add StepDag::downstream_steps for transitive dependency computation"
+```
+
+### Task 5: Add PipelineRun::retry_from_step
+
+**Files:**
+- Modify: `crates/ensemble-core/src/pipeline/engine.rs`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `mod tests` in engine.rs (before the closing `}` of mod tests):
+
+```rust
+#[test]
+fn test_retry_from_step_resets_failed_and_downstream() {
+    // build → review-a ──→ synth
+    //       → review-b ──→
+    let steps = vec![
+        make_step("build", "builder", &[]),
+        make_step("review-a", "reviewer", &["build"]),
+        make_step("review-b", "reviewer", &["build"]),
+        make_step("synth", "synthesizer", &["review-a", "review-b"]),
+    ];
+    let mut run = make_run(&steps);
+
+    // Simulate: build passed, review-a passed, review-b failed
+    run.step_states.insert("build".to_string(), StepState::Passed);
+    run.step_states.insert("review-a".to_string(), StepState::Passed);
+    run.step_states.insert("review-b".to_string(), StepState::Failed {
+        summary: "review-b found issues".to_string(),
+    });
+    // synth never ran (Pending)
+
+    let reset = run.retry_from_step("review-b");
+
+    // review-b + synth (downstream) should be reset
+    assert!(reset.contains("review-b"));
+    assert!(reset.contains("synth"));
+    assert_eq!(reset.len(), 2);
+
+    // build and review-a should remain Passed
+    assert_eq!(run.step_states["build"], StepState::Passed);
+    assert_eq!(run.step_states["review-a"], StepState::Passed);
+
+    // review-b and synth should be Pending
+    assert_eq!(run.step_states["review-b"], StepState::Pending);
+    assert_eq!(run.step_states["synth"], StepState::Pending);
+}
+
+#[test]
+fn test_retry_from_step_leaf_only() {
+    let steps = vec![
+        make_step("build", "builder", &[]),
+        make_step("review", "reviewer", &[]),
+    ];
+    let mut run = make_run(&steps);
+
+    run.step_states.insert("build".to_string(), StepState::Passed);
+    run.step_states.insert("review".to_string(), StepState::Failed {
+        summary: "bad".to_string(),
+    });
+
+    let reset = run.retry_from_step("review");
+
+    assert_eq!(reset, HashSet::from(["review".to_string()]));
+    assert_eq!(run.step_states["review"], StepState::Pending);
+    assert_eq!(run.step_states["build"], StepState::Passed);
+}
+
+#[test]
+fn test_retry_from_step_root_resets_all() {
+    let steps = vec![
+        make_step("build", "builder", &[]),
+        make_step("review", "reviewer", &[]),
+    ];
+    let mut run = make_run(&steps);
+
+    run.step_states.insert("build".to_string(), StepState::Passed);
+    run.step_states.insert("review".to_string(), StepState::Passed);
+
+    let reset = run.retry_from_step("build");
+
+    assert!(reset.contains("build"));
+    assert!(reset.contains("review"));
+    assert_eq!(reset.len(), 2);
+    assert_eq!(run.step_states["build"], StepState::Pending);
+    assert_eq!(run.step_states["review"], StepState::Pending);
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cargo test -p ensemble-core -- pipeline::engine::tests::test_retry_from_step_resets_failed_and_downstream`
+Expected: FAIL — `retry_from_step` method doesn't exist.
+
+- [ ] **Step 3: Implement retry_from_step**
+
+Add to `impl PipelineRun` (after `step_failed`, around line 317):
+
+```rust
+/// Reset `step_name` and all transitive downstream dependents to `Pending`.
+/// Clears their outputs from `step_outputs`. Returns the set of reset step names.
+/// Steps that are already `Pending` remain `Pending` (no-op).
+pub fn retry_from_step(&mut self, step_name: &str) -> HashSet<String> {
+    let downstream = self.dag.downstream_steps(step_name);
+
+    for name in &downstream {
+        self.step_states.insert(name.clone(), StepState::Pending);
+        self.step_outputs.remove(name);
+    }
+
+    downstream
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p ensemble-core -- pipeline::engine`
+Expected: All tests pass including the new retry tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/pipeline/engine.rs
+git commit -m "feat: add PipelineRun::retry_from_step for step-level retry"
+```
+
+---
+
+## Phase 3: on_failure config + orchestrator wiring
+
+### Task 6: Add OnFailure enum and StepConfig fields
+
+**Files:**
+- Modify: `crates/ensemble-core/src/config/ensemble.rs`
+
+- [ ] **Step 1: Add OnFailure enum**
+
+After `StepKind` impl (around line 371), add:
+
+```rust
+/// Controls what happens when a step fails (returns [`StepResult::Failed`]).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OnFailure {
+    /// Whole-issue retry (existing behavior). Destroy PipelineRun, restart from scratch.
+    #[default]
+    RetryIssue,
+    /// Step-level retry. Reset failed step + downstream, preserve passed steps.
+    RetryStep,
+    /// Inject a fixup agent before retrying the failed step.
+    Fixup,
+    /// Halt the pipeline. Do not retry. Wait for manual intervention.
+    Halt,
+}
+```
+
+- [ ] **Step 2: Add on_failure and fixup_agent to StepConfig**
+
+Modify `StepConfig` (lines 374-386):
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct StepConfig {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "StepKind::is_agent")]
+    pub kind: StepKind,
+    pub agent: String,
+    pub depends: Option<Vec<String>>,
+    pub tracker_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval: Option<StepApprovalConfig>,
+    /// Controls retry behavior when this step fails.
+    #[serde(default, skip_serializing_if = "OnFailure::is_default")]
+    pub on_failure: OnFailure,
+    /// Agent to use for fixup retry. Required when on_failure is "fixup".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixup_agent: Option<String>,
+}
+```
+
+Add `is_default` helper for `OnFailure`:
+
+```rust
+impl OnFailure {
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::RetryIssue)
+    }
+}
+```
+
+- [ ] **Step 3: Update DagStep to carry on_failure and fixup_agent**
+
+In `dag.rs`, update `DagStep`:
+
+```rust
+pub struct DagStep {
+    pub name: String,
+    pub agent: String,
+    pub kind: StepKind,
+    pub tracker_state: Option<String>,
+    pub approval: Option<StepApprovalConfig>,
+    pub depends: Vec<String>,
+    pub on_failure: OnFailure,
+    pub fixup_agent: Option<String>,
+}
+```
+
+And in `build_dag`, copy the new fields:
+
+```rust
+resolved.push(DagStep {
+    name: step.name.clone(),
+    agent: step.agent.clone(),
+    kind: step.kind,
+    tracker_state: step.tracker_state.clone(),
+    approval: step.approval.clone(),
+    depends: deps,
+    on_failure: step.on_failure,
+    fixup_agent: step.fixup_agent.clone(),
+});
+```
+
+- [ ] **Step 4: Compile and fix cascading changes**
+
+Run: `cargo build -p ensemble-core 2>&1 | head -40`
+Expected: May have compilation errors in dag.rs if `OnFailure` isn't imported. Add `use crate::config::ensemble::OnFailure;` to dag.rs if needed.
+
+- [ ] **Step 5: Write config test**
+
+Add to `mod tests` in ensemble.rs (or dag.rs):
+
+```rust
+#[test]
+fn test_step_config_on_failure_defaults_to_retry_issue() {
+    let yaml = r#"
+name: build
+agent: builder
+"#;
+    let step: StepConfig = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(step.on_failure, OnFailure::RetryIssue);
+    assert!(step.fixup_agent.is_none());
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p ensemble-core -- config`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-core/src/config/ensemble.rs crates/ensemble-core/src/pipeline/dag.rs
+git commit -m "feat: add OnFailure enum and on_failure/fixup_agent fields to StepConfig"
+```
+
+### Task 7: Add retry_from_step fields to RetryEntry
+
+**Files:**
+- Modify: `crates/ensemble-core/src/tracker/model.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/retry.rs`
+
+- [ ] **Step 1: Add fields to RetryEntry**
+
+In `tracker/model.rs`, lines 71-78:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryEntry {
+    pub issue_id: String,
+    pub identifier: String,
+    pub attempt: u32,
+    pub due_at_ms: u64,
+    pub error: Option<String>,
+    /// If set, retry from this step (step-level retry). None = whole-issue.
+    #[serde(default)]
+    pub retry_from_step: Option<String>,
+    /// Whether to inject a fixup agent before retrying.
+    #[serde(default)]
+    pub with_fixup: bool,
+}
+```
+
+- [ ] **Step 2: Update schedule_failure_retry signature in retry.rs**
+
+Add `retry_from_step: Option<String>` and `with_fixup: bool` parameters to `schedule_failure_retry` (line 58):
+
+```rust
+pub fn schedule_failure_retry(
+    state: &mut OrchestratorState,
+    issue_id: &str,
+    identifier: &str,
+    attempt: u32,
+    max_backoff_ms: u64,
+    max_cycles: u32,
+    error: &str,
+    retry_from_step: Option<String>,
+    with_fixup: bool,
+) -> Option<u64> {
+```
+
+And in the `RetryEntry` construction:
+
+```rust
+let entry = RetryEntry {
+    issue_id: issue_id.to_string(),
+    identifier: identifier.to_string(),
+    attempt,
+    due_at_ms,
+    error: Some(error.to_string()),
+    retry_from_step,
+    with_fixup,
+};
+```
+
+- [ ] **Step 3: Update all schedule_failure_retry call sites**
+
+Search for all `schedule_failure_retry(` calls and add `None, false` as the last two arguments. Run:
+
+```bash
+rg "schedule_failure_retry\(" --type rust crates/
+```
+
+This will find call sites in:
+- `orchestrator/mod.rs` (multiple locations)
+- `orchestrator/retry.rs` (tests)
+
+Add `None, false` to each call.
+
+- [ ] **Step 4: Update retry.rs tests**
+
+Update `test_schedule_failure_retry` and other tests to pass `None, false`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p ensemble-core -- orchestrator::retry`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/tracker/model.rs crates/ensemble-core/src/orchestrator/retry.rs crates/ensemble-core/src/orchestrator/mod.rs
+git commit -m "feat: add retry_from_step and with_fixup to RetryEntry"
+```
+
+### Task 8: Wire on_failure routing in orchestrator
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+
+- [ ] **Step 1: Add helper to read on_failure from config**
+
+Add a method or inline logic in `handle_worker_exit` to read `on_failure` for a step. In the `PipelineAction::Failed { step, reason }` handler (around line 1188), add before the retry scheduling:
+
+```rust
+let on_failure = {
+    let config = self.config.read().await;
+    config.steps
+        .iter()
+        .find(|s| s.name == step)
+        .map(|s| s.on_failure)
+        .unwrap_or_default()
+};
+```
+
+- [ ] **Step 2: Route based on on_failure**
+
+Replace lines 1201-1238 (the `if let Some(entry) = state.remove_running(issue_id)` block) with routing logic:
+
+```rust
+match on_failure {
+    OnFailure::RetryStep => {
+        // Step-level retry: reset failed step + downstream, preserve PipelineRun
+        if let Some(run) = state.get_pipeline_run_mut(issue_id) {
+            run.retry_from_step(&step);
+        }
+        if let Some(entry) = state.remove_running(issue_id) {
+            state.add_runtime_seconds(&entry);
+            completed_identifier = Some(entry.identifier.clone());
+            history_run_id = entry.run_id.clone();
+            let retry_scheduled = schedule_failure_retry(
+                &mut state,
+                issue_id,
+                &entry.identifier,
+                next_attempt(entry.retry_attempt),
+                config.agent.max_retry_backoff_ms,
+                config.max_cycles,
+                &reason,
+                Some(step.clone()),
+                false,
+            );
+            final_failure = retry_scheduled.is_none();
+            if final_failure {
+                history_record = state.get_pipeline_run(issue_id).map(|run| {
+                    rejection_comment = Self::rejection_comment_for_step(run, &step);
+                    self.build_history_record(
+                        issue_id,
+                        HISTORY_OUTCOME_FAILED,
+                        Some(reason.clone()),
+                        &entry,
+                        run,
+                        completed_at,
+                    )
+                });
+            }
+            if retry_scheduled.is_none() && self.tracker.supports_writes() {
+                if let Err(e) = self
+                    .tracker
+                    .set_issue_state(issue_id, &config.on_failure)
+                    .await
+                {
+                    warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
+                }
+            }
+        }
+        // Do NOT remove_pipeline_run for RetryStep
+    }
+    OnFailure::Fixup => {
+        // Fixup: inject fixup agent, then retry
+        let fixup_agent = config.steps
+            .iter()
+            .find(|s| s.name == step)
+            .and_then(|s| s.fixup_agent.clone())
+            .unwrap_or_else(|| "fixer".to_string());
+
+        if let Some(run) = state.get_pipeline_run_mut(issue_id) {
+            run.retry_from_step_with_fixup(&step, &fixup_agent);
+        }
+        if let Some(entry) = state.remove_running(issue_id) {
+            state.add_runtime_seconds(&entry);
+            completed_identifier = Some(entry.identifier.clone());
+            history_run_id = entry.run_id.clone();
+            let retry_scheduled = schedule_failure_retry(
+                &mut state,
+                issue_id,
+                &entry.identifier,
+                next_attempt(entry.retry_attempt),
+                config.agent.max_retry_backoff_ms,
+                config.max_cycles,
+                &reason,
+                Some(step.clone()),
+                true, // with_fixup
+            );
+            final_failure = retry_scheduled.is_none();
+            if final_failure {
+                // same history record logic as RetryStep
+                history_record = state.get_pipeline_run(issue_id).map(|run| {
+                    self.build_history_record(
+                        issue_id,
+                        HISTORY_OUTCOME_FAILED,
+                        Some(reason.clone()),
+                        &entry,
+                        run,
+                        completed_at,
+                    )
+                });
+            }
+            if retry_scheduled.is_none() && self.tracker.supports_writes() {
+                if let Err(e) = self
+                    .tracker
+                    .set_issue_state(issue_id, &config.on_failure)
+                    .await
+                {
+                    warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
+                }
+            }
+        }
+        // Do NOT remove_pipeline_run for Fixup
+    }
+    OnFailure::Halt => {
+        // Halt: do not retry, do not remove PipelineRun, keep issue claimed
+        warn!(
+            issue_id = %issue_id,
+            step = %step,
+            reason = %reason,
+            "pipeline halted, waiting for manual intervention"
+        );
+        if let Some(entry) = state.remove_running(issue_id) {
+            state.add_runtime_seconds(&entry);
+        }
+        // Do NOT remove_pipeline_run, do NOT schedule retry
+        // Do NOT call remove_claimed — issue stays claimed
+    }
+    OnFailure::RetryIssue => {
+        // Existing whole-issue retry behavior
+        if let Some(entry) = state.remove_running(issue_id) {
+            state.add_runtime_seconds(&entry);
+            completed_identifier = Some(entry.identifier.clone());
+            history_run_id = entry.run_id.clone();
+            let retry_scheduled = schedule_failure_retry(
+                &mut state,
+                issue_id,
+                &entry.identifier,
+                next_attempt(entry.retry_attempt),
+                config.agent.max_retry_backoff_ms,
+                config.max_cycles,
+                &reason,
+                None,  // whole-issue
+                false,
+            );
+            final_failure = retry_scheduled.is_none();
+            if final_failure {
+                history_record = state.get_pipeline_run(issue_id).map(|run| {
+                    rejection_comment = Self::rejection_comment_for_step(run, &step);
+                    self.build_history_record(
+                        issue_id,
+                        HISTORY_OUTCOME_FAILED,
+                        Some(reason.clone()),
+                        &entry,
+                        run,
+                        completed_at,
+                    )
+                });
+            }
+            if retry_scheduled.is_none() && self.tracker.supports_writes() {
+                if let Err(e) = self
+                    .tracker
+                    .set_issue_state(issue_id, &config.on_failure)
+                    .await
+                {
+                    warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
+                }
+            }
+        }
+        state.remove_pipeline_run(issue_id);
+    }
+}
+```
+
+- [ ] **Step 3: Update dispatch_issue to reuse PipelineRun for step-level retries**
+
+In `dispatch_issue` (line 580), add an early-return block at the top (after `let cycle = ...`). When a PipelineRun already exists for this issue, skip `build_dag` + `PipelineRun::new` + `insert_pipeline_run`. Instead: re-add to running, call `start()` on the existing run, and dispatch the returned requests through the same dispatch loop.
+
+The key change is inserting right after line 592 (`let cycle = attempt.unwrap_or(1);`):
+
+```rust
+// Check for existing PipelineRun (step-level retry preserved it)
+{
+    let state = self.state.read().await;
+    if state.get_pipeline_run(&issue.id).is_some() {
+        drop(state);
+        // Reuse existing run — retry_from_step was already applied
+        let (config_snapshot, action) = {
+            let mut state = self.state.write().await;
+            state.add_running(issue, attempt);
+            let config = state.get_pipeline_config(&issue.id).cloned();
+            let action = state.get_pipeline_run_mut(&issue.id)
+                .map(|run| { run.cycle = cycle; run.start() })
+                .unwrap_or(PipelineAction::Waiting);
+            (config, action)
+        };
+
+        info!(event = ISSUE_DISPATCH_STARTED, issue_id = %issue.id,
+              identifier = %issue.identifier, cycle = cycle,
+              "resuming with existing pipeline (step-level retry)");
+
+        if let PipelineAction::Dispatch(requests) = action {
+            if let Some(config) = config_snapshot {
+                for req in requests {
+                    // Same dispatch loop as below — prepare workspace, dispatch_step
+                    let workspace_path = match self.prepare_step_workspace(issue, &config).await {
+                        Ok(path) => path,
+                        Err(error) => { /* ... failure handling ... */ return; }
+                    };
+                    let step_outputs = {
+                        let state = self.state.read().await;
+                        state.get_pipeline_run(&issue.id)
+                            .and_then(|r| r.output_context_for(&req.step_name))
+                            .unwrap_or_default()
+                    };
+                    let _ = self.dispatch_step(
+                        issue, Arc::clone(&config),
+                        StepDispatchContext {
+                            step_name: &req.step_name, agent_name: &req.agent_name,
+                            step_kind: req.step_kind, tracker_state: req.tracker_state.as_deref(),
+                            attempt, interaction_response: None,
+                            workspace_path, step_outputs,
+                        },
+                    ).await;
+                }
+            }
+        }
+        return;
+    }
+}
+// ... existing dispatch_issue code continues unchanged
+```
+
+The dispatch loop is duplicated from the existing loop because of async borrow constraints — the state lock cannot be held across `.await` calls to `prepare_step_workspace` and `dispatch_step`.
+
+- [ ] **Step 4: Compile and fix errors**
+
+Run: `cargo build -p ensemble-core 2>&1 | head -50`
+Expected: Initial compilation errors from the new code. Fix borrow/async issues by moving lock acquisitions.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cargo test --workspace --exclude ensemble-desktop`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/orchestrator/mod.rs
+git commit -m "feat: wire on_failure routing and step-level retry dispatch in orchestrator"
+```
+
+### Task 9: Add retry_from_step_with_fixup to PipelineRun
+
+**Files:**
+- Modify: `crates/ensemble-core/src/pipeline/engine.rs`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `mod tests` in engine.rs:
+
+```rust
+#[test]
+fn test_retry_from_step_with_fixup_injects_fixup_before_failed_step() {
+    let steps = vec![
+        make_step("build", "builder", &[]),
+        make_step("synth", "synth", &["build"]),
+    ];
+    let mut run = make_run(&steps);
+    run.step_states.insert("build".to_string(), StepState::Passed);
+    run.step_states.insert("synth".to_string(), StepState::Failed {
+        summary: "synthesis conflict".to_string(),
+    });
+    let reset = run.retry_from_step_with_fixup("synth", "fixer");
+    assert!(reset.contains("synth"));
+    assert!(run.step_states.contains_key("fixup-synth"));
+    assert_eq!(run.step_states["fixup-synth"], StepState::Pending);
+    let synth = run.dag.steps.iter().find(|s| s.name == "synth").unwrap();
+    assert_eq!(synth.depends, vec!["fixup-synth"]);
+    let fixup = run.dag.steps.iter().find(|s| s.name == "fixup-synth").unwrap();
+    assert_eq!(fixup.depends, vec!["build"]);
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cargo test -p ensemble-core -- pipeline::engine::tests::test_retry_from_step_with_fixup`
+Expected: FAIL — method does not exist.
+
+- [ ] **Step 3: Implement retry_from_step_with_fixup**
+
+After `retry_from_step` in engine.rs, add:
+
+```rust
+/// Same as retry_from_step, but injects a synthetic fixup step between the
+/// reset step's dependencies and the reset step itself.
+pub fn retry_from_step_with_fixup(
+    &mut self,
+    step_name: &str,
+    fixup_agent: &str,
+) -> HashSet<String> {
+    let fixup_name = format!("fixup-{step_name}");
+    let original_deps: Vec<String> = self.dag.steps
+        .iter()
+        .find(|s| s.name == step_name)
+        .map(|s| s.depends.clone())
+        .unwrap_or_default();
+    let reset = self.retry_from_step(step_name);
+    let fixup_step = crate::pipeline::dag::DagStep {
+        name: fixup_name.clone(),
+        agent: fixup_agent.to_string(),
+        kind: crate::config::ensemble::StepKind::Agent,
+        tracker_state: None,
+        approval: None,
+        depends: original_deps.clone(),
+        on_failure: crate::config::ensemble::OnFailure::RetryStep,
+        fixup_agent: None,
+    };
+    let failed_idx = self.dag.steps.iter()
+        .position(|s| s.name == step_name)
+        .unwrap_or(self.dag.steps.len());
+    self.dag.steps.insert(failed_idx, fixup_step);
+    if let Some(step) = self.dag.steps.iter_mut().find(|s| s.name == step_name) {
+        step.depends = vec![fixup_name.clone()];
+    }
+    self.step_states.insert(fixup_name, StepState::Pending);
+    reset
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p ensemble-core -- pipeline::engine`
+Expected: All tests pass including fixup test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/pipeline/engine.rs
+git commit -m "feat: add retry_from_step_with_fixup for fixup agent injection"
+```
+
+### Task 10: Update API retry endpoint for step-level retry
+
+**Files:**
+- Modify: `crates/ensemble-core/src/api/controls.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/state.rs`
+
+- [ ] **Step 1: Add find_issue_id_by_identifier to OrchestratorState**
+
+In state.rs, add:
+
+```rust
+/// Find the issue_id for a given identifier across running or waiting states.
+pub fn find_issue_id_by_identifier(&self, identifier: &str) -> Option<String> {
+    for (id, entry) in &self.running {
+        if entry.identifier == identifier { return Some(id.clone()); }
+    }
+    for (id, entry) in &self.waiting_on_human {
+        if entry.identifier == identifier { return Some(id.clone()); }
+    }
+    None
+}
+```
+
+- [ ] **Step 2: Add step query parameter to post_retry**
+
+In controls.rs, update `post_retry`:
+
+```rust
+#[derive(Debug, Deserialize)]
+struct RetryQuery {
+    #[serde(default)]
+    step: Option<String>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/{identifier}/retry",
+    operation_id = "postRetry",
+    params(
+        ("identifier" = String, Path, description = "Issue identifier"),
+        ("step" = Option<String>, Query, description = "Step name for step-level retry")
+    ),
+    // ... existing responses
+)]
+pub async fn post_retry(
+    State(state): State<AppState>,
+    Path(identifier): Path<String>,
+    Query(query): Query<RetryQuery>,
+) -> impl IntoResponse {
+    let mut lock = state.orchestrator_state.write().await;
+
+    let issue_id = match find_issue_presence(&lock, &identifier) {
+        IssuePresence::Retrying(id) => id,
+        IssuePresence::Running(_) => {
+            return issue_error_response(StatusCode::CONFLICT, "not_retrying",
+                format!("issue '{}' is currently running", identifier));
+        }
+        IssuePresence::Finalizing(_) => {
+            return issue_error_response(StatusCode::CONFLICT, "not_retrying",
+                format!("issue '{}' is finalizing", identifier));
+        }
+        IssuePresence::Missing => {
+            // Check for halted issues (PipelineRun exists, not running/retrying)
+            match lock.find_issue_id_by_identifier(&identifier) {
+                Some(id) => id,
+                None => return issue_error_response(StatusCode::NOT_FOUND,
+                    "issue_not_found", format!("no issue with identifier '{}'", identifier)),
+            }
+        }
+    };
+
+    if let Some(step_name) = &query.step {
+        // Step-level retry: apply retry_from_step on PipelineRun, schedule retry
+        if let Some(run) = lock.get_pipeline_run_mut(&issue_id) {
+            run.retry_from_step(step_name);
+        }
+        // Schedule retry with step info
+        let identifier_copy = lock.running.get(&issue_id)
+            .map(|e| e.identifier.clone())
+            .or_else(|| lock.waiting_on_human.get(&issue_id)
+                .map(|e| e.identifier.clone()))
+            .unwrap_or(identifier.clone());
+        let attempt = lock.running.get(&issue_id)
+            .and_then(|e| e.retry_attempt)
+            .map(|a| a + 1)
+            .unwrap_or(1);
+        let config = state.config.read().await;
+        schedule_failure_retry(
+            &mut lock, &issue_id, &identifier_copy, attempt,
+            config.agent.max_retry_backoff_ms, config.max_cycles,
+            "manual step-level retry",
+            Some(step_name.clone()), false,
+        );
+        // Remove any existing retry entry
+        lock.remove_retry(&issue_id);
+    } else {
+        // Whole-issue retry (existing behavior)
+        lock.remove_retry(&issue_id);
+        lock.remove_claimed(&issue_id);
+        // If halted, also remove pipeline run for clean fresh start
+        lock.remove_pipeline_run(&issue_id);
+    }
+
+    drop(lock);
+    state.refresh_requested.notify_one();
+
+    (StatusCode::OK, Json(RetryResponse {
+        retried: true,
+        issue_identifier: identifier,
+        message: if query.step.is_some() {
+            "step-level retry queued".to_string()
+        } else {
+            "removed from retry queue, will be re-dispatched on next poll".to_string()
+        },
+    })).into_response()
+}
+```
+
+- [ ] **Step 3: Update utoipa path annotations**
+
+Add the query param schema and update the `params` in the `#[utoipa::path]` attribute to include `step`.
+
+- [ ] **Step 4: Run API tests**
+
+Run: `cargo test -p ensemble-core -- api::controls`
+Expected: Tests pass, update any that need `Query` extraction.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/api/controls.rs crates/ensemble-core/src/orchestrator/state.rs
+git commit -m "feat: add step-level retry to API with ?step= query parameter"
+```
+
+### Task 11: Update documentation
+
+**Files:**
+- Modify: `docs/pipelines.md`
+
+- [ ] **Step 1: Update verdict → result in pipeline docs**
+
+Replace references to "verdict" with "result" throughout. Update value names: `"approve"` → `"succeeded"`, `"reject"` → `"failed"`. Add `"concern"` documentation.
+
+- [ ] **Step 2: Add on_failure and step-level retry sections**
+
+After the existing "Retries and cycles" section, add:
+
+```markdown
+## Step-level retry
+
+When a step fails, step-level retry preserves passed steps and only re-runs the failed step and downstream dependents. Configured per step with `on_failure`:
+
+```yaml
+steps:
+  - name: implement
+    agent: builder
+    on_failure: halt
+  - name: review
+    agent: reviewer
+    on_failure: retry_step
+  - name: synthesize
+    kind: synthesis
+    agent: synthesizer
+    depends: [review-a, review-b]
+    on_failure: fixup
+    fixup_agent: fixer
+```
+
+### on_failure values
+
+| Value | Behavior |
+|-------|----------|
+| `retry_issue` | Whole-issue retry (default). |
+| `retry_step` | Step-level retry. Reset failed + downstream only. |
+| `fixup` | Inject fixup agent before retrying. |
+| `halt` | Stop pipeline. Require manual retry. |
+
+### Concern result
+
+Agents can return `Concern` to flag issues without halting the pipeline. Downstream steps see concerns in `dependency_outputs`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/pipelines.md
+git commit -m "docs: update for results, step-level retry, on_failure, and Concern"
+```
+
+---
+
+## Verification
+
+```bash
+cargo test --workspace --exclude ensemble-desktop
+cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+cargo fmt --all -- --check
+```
+
+<｜end▁of▁thinking｜>Let me continue writing the remaining tasks for the plan:
+
+<｜｜DSML｜｜tool_calls>
+<｜｜DSML｜｜invoke name="read">
+<｜｜DSML｜｜parameter name="filePath" string="true">/Users/chris/.paseo/worktrees/0mixpvkw/furry-snake/docs/superpowers/plans/2026-06-11-step-retry-and-results.md

--- a/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
+++ b/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
@@ -1,0 +1,252 @@
+# Step-level retry and agent results
+
+**Date:** 2026-06-11
+**Issue:** [#175](https://github.com/chrisbanes/ensemble/issues/175)
+**Status:** Design
+
+## Context
+
+Ensemble pipelines run a DAG of steps. Today, when any step fails, the entire pipeline re-runs from scratch. In a 5-step pipeline where step 4 fails, steps 1–3 are wasted. This is especially expensive when steps involve long-running agent calls.
+
+The verdict model (`Approve`/`Reject`) is binary and judgmental. A review agent has no way to flag concerns without halting the pipeline. The pipeline engine owns the decision-making, but the current contract forces agents to gate.
+
+## Problem
+
+1. **No step-level retry.** The whole pipeline restarts on any failure. `PipelineRun::new()` resets all steps to `Pending`, and `OrchestratorState::remove_pipeline_run()` destroys step state completely.
+
+2. **No middle-ground verdict.** `Reject` kills the pipeline; `Approve` continues. A review that finds minor issues must either block everything or stay silent. The synthesis step never sees the data.
+
+3. **No per-step failure policy.** All steps share one retry strategy. A flaky agent timeout should retry the step; a meaningful rejection should halt for user review.
+
+## Goal
+
+- Rename the verdict model to results: `Succeeded`, `Failed`, `Concern`
+- Add step-level retry that preserves passed step state and only re-dispatches the failed step + downstream dependents
+- Allow each step to configure its failure behavior (`on_failure`)
+- Optionally inject a fixup agent before retrying a failed step
+
+## Non-Goals
+
+- Per-step cycle counters or per-step retry limits (whole-issue `max_cycles` still applies)
+- Workspace state reset on retry (continue from current workspace state)
+- Removing whole-issue retry (coexists alongside step-level)
+- Changing the verdict resolution pipeline (ACP → file → default still applies, with renamed values)
+
+---
+
+## Design
+
+### 1. Rename Verdict → Result
+
+| Current | Proposed | Behavior |
+|---------|----------|----------|
+| `Approve` | `Succeeded` | Step passed. Pipeline continues. |
+| `Reject { summary }` | `Failed { summary }` | Step failed. Pipeline halts. Triggers `on_failure`. |
+| — | `Concern { summary }` | Issues found but not blocking. Pipeline continues. Downstream steps see the flagged output. |
+
+**`Concern`** is the key addition. A review agent that finds naming issues or minor style problems reports `Concern` with details in `summary` and structured `output`. The pipeline does not halt — downstream steps (especially `kind: synthesis`) receive the concern in their `dependency_outputs` and decide what is actionable. `Failed` remains for truly blocking problems (broken build, wrong approach, unsafe code).
+
+**Result resolution** follows the same priority chain:
+1. ACP runtime result (the `result` field in the final session/update event)
+2. `.ensemble/verdict-{step_name}.json` (or legacy `verdict.json`)
+3. Default to `Succeeded`
+
+**Value mapping:** the existing `"approve"` / `"reject"` strings in ACP payloads and verdict files are mapped to `Succeeded` / `Failed`. The new `"concern"` value is also recognized. Old configs continue working.
+
+### 2. Step-level retry
+
+When a step fails and `on_failure` permits it, the orchestrator resets the failed step and all transitive downstream dependents to `Pending`, clears their outputs, and re-dispatches. Passed steps are preserved.
+
+**Downstream computation** (`StepDag::downstream_steps(step_name)`): a BFS from the named step through the dependency graph collects all transitive dependents (including the step itself).
+
+**Retry from a Passed step:** the user can manually retry from any step, including passed ones. This is useful when a downstream failure's root cause is upstream. The passed step, its outputs, and all downstream are reset as if it had failed.
+
+**Example** — `synthesize` fails because `review-b`'s output was poor:
+
+```
+implement → review-a ──→ synthesize
+          → review-b ──→
+```
+
+| Step | Before retry | After `retry_from_step("review-b")` |
+|---|---|---|
+| implement | Passed | **Passed** |
+| review-a | Passed | **Passed** |
+| review-b | Passed | **Pending** (reset + output cleared) |
+| synthesize | Failed | **Pending** (reset + output cleared) |
+
+On re-dispatch, `review-b` runs first (implement still Passed), then `synthesize`. Two steps re-run instead of four.
+
+**Edge case: no downstream.** If the failed step is a leaf, only it resets. One step re-runs instead of the whole pipeline.
+
+### 3. `on_failure` per step
+
+A new field on `StepConfig` controls retry behavior when a step fails:
+
+```yaml
+steps:
+  - name: implement
+    agent: builder
+    on_failure: halt          # stop and wait for manual intervention
+
+  - name: review-a
+    agent: reviewer
+    on_failure: retry_step    # retry just this step (auto)
+
+  - name: synthesize
+    kind: synthesis
+    agent: synthesizer
+    depends: [review-a, review-b]
+    on_failure: fixup         # inject fixup agent, then retry
+    fixup_agent: fixer
+```
+
+| Value | Behavior |
+|-------|----------|
+| `retry_issue` | Whole-issue retry (existing behavior, the default). Destroys PipelineRun, restarts from scratch. |
+| `retry_step` | Step-level retry. Resets failed step + downstream, preserves passed steps. |
+| `fixup` | Step-level retry with an injected fixup agent. The fixup step runs before the retried step. |
+| `halt` | Stop the pipeline. Do not retry. Wait for manual intervention via API/UI. |
+
+`halt` stops the pipeline entirely — no retry is scheduled. The issue remains claimed and the PipelineRun stays in memory. The user must explicitly retry (via API) or stop the issue.
+
+### 4. Fixup retry
+
+When `on_failure: fixup`, a designated fixup agent is injected into the runtime DAG as a synthetic step between the failed step's dependencies and the failed step itself. The fixup agent receives:
+
+- All dependency outputs from the failed step's dependencies
+- The failure reason (`Failed { summary }` text)
+- Full workspace access
+
+The fixup step runs as a standard agent step. If it fails, the pipeline halts (no recursive fixup). If it succeeds, the original failed step retries against the patched workspace.
+
+```
+implement (Passed) ─────┐
+review-a  (Passed) ─────┼── deps ───→ [fixup] → synthesize (retry)
+review-b  (Passed) ─────┘
+```
+
+The fixup step is runtime-only — it does not appear in `config.yaml` and is not persisted. It uses the agent named in `fixup_agent` on the failed step's config.
+
+### 5. PipelineRun changes
+
+Two new methods on `PipelineRun`:
+
+```rust
+/// Reset `step_name` and all transitive downstream dependents to Pending.
+/// Clears their outputs from `step_outputs`. Returns the set of reset names.
+pub fn retry_from_step(&mut self, step_name: &str) -> HashSet<String>;
+
+/// Same as retry_from_step, plus injects a synthetic fixup step between the
+/// reset step's dependencies and the reset step itself. The failed step's
+/// `depends` are rewired to `[fixup_step]`.
+pub fn retry_from_step_with_fixup(
+    &mut self,
+    step_name: &str,
+    fixup_agent: &str,
+) -> HashSet<String>;
+```
+
+`retry_from_step` for a step with no downstream resets only that step. For a root step, it resets everything (functionally a whole-issue retry, but without destroying the PipelineRun).
+
+### 6. Orchestrator changes
+
+**In `handle_worker_exit` — Failed path:**
+
+Today:
+```rust
+state.remove_pipeline_run(issue_id);  // destroys PipelineRun
+schedule_failure_retry(...);          // always whole-issue
+```
+
+With step-level retry:
+```rust
+let on_failure = step_on_failure(step_name);
+match on_failure {
+    OnFailure::RetryStep => {
+        run.retry_from_step(step_name);
+        // do NOT remove_pipeline_run
+        schedule_failure_retry(..., retry_from_step: Some(step_name));
+    }
+    OnFailure::Fixup => {
+        run.retry_from_step_with_fixup(step_name, fixup_agent);
+        schedule_failure_retry(..., retry_from_step: Some(step_name), with_fixup: true);
+    }
+    OnFailure::Halt => {
+        // do NOT remove_pipeline_run, do NOT schedule retry
+        // issue stays claimed, PipelineRun stays in memory
+    }
+    OnFailure::RetryIssue => {
+        state.remove_pipeline_run(issue_id);
+        schedule_failure_retry(...);
+    }
+}
+```
+
+**In `dispatch_issue` — re-dispatch path:**
+
+When retry fires for an issue that still has a PipelineRun (step-level retry didn't remove it), reuse the existing run instead of calling `PipelineRun::new()`:
+
+```rust
+if let Some(run) = state.get_pipeline_run(&issue.id) {
+    // Reuse existing run (already has retry_from_step applied)
+    let action = run.start(); // finds dispatchable steps among the reset states
+} else {
+    // Fresh dispatch
+    let pipeline_run = PipelineRun::new(issue.id.clone(), cycle, dag);
+}
+```
+
+**`RetryEntry` gains:**
+
+```rust
+pub struct RetryEntry {
+    // ... existing fields
+    pub retry_from_step: Option<String>,  // None = whole-issue
+    pub with_fixup: bool,
+}
+```
+
+**API:** `POST /api/v1/issues/:identifier/retry?step=review-b` for manual step-level retry. Without `?step=`, whole-issue retry (existing behavior).
+
+### 7. Step-level retry + `Concern`
+
+`Concern` does not trigger retry — it is not a failure. The pipeline continues to downstream steps. The `on_failure` config only applies to `Failed` results. If a synthesis step receives `Concern` results from its dependencies and then itself returns `Failed`, the step-level retry logic applies normally.
+
+### 8. `max_cycles` interaction
+
+`max_cycles` still applies to the whole issue. A step-level retry counts as one cycle — the same as a whole-issue retry today. The cycle counter on `PipelineRun` increments on retry regardless of retry type.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `crates/ensemble-core/src/pipeline/verdict.rs` | Rename Verdict → Result (`Approve` → `Succeeded`, `Reject` → `Failed`, add `Concern`). Update parsers and resolvers. |
+| `crates/ensemble-core/src/pipeline/engine.rs` | Add `retry_from_step()`, `retry_from_step_with_fixup()`. Update `step_completed()` to handle `Concern` (continue, not fail). |
+| `crates/ensemble-core/src/pipeline/dag.rs` | Add `StepDag::downstream_steps()`. |
+| `crates/ensemble-core/src/config/ensemble.rs` | Add `OnFailure` enum and `on_failure` + `fixup_agent` fields to `StepConfig`. |
+| `crates/ensemble-core/src/orchestrator/mod.rs` | Route step failures through `on_failure`. Preserve PipelineRun on step-level/halt retries. Handle fixup injection in dispatch. Reuse PipelineRun on re-dispatch. |
+| `crates/ensemble-core/src/orchestrator/retry.rs` | Add `retry_from_step` and `with_fixup` to `RetryEntry`. |
+| `crates/ensemble-core/src/orchestrator/state.rs` | Update `remove_pipeline_run` call sites. |
+| `crates/ensemble-core/src/api/controls.rs` | Add `?step=` parameter to retry endpoint. |
+| `crates/ensemble-core/src/agent/` | Propagate `Concern` result type to agent runner and worker result types. |
+| `docs/pipelines.md` | Document results, `on_failure`, step-level retry, fixup. |
+
+## Testing
+
+- **Unit:** `PipelineRun::retry_from_step` for leaf, mid-dag, root, and no-downstream cases
+- **Unit:** `StepDag::downstream_steps` for linear, parallel, and diamond DAGs
+- **Unit:** Verdict parsing of `"concern"` string in ACP payloads and file fallback
+- **Unit:** `on_failure` routing in orchestrator (retry_step, fixup, halt, retry_issue)
+- **Integration:** End-to-end pipeline with step failure, verifying passed steps preserved on re-dispatch
+- **Integration:** Fixup step injection and re-wiring
+- **Integration:** `Concern` result flowing through to synthesis step without halting
+
+## Compatibility
+
+- Existing `"approve"` and `"reject"` values in ACP payloads and verdict files continue to parse (mapped to `Succeeded`/`Failed`)
+- `on_failure` defaults to `retry_issue` (existing behavior)
+- Existing prompt templates continue working (template variables unchanged)
+- `max_cycles` behavior unchanged

--- a/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
+++ b/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
@@ -108,7 +108,7 @@ steps:
 | `fixup` | Step-level retry with an injected fixup agent. The fixup step runs before the retried step. |
 | `halt` | Stop the pipeline. Do not retry. Wait for manual intervention via API/UI. |
 
-`halt` stops the pipeline entirely — no retry is scheduled. The issue remains claimed and the PipelineRun stays in memory. The user must explicitly retry (via API) or stop the issue. **Limitation:** PipelineRun state is in-memory only. An orchestrator restart loses the halted state — the issue unclaims on next poll and can be re-dispatched fresh. This matches existing wait-on-human behavior.
+`halt` stops the pipeline entirely — no retry is scheduled. The issue remains claimed and the PipelineRun stays in memory. The user must explicitly retry (via API) or stop the issue. **Limitation:** PipelineRun state is in-memory only. An orchestrator restart loses the halted state — the issue unclaims on next poll and can be re-dispatched fresh. This matches existing wait-on-human behavior. Tracked in [#195](https://github.com/chrisbanes/ensemble/issues/195).
 
 ### 4. Fixup retry
 

--- a/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
+++ b/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
@@ -108,7 +108,7 @@ steps:
 | `fixup` | Step-level retry with an injected fixup agent. The fixup step runs before the retried step. |
 | `halt` | Stop the pipeline. Do not retry. Wait for manual intervention via API/UI. |
 
-`halt` stops the pipeline entirely — no retry is scheduled. The issue remains claimed and the PipelineRun stays in memory. The user must explicitly retry (via API) or stop the issue.
+`halt` stops the pipeline entirely — no retry is scheduled. The issue remains claimed and the PipelineRun stays in memory. The user must explicitly retry (via API) or stop the issue. **Limitation:** PipelineRun state is in-memory only. An orchestrator restart loses the halted state — the issue unclaims on next poll and can be re-dispatched fresh. This matches existing wait-on-human behavior.
 
 ### 4. Fixup retry
 

--- a/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
+++ b/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
@@ -47,11 +47,11 @@ The verdict model (`Approve`/`Reject`) is binary and judgmental. A review agent 
 **`Concern`** is the key addition. A review agent that finds naming issues or minor style problems reports `Concern` with details in `summary` and structured `output`. The pipeline does not halt — downstream steps (especially `kind: synthesis`) receive the concern in their `dependency_outputs` and decide what is actionable. `Failed` remains for truly blocking problems (broken build, wrong approach, unsafe code).
 
 **Result resolution** follows the same priority chain:
-1. ACP runtime result (the `result` field in the final session/update event)
+1. ACP runtime result (the `result` field in the final session/update event; legacy `verdict` is accepted while migrating)
 2. `.ensemble/verdict-{step_name}.json` (or legacy `verdict.json`)
 3. Default to `Succeeded`
 
-**Value mapping:** the existing `"approve"` / `"reject"` strings in ACP payloads and verdict files are mapped to `Succeeded` / `Failed`. The new `"concern"` value is also recognized. Old configs continue working.
+**Value mapping:** the existing `"approve"` / `"reject"` strings in ACP payloads and verdict files are mapped to `Succeeded` / `Failed`. The new `"succeeded"` / `"failed"` / `"concern"` values are also recognized.
 
 ### 2. Step-level retry
 
@@ -107,6 +107,8 @@ steps:
 | `retry_step` | Step-level retry. Resets failed step + downstream, preserves passed steps. |
 | `fixup` | Step-level retry with an injected fixup agent. The fixup step runs before the retried step. |
 | `halt` | Stop the pipeline. Do not retry. Wait for manual intervention via API/UI. |
+
+When `on_failure: fixup` is configured, `fixup_agent` is required and must reference a configured agent. Missing or unknown fixup agents are config validation errors.
 
 `halt` stops the pipeline entirely — no retry is scheduled. The issue remains claimed and the PipelineRun stays in memory. The user must explicitly retry (via API) or stop the issue. **Limitation:** PipelineRun state is in-memory only. An orchestrator restart loses the halted state — the issue unclaims on next poll and can be re-dispatched fresh. This matches existing wait-on-human behavior. Tracked in [#195](https://github.com/chrisbanes/ensemble/issues/195).
 
@@ -248,5 +250,5 @@ pub struct RetryEntry {
 
 - Existing `"approve"` and `"reject"` values in ACP payloads and verdict files continue to parse (mapped to `Succeeded`/`Failed`)
 - `on_failure` defaults to `retry_issue` (existing behavior)
-- Existing prompt templates continue working (template variables unchanged)
+- Prompt template variables are updated from verdict terminology to result terminology as part of this change
 - `max_cycles` behavior unchanged


### PR DESCRIPTION
## Summary

- Rename agent step verdict handling to result handling, including the new non-blocking `concern` result while preserving legacy payload parsing.
- Add per-step `on_failure` behavior for whole-issue retry, step retry, fixup injection, and halt/manual intervention.
- Preserve `PipelineRun` state for step-level/fixup retries, add retry metadata, and expose manual step retry via `POST /api/v1/{identifier}/retry?step=...`.
- Update pipeline documentation and the design/plan notes for the corrected behavior.

## Validation

- `cargo build -p ensemble-core`
- `cargo clippy -p ensemble-core -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -p ensemble-core -- orchestrator api::controls pipeline::engine pipeline::dag pipeline::verdict openapi`

`SKIP_UI_BUILD=1 cargo test --workspace --exclude ensemble-desktop` was also attempted. It reached core tests but failed in environment-sensitive tests: GitHub/Notion tracker mock servers cannot bind OS ports in this sandbox, and `config_watcher::tests::watcher_applies_external_config_change` timed out. Running without `SKIP_UI_BUILD=1` fails earlier because generated UI assets are missing.

Fixes #175