### PR TITLE
Make CLI web UI optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
-  SKIP_UI_BUILD: 1
 
 jobs:
   ci:
@@ -36,6 +35,11 @@ jobs:
 
       - name: Test
         run: cargo test --workspace --exclude ensemble-desktop
+
+      - name: Check CLI web UI feature
+        run: cargo check -p ensemble-cli --features web-ui
+        env:
+          SKIP_UI_BUILD: 1
 
   frontend:
     name: Frontend Test and Build
@@ -121,6 +125,8 @@ jobs:
 
       - name: Run E2E smoke test (verify app launches)
         run: ${{ matrix.runner == 'ubuntu-latest' && 'xvfb-run -a' || '' }} cargo test -p ensemble-desktop --test e2e app_launches_without_crash -- --ignored --nocapture
+        env:
+          SKIP_UI_BUILD: 1
         timeout-minutes: 2
 
   # Full Tauri bundle (dmg/deb/AppImage). Runs on:
@@ -202,6 +208,8 @@ jobs:
 
       - name: Run E2E smoke test (verify app launches)
         run: ${{ matrix.runner == 'ubuntu-latest' && 'xvfb-run -a' || '' }} cargo test -p ensemble-desktop --test e2e app_launches_without_crash -- --ignored --nocapture
+        env:
+          SKIP_UI_BUILD: 1
         timeout-minutes: 2
 
       - name: Upload desktop artifacts
@@ -250,7 +258,7 @@ jobs:
           path: crates/ensemble-cli/assets/spa/
 
       - name: Build CLI
