### PR TITLE
Add product E2E workflow test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Test
         run: cargo test --workspace --exclude ensemble-desktop
 
+      - name: Product E2E
+        run: cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
+        env:
+          SKIP_UI_BUILD: 1
+
       - name: Check CLI web UI feature
         run: cargo check -p ensemble-cli --features web-ui
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,15 +35,15 @@ ensemble/
 │   │   └── tests/
 │   │       └── workflow_to_workspace.rs  # integration test
 │   ├── ensemble-cli/             # CLI binary
-│   │   ├── build.rs              # SPA build + embed script
+│   │   ├── build.rs              # optional SPA build + embed script (`web-ui` feature)
 │   │   ├── src/
 │   │   │   ├── main.rs           # CLI entry point, subcommand dispatch
-│   │   │   ├── embedded_ui.rs    # rust-embed SPA serving
+│   │   │   ├── embedded_ui.rs    # rust-embed SPA serving (`web-ui` feature)
 │   │   │   └── commands/
 │   │   │       ├── mod.rs        # re-exports
 │   │   │       ├── init.rs       # `ensemble init` interactive config wizard
 │   │   │       ├── run.rs        # `ensemble run` headless orchestrator
-│   │   │       └── web.rs        # `ensemble web` orchestrator + SPA + API
+│   │   │       └── web.rs        # `ensemble web` orchestrator + SPA + API (`web-ui` feature)
 │   │   └── tests/
 │   └── ensemble-desktop/         # Tauri desktop app
 │       ├── build.rs              # tauri-build + SPA embed script
@@ -65,6 +65,9 @@ cargo clippy --workspace -- -D warnings
 cargo fmt --all -- --check
 ```
 
+Default `ensemble-cli` builds are headless. Compile the web dashboard command with
+`--features web-ui`; for Rust-only checks of that feature, use `SKIP_UI_BUILD=1`.
+
 ## Pre-push checklist
 
 Before pushing commits, ensure all checks pass locally:
@@ -72,6 +75,8 @@ Before pushing commits, ensure all checks pass locally:
 ```sh
 # Rust code
 cargo test --workspace --exclude ensemble-desktop
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
 cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
 cargo fmt --all -- --check
 
@@ -85,7 +90,10 @@ CI will run these checks on your PR; failures block merge.
 
 ## CI
 
-GitHub Actions runs on push to `main` and all PRs. Four parallel jobs: check, test, clippy, fmt. All must pass. `RUSTFLAGS=-Dwarnings` is set globally — treat warnings as errors.
+GitHub Actions runs on push to `main` and all PRs. The main CI job runs format, clippy,
+default non-desktop Rust tests, the feature-enabled product E2E test, and a CLI
+`web-ui` feature check. Frontend and desktop jobs run separately. All must pass.
+`RUSTFLAGS=-Dwarnings` is set globally — treat warnings as errors.
 
 ## Release
 
@@ -138,7 +146,7 @@ Before finishing any change, check whether it changes documented behavior. Updat
 - **Config directory based**: All runtime config lives in a configuration directory containing `config.yaml`. `EnsembleConfig` provides typed access with defaults and `$ENV_VAR` resolution. The config directory is resolved via `--config-dir`, `ENSEMBLE_CONFIG_DIR`, or platform defaults. Agent definitions, step DAG, and prompt references are all defined in `config.yaml`. Relative paths are resolved from the config directory.
 - **Agent model discovery**: During `ensemble init`, acpx agent sessions are probed to discover available models. The selected model is stored as `model` in `AgentConfig` and emitted in `ensemble.yaml`.
 - **Multi-agent pipelines**: Named agents run through a step DAG (GitHub Actions-style: sequential by default, `depends` for parallelism). The orchestrator drives state transitions at step boundaries and collects verdicts from review agents.
