### PR TITLE
Fix pipeline journal recovery

### DIFF
--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -2,6 +2,7 @@ use crate::agent::cancellation::{cancel_issue, clear_issue_cancellation};
 use crate::api::handlers::{api_error, ApiError};
 use crate::api::router::AppState;
 use crate::interaction::{InteractionStatus, InteractionStore};
+use crate::orchestrator::pipeline_journal::PipelineRunJournal;
 use crate::orchestrator::retry::{next_attempt, schedule_failure_retry, FailureRetryRequest};
 use crate::orchestrator::state::{FinalizeStatus, OrchestratorState};
 use axum::extract::{Path, Query, State};
@@ -155,6 +156,35 @@ fn interaction_store(state: &AppState) -> InteractionStore {
     InteractionStore::new(config_dir)
 }
 
+fn pipeline_journal(state: &AppState) -> PipelineRunJournal {
+    let config_dir = state
+        .config_runtime
+        .config_path
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    PipelineRunJournal::new(config_dir)
+}
+
+async fn append_release_record(
+    state: &AppState,
+    issue_id: &str,
+    identifier: &str,
+    run_id: Option<String>,
+    reason: &str,
+) {
+    if let Err(error) = pipeline_journal(state)
+        .append_released(issue_id, identifier, run_id, reason)
+        .await
+    {
+        tracing::warn!(
+            issue_id = %issue_id,
+            error = %error,
+            "failed to append pipeline release record from api control"
+        );
+    }
+}
+
 /// POST /api/v1/{identifier}/stop
 ///
 /// Stops a running agent for the specified issue. Sends SIGTERM to the agent process
@@ -249,12 +279,17 @@ pub async fn post_stop(
     }
 
     clear_issue_cancellation(&state.cancellation_registry, &issue_id);
+    let release_run_id = lock
+        .get_running(&issue_id)
+        .and_then(|entry| entry.run_id.clone());
     if let Some(entry) = lock.remove_running(&issue_id) {
         lock.add_runtime_seconds(&entry);
     }
     lock.remove_claimed(&issue_id);
     lock.remove_pipeline_run(&issue_id);
     drop(lock);
+
+    append_release_record(&state, &issue_id, &identifier, release_run_id, "stopped").await;
 
     (
         StatusCode::OK,
@@ -343,6 +378,8 @@ pub async fn post_retry(
         },
     };
 
+    let mut release_record: Option<(String, String, Option<String>, &'static str)> = None;
+
     if let Some(step_name) = query.step.as_ref() {
         let Some(run) = lock.get_pipeline_run_mut(&issue_id) else {
             return issue_error_response(
@@ -403,12 +440,31 @@ pub async fn post_retry(
         );
     } else {
         // Whole-issue retry: release the claim so the next poll can pick it up fresh.
+        let release_identifier = identifier.clone();
+        let release_run_id = lock
+            .get_running(&issue_id)
+            .and_then(|entry| entry.run_id.clone())
+            .or_else(|| {
+                lock.waiting_on_human
+                    .get(&issue_id)
+                    .and_then(|entry| entry.run_id.clone())
+            });
         lock.remove_retry(&issue_id);
         lock.remove_waiting_on_human(&issue_id);
         lock.remove_claimed(&issue_id);
         lock.remove_pipeline_run(&issue_id);
+        release_record = Some((
+            issue_id.clone(),
+            release_identifier,
+            release_run_id,
+            "whole_issue_retry",
+        ));
     }
     drop(lock);
+
+    if let Some((issue_id, identifier, run_id, reason)) = release_record {
+        append_release_record(&state, &issue_id, &identifier, run_id, reason).await;
+    }
 
     // Signal the orchestrator to poll immediately so it picks up the now-unclaimed issue
     state.refresh_requested.notify_one();
@@ -769,6 +825,7 @@ mod tests {
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
     use crate::config::ensemble::{ConcurrencyConfig, OnFailure, StepConfig, StepKind};
     use crate::interaction::model::InteractionKind;
+    use crate::orchestrator::pipeline_journal::PipelineTransitionKind;
     use crate::orchestrator::state::{
         FinalizeStatus, IssueFinalizeState, OrchestratorState, RepoFinalizeState,
         WaitingOnHumanEntry,
@@ -1102,6 +1159,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn post_stop_appends_pipeline_released_record() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_app_state_with_running_pid(None);
+        state.config_runtime.config_path = temp.path().join("config.yaml");
+        let cancellation = CancellationToken::new();
+        register_issue_cancellation(
+            &state.cancellation_registry,
+            "NODE_123",
+            cancellation.clone(),
+        );
+
+        let response = post_stop(State(state.clone()), Path("my-repo#42".to_string()))
+            .await
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let journal = PipelineRunJournal::new(temp.path());
+        let records = journal.read_records_for_issue("NODE_123").await.unwrap();
+        assert!(records
+            .iter()
+            .any(|record| record.kind == PipelineTransitionKind::Released));
+    }
+
+    #[tokio::test]
     async fn test_stop_running_issue_without_session_keeps_conflict_even_if_cancelled() {
         let state = build_app_state_with_running();
         let cancellation = CancellationToken::new();
@@ -1170,6 +1251,28 @@ mod tests {
         let lock = state.orchestrator_state.read().await;
         assert!(lock.retry_attempts.is_empty());
         assert!(!lock.is_claimed("NODE_456"));
+    }
+
+    #[tokio::test]
+    async fn whole_issue_retry_appends_pipeline_released_record() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_app_state_with_retry();
+        state.config_runtime.config_path = temp.path().join("config.yaml");
+
+        let response = post_retry(
+            State(state.clone()),
+            Path("my-repo#99".to_string()),
+            Query(RetryQuery { step: None }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let journal = PipelineRunJournal::new(temp.path());
+        let records = journal.read_records_for_issue("NODE_456").await.unwrap();
+        assert!(records
+            .iter()
+            .any(|record| record.kind == PipelineTransitionKind::Released));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/test_helpers.rs
+++ b/crates/ensemble-core/src/api/test_helpers.rs
@@ -15,7 +15,10 @@ const MINIMAL_CONFIG: &str = "tracker:\n  kind: todo_file\nagents:\n  build:\n  
 
 pub(crate) fn parsed_document_state() -> ConfigDocumentState {
     ConfigDocumentState {
-        path: PathBuf::from("ensemble.yaml"),
+        path: std::env::temp_dir().join(format!(
+            "ensemble-api-test-{}-config.yaml",
+            std::process::id()
+        )),
         kind: ConfigStateKind::Parsed,
         raw_yaml: None,
         document: None,

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -395,6 +395,13 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
             field: Some("kind".to_string()),
             path: Some(format!("steps.{}", step)),
         },
+        PipelineError::InvalidSnapshot { reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("invalid pipeline snapshot: {}", reason),
+            section: "runtime".to_string(),
+            field: None,
+            path: None,
+        },
     }
 }
 

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -144,4 +144,6 @@ pub enum PipelineError {
     InvalidRuntimeConfig { agent: String, reason: String },
     #[error("invalid synthesis step {step}: {reason}")]
     InvalidSynthesisStep { step: String, reason: String },
+    #[error("invalid pipeline snapshot: {reason}")]
+    InvalidSnapshot { reason: String },
 }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1,3 +1,4 @@
+pub mod pipeline_journal;
 pub mod reconciler;
 pub mod retry;
 pub mod scheduler;

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -43,9 +43,13 @@ use crate::observability::events_contract::{
     ORCH_TICK_STARTED, STEP_STARTED, TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED,
     TRACKER_TRANSITION_SUCCEEDED,
 };
+use crate::orchestrator::pipeline_journal::{
+    PipelineRunJournal, PipelineTransitionKind, PipelineTransitionRecord,
+};
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{
-    DispatchRequest, PipelineAction, PipelineRun, StepOutputTemplateContext, StepState,
+    DispatchRequest, PipelineAction, PipelineRun, PipelineRunSnapshot, StepOutputTemplateContext,
+    StepState,
 };
 use crate::pipeline::verdict::{resolve_verdict_with_source, StepResult, VerdictSource};
 use crate::timeline::persistence::TimelinePersistence;
@@ -106,6 +110,7 @@ pub struct Orchestrator {
     cancellation_registry: CancellationRegistry,
     history_write_lock: Arc<tokio::sync::Mutex<()>>,
     history_store: Option<HistoryStore>,
+    pipeline_journal: PipelineRunJournal,
     event_bus: EventBus,
     timeline_persistence: Option<TimelinePersistence>,
     worker_tx: mpsc::Sender<WorkerEvent>,
@@ -195,6 +200,7 @@ impl Orchestrator {
                 error
             })
             .ok(),
+            pipeline_journal: PipelineRunJournal::new(config_dir.to_path_buf()),
             event_bus: parts.event_bus,
             timeline_persistence: Some(TimelinePersistence::new(parts.workspace_root)),
             worker_tx,
@@ -234,6 +240,8 @@ impl Orchestrator {
             state.max_concurrent_agents = max_concurrent_agents;
             state.init_state_lists(&config_clone);
         }
+
+        self.restore_pipeline_runs_from_journal().await;
 
         // Startup terminal workspace cleanup
         {
@@ -2497,6 +2505,123 @@ impl Orchestrator {
         }
     }
 
+    async fn restore_pipeline_runs_from_journal(&self) {
+        let records = match self.pipeline_journal.latest_live_records().await {
+            Ok(records) => records,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "failed to read pipeline transition journal during startup"
+                );
+                return;
+            }
+        };
+
+        if records.is_empty() {
+            return;
+        }
+
+        let config_snapshot = {
+            let config = self.config.read().await;
+            Arc::new(config.clone())
+        };
+
+        let issue_ids = records
+            .iter()
+            .map(|record| record.issue_id.clone())
+            .collect::<Vec<_>>();
+        let issues = self
+            .tracker
+            .fetch_issue_states_by_ids(&issue_ids)
+            .await
+            .unwrap_or_default();
+        let issues_by_id: HashMap<String, Issue> = issues
+            .into_iter()
+            .map(|issue| (issue.id.clone(), issue))
+            .collect();
+
+        for record in records {
+            if let Err(error) = self
+                .restore_pipeline_run_record(&record, Arc::clone(&config_snapshot), &issues_by_id)
+                .await
+            {
+                warn!(
+                    issue_id = %record.issue_id,
+                    error = %error,
+                    "failed to restore pipeline run from transition journal"
+                );
+            }
+        }
+    }
+
+    async fn restore_pipeline_run_record(
+        &self,
+        record: &PipelineTransitionRecord,
+        config_snapshot: Arc<EnsembleConfig>,
+        issues_by_id: &HashMap<String, Issue>,
+    ) -> Result<(), EnsembleError> {
+        let snapshot = record
+            .snapshot
+            .clone()
+            .ok_or_else(|| AgentError::PromptError {
+                reason: format!(
+                    "pipeline journal record {} for issue '{}' has no snapshot",
+                    record.seq, record.issue_id
+                ),
+            })?;
+
+        validate_restored_snapshot_against_config(&snapshot, &config_snapshot)?;
+        let mut run = PipelineRun::from_snapshot(snapshot)?;
+        run.normalize_stale_running_steps();
+
+        let mut state = self.state.write().await;
+        if state.get_pipeline_run(&record.issue_id).is_some() || state.is_running(&record.issue_id)
+        {
+            return Ok(());
+        }
+
+        state.insert_pipeline_run(&record.issue_id, run, Arc::clone(&config_snapshot));
+        state.add_claimed(&record.issue_id);
+        if let Some(run_id) = record.run_id.clone() {
+            state.issue_run_ids.insert(record.issue_id.clone(), run_id);
+        }
+
+        if let Some(retry) = record.retry.clone() {
+            state.add_retry(retry);
+        }
+
+        if record.kind == PipelineTransitionKind::PipelineHalted {
+            let step_name = record.step.clone().unwrap_or_default();
+            let agent_name = state
+                .get_pipeline_run(&record.issue_id)
+                .and_then(|run| run.step(&step_name))
+                .map(|step| step.agent.clone())
+                .unwrap_or_default();
+            state.add_waiting_on_human(WaitingOnHumanEntry {
+                issue_id: record.issue_id.clone(),
+                identifier: record.identifier.clone(),
+                interaction_request_id: format!("halted:{}:{step_name}", record.issue_id),
+                step_name,
+                kind: InteractionKind::Handoff,
+                prompt: record
+                    .reason
+                    .clone()
+                    .unwrap_or_else(|| "pipeline halted".to_string()),
+                agent_name,
+                retry_attempt: Some(record.cycle.max(1)),
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: record.written_at,
+                run_id: record.run_id.clone(),
+                issue: issues_by_id.get(&record.issue_id).cloned(),
+            });
+        }
+
+        Ok(())
+    }
+
     async fn cancel_open_interaction(&self, interaction_request_id: Option<String>) {
         let Some(interaction_request_id) = interaction_request_id else {
             return;
@@ -4079,6 +4204,46 @@ fn interaction_kind_name(kind: &InteractionKind) -> &'static str {
     }
 }
 
+fn validate_restored_snapshot_against_config(
+    snapshot: &PipelineRunSnapshot,
+    config: &EnsembleConfig,
+) -> Result<(), EnsembleError> {
+    for persisted_step in &snapshot.dag_steps {
+        if snapshot
+            .synthetic_fixup_steps
+            .contains(&persisted_step.name)
+        {
+            continue;
+        }
+
+        let Some(config_step) = config
+            .steps
+            .iter()
+            .find(|candidate| candidate.name == persisted_step.name)
+        else {
+            return Err(AgentError::PromptError {
+                reason: format!(
+                    "persisted pipeline step '{}' no longer exists in config",
+                    persisted_step.name
+                ),
+            }
+            .into());
+        };
+
+        if config_step.agent != persisted_step.agent || config_step.kind != persisted_step.kind {
+            return Err(AgentError::PromptError {
+                reason: format!(
+                    "persisted pipeline step '{}' no longer matches config",
+                    persisted_step.name
+                ),
+            }
+            .into());
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4091,7 +4256,10 @@ mod tests {
         InteractionKind, InteractionResponse, InteractionResumeStrategy, InteractionStatus,
         InteractionStore,
     };
+    use crate::orchestrator::pipeline_journal::{PipelineTransitionInput, PipelineTransitionKind};
+    use crate::orchestrator::retry::current_time_ms;
     use crate::pipeline::verdict::{StepOutput, StepResult};
+    use crate::tracker::model::RetryEntry;
     use crate::tracker::TrackerError;
     use async_trait::async_trait;
 
@@ -4485,6 +4653,149 @@ agent:
   stall_timeout_ms: 300000
 "#;
         parse_config(yaml).unwrap()
+    }
+
+    #[tokio::test]
+    async fn restore_pipeline_runs_from_journal_restores_halted_pipeline() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_retry_step_config();
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let workspace_root = temp.path().join("workspaces");
+        let workspace_mgr = WorkspaceManager::new(&workspace_root, None).unwrap();
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr,
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.step_failed("build", "manual halt".to_string());
+        orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::PipelineHalted,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("manual halt".to_string()),
+                retry: None,
+                snapshot: Some(run.to_snapshot()),
+            })
+            .await
+            .unwrap();
+
+        orchestrator.restore_pipeline_runs_from_journal().await;
+
+        let lock = state.read().await;
+        assert!(lock.get_pipeline_run(&issue.id).is_some());
+        assert!(lock.is_claimed(&issue.id));
+        assert!(lock.is_waiting_on_human(&issue.id));
+    }
+
+    #[tokio::test]
+    async fn restore_pipeline_runs_from_journal_restores_step_retry_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_retry_step_config();
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.retry_from_step("build");
+        let retry = RetryEntry {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            attempt: 2,
+            due_at_ms: current_time_ms().saturating_sub(1),
+            error: Some("retry".to_string()),
+            retry_from_step: Some("build".to_string()),
+            with_fixup: false,
+        };
+        orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepRetryScheduled,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("retry".to_string()),
+                retry: Some(retry),
+                snapshot: Some(run.to_snapshot()),
+            })
+            .await
+            .unwrap();
+
+        orchestrator.restore_pipeline_runs_from_journal().await;
+
+        let lock = state.read().await;
+        assert!(lock.get_pipeline_run(&issue.id).is_some());
+        assert!(lock.retry_attempts.contains_key(&issue.id));
+        assert_eq!(
+            lock.retry_attempts
+                .get(&issue.id)
+                .and_then(|entry| entry.retry_from_step.as_deref()),
+            Some("build")
+        );
     }
 
     fn make_fixup_config() -> EnsembleConfig {

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -5015,6 +5015,103 @@ agent:
     }
 
     #[tokio::test]