-        run: cargo build --release -p ensemble-cli --target ${{ matrix.target }}
+        run: cargo build --release -p ensemble-cli --features web-ui --target ${{ matrix.target }}
 
       - name: Package binary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,6 @@ dependencies = [
  "dirs",
  "ensemble-core",
  "inquire",
- "mime_guess",
  "opener",
  "reqwest",
  "rust-embed",

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ cd ensemble
 cargo install --path crates/ensemble-cli
 ```
 
+Source installs are headless by default and include `ensemble init`, `ensemble run`, and
+`ensemble open-config-dir`. To include the embedded web dashboard, generate the frontend first and
+enable the `web-ui` feature:
+
+```sh
+cd crates/ensemble-ui/src-ui
+pnpm install --frozen-lockfile
+pnpm run codegen
+cd ../../..
+cargo install --path crates/ensemble-cli --features web-ui
+```
+
 ## Quick start
 
 **1. Create a configuration directory:**
@@ -74,6 +86,9 @@ To also start the web dashboard:
 ```sh
 ensemble web --port 3000
 ```
+
+The `web` subcommand is available in release builds and source builds installed with
+`--features web-ui`.
 
 Then open `http://localhost:3000` in your browser.
 

--- a/crates/ensemble-cli/Cargo.toml
+++ b/crates/ensemble-cli/Cargo.toml
@@ -13,19 +13,19 @@ path = "src/main.rs"
 [features]
 default = ["open-config-dir"]
 open-config-dir = ["dep:opener"]
+web-ui = ["dep:axum", "dep:rust-embed"]
 
 [dependencies]
 ensemble-core = { path = "../ensemble-core" }
 tokio = { workspace = true }
 clap = { workspace = true }
 tracing = { workspace = true }
-axum = { workspace = true }
+axum = { workspace = true, optional = true }
 inquire = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
-rust-embed = { workspace = true }
-mime_guess = { workspace = true }
+rust-embed = { workspace = true, optional = true }
 reqwest = { workspace = true }
 dirs = { workspace = true }
 opener = { workspace = true, optional = true }

--- a/crates/ensemble-cli/build.rs
+++ b/crates/ensemble-cli/build.rs
@@ -2,6 +2,12 @@ use std::path::Path;
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_WEB_UI");
+
+    if std::env::var("CARGO_FEATURE_WEB_UI").is_err() {
+        return;
+    }
+
     // Only rebuild if UI source changes
     println!("cargo:rerun-if-changed=../ensemble-ui/src-ui/src");
     println!("cargo:rerun-if-changed=../ensemble-ui/src-ui/package.json");
@@ -48,6 +54,14 @@ fn main() {
     // which would deadlock (cargo already holds the build lock).
     let openapi_json = ui_dir.join("openapi.json");
     if !openapi_json.exists() {
+        if prebuilt_spa_exists(assets_dir) {
+            println!(
+                "cargo:warning=openapi.json not found at {}. Using existing embedded UI assets.",
+                openapi_json.display()
+            );
+            println!("cargo:warning=Run `pnpm run codegen:spec` in crates/ensemble-ui/src-ui/ to regenerate it.");
+            return;
+        }
         println!(
             "cargo:warning=openapi.json not found at {}. UI will not be embedded.",
             openapi_json.display()

--- a/crates/ensemble-cli/src/commands/mod.rs
+++ b/crates/ensemble-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod init;
 pub mod open_config_dir;
 pub mod run;
+#[cfg(feature = "web-ui")]
 pub mod web;

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+#[cfg(feature = "web-ui")]
 mod embedded_ui;
 
 use clap::{Args, Parser, Subcommand};
@@ -34,6 +35,7 @@ enum Command {
     /// Start the ensemble orchestrator in headless mode.
     Run,
     /// Start the ensemble orchestrator with web UI.
+    #[cfg(feature = "web-ui")]
     Web {
         /// HTTP server bind address.
         #[arg(long, env = "HOST", default_value = "127.0.0.1")]
@@ -134,6 +136,7 @@ async fn main() -> ExitCode {
             commands::init::execute(commands::init::InitArgs { config_dir }).await
         }
         Some(Command::Run) => commands::run::execute(commands::run::RunArgs { config_dir }).await,
+        #[cfg(feature = "web-ui")]
         Some(Command::Web { host, port }) => {
             commands::web::execute(commands::web::WebArgs {
                 config_dir,
@@ -227,6 +230,16 @@ mod tests {
 
     // ---- `ensemble web` subcommand ----
 
+    #[cfg(not(feature = "web-ui"))]
+    #[test]
+    fn test_cli_rejects_web_when_web_ui_disabled() {
+        let (_guard, host, port) = lock_and_clear_env();
+        let result = Cli::try_parse_from(["ensemble", "web"]);
+        assert!(result.is_err());
+        restore_env(host, port);
+    }
+
+    #[cfg(feature = "web-ui")]
     #[test]
     fn test_cli_parse_web_defaults() {
         let (_guard, host, port) = lock_and_clear_env();
@@ -242,6 +255,7 @@ mod tests {
         restore_env(host, port);
     }
 
+    #[cfg(feature = "web-ui")]
     #[test]
     fn test_cli_parse_web_custom_args() {
         let (_guard, host, port) = lock_and_clear_env();
@@ -266,6 +280,7 @@ mod tests {
         restore_env(host, port);
     }
 
+    #[cfg(feature = "web-ui")]
     #[test]
     fn test_cli_web_env_host() {
         let (_guard, host, port) = lock_and_clear_env();
@@ -278,6 +293,7 @@ mod tests {
         restore_env(host, port);
     }
 
+    #[cfg(feature = "web-ui")]
     #[test]
     fn test_cli_web_env_port() {
         let (_guard, host, port) = lock_and_clear_env();
@@ -290,6 +306,7 @@ mod tests {
         restore_env(host, port);
     }
 
+    #[cfg(feature = "web-ui")]
     #[test]
     fn test_cli_web_flag_overrides_env() {
         let (_guard, host, port) = lock_and_clear_env();
@@ -308,6 +325,7 @@ mod tests {
         restore_env(host, port);
     }
 
+    #[cfg(feature = "web-ui")]
     #[test]
     fn test_cli_web_ephemeral_port() {
         let (_guard, host, port) = lock_and_clear_env();

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1903,6 +1903,8 @@ If implemented:
 - The implementation may serve server-rendered HTML or a client-side application for the dashboard.
 - The dashboard/API must be observability/control surfaces only and must not become required for
   orchestrator correctness.
+- CLI builds may compile this extension behind an optional feature. When the feature is disabled,
+  the HTTP server subcommand is not part of the CLI command surface.
 
 Enablement (extension):
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,6 +11,21 @@ cargo clippy --workspace -- -D warnings   # lint
 cargo fmt --all -- --check       # check formatting
 ```
 
+The CLI's embedded dashboard is optional. Default `ensemble-cli` builds are headless and do not
+require Node, pnpm, OpenAPI generation, or frontend assets. To compile the web UI command from
+source, generate the frontend inputs and enable the feature:
+
+```sh
+cd crates/ensemble-ui/src-ui
+pnpm install --frozen-lockfile
+pnpm run codegen
+cd ../../..
+cargo build -p ensemble-cli --features web-ui
+```
+
+For Rust-only checks that intentionally compile the `web-ui` feature without rebuilding frontend
+assets, set `SKIP_UI_BUILD=1`.
+
 Run all four before pushing — CI enforces them.
 
 ## Project structure


### PR DESCRIPTION
## Summary

- Add an opt-in `web-ui` feature for the CLI embedded dashboard.
- Keep default source builds headless so they do not require Node, pnpm, OpenAPI generation, or SPA assets.
- Compile `ensemble web`, embedded SPA serving, and the CLI UI build workflow only when `web-ui` is enabled.
- Update CI, release builds, README, contributing docs, and the spec to document the split.

Fixes #198.

## Validation

- `cargo test --workspace --exclude ensemble-desktop`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `SKIP_UI_BUILD=1 cargo clippy -p ensemble-cli --features web-ui -- -D warnings`
- `cargo fmt --all -- --check`

Note: the first workspace test run hit sandbox port-binding/file-watcher limits; the same command passed when rerun with unsandboxed local test execution.