-- **Shared orchestrator startup**: `ensemble run`, `ensemble web`, and desktop/Tauri should all start the same real orchestrator runtime path. Do not add placeholder poll loops or separate per-frontend orchestrator implementations when the shared bootstrap can be reused.
+- **Shared orchestrator startup**: `ensemble run`, `ensemble web` (when compiled with `web-ui`), and desktop/Tauri should all start the same real orchestrator runtime path. Do not add placeholder poll loops or separate per-frontend orchestrator implementations when the shared bootstrap can be reused.
 - **Manual refresh behavior**: Refresh, retry, and resume controls should signal the orchestrator loop to run a tick; do not implement ad-hoc polling/state mutation in API or UI handlers that bypasses the orchestrator.
 - **Workspace isolation**: Each issue gets a directory under a configurable root, keyed by sanitized identifier. Workspaces are reused across retries and cleaned up on completion.
 - **Hook lifecycle**: Shell hooks (after_create, before_run, after_run, before_remove) run in workspace directories with configurable timeouts. Non-fatal hooks use best-effort mode.

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "web-ui")]
+
 use serde_json::Value;
 use std::ffi::OsString;
 use std::fs;

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -121,7 +121,6 @@ impl TestFixture {
         let acpx_log_path = root.join("mock-acpx.log");
 
         fs::create_dir_all(&workspace_root)?;
-        fs::create_dir_all(workspace_root.join(".ensemble").join("history.db"))?;
         fs::create_dir_all(&mock_bin_dir)?;
         fs::write(&todo_path, todo_fixture())?;
         fs::write(

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -1,0 +1,397 @@
+use serde_json::Value;
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const ISSUE_ID: &str = "E2E-1";
+const ISSUE_TITLE: &str = "Exercise product workflow";
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl ChildGuard {
+    fn new(child: Child) -> Self {
+        Self { child }
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn web_cli_runs_todo_issue_to_completion_with_mock_acpx() {
+    let fixture = TestFixture::new().expect("fixture setup");
+    let port = reserve_local_port().expect("reserve local port");
+    let base_url = format!("http://127.0.0.1:{port}");
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_LOG", "info")
+        .env("ENSEMBLE_LOG_FORMAT", "json")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let child = command.spawn().expect("spawn ensemble web");
+    let _guard = ChildGuard::new(child);
+    let client = reqwest::Client::new();
+
+    wait_for_server(&client, &base_url)
+        .await
+        .expect("server should become reachable");
+
+    let detail = wait_for_completed_issue(&client, &base_url)
+        .await
+        .expect("issue should complete successfully");
+    assert_eq!(detail["issue_identifier"], ISSUE_ID);
+    assert_eq!(detail["status"], "completed_succeeded");
+    assert!(
+        detail["workflow_steps"]
+            .as_array()
+            .expect("workflow_steps should be an array")
+            .iter()
+            .any(|step| step["name"] == "implement" && step["state"] == "passed"),
+        "issue detail should show implement step passed: {detail:#?}"
+    );
+
+    let history = wait_for_history_record(&client, &base_url, &fixture.workspace_root)
+        .await
+        .expect("history should contain completed run");
+    assert_eq!(history["issue_identifier"], ISSUE_ID);
+    assert_eq!(history["outcome"], "succeeded");
+    assert!(
+        history["steps_traversed"]
+            .as_array()
+            .expect("steps_traversed should be an array")
+            .iter()
+            .any(|step| step == "implement"),
+        "history record should include implement step: {history:#?}"
+    );
+
+    wait_for_timeline_artifact(&fixture.workspace_root)
+        .await
+        .expect("timeline artifact should be persisted");
+
+    let todo = fs::read_to_string(&fixture.todo_path).expect("read TODO.md");
+    assert!(
+        section_contains_issue(&todo, "Done", ISSUE_ID),
+        "completed issue should be under Done section:\n{todo}"
+    );
+
+    let acpx_log = fs::read_to_string(&fixture.acpx_log_path).expect("read mock acpx log");
+    assert!(
+        acpx_log.lines().any(|line| line.contains(" prompt ")),
+        "mock acpx should have received a prompt command:\n{acpx_log}"
+    );
+}
+
+struct TestFixture {
+    config_dir: TempDir,
+    todo_path: PathBuf,
+    workspace_root: PathBuf,
+    acpx_log_path: PathBuf,
+    mock_bin_dir: PathBuf,
+}
+
+impl TestFixture {
+    fn new() -> io::Result<Self> {
+        let config_dir = TempDir::new()?;
+        let root = config_dir.path();
+        let todo_path = root.join("TODO.md");
+        let workspace_root = root.join("workspaces");
+        let mock_bin_dir = root.join("bin");
+        let acpx_log_path = root.join("mock-acpx.log");
+
+        fs::create_dir_all(&workspace_root)?;
+        fs::create_dir_all(workspace_root.join(".ensemble").join("history.db"))?;
+        fs::create_dir_all(&mock_bin_dir)?;
+        fs::write(&todo_path, todo_fixture())?;
+        fs::write(
+            root.join("config.yaml"),
+            config_yaml(&todo_path, &workspace_root),
+        )?;
+        fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(mock_bin_dir.join("acpx"), fs::Permissions::from_mode(0o755))?;
+        }
+
+        Ok(Self {
+            config_dir,
+            todo_path,
+            workspace_root,
+            acpx_log_path,
+            mock_bin_dir,
+        })
+    }
+
+    fn path_with_mock_bin(&self) -> OsString {
+        let old_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut combined = OsString::from(&self.mock_bin_dir);
+        combined.push(":");
+        combined.push(old_path);
+        combined
+    }
+}
+
+fn reserve_local_port() -> io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+fn todo_fixture() -> String {
+    format!(
+        "## Todo\n\n- [{ISSUE_ID}] {ISSUE_TITLE}\n  Verify that Ensemble can run a local black-box workflow.\n\n## In Progress\n\n## Done\n\n## Failed\n"
+    )
+}
+
+fn config_yaml(todo_path: &Path, workspace_root: &Path) -> String {
+    format!(
+        r#"
+tracker:
+  kind: todo_file
+  path: {}
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+workspace:
+  root: {}
+agents:
+  builder:
+    acpx_agent: builder
+    prompt: "Implement {{{{ issue.identifier }}}}: {{{{ issue.title }}}}"
+steps:
+  - name: implement
+    agent: builder
+    tracker_state: In Progress
+on_success: Done
+on_failure: Failed
+max_cycles: 1
+polling:
+  interval_ms: 5000
+concurrency:
+  max_concurrent_agents: 1
+  max_step_parallelism: 1
+agent:
+  read_timeout_ms: 5000
+  turn_timeout_ms: 10000
+  max_retry_backoff_ms: 100
+"#,
+        yaml_quote(&todo_path.display().to_string()),
+        yaml_quote(&workspace_root.display().to_string())
+    )
+}
+
+fn yaml_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn mock_acpx_script() -> &'static str {
+    r#"#!/bin/bash
+set -euo pipefail
+
+log="${ENSEMBLE_E2E_ACPX_LOG:?ENSEMBLE_E2E_ACPX_LOG must be set}"
+printf ' %s ' "$@" >> "$log"
+printf '\n' >> "$log"
+
+cwd=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--cwd" && $((i + 1)) -lt ${#args[@]} ]]; then
+    cwd="${args[$((i + 1))]}"
+  fi
+done
+
+if [[ " $* " == *" sessions ensure "* ]]; then
+  exit 0
+fi
+
+if [[ " $* " == *" sessions close "* ]]; then
+  exit 0
+fi
+
+if [[ " $* " == *" prompt "* ]]; then
+  if [[ -z "$cwd" ]]; then
+    echo "mock acpx missing --cwd" >&2
+    exit 2
+  fi
+
+  mkdir -p "$cwd/.ensemble"
+  cat > "$cwd/.ensemble/mock-prompt.txt"
+  cat > "$cwd/.ensemble/verdict-implement.json" <<'JSON'
+{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}}
+JSON
+
+  printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"mock agent completed"}}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"turn_complete","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7},"verdict":{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}},"stopReason":"end_turn"}}}'
+  exit 0
+fi
+
+echo "unexpected mock acpx invocation: $*" >&2
+exit 2
+"#
+}
+
+async fn wait_for_server(client: &reqwest::Client, base_url: &str) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match client.get(format!("{base_url}/api/v1/state")).send().await {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(response) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("state endpoint returned {}", response.status()));
+                }
+            }
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("state endpoint did not become reachable: {error}"));
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_completed_issue(
+    client: &reqwest::Client,
+    base_url: &str,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let url = format!("{base_url}/api/v1/{ISSUE_ID}");
+    loop {
+        match client.get(&url).send().await {
+            Ok(response) if response.status().is_success() => {
+                let json = response.json::<Value>().await.map_err(|e| e.to_string())?;
+                if json["status"] == "completed_succeeded"
+                    && json["workflow_steps"].as_array().is_some_and(|steps| {
+                        steps
+                            .iter()
+                            .any(|step| step["name"] == "implement" && step["state"] == "passed")
+                    })
+                {
+                    return Ok(json);
+                }
+                if Instant::now() >= deadline {
+                    return Err(format!("issue did not complete before timeout: {json:#?}"));
+                }
+            }
+            Ok(response) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("issue detail returned {}", response.status()));
+                }
+            }
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("issue detail request failed: {error}"));
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_history_record(
+    client: &reqwest::Client,
+    base_url: &str,
+    workspace_root: &Path,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let url = format!("{base_url}/api/v1/history?outcome=succeeded&step=implement");
+    loop {
+        let response = client.get(&url).send().await.map_err(|e| e.to_string())?;
+        let json = response.json::<Value>().await.map_err(|e| e.to_string())?;
+        if let Some(record) = json["records"]
+            .as_array()
+            .and_then(|records| records.iter().find(|r| r["issue_identifier"] == ISSUE_ID))
+        {
+            return Ok(record.clone());
+        }
+        if Instant::now() >= deadline {
+            let history_path = workspace_root.join("ensemble_history.jsonl");
+            let persisted_history = fs::read_to_string(&history_path).unwrap_or_else(|error| {
+                format!("could not read {}: {error}", history_path.display())
+            });
+            return Err(format!(
+                "history record not found before timeout: {json:#?}\npersisted history:\n{persisted_history}"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_timeline_artifact(workspace_root: &Path) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(contents) = read_first_timeline_file(workspace_root)? {
+            if contents.contains(ISSUE_ID) && contents.contains("step_started") {
+                return Ok(());
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timeline artifact not found under {}",
+                workspace_root.display()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn read_first_timeline_file(workspace_root: &Path) -> Result<Option<String>, String> {
+    let runs_dir = workspace_root.join(".ensemble").join("runs");
+    let entries = match fs::read_dir(&runs_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path().join("events.jsonl");
+        match fs::read_to_string(&path) {
+            Ok(contents) => return Ok(Some(contents)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+
+    Ok(None)
+}
+
+fn section_contains_issue(markdown: &str, section: &str, issue_id: &str) -> bool {
+    let target_heading = format!("## {section}");
+    let mut in_target = false;
+
+    for line in markdown.lines() {
+        if line.starts_with("## ") {
+            in_target = line.trim() == target_heading;
+            continue;
+        }
+        if in_target && line.contains(&format!("[{issue_id}]")) {
+            return true;
+        }
+    }
+
+    false
+}

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -173,6 +173,7 @@ tracker:
   path: {}
   active_states:
     - Todo
+    - In Progress
   terminal_states:
     - Done
 workspace:
@@ -189,7 +190,7 @@ on_success: Done
 on_failure: Failed
 max_cycles: 1
 polling:
-  interval_ms: 5000
+  interval_ms: 100
 concurrency:
   max_concurrent_agents: 1
   max_step_parallelism: 1

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,12 +33,13 @@ Run all four before pushing — CI enforces them.
 Run the local product E2E test with:
 
 ```sh
-SKIP_UI_BUILD=1 cargo test -p ensemble-cli --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
 ```
 
-`SKIP_UI_BUILD=1` is required locally because the CLI `build.rs` expects either
-generated UI assets/openapi.json or the skip flag. CI already sets
-`SKIP_UI_BUILD=1` globally.
+The test exercises the real `ensemble web` command, so it must compile the optional
+`web-ui` feature. `SKIP_UI_BUILD=1` keeps the Rust E2E focused on backend product
+behavior without rebuilding frontend assets; omit it when you specifically want to
+verify frontend embedding as part of the build.
 
 The test starts a real `ensemble web` server on localhost with a temporary
 config directory, a todo-file tracker fixture, and mock `acpx`. It does not

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,6 +28,22 @@ assets, set `SKIP_UI_BUILD=1`.
 
 Run all four before pushing — CI enforces them.
 
+## Product E2E
+
+Run the local product E2E test with:
+
+```sh
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --test product_e2e -- --nocapture
+```
+
+`SKIP_UI_BUILD=1` is required locally because the CLI `build.rs` expects either
+generated UI assets/openapi.json or the skip flag. CI already sets
+`SKIP_UI_BUILD=1` globally.
+
+The test starts a real `ensemble web` server on localhost with a temporary
+config directory, a todo-file tracker fixture, and mock `acpx`. It does not
+require GitHub, Notion, real ACP credentials, or non-localhost network access.
+
 ## Project structure
 
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,8 +5,8 @@
 Ensemble is a Rust workspace. You need Rust 1.80+ installed.
 
 ```sh
-cargo build --workspace          # compile
-cargo test --workspace           # run all tests
+cargo build --workspace          # compile default targets
+cargo test --workspace           # run default Rust tests
 cargo clippy --workspace -- -D warnings   # lint
 cargo fmt --all -- --check       # check formatting
 ```
@@ -79,7 +79,10 @@ ensemble/
 
 ## CI
 
-GitHub Actions runs on push to `main` and all PRs. Four parallel jobs: check, test, clippy, fmt. All must pass. `RUSTFLAGS=-Dwarnings` is set globally.
+GitHub Actions runs on push to `main` and all PRs. The main CI job runs format, clippy,
+default non-desktop Rust tests, the feature-enabled product E2E test, and a CLI
+`web-ui` feature check. Frontend and desktop jobs run separately. All must pass.
+`RUSTFLAGS=-Dwarnings` is set globally.
 
 ## Further reading
 

--- a/docs/superpowers/plans/2026-06-12-product-e2e-test.md
+++ b/docs/superpowers/plans/2026-06-12-product-e2e-test.md
@@ -199,6 +199,7 @@ tracker:
   path: {}
   active_states:
     - Todo
+    - In Progress
   terminal_states:
     - Done
 workspace:
@@ -426,7 +427,7 @@ Run:
 cargo test -p ensemble-cli --test product_e2e -- --nocapture
 ```
 
-Expected before any fixes: this may either pass immediately or fail with a concrete product/fixture error. Acceptable failures include a config validation error, mock `acpx` invocation mismatch, timeout waiting for completion, or an assertion that points at a missing observable. Do not broaden scope for retry, human interaction, or UI automation.
+Expected before any fixes: this may either pass immediately or fail with a concrete product/fixture error. Acceptable failures include a config validation error, mock `acpx` invocation mismatch, timeout waiting for completion, or an assertion that points at a missing observable. Do not broaden scope for retry, human interaction, or UI automation. Keep both `Todo` and `In Progress` in `active_states`; `In Progress` is required because the step transitions the tracker to that state while the worker runs.
 
 - [ ] **Step 3: If the mock invocation does not match, adjust only the script matcher**
 

--- a/docs/superpowers/plans/2026-06-12-product-e2e-test.md
+++ b/docs/superpowers/plans/2026-06-12-product-e2e-test.md
@@ -424,7 +424,7 @@ fn section_contains_issue(markdown: &str, section: &str, issue_id: &str) -> bool
 Run:
 
 ```sh
-cargo test -p ensemble-cli --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
 ```
 
 Expected before any fixes: this may either pass immediately or fail with a concrete product/fixture error. Acceptable failures include a config validation error, mock `acpx` invocation mismatch, timeout waiting for completion, or an assertion that points at a missing observable. Do not broaden scope for retry, human interaction, or UI automation. Keep both `Todo` and `In Progress` in `active_states`; `In Progress` is required because the step transitions the tracker to that state while the worker runs.
@@ -454,7 +454,7 @@ Expected: the matcher handles the actual `acpx` argument order emitted by `AcpxC
 Run:
 
 ```sh
-cargo test -p ensemble-cli --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
 ```
 
 Expected: `web_cli_runs_todo_issue_to_completion_with_mock_acpx ... ok`.
@@ -485,7 +485,7 @@ In `docs/contributing.md`, after the initial build/test command block, add:
 Run the black-box product workflow test with:
 
 ```sh
-cargo test -p ensemble-cli --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
 ```
 
 The test starts the real `ensemble web` CLI entrypoint on localhost with a temporary config directory, a todo-file tracker fixture, and a mock `acpx` executable. It does not require GitHub, Notion, real ACP credentials, or network access beyond localhost.
@@ -496,7 +496,7 @@ The test starts the real `ensemble web` CLI entrypoint on localhost with a tempo
 Run:
 
 ```sh
-cargo test -p ensemble-cli --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
 ```
 
 Expected: the E2E test still passes. There is no separate Markdown linter in this repository, so the practical validation is keeping the documented command accurate.
@@ -523,7 +523,7 @@ git commit -m "docs: document product e2e test"
 Run:
 
 ```sh
-cargo test -p ensemble-cli --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
 ```
 
 Expected: the product E2E test passes.

--- a/docs/superpowers/plans/2026-06-12-product-e2e-test.md
+++ b/docs/superpowers/plans/2026-06-12-product-e2e-test.md
@@ -1,0 +1,578 @@
+# Product E2E Workflow Test Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one CI-safe product E2E test that starts the real `ensemble web` CLI path, runs a local todo-file issue through a mock `acpx` agent, and verifies completion through public API and persisted artifacts.
+
+**Architecture:** The test lives in `ensemble-cli` because that crate owns the `ensemble` binary. It creates a temporary config directory, starts the built CLI as a child process on localhost, places a mock `acpx` executable first in `PATH`, and polls HTTP APIs until the workflow completes. The first implementation covers only the happy path; retry, human interaction, and browser UI coverage are follow-up work.
+
+**Tech Stack:** Rust integration tests, `tokio`, `reqwest`, `serde_json`, `tempfile`, std process/filesystem APIs, Bash mock executable.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-product-e2e-test-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `crates/ensemble-cli/tests/product_e2e.rs` | New black-box product E2E test, fixture setup, mock `acpx` script, child process guard, HTTP polling helpers, assertions. |
+| `docs/contributing.md` | Add a short section explaining how to run the product E2E test locally and what it depends on. |
+
+No production Rust code should change in this first pass. If the E2E test reveals a product bug, stop and diagnose it separately before widening the implementation scope.
+
+---
+
+### Task 1: Add the Failing Product E2E Test
+
+**Files:**
+- Create: `crates/ensemble-cli/tests/product_e2e.rs`
+
+- [ ] **Step 1: Create the test file**
+
+Add `crates/ensemble-cli/tests/product_e2e.rs` with this full content:
+
+```rust
+use serde_json::Value;
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const ISSUE_ID: &str = "E2E-1";
+const ISSUE_TITLE: &str = "Exercise product workflow";
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl ChildGuard {
+    fn new(child: Child) -> Self {
+        Self { child }
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn web_cli_runs_todo_issue_to_completion_with_mock_acpx() {
+    let fixture = TestFixture::new().expect("fixture setup");
+    let port = reserve_local_port().expect("reserve local port");
+    let base_url = format!("http://127.0.0.1:{port}");
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_LOG", "info")
+        .env("ENSEMBLE_LOG_FORMAT", "json")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let child = command.spawn().expect("spawn ensemble web");
+    let _guard = ChildGuard::new(child);
+    let client = reqwest::Client::new();
+
+    wait_for_server(&client, &base_url)
+        .await
+        .expect("server should become reachable");
+
+    let detail = wait_for_completed_issue(&client, &base_url)
+        .await
+        .expect("issue should complete successfully");
+    assert_eq!(detail["issue_identifier"], ISSUE_ID);
+    assert_eq!(detail["status"], "completed_succeeded");
+
+    let history = wait_for_history_record(&client, &base_url)
+        .await
+        .expect("history should contain completed run");
+    assert_eq!(history["issue_identifier"], ISSUE_ID);
+    assert_eq!(history["outcome"], "succeeded");
+    assert!(
+        history["steps_traversed"]
+            .as_array()
+            .expect("steps_traversed should be an array")
+            .iter()
+            .any(|step| step == "implement"),
+        "history record should include implement step: {history:#?}"
+    );
+
+    wait_for_timeline_artifact(&fixture.workspace_root)
+        .await
+        .expect("timeline artifact should be persisted");
+
+    let todo = fs::read_to_string(&fixture.todo_path).expect("read TODO.md");
+    assert!(
+        section_contains_issue(&todo, "Done", ISSUE_ID),
+        "completed issue should be under Done section:\n{todo}"
+    );
+
+    let acpx_log = fs::read_to_string(&fixture.acpx_log_path).expect("read mock acpx log");
+    assert!(
+        acpx_log.lines().any(|line| line.contains(" prompt ")),
+        "mock acpx should have received a prompt command:\n{acpx_log}"
+    );
+}
+
+struct TestFixture {
+    config_dir: TempDir,
+    todo_path: PathBuf,
+    workspace_root: PathBuf,
+    acpx_log_path: PathBuf,
+    mock_bin_dir: PathBuf,
+}
+
+impl TestFixture {
+    fn new() -> io::Result<Self> {
+        let config_dir = TempDir::new()?;
+        let root = config_dir.path();
+        let todo_path = root.join("TODO.md");
+        let workspace_root = root.join("workspaces");
+        let mock_bin_dir = root.join("bin");
+        let acpx_log_path = root.join("mock-acpx.log");
+
+        fs::create_dir_all(&workspace_root)?;
+        fs::create_dir_all(&mock_bin_dir)?;
+        fs::write(&todo_path, todo_fixture())?;
+        fs::write(root.join("config.yaml"), config_yaml(&todo_path, &workspace_root))?;
+        fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(
+                mock_bin_dir.join("acpx"),
+                fs::Permissions::from_mode(0o755),
+            )?;
+        }
+
+        Ok(Self {
+            config_dir,
+            todo_path,
+            workspace_root,
+            acpx_log_path,
+            mock_bin_dir,
+        })
+    }
+
+    fn path_with_mock_bin(&self) -> OsString {
+        let old_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut combined = OsString::from(&self.mock_bin_dir);
+        combined.push(":");
+        combined.push(old_path);
+        combined
+    }
+}
+
+fn reserve_local_port() -> io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+fn todo_fixture() -> String {
+    format!(
+        "## Todo\n\n- [{ISSUE_ID}] {ISSUE_TITLE}\n  Verify that Ensemble can run a local black-box workflow.\n\n## In Progress\n\n## Done\n\n## Failed\n"
+    )
+}
+
+fn config_yaml(todo_path: &Path, workspace_root: &Path) -> String {
+    format!(
+        r#"
+tracker:
+  kind: todo_file
+  path: {}
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+workspace:
+  root: {}
+agents:
+  builder:
+    acpx_agent: builder
+    prompt: "Implement {{{{ issue.identifier }}}}: {{{{ issue.title }}}}"
+steps:
+  - name: implement
+    agent: builder
+    tracker_state: In Progress
+on_success: Done
+on_failure: Failed
+max_cycles: 1
+polling:
+  interval_ms: 100
+concurrency:
+  max_concurrent_agents: 1
+  max_step_parallelism: 1
+agent:
+  read_timeout_ms: 5000
+  turn_timeout_ms: 10000
+  max_retry_backoff_ms: 100
+"#,
+        yaml_quote(&todo_path.display().to_string()),
+        yaml_quote(&workspace_root.display().to_string())
+    )
+}
+
+fn yaml_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn mock_acpx_script() -> &'static str {
+    r#"#!/bin/bash
+set -euo pipefail
+
+log="${ENSEMBLE_E2E_ACPX_LOG:?ENSEMBLE_E2E_ACPX_LOG must be set}"
+printf ' %s ' "$@" >> "$log"
+printf '\n' >> "$log"
+
+cwd=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--cwd" && $((i + 1)) -lt ${#args[@]} ]]; then
+    cwd="${args[$((i + 1))]}"
+  fi
+done
+
+if [[ " $* " == *" sessions ensure "* ]]; then
+  exit 0
+fi
+
+if [[ " $* " == *" sessions close "* ]]; then
+  exit 0
+fi
+
+if [[ " $* " == *" prompt "* ]]; then
+  if [[ -z "$cwd" ]]; then
+    echo "mock acpx missing --cwd" >&2
+    exit 2
+  fi
+
+  mkdir -p "$cwd/.ensemble"
+  cat > "$cwd/.ensemble/mock-prompt.txt"
+  cat > "$cwd/.ensemble/verdict-implement.json" <<'JSON'
+{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}}
+JSON
+
+  printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"mock agent completed"}}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"turn_complete","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7},"stopReason":"end_turn"}}}'
+  exit 0
+fi
+
+echo "unexpected mock acpx invocation: $*" >&2
+exit 2
+"#
+}
+
+async fn wait_for_server(client: &reqwest::Client, base_url: &str) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match client
+            .get(format!("{base_url}/api/v1/state"))
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(response) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("state endpoint returned {}", response.status()));
+                }
+            }
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("state endpoint did not become reachable: {error}"));
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_completed_issue(
+    client: &reqwest::Client,
+    base_url: &str,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let url = format!("{base_url}/api/v1/{ISSUE_ID}");
+    loop {
+        match client.get(&url).send().await {
+            Ok(response) if response.status().is_success() => {
+                let json = response.json::<Value>().await.map_err(|e| e.to_string())?;
+                if json["status"] == "completed_succeeded" {
+                    return Ok(json);
+                }
+                if Instant::now() >= deadline {
+                    return Err(format!("issue did not complete before timeout: {json:#?}"));
+                }
+            }
+            Ok(response) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("issue detail returned {}", response.status()));
+                }
+            }
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("issue detail request failed: {error}"));
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_history_record(
+    client: &reqwest::Client,
+    base_url: &str,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let url = format!("{base_url}/api/v1/history?outcome=succeeded&step=implement");
+    loop {
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+        let json = response.json::<Value>().await.map_err(|e| e.to_string())?;
+        if let Some(record) = json["records"]
+            .as_array()
+            .and_then(|records| records.iter().find(|r| r["issue_identifier"] == ISSUE_ID))
+        {
+            return Ok(record.clone());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("history record not found before timeout: {json:#?}"));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_timeline_artifact(workspace_root: &Path) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(contents) = read_first_timeline_file(workspace_root)? {
+            if contents.contains(ISSUE_ID) && contents.contains("step_started") {
+                return Ok(());
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timeline artifact not found under {}",
+                workspace_root.display()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn read_first_timeline_file(workspace_root: &Path) -> Result<Option<String>, String> {
+    let runs_dir = workspace_root.join(".ensemble").join("runs");
+    let entries = match fs::read_dir(&runs_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path().join("events.jsonl");
+        match fs::read_to_string(&path) {
+            Ok(contents) => return Ok(Some(contents)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+
+    Ok(None)
+}
+
+fn section_contains_issue(markdown: &str, section: &str, issue_id: &str) -> bool {
+    let target_heading = format!("## {section}");
+    let mut in_target = false;
+
+    for line in markdown.lines() {
+        if line.starts_with("## ") {
+            in_target = line.trim() == target_heading;
+            continue;
+        }
+        if in_target && line.contains(&format!("[{issue_id}]")) {
+            return true;
+        }
+    }
+
+    false
+}
+```
+
+- [ ] **Step 2: Run the new test and verify it fails or exposes missing assumptions**
+
+Run:
+
+```sh
+cargo test -p ensemble-cli --test product_e2e -- --nocapture
+```
+
+Expected before any fixes: this may either pass immediately or fail with a concrete product/fixture error. Acceptable failures include a config validation error, mock `acpx` invocation mismatch, timeout waiting for completion, or an assertion that points at a missing observable. Do not broaden scope for retry, human interaction, or UI automation.
+
+- [ ] **Step 3: If the mock invocation does not match, adjust only the script matcher**
+
+If the failure says `unexpected mock acpx invocation`, inspect `mock-acpx.log` from the test output or re-run with `--nocapture`, then update only `mock_acpx_script()` command matching. Keep these command branches:
+
+```bash
+if [[ " $* " == *" sessions ensure "* ]]; then
+  exit 0
+fi
+
+if [[ " $* " == *" sessions close "* ]]; then
+  exit 0
+fi
+
+if [[ " $* " == *" prompt "* ]]; then
+  # write verdict and terminal JSON-RPC update
+fi
+```
+
+Expected: the matcher handles the actual `acpx` argument order emitted by `AcpxCli`.
+
+- [ ] **Step 4: Re-run the E2E test**
+
+Run:
+
+```sh
+cargo test -p ensemble-cli --test product_e2e -- --nocapture
+```
+
+Expected: `web_cli_runs_todo_issue_to_completion_with_mock_acpx ... ok`.
+
+- [ ] **Step 5: Commit the test**
+
+Run:
+
+```sh
+git add crates/ensemble-cli/tests/product_e2e.rs
+git commit -m "test: add product e2e workflow"
+```
+
+---
+
+### Task 2: Document the Local E2E Command
+
+**Files:**
+- Modify: `docs/contributing.md`
+
+- [ ] **Step 1: Add the E2E section**
+
+In `docs/contributing.md`, after the initial build/test command block, add:
+
+````markdown
+## Product E2E
+
+Run the black-box product workflow test with:
+
+```sh
+cargo test -p ensemble-cli --test product_e2e -- --nocapture
+```
+
+The test starts the real `ensemble web` CLI entrypoint on localhost with a temporary config directory, a todo-file tracker fixture, and a mock `acpx` executable. It does not require GitHub, Notion, real ACP credentials, or network access beyond localhost.
+````
+
+- [ ] **Step 2: Verify the documentation renders as valid Markdown**
+
+Run:
+
+```sh
+cargo test -p ensemble-cli --test product_e2e -- --nocapture
+```
+
+Expected: the E2E test still passes. There is no separate Markdown linter in this repository, so the practical validation is keeping the documented command accurate.
+
+- [ ] **Step 3: Commit the docs update**
+
+Run:
+
+```sh
+git add docs/contributing.md
+git commit -m "docs: document product e2e test"
+```
+
+---
+
+### Task 3: Final Verification
+
+**Files:**
+- Verify: `crates/ensemble-cli/tests/product_e2e.rs`
+- Verify: `docs/contributing.md`
+
+- [ ] **Step 1: Run the focused E2E test**
+
+Run:
+
+```sh
+cargo test -p ensemble-cli --test product_e2e -- --nocapture
+```
+
+Expected: the product E2E test passes.
+
+- [ ] **Step 2: Run all CLI tests**
+
+Run:
+
+```sh
+cargo test -p ensemble-cli
+```
+
+Expected: all `ensemble-cli` tests pass.
+
+- [ ] **Step 3: Run formatting check**
+
+Run:
+
+```sh
+cargo fmt --all -- --check
+```
+
+Expected: formatting check passes. If it fails, run `cargo fmt --all`, inspect the diff, and re-run the check.
+
+- [ ] **Step 4: Run the CI-equivalent Rust test set**
+
+Run:
+
+```sh
+cargo test --workspace --exclude ensemble-desktop
+```
+
+Expected: all non-desktop workspace tests pass, including the new product E2E.
+
+- [ ] **Step 5: Commit any verification-only formatting changes**
+
+If `cargo fmt --all` changed `crates/ensemble-cli/tests/product_e2e.rs`, commit only that formatting change:
+
+```sh
+git add crates/ensemble-cli/tests/product_e2e.rs
+git commit -m "style: format product e2e test"
+```
+
+If there were no formatting changes, skip this step.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: the plan starts the real CLI web entrypoint, uses temp todo-file config, uses a mock local `acpx`, verifies public API completion and history, verifies persisted timeline artifacts, verifies tracker state, and documents the local command.
+- Scope check: retry, human interaction, UI browser automation, desktop E2E, and external services are explicitly out of scope.
+- Placeholder scan: no task depends on unspecified helper code; helper functions and mock script content are included in Task 1.
+- Type consistency: all JSON assertions use `serde_json::Value`; no new production API types are introduced.

--- a/docs/superpowers/specs/2026-06-12-product-e2e-test-design.md
+++ b/docs/superpowers/specs/2026-06-12-product-e2e-test-design.md
@@ -16,7 +16,7 @@ The first test should be the simplest reliable path: a happy-path web/CLI workfl
 - Use only temporary local files and localhost networking.
 - Use the `todo_file` tracker and a mock local `acpx` executable.
 - Verify the workflow through public HTTP APIs, tracker-visible file state, and persisted runtime artifacts.
-- Run in normal CI as part of `cargo test --workspace --exclude ensemble-desktop`.
+- Run in normal CI as a feature-enabled product E2E step for `ensemble-cli`.
 - Document how to run the E2E test locally.
 
 ## Non-Goals

--- a/docs/superpowers/specs/2026-06-12-product-e2e-test-design.md
+++ b/docs/superpowers/specs/2026-06-12-product-e2e-test-design.md
@@ -1,0 +1,130 @@
+# Product E2E workflow test
+
+**Date:** 2026-06-12
+**Issue:** [#197](https://github.com/chrisbanes/ensemble/issues/197)
+**Status:** Design
+
+## Context
+
+Ensemble has unit, integration, API, orchestrator, workspace, and desktop launch smoke coverage, but no CI-safe black-box product test that starts Ensemble the way a user would. Issue #197 asks for at least one full workflow that uses local fixtures, avoids external credentials, and verifies observable state through public API or UI surfaces.
+
+The first test should be the simplest reliable path: a happy-path web/CLI workflow. Retry and human-interaction coverage remain follow-up tests once the fixture is stable.
+
+## Goals
+
+- Start the real `ensemble` CLI binary in `web` mode.
+- Use only temporary local files and localhost networking.
+- Use the `todo_file` tracker and a mock local `acpx` executable.
+- Verify the workflow through public HTTP APIs, tracker-visible file state, and persisted runtime artifacts.
+- Run in normal CI as part of `cargo test --workspace --exclude ensemble-desktop`.
+- Document how to run the E2E test locally.
+
+## Non-Goals
+
+- Browser automation against the React UI.
+- Desktop/Tauri E2E coverage.
+- Failure, retry, or human-interaction coverage in the first test.
+- Real GitHub, Notion, ACP credentials, or live agent processes.
+
+## Test Location
+
+Add the test under `crates/ensemble-cli/tests/`, because Cargo integration tests for `ensemble-cli` can spawn the built CLI binary using `CARGO_BIN_EXE_ensemble`. This exercises the packaged command-line entrypoint instead of calling `ensemble-core` internals directly.
+
+## Fixture Setup
+
+The test creates a temporary directory containing:
+
+- `config.yaml`
+- `TODO.md`
+- `workspaces/`
+- `bin/acpx`, a mock executable placed first in the spawned process `PATH`
+
+The config uses:
+
+- `tracker.kind: todo_file`
+- `tracker.path` pointing at the temp `TODO.md`
+- active state `Todo`
+- terminal state `Done`
+- one `acpx_agent` agent with an inline prompt
+- one `implement` step with `tracker_state: In Progress`
+- `on_success: Done`
+- `on_failure: Failed`
+- a short polling interval so the test does not wait on the production default
+- a temp workspace root
+
+The TODO fixture starts with one active issue:
+
+```markdown
+## Todo
+
+- [E2E-1] Exercise product workflow
+  Verify that Ensemble can run a local black-box workflow.
+
+## In Progress
+
+## Done
+
+## Failed
+```
+
+## Mock Agent
+
+The mock executable is named `acpx` so the spawned `ensemble` binary uses it through normal command resolution. The test must not rely on `#[cfg(test)]` environment hooks such as `ENSEMBLE_TEST_ACPX_EXECUTABLE`, because those are not compiled into the spawned release/test binary.
+
+The mock supports the commands used by `AcpxRuntime`:
+
+- `sessions ensure ...` exits successfully.
+- `prompt --session ...` writes a deterministic ACP JSON-RPC `session/update` stream to stdout, including text output, token usage, `stopReason: end_turn`, and a structured successful result.
+- `sessions close ...` exits successfully.
+- unexpected commands exit non-zero with a diagnostic.
+
+The successful result should use the current result terminology, for example:
+
+```json
+{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}}
+```
+
+## Process Lifecycle
+
+The test starts:
+
+```sh
+ensemble web --config-dir <temp-config-dir> --host 127.0.0.1 --port <free-port>
+```
+
+Use a pre-bound local port chosen by the test, then release it before spawning the child. This avoids parsing structured logs while still keeping the server address deterministic. The test should use bounded polling to wait for `GET /api/v1/state` to become available.
+
+The child process must be killed and waited on in test cleanup, even on assertion failure. A small process guard type is enough.
+
+## Assertions
+
+After the server is reachable, the test polls public APIs until completion:
+
+1. `GET /api/v1/state` becomes available.
+2. `GET /api/v1/E2E-1` eventually returns `status: "completed_succeeded"`.
+3. `GET /api/v1/history` returns at least one record for `E2E-1` with `outcome: "succeeded"` and step `implement`.
+4. The workspace root contains persisted run timeline data under `.ensemble/runs/` or the history SQLite database contains run event rows for `E2E-1`.
+5. `TODO.md` contains `[E2E-1] Exercise product workflow` under `## Done`.
+6. The mock agent log file shows that the `prompt` command was invoked.
+
+The current history API returns `HistoryRecord` values without a public `run_id`, while the timeline API requires a `run_id` query parameter. The first test should not add API contract scope just to assert timeline through HTTP. If a later change exposes `run_id` in history responses, this assertion can move to `GET /api/v1/E2E-1/timeline?run_id=<run-id>`.
+
+Bound all polling with clear timeout errors so CI failures point at the missing observable state.
+
+## Documentation
+
+Update `docs/contributing.md` with a short E2E section:
+
+```sh
+cargo test -p ensemble-cli --test product_e2e
+```
+
+Mention that the test uses temp files, a mock `acpx`, and localhost only.
+
+## Follow-Up Coverage
+
+After this happy-path fixture is stable, add separate tests for:
+
+- failed verdict followed by retry
+- human interaction request and resume
+- browser-level UI smoke for the web app

--- a/docs/superpowers/specs/2026-06-12-product-e2e-test-design.md
+++ b/docs/superpowers/specs/2026-06-12-product-e2e-test-design.md
@@ -43,7 +43,7 @@ The config uses:
 
 - `tracker.kind: todo_file`
 - `tracker.path` pointing at the temp `TODO.md`
-- active state `Todo`
+- active states `Todo` and `In Progress`, because the step transitions the tracker to `In Progress` while the worker runs and reconciliation stops claimed issues that are no longer active
 - terminal state `Done`
 - one `acpx_agent` agent with an inline prompt
 - one `implement` step with `tracker_state: In Progress`

--- a/docs/superpowers/specs/2026-06-12-product-e2e-test-design.md
+++ b/docs/superpowers/specs/2026-06-12-product-e2e-test-design.md
@@ -116,7 +116,7 @@ Bound all polling with clear timeout errors so CI failures point at the missing 
 Update `docs/contributing.md` with a short E2E section:
 
 ```sh
-cargo test -p ensemble-cli --test product_e2e
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e
 ```
 
 Mention that the test uses temp files, a mock `acpx`, and localhost only.


### PR DESCRIPTION
## Summary
- Add a black-box product E2E test for the real `ensemble web` path using a temp todo-file tracker and mock `acpx` runtime.
- Verify completion through public API state/history, persisted timeline artifacts, tracker state transition, and mock prompt execution.
- Document the product E2E workflow and update contributor/AGENTS guidance for the optional `web-ui` feature.

## Validation
- `rtk cargo fmt --all -- --check`
- `rtk cargo test -p ensemble-cli --test product_e2e -- --nocapture`
- `rtk env SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`
- `rtk cargo test --workspace --exclude ensemble-desktop`
- `rtk env SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `rtk cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`

Fixes 197