+    async fn hydrate_waiting_interaction_keeps_restored_pipeline_run() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_config();
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        let interaction = crate::interaction::model::InteractionRequest {
+            id: "interaction-1".to_string(),
+            schema_version: 1,
+            issue_id: issue.id.clone(),
+            issue_identifier: issue.identifier.clone(),
+            pipeline_cycle: 1,
+            completed_steps: vec![],
+            step_name: "build".to_string(),
+            agent_name: "builder".to_string(),
+            step_depends: vec![],
+            step_tracker_state: None,
+            kind: InteractionKind::Question,
+            status: InteractionStatus::Open,
+            blocking: true,
+            awaiting_resume: true,
+            resume_strategy: InteractionResumeStrategy::RerunStep,
+            title: "Need input".to_string(),
+            body: "Need input".to_string(),
+            options: vec![],
+            artifacts: vec![],
+            thread_root_comment_id: None,
+            thread_root_comment_url: None,
+            last_processed_comment_id: None,
+            accepted_command: None,
+            ignored_commands: vec![],
+            response: None,
+            waiting_started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: Utc::now(),
+            resolved_at: None,
+        };
+        orchestrator
+            .interaction_store
+            .create(interaction)
+            .await
+            .unwrap();
+
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.step_blocked_on_human("build", "interaction-1".to_string());
+        {
+            let mut lock = state.write().await;
+            lock.insert_pipeline_run(&issue.id, run, Arc::new(cfg.clone()));
+            lock.add_claimed(&issue.id);
+        }
+
+        orchestrator.hydrate_waiting_on_human_from_store().await;
+
+        let lock = state.read().await;
+        let run = lock.get_pipeline_run(&issue.id).unwrap();
+        assert!(matches!(
+            run.step_states.get("build"),
+            Some(StepState::BlockedOnHuman { interaction_request_id })
+                if interaction_request_id == "interaction-1"
+        ));
+        assert!(lock.is_waiting_on_human(&issue.id));
+    }
+
+    #[tokio::test]
     async fn dispatch_issue_writes_run_started_and_step_running_transitions() {
         let temp = tempfile::tempdir().unwrap();
         let issues = Arc::new(RwLock::new(vec![test_issue("1", "Todo")]));

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -5313,7 +5313,7 @@ agent:
             cfg.polling.interval_ms,
             &cfg.concurrency,
         )));
