### PR TITLE
Document long-term compatibility policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ This bumps versions in `Cargo.toml` + `tauri.conf.json`, commits, tags, and push
 
 ## Code conventions
 
+- **Compatibility policy**: Do not preserve backwards compatibility unless it is explicitly requested for the change. When choosing between compatibility and a better long-term design, prefer the option that is cleaner, more scalable, and easier to maintain, even if it requires more work upfront.
 - **Rust 2021 edition**, minimum rust-version 1.80
 - **Async traits**: The codebase currently uses the `async-trait` crate/macro. Follow the existing pattern in the surrounding module; prefer native `async fn` in traits only where it fits the existing interface and compatibility requirements.
 - **Error handling**: `thiserror` enums (`EnsembleError`, `ConfigError`, `WorkspaceError`, `TrackerError`). Use `?` propagation, not `.unwrap()` in library code. Tests may unwrap. Return `anyhow::Result<()>` from executable `main` functions to avoid manual `process::exit` boilerplate.


### PR DESCRIPTION
## Summary

Adds an AGENTS.md compatibility policy telling agents not to preserve backwards compatibility unless explicitly requested, and to prefer cleaner, more scalable long-term designs even when they require more work upfront.

## Validation

Docs-only change; no test suite was run.