-        let mut orchestrator = Orchestrator::new_with_state(
+        let orchestrator = Orchestrator::new_with_state(
             OrchestratorRuntimeParts {
                 state,
                 config,

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -44,7 +44,7 @@ use crate::observability::events_contract::{
     TRACKER_TRANSITION_SUCCEEDED,
 };
 use crate::orchestrator::pipeline_journal::{
-    PipelineRunJournal, PipelineTransitionKind, PipelineTransitionRecord,
+    PipelineRunJournal, PipelineTransitionInput, PipelineTransitionKind, PipelineTransitionRecord,
 };
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{
@@ -53,7 +53,7 @@ use crate::pipeline::engine::{
 };
 use crate::pipeline::verdict::{resolve_verdict_with_source, StepResult, VerdictSource};
 use crate::timeline::persistence::TimelinePersistence;
-use crate::tracker::model::Issue;
+use crate::tracker::model::{Issue, RetryEntry};
 use crate::tracker::IssueTracker;
 use crate::workspace::finalize::FinalizeMode;
 use crate::workspace::manager::WorkspaceManager;
@@ -579,7 +579,16 @@ impl Orchestrator {
                 )
             };
 
-            if eligible.is_none() {
+            let restored_pipeline_ready = {
+                let state = self.state.read().await;
+                state.get_pipeline_run(&issue.id).is_some()
+                    && state.is_claimed(&issue.id)
+                    && !state.is_running(&issue.id)
+                    && !state.is_waiting_on_human(&issue.id)
+                    && !state.retry_attempts.contains_key(&issue.id)
+            };
+
+            if eligible.is_none() || restored_pipeline_ready {
                 self.dispatch_issue(issue, None).await;
             }
         }
@@ -730,10 +739,22 @@ impl Orchestrator {
             "dispatching issue with pipeline"
         );
 
-        {
+        let run_started_transition = {
             let mut state = self.state.write().await;
             state.add_running(issue, attempt);
             state.insert_pipeline_run(&issue.id, pipeline_run, Arc::clone(&config_snapshot));
+            Self::transition_input_for_run(
+                &state,
+                &issue.id,
+                &issue.identifier,
+                PipelineTransitionKind::RunStarted,
+                None,
+                None,
+                None,
+            )
+        };
+        if let Some(input) = run_started_transition {
+            self.append_pipeline_transition(input).await;
         }
 
         // Process initial dispatch requests
@@ -881,7 +902,7 @@ impl Orchestrator {
         }
 
         // Mark step as running in pipeline
-        let (run_id, sequence, attempt_num) = {
+        let (run_id, sequence, attempt_num, step_running_transition) = {
             let mut state = self.state.write().await;
             let run_context = Self::run_context_for_issue(&mut state, &issue.id);
             {
@@ -895,8 +916,21 @@ impl Orchestrator {
                     );
                 }
             }
-            run_context
+            let transition = Self::transition_input_for_run(
+                &state,
+                &issue.id,
+                &issue.identifier,
+                PipelineTransitionKind::StepRunning,
+                Some(dispatch.step_name.to_string()),
+                None,
+                None,
+            );
+            (run_context.0, run_context.1, run_context.2, transition)
         };
+
+        if let Some(input) = step_running_transition {
+            self.append_pipeline_transition(input).await;
+        }
 
         self.publish_pipeline_event(
             run_id,
@@ -1154,6 +1188,18 @@ impl Orchestrator {
                 };
 
                 if let Some((action, config_snapshot)) = pipeline_action {
+                    let step_transition = Self::transition_input_for_run(
+                        &state,
+                        issue_id,
+                        issue_snapshot
+                            .as_ref()
+                            .map(|issue| issue.identifier.as_str())
+                            .unwrap_or(issue_id),
+                        Self::transition_kind_for_action(&action),
+                        Some(step_name.to_string()),
+                        Some(verdict_value.to_string()),
+                        None,
+                    );
                     match action {
                         PipelineAction::Dispatch(requests) => {
                             // Collect output contexts while state lock is still held
@@ -1174,6 +1220,9 @@ impl Orchestrator {
                             };
                             // Need to drop state lock before dispatching
                             drop(state);
+                            if let Some(input) = step_transition {
+                                self.append_pipeline_transition(input).await;
+                            }
                             if let Some(ref issue) = issue_snapshot {
                                 let Some(config_snapshot) = config_snapshot else {
                                     warn!(issue_id = %issue_id, "no config snapshot found for pipeline dispatch");
@@ -1301,7 +1350,22 @@ impl Orchestrator {
                                 let history_run_id = running_entry
                                     .as_ref()
                                     .and_then(|entry| entry.run_id.clone());
+                                let release_identifier = running_entry
+                                    .as_ref()
+                                    .map(|entry| entry.identifier.clone())
+                                    .unwrap_or_else(|| issue_identifier.clone());
+                                let release_run_id = history_run_id.clone();
                                 drop(state);
+                                if let Some(input) = step_transition {
+                                    self.append_pipeline_transition(input).await;
+                                }
+                                self.append_pipeline_release(
+                                    issue_id,
+                                    &release_identifier,
+                                    release_run_id,
+                                    "completed",
+                                )
+                                .await;
                                 if let Some(record) = history_record {
                                     self.append_history_record(history_run_id.as_deref(), record)
                                         .await;
@@ -1588,6 +1652,9 @@ impl Orchestrator {
                             approval_state,
                         } => {
                             drop(state);
+                            if let Some(input) = step_transition {
+                                self.append_pipeline_transition(input).await;
+                            }
                             if let Err(error) = self
                                 .handle_post_step_approval(
                                     issue_id,
@@ -1641,6 +1708,10 @@ impl Orchestrator {
                             }
 
                             debug!(issue_id = %issue_id, "pipeline waiting for other steps");
+                            drop(state);
+                            if let Some(input) = step_transition {
+                                self.append_pipeline_transition(input).await;
+                            }
                         }
                     }
                 }
@@ -2620,6 +2691,82 @@ impl Orchestrator {
         }
 
         Ok(())
+    }
+
+    async fn append_pipeline_transition(&self, input: PipelineTransitionInput) {
+        if let Err(error) = self.pipeline_journal.append(input).await {
+            warn!(
+                error = %error,
+                "failed to append pipeline transition journal record"
+            );
+        }
+    }
+
+    async fn append_pipeline_release(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+        run_id: Option<String>,
+        reason: &str,
+    ) {
+        if let Err(error) = self
+            .pipeline_journal
+            .append_released(issue_id, identifier, run_id, reason)
+            .await
+        {
+            warn!(
+                issue_id = %issue_id,
+                error = %error,
+                "failed to append pipeline release journal record"
+            );
+        }
+    }
+
+    fn transition_input_for_run(
+        state: &OrchestratorState,
+        issue_id: &str,
+        identifier: &str,
+        kind: PipelineTransitionKind,
+        step: Option<String>,
+        reason: Option<String>,
+        retry: Option<RetryEntry>,
+    ) -> Option<PipelineTransitionInput> {
+        let run = state.get_pipeline_run(issue_id)?;
+        let run_id = state
+            .running
+            .get(issue_id)
+            .and_then(|entry| entry.run_id.clone())
+            .or_else(|| {
+                state
+                    .waiting_on_human
+                    .get(issue_id)
+                    .and_then(|entry| entry.run_id.clone())
+            })
+            .or_else(|| state.issue_run_ids.get(issue_id).cloned());
+
+        Some(PipelineTransitionInput {
+            kind,
+            issue_id: issue_id.to_string(),
+            identifier: identifier.to_string(),
+            run_id,
+            cycle: run.cycle,
+            step,
+            reason,
+            retry,
+            snapshot: Some(run.to_snapshot()),
+        })
+    }
+
+    fn transition_kind_for_action(action: &PipelineAction) -> PipelineTransitionKind {
+        match action {
+            PipelineAction::Dispatch(_) | PipelineAction::Succeeded => {
+                PipelineTransitionKind::StepCompleted
+            }
+            PipelineAction::Failed { .. } => PipelineTransitionKind::StepFailed,
+            PipelineAction::BlockedOnHuman { .. } => PipelineTransitionKind::StepBlockedOnHuman,
+            PipelineAction::AwaitingApproval { .. } => PipelineTransitionKind::StepAwaitingApproval,
+            PipelineAction::Waiting => PipelineTransitionKind::StepCompleted,
+        }
     }
 
     async fn cancel_open_interaction(&self, interaction_request_id: Option<String>) {
@@ -4796,6 +4943,125 @@ agent:
                 .and_then(|entry| entry.retry_from_step.as_deref()),
             Some("build")
         );
+    }
+
+    #[tokio::test]
+    async fn restored_live_pipeline_run_dispatches_on_next_tick() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_config();
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        let dag = build_dag(&cfg.steps).unwrap();
+        let run = PipelineRun::new(issue.id.clone(), 1, dag);
+        orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::RunStarted,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: None,
+                reason: None,
+                retry: None,
+                snapshot: Some(run.to_snapshot()),
+            })
+            .await
+            .unwrap();
+
+        orchestrator.restore_pipeline_runs_from_journal().await;
+        assert!(state.read().await.is_claimed(&issue.id));
+
+        orchestrator.handle_tick().await;
+
+        let lock = state.read().await;
+        assert!(lock.is_running(&issue.id));
+        assert!(matches!(
+            lock.get_pipeline_run(&issue.id)
+                .and_then(|run| run.step_states.get("build")),
+            Some(StepState::Running { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispatch_issue_writes_run_started_and_step_running_transitions() {
+        let temp = tempfile::tempdir().unwrap();
+        let issues = Arc::new(RwLock::new(vec![test_issue("1", "Todo")]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let cfg = make_config();
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let mut orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state,
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        orchestrator.handle_tick().await;
+
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        assert!(records
+            .iter()
+            .any(|record| record.kind == PipelineTransitionKind::RunStarted));
+        assert!(records
+            .iter()
+            .any(|record| record.kind == PipelineTransitionKind::StepRunning));
     }
 
     fn make_fixup_config() -> EnsembleConfig {

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -640,70 +640,158 @@ impl Orchestrator {
                     "resuming with existing pipeline"
                 );
 
-                if let PipelineAction::Dispatch(requests) = action {
-                    for req in requests {
-                        let workspace_path =
-                            match self.prepare_step_workspace(issue, &config_snapshot).await {
-                                Ok(path) => path,
-                                Err(error) => {
-                                    warn!(
-                                        issue_id = %issue.id,
-                                        step = %req.step_name,
-                                        error = %error,
-                                        "failed to prepare step workspace"
-                                    );
-                                    let mut state = self.state.write().await;
-                                    if let Some(run) = state.get_pipeline_run_mut(&issue.id) {
-                                        run.step_failed(&req.step_name, error.to_string());
-                                    }
-                                    if let Some(entry) = state.remove_running(&issue.id) {
-                                        state.add_runtime_seconds(&entry);
-                                        schedule_failure_retry(
-                                            &mut state,
-                                            FailureRetryRequest {
-                                                issue_id: &issue.id,
-                                                identifier: &entry.identifier,
-                                                attempt: next_attempt(entry.retry_attempt),
-                                                max_backoff_ms: config_snapshot
-                                                    .agent
-                                                    .max_retry_backoff_ms,
-                                                max_cycles: config_snapshot.max_cycles,
-                                                error: &error.to_string(),
-                                                retry_from_step: None,
-                                                with_fixup: false,
-                                            },
-                                        );
-                                    }
-                                    state.remove_pipeline_run(&issue.id);
-                                    return;
-                                }
-                            };
+                match action {
+                    PipelineAction::Succeeded => {
+                        info!(
+                            issue_id = %issue.id,
+                            "restored pipeline already succeeded"
+                        );
+                        let finalize_state = self
+                            .run_finalize_phase(&issue.identifier, &config_snapshot)
+                            .await;
+                        let completed_at = Utc::now();
+                        let (history_record, history_run_id, release_run_id, should_release) = {
+                            let mut state = self.state.write().await;
+                            let history_record = state
+                                .running
+                                .get(&issue.id)
+                                .zip(state.get_pipeline_run(&issue.id))
+                                .map(|(entry, run)| {
+                                    self.build_history_record(
+                                        &issue.id,
+                                        HISTORY_OUTCOME_SUCCEEDED,
+                                        None,
+                                        entry,
+                                        run,
+                                        completed_at,
+                                    )
+                                });
+                            let running_entry = state.get_running(&issue.id).cloned();
+                            let history_run_id = running_entry
+                                .as_ref()
+                                .and_then(|entry| entry.run_id.clone());
+                            let release_run_id = history_run_id.clone();
 
-                        let step_outputs = {
-                            let state = self.state.read().await;
-                            state
-                                .get_pipeline_run(&issue.id)
-                                .and_then(|run| run.output_context_for(&req.step_name))
-                                .unwrap_or_default()
+                            if finalize_state.status == FinalizeStatus::Succeeded
+                                || finalize_state.status == FinalizeStatus::NotRequired
+                            {
+                                state.add_completed(
+                                    issue.id.clone(),
+                                    issue.identifier.clone(),
+                                    "completed_succeeded".to_string(),
+                                );
+                                if let Some(entry) = state.remove_running(&issue.id) {
+                                    state.add_runtime_seconds(&entry);
+                                }
+                                state.release_claim(&issue.id);
+                                state.remove_pipeline_run(&issue.id);
+                                state.clear_finalize_state(&issue.id);
+                                (history_record, history_run_id, release_run_id, true)
+                            } else {
+                                state.set_finalize_state(&issue.id, finalize_state);
+                                state.remove_pipeline_run(&issue.id);
+                                (history_record, history_run_id, release_run_id, false)
+                            }
                         };
 
-                        let _ = self
-                            .dispatch_step(
-                                issue,
-                                Arc::clone(&config_snapshot),
-                                StepDispatchContext {
-                                    step_name: &req.step_name,
-                                    agent_name: &req.agent_name,
-                                    step_kind: req.step_kind,
-                                    tracker_state: req.tracker_state.as_deref(),
-                                    attempt,
-                                    interaction_response: None,
-                                    workspace_path,
-                                    step_outputs,
-                                },
+                        if should_release && self.tracker.supports_writes() {
+                            if let Err(error) = self
+                                .tracker
+                                .set_issue_state(&issue.id, &config_snapshot.on_success)
+                                .await
+                            {
+                                warn!(
+                                    issue_id = %issue.id,
+                                    error = %error,
+                                    "failed to set tracker success state for restored pipeline"
+                                );
+                            }
+                        }
+
+                        if should_release {
+                            self.append_pipeline_release(
+                                &issue.id,
+                                &issue.identifier,
+                                release_run_id,
+                                "completed",
                             )
                             .await;
+                        }
+
+                        if let Some(record) = history_record {
+                            self.append_history_record(history_run_id.as_deref(), record)
+                                .await;
+                        }
                     }
+                    PipelineAction::Dispatch(requests) => {
+                        for req in requests {
+                            let workspace_path =
+                                match self.prepare_step_workspace(issue, &config_snapshot).await {
+                                    Ok(path) => path,
+                                    Err(error) => {
+                                        warn!(
+                                            issue_id = %issue.id,
+                                            step = %req.step_name,
+                                            error = %error,
+                                            "failed to prepare step workspace"
+                                        );
+                                        let mut state = self.state.write().await;
+                                        if let Some(run) = state.get_pipeline_run_mut(&issue.id) {
+                                            run.step_failed(&req.step_name, error.to_string());
+                                        }
+                                        if let Some(entry) = state.remove_running(&issue.id) {
+                                            state.add_runtime_seconds(&entry);
+                                            schedule_failure_retry(
+                                                &mut state,
+                                                FailureRetryRequest {
+                                                    issue_id: &issue.id,
+                                                    identifier: &entry.identifier,
+                                                    attempt: next_attempt(entry.retry_attempt),
+                                                    max_backoff_ms: config_snapshot
+                                                        .agent
+                                                        .max_retry_backoff_ms,
+                                                    max_cycles: config_snapshot.max_cycles,
+                                                    error: &error.to_string(),
+                                                    retry_from_step: None,
+                                                    with_fixup: false,
+                                                },
+                                            );
+                                        }
+                                        state.remove_pipeline_run(&issue.id);
+                                        return;
+                                    }
+                                };
+
+                            let step_outputs = {
+                                let state = self.state.read().await;
+                                state
+                                    .get_pipeline_run(&issue.id)
+                                    .and_then(|run| run.output_context_for(&req.step_name))
+                                    .unwrap_or_default()
+                            };
+
+                            let _ = self
+                                .dispatch_step(
+                                    issue,
+                                    Arc::clone(&config_snapshot),
+                                    StepDispatchContext {
+                                        step_name: &req.step_name,
+                                        agent_name: &req.agent_name,
+                                        step_kind: req.step_kind,
+                                        tracker_state: req.tracker_state.as_deref(),
+                                        attempt,
+                                        interaction_response: None,
+                                        workspace_path,
+                                        step_outputs,
+                                    },
+                                )
+                                .await;
+                        }
+                    }
+                    PipelineAction::Waiting
+                    | PipelineAction::Failed { .. }
+                    | PipelineAction::BlockedOnHuman { .. }
+                    | PipelineAction::AwaitingApproval { .. } => {}
                 }
 
                 info!(
@@ -1402,6 +1490,10 @@ impl Orchestrator {
                             let mut completed_identifier = None;
                             let mut rejection_comment = None;
                             let mut history_run_id = None;
+                            let mut post_failure_transitions = Vec::new();
+                            if let Some(input) = step_transition {
+                                post_failure_transitions.push(input);
+                            }
                             let runtime_step = state
                                 .get_pipeline_run(issue_id)
                                 .and_then(|run| run.step(&step))
@@ -1421,12 +1513,13 @@ impl Orchestrator {
                                         state.add_runtime_seconds(&entry);
                                         completed_identifier = Some(entry.identifier.clone());
                                         history_run_id = entry.run_id.clone();
+                                        let attempt = next_attempt(entry.retry_attempt);
                                         let retry_scheduled = schedule_failure_retry(
                                             &mut state,
                                             FailureRetryRequest {
                                                 issue_id,
                                                 identifier: &entry.identifier,
-                                                attempt: next_attempt(entry.retry_attempt),
+                                                attempt,
                                                 max_backoff_ms: config.agent.max_retry_backoff_ms,
                                                 max_cycles: config.max_cycles,
                                                 error: &reason,
@@ -1463,6 +1556,37 @@ impl Orchestrator {
                                                 warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
                                             }
                                         }
+                                        if let Some(due_at_ms) = retry_scheduled {
+                                            if let Some(input) = Self::transition_input_for_run(
+                                                &state,
+                                                issue_id,
+                                                &entry.identifier,
+                                                PipelineTransitionKind::StepRetryScheduled,
+                                                Some(step.clone()),
+                                                Some(reason.clone()),
+                                                Some(RetryEntry {
+                                                    issue_id: issue_id.to_string(),
+                                                    identifier: entry.identifier.clone(),
+                                                    attempt,
+                                                    due_at_ms,
+                                                    error: Some(reason.clone()),
+                                                    retry_from_step: Some(step.clone()),
+                                                    with_fixup: false,
+                                                }),
+                                            ) {
+                                                post_failure_transitions.push(input);
+                                            }
+                                        } else if let Some(input) = Self::transition_input_for_run(
+                                            &state,
+                                            issue_id,
+                                            &entry.identifier,
+                                            PipelineTransitionKind::PipelineFailed,
+                                            Some(step.clone()),
+                                            Some(reason.clone()),
+                                            None,
+                                        ) {
+                                            post_failure_transitions.push(input);
+                                        }
                                     }
                                 }
                                 OnFailure::Fixup => {
@@ -1492,12 +1616,13 @@ impl Orchestrator {
                                         state.add_runtime_seconds(&entry);
                                         completed_identifier = Some(entry.identifier.clone());
                                         history_run_id = entry.run_id.clone();
+                                        let attempt = next_attempt(entry.retry_attempt);
                                         let retry_scheduled = schedule_failure_retry(
                                             &mut state,
                                             FailureRetryRequest {
                                                 issue_id,
                                                 identifier: &entry.identifier,
-                                                attempt: next_attempt(entry.retry_attempt),
+                                                attempt,
                                                 max_backoff_ms: config.agent.max_retry_backoff_ms,
                                                 max_cycles: config.max_cycles,
                                                 error: &reason,
@@ -1534,6 +1659,37 @@ impl Orchestrator {
                                                 warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
                                             }
                                         }
+                                        if let Some(due_at_ms) = retry_scheduled {
+                                            if let Some(input) = Self::transition_input_for_run(
+                                                &state,
+                                                issue_id,
+                                                &entry.identifier,
+                                                PipelineTransitionKind::FixupRetryScheduled,
+                                                Some(step.clone()),
+                                                Some(reason.clone()),
+                                                Some(RetryEntry {
+                                                    issue_id: issue_id.to_string(),
+                                                    identifier: entry.identifier.clone(),
+                                                    attempt,
+                                                    due_at_ms,
+                                                    error: Some(reason.clone()),
+                                                    retry_from_step: Some(step.clone()),
+                                                    with_fixup: true,
+                                                }),
+                                            ) {
+                                                post_failure_transitions.push(input);
+                                            }
+                                        } else if let Some(input) = Self::transition_input_for_run(
+                                            &state,
+                                            issue_id,
+                                            &entry.identifier,
+                                            PipelineTransitionKind::PipelineFailed,
+                                            Some(step.clone()),
+                                            Some(reason.clone()),
+                                            None,
+                                        ) {
+                                            post_failure_transitions.push(input);
+                                        }
                                     }
                                 }
                                 OnFailure::Halt => {
@@ -1569,6 +1725,17 @@ impl Orchestrator {
                                             run_id: entry.run_id.clone(),
                                             issue: Some(entry.issue.clone()),
                                         });
+                                        if let Some(input) = Self::transition_input_for_run(
+                                            &state,
+                                            issue_id,
+                                            &entry.identifier,
+                                            PipelineTransitionKind::PipelineHalted,
+                                            Some(step.clone()),
+                                            Some(reason.clone()),
+                                            None,
+                                        ) {
+                                            post_failure_transitions.push(input);
+                                        }
                                     }
                                 }
                                 OnFailure::RetryIssue => {
@@ -1576,12 +1743,13 @@ impl Orchestrator {
                                         state.add_runtime_seconds(&entry);
                                         completed_identifier = Some(entry.identifier.clone());
                                         history_run_id = entry.run_id.clone();
+                                        let attempt = next_attempt(entry.retry_attempt);
                                         let retry_scheduled = schedule_failure_retry(
                                             &mut state,
                                             FailureRetryRequest {
                                                 issue_id,
                                                 identifier: &entry.identifier,
-                                                attempt: next_attempt(entry.retry_attempt),
+                                                attempt,
                                                 max_backoff_ms: config.agent.max_retry_backoff_ms,
                                                 max_cycles: config.max_cycles,
                                                 error: &reason,
@@ -1618,6 +1786,19 @@ impl Orchestrator {
                                                 warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
                                             }
                                         }
+                                        if final_failure {
+                                            if let Some(input) = Self::transition_input_for_run(
+                                                &state,
+                                                issue_id,
+                                                &entry.identifier,
+                                                PipelineTransitionKind::PipelineFailed,
+                                                Some(step.clone()),
+                                                Some(reason.clone()),
+                                                None,
+                                            ) {
+                                                post_failure_transitions.push(input);
+                                            }
+                                        }
                                     }
                                     state.remove_pipeline_run(issue_id);
                                 }
@@ -1633,6 +1814,9 @@ impl Orchestrator {
                             }
 
                             drop(state);
+                            for input in post_failure_transitions {
+                                self.append_pipeline_transition(input).await;
+                            }
                             if final_failure {
                                 if let Some((step_name, summary)) = rejection_comment {
                                     self.post_rejection_summary_comment(
@@ -5161,6 +5345,159 @@ agent:
             .any(|record| record.kind == PipelineTransitionKind::StepRunning));
     }
 
+    #[tokio::test]
+    async fn failed_step_retry_writes_retry_transition_as_latest_record() {
+        let config = Arc::new(RwLock::new(make_retry_step_config()));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    runtime_verdict: Some(serde_json::json!({
+                        "result": "failed",
+                        "summary": "tests failed"
+                    })),
+                    approval_request: None,
+                },
+            )
+            .await;
+
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        let latest = records.last().expect("journal record");
+        assert_eq!(latest.kind, PipelineTransitionKind::StepRetryScheduled);
+        assert_eq!(
+            latest
+                .retry
+                .as_ref()
+                .and_then(|retry| retry.retry_from_step.as_deref()),
+            Some("build")
+        );
+        assert!(matches!(
+            latest
+                .snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.step_states.get("build")),
+            Some(StepState::Pending)
+        ));
+    }
+
+    #[tokio::test]
+    async fn restored_all_passed_pipeline_completes_on_next_tick() {
+        let temp = tempfile::tempdir().unwrap();
+        let issue = test_issue("1", "Todo");
+        let issues = Arc::new(RwLock::new(vec![issue.clone()]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let cfg = make_config();
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.step_completed(
+            "build",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: None,
+            },
+            false,
+        );
+        orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepCompleted,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("succeeded".to_string()),
+                retry: None,
+                snapshot: Some(run.to_snapshot()),
+            })
+            .await
+            .unwrap();
+
+        orchestrator.restore_pipeline_runs_from_journal().await;
+        orchestrator.handle_tick().await;
+
+        let lock = state.read().await;
+        assert!(
+            lock.completed.contains_key(&issue.id),
+            "restored all-passed pipeline should complete"
+        );
+        assert!(
+            lock.get_pipeline_run(&issue.id).is_none(),
+            "completed restored pipeline should be released"
+        );
+        assert!(
+            !lock.is_running(&issue.id),
+            "completed restored pipeline should not remain running"
+        );
+    }
+
     fn make_fixup_config() -> EnsembleConfig {
         let yaml = r#"
 tracker:
@@ -5749,6 +6086,17 @@ agent:
         assert_eq!(waiting.step_name, "build");
         assert_eq!(waiting.prompt, "needs manual repair");
         assert!(matches!(waiting.kind, InteractionKind::Handoff));
+        drop(state);
+
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        assert_eq!(
+            records.last().map(|record| record.kind),
+            Some(PipelineTransitionKind::PipelineHalted)
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -1,0 +1,431 @@
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tracing::warn;
+
+use crate::pipeline::engine::PipelineRunSnapshot;
+use crate::tracker::model::RetryEntry;
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PipelineTransitionKind {
+    RunStarted,
+    StepRunning,
+    StepCompleted,
+    StepFailed,
+    StepBlockedOnHuman,
+    StepAwaitingApproval,
+    ApprovalResolved,
+    StepRetryScheduled,
+    FixupRetryScheduled,
+    PipelineHalted,
+    PipelineSucceeded,
+    PipelineFailed,
+    Released,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineTransitionRecord {
+    pub schema_version: u32,
+    pub seq: u64,
+    pub kind: PipelineTransitionKind,
+    pub issue_id: String,
+    pub identifier: String,
+    pub run_id: Option<String>,
+    pub cycle: u32,
+    pub step: Option<String>,
+    pub reason: Option<String>,
+    pub retry: Option<RetryEntry>,
+    pub snapshot: Option<PipelineRunSnapshot>,
+    pub written_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PipelineTransitionInput {
+    pub kind: PipelineTransitionKind,
+    pub issue_id: String,
+    pub identifier: String,
+    pub run_id: Option<String>,
+    pub cycle: u32,
+    pub step: Option<String>,
+    pub reason: Option<String>,
+    pub retry: Option<RetryEntry>,
+    pub snapshot: Option<PipelineRunSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PipelineRunJournal {
+    root: PathBuf,
+}
+
+impl PipelineRunJournal {
+    pub fn new(config_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            root: config_dir.into().join("state").join("pipeline-runs"),
+        }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn path_for_issue(&self, issue_id: &str) -> PathBuf {
+        self.root
+            .join(format!("{}.jsonl", encode_issue_id(issue_id)))
+    }
+
+    pub async fn append(
+        &self,
+        input: PipelineTransitionInput,
+    ) -> Result<PipelineTransitionRecord, std::io::Error> {
+        tokio::fs::create_dir_all(&self.root).await?;
+        let path = self.path_for_issue(&input.issue_id);
+        let seq = self
+            .read_last_valid_record(&path)
+            .await?
+            .map(|record| record.seq + 1)
+            .unwrap_or(1);
+
+        let record = PipelineTransitionRecord {
+            schema_version: SCHEMA_VERSION,
+            seq,
+            kind: input.kind,
+            issue_id: input.issue_id,
+            identifier: input.identifier,
+            run_id: input.run_id,
+            cycle: input.cycle,
+            step: input.step,
+            reason: input.reason,
+            retry: input.retry,
+            snapshot: input.snapshot,
+            written_at: Utc::now(),
+        };
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        let line =
+            serde_json::to_string(&record).map_err(|error| invalid_data(error.to_string()))?;
+        file.write_all(line.as_bytes()).await?;
+        file.write_all(b"\n").await?;
+        file.flush().await?;
+        Ok(record)
+    }
+
+    pub async fn append_released(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+        run_id: Option<String>,
+        reason: &str,
+    ) -> Result<PipelineTransitionRecord, std::io::Error> {
+        self.append(PipelineTransitionInput {
+            kind: PipelineTransitionKind::Released,
+            issue_id: issue_id.to_string(),
+            identifier: identifier.to_string(),
+            run_id,
+            cycle: 0,
+            step: None,
+            reason: Some(reason.to_string()),
+            retry: None,
+            snapshot: None,
+        })
+        .await
+    }
+
+    pub async fn read_records_for_issue(
+        &self,
+        issue_id: &str,
+    ) -> Result<Vec<PipelineTransitionRecord>, std::io::Error> {
+        self.read_records_from_path(&self.path_for_issue(issue_id))
+            .await
+    }
+
+    pub async fn latest_live_records(
+        &self,
+    ) -> Result<Vec<PipelineTransitionRecord>, std::io::Error> {
+        let mut records = Vec::new();
+        let mut entries = match tokio::fs::read_dir(&self.root).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(records),
+            Err(error) => return Err(error),
+        };
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+                continue;
+            }
+            if let Some(record) = self.read_last_valid_record(&path).await? {
+                if record.schema_version == SCHEMA_VERSION
+                    && record.kind != PipelineTransitionKind::Released
+                    && record.snapshot.is_some()
+                {
+                    records.push(record);
+                }
+            }
+        }
+
+        records.sort_by(|left, right| left.issue_id.cmp(&right.issue_id));
+        Ok(records)
+    }
+
+    async fn read_last_valid_record(
+        &self,
+        path: &Path,
+    ) -> Result<Option<PipelineTransitionRecord>, std::io::Error> {
+        let records = self.read_records_from_path(path).await?;
+        Ok(records.into_iter().last())
+    }
+
+    async fn read_records_from_path(
+        &self,
+        path: &Path,
+    ) -> Result<Vec<PipelineTransitionRecord>, std::io::Error> {
+        let file = match tokio::fs::File::open(path).await {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error),
+        };
+
+        let mut records = Vec::new();
+        let mut lines = BufReader::new(file).lines();
+        while let Some(line) = lines.next_line().await? {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<PipelineTransitionRecord>(&line) {
+                Ok(record) if record.schema_version == SCHEMA_VERSION => records.push(record),
+                Ok(record) => {
+                    warn!(
+                        schema_version = record.schema_version,
+                        path = %path.display(),
+                        "skipping unsupported pipeline journal record"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        path = %path.display(),
+                        error = %error,
+                        "skipping malformed pipeline journal line"
+                    );
+                }
+            }
+        }
+        Ok(records)
+    }
+}
+
+fn encode_issue_id(issue_id: &str) -> String {
+    if issue_id.is_empty() {
+        return "%EMPTY".to_string();
+    }
+
+    let mut encoded = String::new();
+    for byte in issue_id.as_bytes() {
+        match *byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-' => {
+                encoded.push(*byte as char);
+            }
+            other => {
+                encoded.push('%');
+                encoded.push_str(&format!("{other:02X}"));
+            }
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+fn decode_issue_id(encoded: &str) -> Result<String, std::io::Error> {
+    if encoded == "%EMPTY" {
+        return Ok(String::new());
+    }
+
+    let mut bytes = Vec::new();
+    let mut chars = encoded.as_bytes().iter().copied().peekable();
+    while let Some(byte) = chars.next() {
+        if byte != b'%' {
+            bytes.push(byte);
+            continue;
+        }
+        let high = chars
+            .next()
+            .ok_or_else(|| invalid_data("truncated percent escape"))?;
+        let low = chars
+            .next()
+            .ok_or_else(|| invalid_data("truncated percent escape"))?;
+        let value = hex_value(high)? * 16 + hex_value(low)?;
+        bytes.push(value);
+    }
+    String::from_utf8(bytes).map_err(|error| invalid_data(error.to_string()))
+}
+
+#[cfg(test)]
+fn hex_value(byte: u8) -> Result<u8, std::io::Error> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(invalid_data("invalid percent escape")),
+    }
+}
+
+fn invalid_data(reason: impl Into<String>) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, reason.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ensemble::{OnFailure, StepConfig, StepKind};
+    use crate::pipeline::dag::build_dag;
+    use crate::pipeline::engine::{PipelineRun, StepState};
+    use tempfile::tempdir;
+    use tokio::io::AsyncWriteExt;
+
+    fn step(name: &str, depends: Option<Vec<String>>) -> StepConfig {
+        StepConfig {
+            name: name.to_string(),
+            kind: StepKind::Agent,
+            agent: "builder".to_string(),
+            depends,
+            tracker_state: None,
+            approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
+        }
+    }
+
+    fn snapshot() -> PipelineRunSnapshot {
+        let dag = build_dag(&[step("build", Some(vec![]))]).unwrap();
+        let mut run = PipelineRun::new("issue/1".to_string(), 1, dag);
+        run.step_states
+            .insert("build".to_string(), StepState::Passed);
+        run.to_snapshot()
+    }
+
+    #[tokio::test]
+    async fn journal_appends_records_with_incrementing_seq() {
+        let dir = tempdir().unwrap();
+        let journal = PipelineRunJournal::new(dir.path());
+
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::RunStarted,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: None,
+                reason: None,
+                retry: None,
+                snapshot: Some(snapshot()),
+            })
+            .await
+            .unwrap();
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepCompleted,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("passed".to_string()),
+                retry: None,
+                snapshot: Some(snapshot()),
+            })
+            .await
+            .unwrap();
+
+        let records = journal.read_records_for_issue("issue/1").await.unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].seq, 1);
+        assert_eq!(records[1].seq, 2);
+        assert_eq!(records[1].kind, PipelineTransitionKind::StepCompleted);
+    }
+
+    #[tokio::test]
+    async fn latest_live_records_skip_released_issues() {
+        let dir = tempdir().unwrap();
+        let journal = PipelineRunJournal::new(dir.path());
+
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::RunStarted,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: None,
+                cycle: 1,
+                step: None,
+                reason: None,
+                retry: None,
+                snapshot: Some(snapshot()),
+            })
+            .await
+            .unwrap();
+        journal
+            .append_released("issue/1", "repo#1", None, "completed")
+            .await
+            .unwrap();
+
+        let live = journal.latest_live_records().await.unwrap();
+        assert!(live.is_empty());
+    }
+
+    #[tokio::test]
+    async fn malformed_trailing_line_does_not_hide_last_valid_record() {
+        let dir = tempdir().unwrap();
+        let journal = PipelineRunJournal::new(dir.path());
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::RunStarted,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: None,
+                cycle: 1,
+                step: None,
+                reason: None,
+                retry: None,
+                snapshot: Some(snapshot()),
+            })
+            .await
+            .unwrap();
+
+        let path = journal.path_for_issue("issue/1");
+        tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .await
+            .unwrap()
+            .write_all(b"{not json}\n")
+            .await
+            .unwrap();
+
+        let live = journal.latest_live_records().await.unwrap();
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].issue_id, "issue/1");
+    }
+
+    #[test]
+    fn issue_id_encoding_is_reversible_and_filename_safe() {
+        let issue_id = "repo/name#42 with spaces";
+        let encoded = encode_issue_id(issue_id);
+        assert!(!encoded.contains('/'));
+        assert!(!encoded.contains(' '));
+        assert_eq!(decode_issue_id(&encoded).unwrap(), issue_id);
+    }
+
+    #[test]
+    fn issue_id_encoding_round_trips_empty_issue_id() {
+        let encoded = encode_issue_id("");
+        assert_eq!(decode_issue_id(&encoded).unwrap(), "");
+    }
+}

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -164,7 +164,7 @@ impl PipelineRunJournal {
             }
             if let Some(record) = self.read_last_valid_record(&path).await? {
                 if record.schema_version == SCHEMA_VERSION
-                    && record.kind != PipelineTransitionKind::Released
+                    && !record.kind.is_terminal()
                     && record.snapshot.is_some()
                 {
                     records.push(record);
@@ -219,6 +219,15 @@ impl PipelineRunJournal {
             }
         }
         Ok(records)
+    }
+}
+
+impl PipelineTransitionKind {
+    fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            PipelineTransitionKind::PipelineFailed | PipelineTransitionKind::Released
+        )
     }
 }
 
@@ -373,6 +382,30 @@ mod tests {
             .unwrap();
         journal
             .append_released("issue/1", "repo#1", None, "completed")
+            .await
+            .unwrap();
+
+        let live = journal.latest_live_records().await.unwrap();
+        assert!(live.is_empty());
+    }
+
+    #[tokio::test]
+    async fn latest_live_records_skip_terminal_failed_issues() {
+        let dir = tempdir().unwrap();
+        let journal = PipelineRunJournal::new(dir.path());
+
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::PipelineFailed,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("failed".to_string()),
+                retry: None,
+                snapshot: Some(snapshot()),
+            })
             .await
             .unwrap();
 

--- a/crates/ensemble-core/src/pipeline/dag.rs
+++ b/crates/ensemble-core/src/pipeline/dag.rs
@@ -1,10 +1,12 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use serde::{Deserialize, Serialize};
+
 use crate::config::ensemble::{OnFailure, StepApprovalConfig, StepConfig, StepKind};
 use crate::error::PipelineError;
 
 /// A single step in the resolved DAG, with its explicit dependency list.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DagStep {
     pub name: String,
     pub agent: String,
@@ -21,7 +23,7 @@ pub struct DagStep {
 /// `steps` is ordered such that every dependency appears before the steps
 /// that depend on it (topological order). Use [`root_steps`] and
 /// [`ready_steps`] to drive execution.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StepDag {
     pub steps: Vec<DagStep>,
 }

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -190,6 +190,9 @@ impl PipelineRun {
     /// Compute the initial dispatch action — all root steps (no dependencies)
     /// are ready to run immediately.
     pub fn start(&self) -> PipelineAction {
+        if self.all_passed() {
+            return PipelineAction::Succeeded;
+        }
         self.find_dispatchable()
     }
 

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -1,13 +1,14 @@
 use std::collections::{HashMap, HashSet};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::ensemble::{OnFailure, StepKind};
 use crate::pipeline::dag::{DagStep, StepDag};
 use crate::pipeline::verdict::{StepOutput, StepResult};
 
 /// The execution state of a single pipeline step.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum StepState {
     /// Step has not started yet.
     Pending,
@@ -122,6 +123,16 @@ pub struct PipelineRun {
     synthetic_fixup_steps: HashSet<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PipelineRunSnapshot {
+    pub issue_id: String,
+    pub cycle: u32,
+    pub step_states: HashMap<String, StepState>,
+    pub step_outputs: HashMap<String, StepOutput>,
+    pub dag_steps: Vec<DagStep>,
+    pub synthetic_fixup_steps: HashSet<String>,
+}
+
 impl PipelineRun {
     /// Create a new `PipelineRun` for the given issue, initialising all steps
     /// as [`StepState::Pending`].
@@ -138,6 +149,41 @@ impl PipelineRun {
             step_outputs: HashMap::new(),
             dag,
             synthetic_fixup_steps: HashSet::new(),
+        }
+    }
+
+    pub fn to_snapshot(&self) -> PipelineRunSnapshot {
+        PipelineRunSnapshot {
+            issue_id: self.issue_id.clone(),
+            cycle: self.cycle,
+            step_states: self.step_states.clone(),
+            step_outputs: self.step_outputs.clone(),
+            dag_steps: self.dag.steps.clone(),
+            synthetic_fixup_steps: self.synthetic_fixup_steps.clone(),
+        }
+    }
+
+    pub fn from_snapshot(
+        snapshot: PipelineRunSnapshot,
+    ) -> Result<Self, crate::error::PipelineError> {
+        validate_snapshot(&snapshot)?;
+        Ok(Self {
+            issue_id: snapshot.issue_id,
+            cycle: snapshot.cycle,
+            step_states: snapshot.step_states,
+            step_outputs: snapshot.step_outputs,
+            dag: StepDag {
+                steps: snapshot.dag_steps,
+            },
+            synthetic_fixup_steps: snapshot.synthetic_fixup_steps,
+        })
+    }
+
+    pub fn normalize_stale_running_steps(&mut self) {
+        for state in self.step_states.values_mut() {
+            if matches!(state, StepState::Running { .. }) {
+                *state = StepState::Pending;
+            }
         }
     }
 
@@ -556,6 +602,107 @@ impl PipelineRun {
     }
 }
 
+fn validate_snapshot(snapshot: &PipelineRunSnapshot) -> Result<(), crate::error::PipelineError> {
+    if snapshot.dag_steps.is_empty() {
+        return Err(crate::error::PipelineError::InvalidSnapshot {
+            reason: "runtime dag has no steps".to_string(),
+        });
+    }
+
+    let mut known_steps = HashSet::new();
+    for step in &snapshot.dag_steps {
+        if !known_steps.insert(step.name.as_str()) {
+            return Err(crate::error::PipelineError::InvalidSnapshot {
+                reason: format!("runtime dag contains duplicate step '{}'", step.name),
+            });
+        }
+    }
+
+    for step_name in snapshot.step_states.keys() {
+        if !known_steps.contains(step_name.as_str()) {
+            return Err(crate::error::PipelineError::InvalidSnapshot {
+                reason: format!("step state references missing step '{step_name}'"),
+            });
+        }
+    }
+
+    for step_name in snapshot.step_outputs.keys() {
+        if !known_steps.contains(step_name.as_str()) {
+            return Err(crate::error::PipelineError::InvalidSnapshot {
+                reason: format!("step output references missing step '{step_name}'"),
+            });
+        }
+    }
+
+    for step in &snapshot.dag_steps {
+        if !snapshot.step_states.contains_key(&step.name) {
+            return Err(crate::error::PipelineError::InvalidSnapshot {
+                reason: format!("runtime dag step '{}' has no step state", step.name),
+            });
+        }
+        for dependency in &step.depends {
+            if !known_steps.contains(dependency.as_str()) {
+                return Err(crate::error::PipelineError::InvalidSnapshot {
+                    reason: format!(
+                        "step '{}' depends on missing step '{}'",
+                        step.name, dependency
+                    ),
+                });
+            }
+        }
+    }
+
+    validate_snapshot_acyclic(snapshot)?;
+
+    Ok(())
+}
+
+fn validate_snapshot_acyclic(
+    snapshot: &PipelineRunSnapshot,
+) -> Result<(), crate::error::PipelineError> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum VisitState {
+        Visiting,
+        Visited,
+    }
+
+    fn visit<'a>(
+        step_name: &'a str,
+        steps_by_name: &HashMap<&'a str, &'a DagStep>,
+        visit_states: &mut HashMap<&'a str, VisitState>,
+    ) -> Result<(), crate::error::PipelineError> {
+        match visit_states.get(step_name) {
+            Some(VisitState::Visiting) => {
+                return Err(crate::error::PipelineError::InvalidSnapshot {
+                    reason: format!("runtime dag contains a cycle at step '{step_name}'"),
+                });
+            }
+            Some(VisitState::Visited) => return Ok(()),
+            None => {}
+        }
+
+        visit_states.insert(step_name, VisitState::Visiting);
+        if let Some(step) = steps_by_name.get(step_name) {
+            for dependency in &step.depends {
+                visit(dependency, steps_by_name, visit_states)?;
+            }
+        }
+        visit_states.insert(step_name, VisitState::Visited);
+        Ok(())
+    }
+
+    let steps_by_name: HashMap<&str, &DagStep> = snapshot
+        .dag_steps
+        .iter()
+        .map(|step| (step.name.as_str(), step))
+        .collect();
+    let mut visit_states = HashMap::new();
+    for step in &snapshot.dag_steps {
+        visit(step.name.as_str(), &steps_by_name, &mut visit_states)?;
+    }
+    Ok(())
+}
+
 fn template_entry(step: &str, output: &StepOutput) -> StepOutputTemplateEntry {
     StepOutputTemplateEntry {
         step: step.to_string(),
@@ -595,6 +742,157 @@ mod tests {
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
         }
+    }
+
+    fn test_step(name: &str, agent: &str, depends: Option<Vec<String>>) -> StepConfig {
+        StepConfig {
+            name: name.to_string(),
+            kind: StepKind::Agent,
+            agent: agent.to_string(),
+            depends,
+            tracker_state: None,
+            approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
+        }
+    }
+
+    #[test]
+    fn pipeline_run_snapshot_round_trips_runtime_dag_and_outputs() {
+        let steps = vec![
+            test_step("build", "builder", Some(vec![])),
+            test_step("review", "reviewer", Some(vec!["build".to_string()])),
+        ];
+        let dag = crate::pipeline::dag::build_dag(&steps).unwrap();
+        let mut run = PipelineRun::new("issue-1".to_string(), 2, dag);
+        run.mark_running("build", "session-build".to_string());
+        run.step_completed(
+            "build",
+            crate::pipeline::verdict::StepOutput {
+                result: crate::pipeline::verdict::StepResult::Succeeded,
+                summary: Some("compiled".to_string()),
+                output: Some(serde_json::json!({"binary": "ok"})),
+            },
+            false,
+        );
+        run.retry_from_step_with_fixup("review", "fixer");
+
+        let snapshot = run.to_snapshot();
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let decoded: PipelineRunSnapshot = serde_json::from_str(&json).unwrap();
+        let restored = PipelineRun::from_snapshot(decoded).unwrap();
+
+        assert_eq!(restored.issue_id, "issue-1");
+        assert_eq!(restored.cycle, 2);
+        assert_eq!(restored.step_states.get("build"), Some(&StepState::Passed));
+        assert!(restored.step_outputs.contains_key("build"));
+        assert!(restored.step("fixup-review").is_some());
+        assert_eq!(
+            restored.step("review").unwrap().depends,
+            vec!["fixup-review".to_string()]
+        );
+    }
+
+    #[test]
+    fn pipeline_run_snapshot_normalizes_stale_running_steps_to_pending() {
+        let steps = vec![test_step("build", "builder", Some(vec![]))];
+        let dag = crate::pipeline::dag::build_dag(&steps).unwrap();
+        let mut run = PipelineRun::new("issue-1".to_string(), 1, dag);
+        run.mark_running("build", "session-build".to_string());
+
+        let mut restored = PipelineRun::from_snapshot(run.to_snapshot()).unwrap();
+        restored.normalize_stale_running_steps();
+
+        assert_eq!(restored.step_states.get("build"), Some(&StepState::Pending));
+    }
+
+    #[test]
+    fn pipeline_run_snapshot_rejects_step_state_outside_runtime_dag() {
+        let steps = vec![test_step("build", "builder", Some(vec![]))];
+        let dag = crate::pipeline::dag::build_dag(&steps).unwrap();
+        let run = PipelineRun::new("issue-1".to_string(), 1, dag);
+        let mut snapshot = run.to_snapshot();
+        snapshot
+            .step_states
+            .insert("missing".to_string(), StepState::Passed);
+
+        let err = PipelineRun::from_snapshot(snapshot).unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn pipeline_run_snapshot_rejects_step_output_outside_runtime_dag() {
+        let steps = vec![test_step("build", "builder", Some(vec![]))];
+        let dag = crate::pipeline::dag::build_dag(&steps).unwrap();
+        let run = PipelineRun::new("issue-1".to_string(), 1, dag);
+        let mut snapshot = run.to_snapshot();
+        snapshot.step_outputs.insert(
+            "missing".to_string(),
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: None,
+            },
+        );
+
+        let err = PipelineRun::from_snapshot(snapshot).unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn pipeline_run_snapshot_rejects_missing_dependency() {
+        let steps = vec![test_step("build", "builder", Some(vec![]))];
+        let dag = crate::pipeline::dag::build_dag(&steps).unwrap();
+        let run = PipelineRun::new("issue-1".to_string(), 1, dag);
+        let mut snapshot = run.to_snapshot();
+        snapshot.dag_steps[0].depends = vec!["missing".to_string()];
+
+        let err = PipelineRun::from_snapshot(snapshot).unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn pipeline_run_snapshot_rejects_dag_step_without_state() {
+        let steps = vec![test_step("build", "builder", Some(vec![]))];
+        let dag = crate::pipeline::dag::build_dag(&steps).unwrap();
+        let run = PipelineRun::new("issue-1".to_string(), 1, dag);
+        let mut snapshot = run.to_snapshot();
+        snapshot.step_states.remove("build");
+
+        let err = PipelineRun::from_snapshot(snapshot).unwrap_err();
+        assert!(err.to_string().contains("no step state"));
+    }
+
+    #[test]
+    fn pipeline_run_snapshot_rejects_duplicate_dag_steps() {
+        let steps = vec![test_step("build", "builder", Some(vec![]))];
+        let dag = crate::pipeline::dag::build_dag(&steps).unwrap();
+        let run = PipelineRun::new("issue-1".to_string(), 1, dag);
+        let mut snapshot = run.to_snapshot();
+        snapshot.dag_steps.push(snapshot.dag_steps[0].clone());
+
+        let err = PipelineRun::from_snapshot(snapshot).unwrap_err();
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn pipeline_run_snapshot_rejects_cycles() {
+        let steps = vec![
+            test_step("build", "builder", Some(vec![])),
+            test_step("review", "reviewer", Some(vec!["build".to_string()])),
+        ];
+        let dag = crate::pipeline::dag::build_dag(&steps).unwrap();
+        let run = PipelineRun::new("issue-1".to_string(), 1, dag);
+        let mut snapshot = run.to_snapshot();
+        snapshot
+            .dag_steps
+            .iter_mut()
+            .find(|step| step.name == "build")
+            .unwrap()
+            .depends = vec!["review".to_string()];
+
+        let err = PipelineRun::from_snapshot(snapshot).unwrap_err();
+        assert!(err.to_string().contains("cycle"));
     }
 
     fn make_step_with_state(

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -1,10 +1,11 @@
 use std::path::Path;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 /// The result returned by an agent at the end of a pipeline step.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum StepResult {
     /// The step output succeeded; continue to the next step or mark success.
     Succeeded,
@@ -21,7 +22,7 @@ pub enum VerdictSource {
     Default,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StepOutput {
     pub result: StepResult,
     pub summary: Option<String>,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -278,6 +278,18 @@ orchestrator updates the issue tracker state to `approval.state` (if set) and wa
 `Rejected` transition does not write a separate rejection state — it is treated as a failure in the
 `on_failure` sense.
 
+Pipeline run recovery:
+
+- Ensemble appends pipeline transition records to
+  `<config_dir>/state/pipeline-runs/<encoded_issue_id>.jsonl`.
+- Each recoverable transition includes a full `PipelineRun` snapshot.
+- On orchestrator startup, Ensemble restores the latest non-released snapshot for each issue before
+  the first poll tick.
+- Stale `Running` steps from a previous process are normalized to `Pending`; agent processes are not
+  recovered across orchestrator restarts.
+- A `released` transition prevents older snapshots for the issue from being restored after
+  completion, stop, terminal reconciliation, or whole-issue retry.
+
 #### 4.1.7 Verdict
 
 Agent judgment returned after a pipeline step completes:

--- a/docs/superpowers/specs/2026-06-11-pipeline-run-transition-journal-design.md
+++ b/docs/superpowers/specs/2026-06-11-pipeline-run-transition-journal-design.md
@@ -1,0 +1,284 @@
+# Pipeline run transition journal
+
+**Date:** 2026-06-11
+**Issue:** [#195](https://github.com/chrisbanes/ensemble/issues/195)
+**Status:** Design
+
+## Context
+
+`PipelineRun` is the per-issue runtime state for step DAG execution. It tracks the current cycle,
+step states, step outputs, the resolved runtime DAG, and synthetic fixup steps introduced by
+step-level retry. Today that state lives only in `OrchestratorState`.
+
+If Ensemble restarts while a pipeline is halted, awaiting approval, blocked on human input, or
+queued for step-level retry, the in-memory `PipelineRun` is lost. The next poll can treat the issue
+as fresh work and re-dispatch it from the beginning, wasting completed steps and hiding the actual
+reason the pipeline stopped.
+
+The interaction store partially reconstructs `BlockedOnHuman` and `AwaitingApproval`, but it only
+stores coarse fields such as `completed_steps`. It cannot restore step outputs, failed-step
+summaries, non-passed step states, or runtime DAG mutations such as synthetic fixup steps.
+
+## Goal
+
+- Persist every meaningful pipeline transition as append-only JSONL.
+- Include recovery snapshots in transition records so startup does not need fragile event replay.
+- Restore paused or retryable pipeline state after orchestrator restart.
+- Keep the journal useful for debugging by recording what transition happened and why.
+- Release persisted pipeline state when the issue completes, is stopped, or is intentionally
+  restarted from scratch.
+
+## Non-goals
+
+- Pure event sourcing where restore depends on replaying every historical delta.
+- Persisting process-local worker state such as agent PIDs, live runtime sessions, turn counters, or
+  last agent messages.
+- Recovering an in-flight agent process after the orchestrator process exits.
+- Replacing the interaction store, timeline events, or history store.
+- Adding UI log browsing in this change.
+
+## Design
+
+### 1. Storage layout
+
+Add a per-issue JSONL journal under the config state directory:
+
+```text
+<config_dir>/state/pipeline-runs/<safe_issue_id>.jsonl
+```
+
+`<safe_issue_id>` should be a reversible percent-encoding of the issue ID bytes, leaving only
+ASCII letters, digits, `.`, `_`, and `-` unescaped. This avoids collisions without adding a new
+dependency and keeps common tracker IDs readable.
+
+Each line is one `PipelineTransitionRecord`. The file is append-only during normal operation. The
+implementation may add compaction later, but compaction is not required for issue #195.
+
+### 2. Record format
+
+Each record captures both a transition and, when the pipeline is still recoverable, the full
+post-transition snapshot.
+
+```json
+{
+  "schema_version": 1,
+  "seq": 17,
+  "kind": "step_completed",
+  "issue_id": "NODE_123",
+  "identifier": "ENS-42",
+  "run_id": "run-1781190000000-1",
+  "cycle": 2,
+  "step": "review",
+  "reason": "review raised concern",
+  "snapshot": {
+    "issue_id": "NODE_123",
+    "cycle": 2,
+    "step_states": {},
+    "step_outputs": {},
+    "dag_steps": [],
+    "synthetic_fixup_steps": []
+  },
+  "written_at": "2026-06-11T12:00:00Z"
+}
+```
+
+Fields:
+
+- `schema_version`: starts at `1`.
+- `seq`: monotonically increasing per journal file. The store reads the last valid record's `seq`
+  before append and writes `seq + 1`; if no valid record exists, it writes `1`.
+- `kind`: transition kind.
+- `issue_id`: tracker issue ID used by `OrchestratorState`.
+- `identifier`: human-readable issue identifier used for workspaces and API display.
+- `run_id`: optional orchestrator run ID for cross-referencing timeline/history.
+- `cycle`: pipeline cycle at the time of the transition.
+- `step`: optional step name for step-scoped transitions.
+- `reason`: optional human-readable reason for failures, halts, retries, or releases.
+- `snapshot`: optional `PipelineRunSnapshot`. Present for recoverable transitions; absent for
+  `released`.
+- `written_at`: UTC timestamp.
+
+The record is intentionally self-describing. Developers can inspect the JSONL file directly to see
+how the pipeline moved through states.
+
+### 3. Transition kinds
+
+Initial transition kinds:
+
+| Kind | Snapshot | Meaning |
+|------|----------|---------|
+| `run_started` | yes | New `PipelineRun` created. |
+| `step_running` | yes | Step marked running and worker dispatch started. |
+| `step_completed` | yes | Step returned a successful, failed, or concern result. |
+| `step_failed` | yes | Step errored due to worker/runtime failure. |
+| `step_blocked_on_human` | yes | Step emitted a blocking human interaction request. |
+| `step_awaiting_approval` | yes | Step completed and is waiting at an approval gate. |
+| `approval_resolved` | yes | Approval gate was approved or rejected. |
+| `step_retry_scheduled` | yes | Failed step and downstream steps were reset for step-level retry. |
+| `fixup_retry_scheduled` | yes | Runtime DAG was mutated to insert a synthetic fixup step. |
+| `pipeline_halted` | yes | `on_failure: halt` stopped the pipeline for manual intervention. |
+| `pipeline_succeeded` | yes | All pipeline steps passed before final release/cleanup. |
+| `pipeline_failed` | yes | Pipeline reached final failure before final release/cleanup. |
+| `released` | no | This issue must not be restored from earlier snapshots. |
+
+The implementation must cover every listed transition kind that has a corresponding code path in
+the current orchestrator. It should not persist high-volume agent telemetry such as output chunks or
+token updates.
+
+### 4. Snapshot format
+
+`PipelineRunSnapshot` is the durable form of `PipelineRun`:
+
+```rust
+pub struct PipelineRunSnapshot {
+    pub issue_id: String,
+    pub cycle: u32,
+    pub step_states: HashMap<String, StepState>,
+    pub step_outputs: HashMap<String, StepOutput>,
+    pub dag_steps: Vec<DagStep>,
+    pub synthetic_fixup_steps: HashSet<String>,
+}
+```
+
+The following types need serde support, either directly or through separate persisted DTOs:
+
+- `StepState`
+- `StepResult`
+- `StepOutput`
+- `DagStep`
+- `StepDag`
+
+Persisting `dag_steps` matters. Step-level `fixup` mutates the runtime DAG by inserting a synthetic
+step and rewiring the failed step to depend on it. Rebuilding only from `config.steps` would lose
+that mutation and could dispatch the wrong next step after restart.
+
+`PipelineRun` should expose explicit conversion methods instead of making all internals public:
+
+```rust
+impl PipelineRun {
+    pub fn to_snapshot(&self) -> PipelineRunSnapshot;
+    pub fn from_snapshot(snapshot: PipelineRunSnapshot) -> Result<Self, PipelineError>;
+}
+```
+
+### 5. Restore behavior
+
+Startup restore happens after config-derived orchestrator state is initialized and before the first
+poll tick. It should run before interaction hydration so persisted pipeline state can be the richer
+source of truth.
+
+Restore algorithm:
+
+1. Scan `<config_dir>/state/pipeline-runs/*.jsonl`.
+2. For each file, read records in order and keep the latest valid record.
+3. If the latest valid record is `released`, restore nothing for that issue.
+4. If the latest valid record has a snapshot, rebuild `PipelineRun` from that snapshot.
+5. Normalize stale `StepState::Running { .. }` values to `StepState::Pending`.
+6. Validate the snapshot enough to avoid unsafe restoration:
+   - all `step_states` keys exist in the persisted runtime DAG,
+   - all `step_outputs` keys exist in the persisted runtime DAG,
+   - every dependency in `dag_steps` references another persisted step,
+   - configured non-synthetic steps still exist in the current config,
+   - configured non-synthetic step agent/kind/dependencies match the current config unless the
+     dependency difference is caused by a persisted synthetic fixup rewrite.
+7. Insert the run into `state.pipeline_runs` and insert the current config snapshot into
+   `state.pipeline_configs`.
+8. Ensure the issue remains claimed if the restored state is waiting, halted, or retryable.
+
+Malformed trailing lines are ignored with a warning. Unknown future schema versions are skipped.
+If no valid live snapshot remains for a file, the issue is not restored.
+
+### 6. Running step recovery policy
+
+The orchestrator does not try to recover old worker processes. Any `Running` step in a restored
+snapshot came from a previous process and is stale.
+
+Normalize stale `Running` steps to `Pending`. This preserves completed upstream work and allows the
+same step to be dispatched again when the issue becomes eligible. It is safer than pretending the
+old session is still active, and less punitive than marking the step errored solely because the
+orchestrator restarted.
+
+### 7. Write points
+
+Append transition records immediately after durable pipeline mutations:
+
+- new pipeline run inserted,
+- step marked running,
+- step completed and `PipelineRun::step_completed` mutates state,
+- step failed via `PipelineRun::step_failed`,
+- blocked-on-human state recorded,
+- approval interaction bound,
+- approval accepted/rejected,
+- step-level retry reset applied,
+- fixup retry mutation applied,
+- halt waiting entry recorded,
+- pipeline success/failure decided.
+
+Append `released` records when persisted state must no longer restore:
+
+- successful completion after finalization succeeds or is not required,
+- final failure after retries are exhausted,
+- terminal tracker reconciliation releases the issue,
+- API stop releases the issue,
+- manual whole-issue retry intentionally discards the existing pipeline run,
+- workspace cleanup/release paths that call `release_claim` for an active issue.
+
+The cleanest implementation is to funnel release writes through orchestrator methods near
+`remove_pipeline_run` / `release_claim` call sites rather than hiding async filesystem writes inside
+`OrchestratorState`.
+
+### 8. Interaction store integration
+
+The interaction store remains responsible for interaction request/response lifecycle. The pipeline
+journal becomes the richer source for `PipelineRun` recovery.
+
+On startup:
+
+- Restore live pipeline runs from the journal first.
+- Hydrate waiting interactions second.
+- If a waiting interaction exists for an issue with a restored pipeline run, attach/update the
+  `WaitingOnHumanEntry` without reconstructing `PipelineRun` from `completed_steps`.
+- If no journal snapshot exists, keep the existing coarse reconstruction path as a fallback for
+  older state files.
+
+This preserves backward compatibility while fixing the incomplete restore path for new runs.
+
+### 9. Error handling
+
+Journal append failures should be logged as warnings and should not crash the orchestrator. Runtime
+work should continue even if persistence is temporarily unavailable.
+
+Restore failures for one issue should not block restoring other issues. The failed issue should be
+left un-restored and a warning should include the issue ID, file path, and reason.
+
+The implementation should prefer append-open-write-flush for each record. A partially written final
+line after a crash is acceptable because restore skips malformed trailing lines.
+
+### 10. Tests
+
+Unit tests:
+
+- `PipelineRunSnapshot` round-trips `StepState`, `StepOutput`, runtime DAG steps, and synthetic
+  fixup steps.
+- Stale `Running` steps normalize to `Pending` on restore.
+- A `released` record suppresses restoration of earlier snapshots.
+- A malformed trailing JSONL line is ignored when an earlier valid record exists.
+- Unknown schema versions are skipped.
+- Config validation rejects snapshots whose configured steps no longer match the current config.
+
+Orchestrator tests:
+
+- A halted pipeline is restored after creating a fresh orchestrator state.
+- An awaiting-approval pipeline restores step output and approval state.
+- A blocked-on-human issue with a journal snapshot does not fall back to lossy `completed_steps`
+  reconstruction.
+- A fixup retry restores the synthetic fixup step and dependency rewrite.
+- Whole-issue retry appends `released` and does not restore the old run.
+- Successful completion appends `released` and does not restore the old run.
+
+## Deferred work
+
+- Compact long journal files by rewriting the latest live record, if the files become large in
+  practice.
+- Expose the journal through an API endpoint or UI panel for debugging. This design only writes the
+  file.

--- a/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
+++ b/docs/superpowers/specs/2026-06-11-step-retry-and-results-design.md
@@ -110,7 +110,10 @@ steps:
 
 When `on_failure: fixup` is configured, `fixup_agent` is required and must reference a configured agent. Missing or unknown fixup agents are config validation errors.
 
-`halt` stops the pipeline entirely — no retry is scheduled. The issue remains claimed and the PipelineRun stays in memory. The user must explicitly retry (via API) or stop the issue. **Limitation:** PipelineRun state is in-memory only. An orchestrator restart loses the halted state — the issue unclaims on next poll and can be re-dispatched fresh. This matches existing wait-on-human behavior. Tracked in [#195](https://github.com/chrisbanes/ensemble/issues/195).
+`halt` stops the pipeline entirely — no retry is scheduled. The issue remains claimed and the user
+must explicitly retry (via API) or stop the issue. PipelineRun state is persisted by the pipeline
+transition journal introduced for [#195](https://github.com/chrisbanes/ensemble/issues/195), so a
+halted pipeline can be restored after orchestrator restart.
 
 ### 4. Fixup retry
 


### PR DESCRIPTION
## Summary

Fixes #195.

Fixes two recovery gaps in the pipeline transition journal path:

- failed step outcomes now append durable journal transitions for retry, fixup retry, halt, and final failure states
- restored pipeline runs whose steps are already all `Passed` now complete/finalize on the next tick instead of remaining idle as running work

## Root Cause

The failed-step path created a `step_transition` but did not append it for `PipelineAction::Failed`, leaving the latest journal record at the previous `StepRunning` snapshot. Also, restored all-passed `PipelineRun`s called `start()`, which only looked for pending dispatchable work and returned `Waiting`.

## Validation

- `rtk cargo test -p ensemble-core` -> 882 passed, 1 ignored
- `rtk cargo fmt --all -- --check`
- `rtk git diff --check`