### PR TITLE
Two-phase structured output for verdict extraction

### DIFF
--- a/crates/ensemble-cli/src/commands/init/generate.rs
+++ b/crates/ensemble-cli/src/commands/init/generate.rs
@@ -354,7 +354,8 @@ mod tests {
     fn test_generate_template_review() {
         let template = generate_template("review");
         assert!(template.contains("{{ issue.title }}"));
-        assert!(template.contains("verdict"));
+        assert!(template.contains("Ensemble will extract the structured result afterward"));
+        assert!(!template.contains(".ensemble/verdict.json"));
         assert!(template.contains("Review the changes"));
     }
 

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -276,6 +276,40 @@ fn should_emit_turn_events(turn: &SessionTurn) -> bool {
     turn.visibility == TurnVisibility::Visible
 }
 
+async fn emit_permission_events_if_visible(
+    visibility: TurnVisibility,
+    tx: &mpsc::Sender<WorkerEvent>,
+    issue_id: &str,
+    step_name: &str,
+    event: AgentEvent,
+) {
+    if visibility != TurnVisibility::Visible {
+        return;
+    }
+
+    emit_event(tx, issue_id, step_name, event).await;
+}
+
+fn map_session_error(error_msg: String, read_timeout_ms: u64, turn_timeout_ms: u64) -> AgentError {
+    if error_msg.contains("response timeout") {
+        AgentError::ResponseTimeout {
+            timeout_ms: read_timeout_ms,
+        }
+    } else if error_msg.contains("turn timeout") || error_msg.contains("TimedOut") {
+        AgentError::TurnTimeout {
+            timeout_ms: turn_timeout_ms,
+        }
+    } else if error_msg.contains("verdict extraction failed") {
+        AgentError::ResponseError { reason: error_msg }
+    } else if error_msg.contains("initialize") || error_msg.contains("session") {
+        AgentError::SessionStartupFailed { reason: error_msg }
+    } else if error_msg.contains("cancelled") {
+        AgentError::TurnCancelled
+    } else {
+        AgentError::IoError { reason: error_msg }
+    }
+}
+
 #[derive(Debug)]
 enum CompletedTurnAction {
     Queue(SessionTurn),
@@ -567,6 +601,7 @@ pub async fn run_acp_session(
     let turn_results: Arc<Mutex<Vec<TurnResult>>> = Arc::new(Mutex::new(Vec::new()));
     let final_output: Arc<Mutex<Option<StepOutput>>> = Arc::new(Mutex::new(None));
     let session_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let current_turn_visibility = Arc::new(Mutex::new(TurnVisibility::Visible));
     let discovered_capabilities: Arc<Mutex<DiscoveredCapabilities>> =
         Arc::new(Mutex::new(DiscoveredCapabilities::default()));
     let working_turn = Arc::new(working_turn);
@@ -581,16 +616,19 @@ pub async fn run_acp_session(
     let final_output_inner = final_output.clone();
     let session_error_inner = session_error.clone();
     let session_error_outer = session_error.clone();
+    let current_turn_visibility_inner = current_turn_visibility.clone();
     let discovered_capabilities_inner = discovered_capabilities.clone();
 
     let builder = Client.builder().name("ensemble").on_receive_request(
         async move |request: RequestPermissionRequest,
                     responder: agent_client_protocol::Responder<RequestPermissionResponse>,
                     _cx| {
+            let visibility = *current_turn_visibility_inner.lock().await;
             let tool_call_id = request.tool_call.tool_call_id.to_string();
             let title = request.tool_call.fields.title.clone();
 
-            emit_event(
+            emit_permission_events_if_visible(
+                visibility,
                 &event_tx_clone,
                 &issue_id_owned,
                 &step_name_owned,
@@ -602,10 +640,15 @@ pub async fn run_acp_session(
             )
             .await;
 
-            let decision = resolve_permission_outcome(&permission_policy, &request.options);
+            let decision = if visibility == TurnVisibility::Visible {
+                resolve_permission_outcome(&permission_policy, &request.options)
+            } else {
+                cancelled_decision()
+            };
             let response = RequestPermissionResponse::new(decision.outcome.clone());
 
-            emit_event(
+            emit_permission_events_if_visible(
+                visibility,
                 &event_tx_clone,
                 &issue_id_owned,
                 &step_name_owned,
@@ -753,6 +796,7 @@ pub async fn run_acp_session(
             while let Some(turn) = turns.pop_front() {
                 turn_index += 1;
                 let visible = should_emit_turn_events(&turn);
+                *current_turn_visibility.lock().await = turn.visibility;
                 if cancel_token.is_cancelled() {
                     if visible {
                         emit_event(
@@ -980,36 +1024,16 @@ pub async fn run_acp_session(
         let error_msg = e.to_string();
         let captured = session_error_outer.lock().await.clone();
         let msg = captured.unwrap_or(error_msg);
-        if msg.contains("response timeout") {
-            return Err(AgentError::ResponseTimeout {
-                timeout_ms: read_timeout_ms,
-            });
-        }
-        if msg.contains("turn timeout") || msg.contains("TimedOut") {
-            return Err(AgentError::TurnTimeout {
-                timeout_ms: turn_timeout_ms,
-            });
-        }
-        return Err(AgentError::IoError { reason: msg });
+        return Err(map_session_error(msg, read_timeout_ms, turn_timeout_ms));
     }
 
     let captured_error = session_error_outer.lock().await.clone();
     if let Some(error_msg) = captured_error {
-        if error_msg.contains("response timeout") {
-            return Err(AgentError::ResponseTimeout {
-                timeout_ms: read_timeout_ms,
-            });
-        } else if error_msg.contains("turn timeout") || error_msg.contains("TimedOut") {
-            return Err(AgentError::TurnTimeout {
-                timeout_ms: turn_timeout_ms,
-            });
-        } else if error_msg.contains("initialize") || error_msg.contains("session") {
-            return Err(AgentError::SessionStartupFailed { reason: error_msg });
-        } else if error_msg.contains("cancelled") {
-            return Err(AgentError::TurnCancelled);
-        } else {
-            return Err(AgentError::IoError { reason: error_msg });
-        }
+        return Err(map_session_error(
+            error_msg,
+            read_timeout_ms,
+            turn_timeout_ms,
+        ));
     }
 
     let output = final_output
@@ -1309,6 +1333,41 @@ mod tests {
             visibility: TurnVisibility::Visible,
             purpose: TurnPurpose::Working,
         }));
+    }
+
+    #[tokio::test]
+    async fn hidden_permission_callback_does_not_emit_visible_events() {
+        let (tx, mut rx) = mpsc::channel(10);
+
+        emit_permission_events_if_visible(
+            TurnVisibility::Hidden,
+            &tx,
+            "issue-1",
+            "build",
+            AgentEvent::PermissionRequested {
+                tool_call_id: "tool-1".to_string(),
+                title: "read file".to_string(),
+                options: Vec::new(),
+            },
+        )
+        .await;
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn extraction_failure_maps_to_response_error() {
+        let error = map_session_error(
+            "verdict extraction failed: failed results require a non-empty summary".to_string(),
+            100,
+            200,
+        );
+
+        assert!(matches!(
+            error,
+            AgentError::ResponseError { reason }
+                if reason.contains("verdict extraction failed")
+        ));
     }
 
     #[test]

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -291,20 +291,23 @@ async fn emit_permission_events_if_visible(
 }
 
 fn map_session_error(error_msg: String, read_timeout_ms: u64, turn_timeout_ms: u64) -> AgentError {
-    if error_msg.contains("response timeout") {
+    let normalized_error = error_msg.to_lowercase();
+    if normalized_error.contains("response timeout") {
         AgentError::ResponseTimeout {
             timeout_ms: read_timeout_ms,
         }
-    } else if error_msg.contains("turn timeout") || error_msg.contains("TimedOut") {
+    } else if normalized_error.contains("turn timeout") || normalized_error.contains("timedout") {
         AgentError::TurnTimeout {
             timeout_ms: turn_timeout_ms,
         }
-    } else if error_msg.contains("verdict extraction failed") {
+    } else if normalized_error.contains("verdict extraction failed") {
         AgentError::ResponseError { reason: error_msg }
-    } else if error_msg.contains("initialize") || error_msg.contains("session") {
+    } else if normalized_error.contains("initialize") || normalized_error.contains("session") {
         AgentError::SessionStartupFailed { reason: error_msg }
-    } else if error_msg.contains("cancelled") {
+    } else if normalized_error.contains("cancelled") {
         AgentError::TurnCancelled
+    } else if normalized_error.contains("stop reason") {
+        AgentError::TurnFailed { reason: error_msg }
     } else {
         AgentError::IoError { reason: error_msg }
     }
@@ -981,9 +984,10 @@ pub async fn run_acp_session(
                 }
 
                 if let TurnResult::Failed { ref reason, .. } = turn_result {
+                    let mut err = session_error_inner.lock().await;
+                    *err = Some(reason.clone());
+
                     if timed_out {
-                        let mut err = session_error_inner.lock().await;
-                        *err = Some(reason.clone());
                         turn_results_inner.lock().await.push(turn_result);
                         return Ok(());
                     }
@@ -1346,7 +1350,7 @@ mod tests {
             "build",
             AgentEvent::PermissionRequested {
                 tool_call_id: "tool-1".to_string(),
-                title: "read file".to_string(),
+                title: Some("read file".to_string()),
                 options: Vec::new(),
             },
         )
@@ -1367,6 +1371,23 @@ mod tests {
             error,
             AgentError::ResponseError { reason }
                 if reason.contains("verdict extraction failed")
+        ));
+    }
+
+    #[test]
+    fn cancelled_stop_reason_maps_to_turn_cancelled() {
+        let error = map_session_error("stop reason: Cancelled".to_string(), 100, 200);
+
+        assert!(matches!(error, AgentError::TurnCancelled));
+    }
+
+    #[test]
+    fn failed_stop_reason_maps_to_turn_failed() {
+        let error = map_session_error("stop reason: Refusal".to_string(), 100, 200);
+
+        assert!(matches!(
+            error,
+            AgentError::TurnFailed { reason } if reason == "stop reason: Refusal"
         ));
     }
 

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,6 +21,7 @@ use crate::config::ensemble::{
     PermissionRequestPolicyMode,
 };
 use crate::error::AgentError;
+use crate::pipeline::verdict::StepOutput;
 
 use super::events::{
     AgentEvent, AgentPermissionOption, AgentPermissionOptionKind, AgentPermissionOutcome,
@@ -71,6 +73,40 @@ pub struct AcpSessionConfig {
     pub cancel_token: CancellationToken,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnVisibility {
+    Visible,
+    Hidden,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnPurpose {
+    Working,
+    Extraction,
+    Repair,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionTurn {
+    pub prompt: String,
+    pub visibility: TurnVisibility,
+    pub purpose: TurnPurpose,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExtractionContext {
+    pub step_name: String,
+    pub issue_identifier: String,
+    pub original_prompt: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AcpSessionOutcome {
+    pub output: StepOutput,
+    pub turn_results: Vec<TurnResult>,
+    pub capabilities: DiscoveredCapabilities,
+}
+
 #[derive(Debug)]
 pub struct AcpCapabilityDiscoveryConfig {
     pub command: ResolvedCommand,
@@ -83,11 +119,13 @@ pub enum TurnResult {
     Completed {
         usage: Option<TokenUsage>,
         runtime_verdict: Option<serde_json::Value>,
+        output_text: String,
     },
     Failed {
         reason: String,
         usage: Option<TokenUsage>,
         runtime_verdict: Option<serde_json::Value>,
+        output_text: String,
     },
 }
 
@@ -232,6 +270,66 @@ fn runtime_verdict_from_value(value: &serde_json::Value) -> Option<serde_json::V
         .get("result")
         .cloned()
         .or_else(|| value.get("verdict").cloned())
+}
+
+fn should_emit_turn_events(turn: &SessionTurn) -> bool {
+    turn.visibility == TurnVisibility::Visible
+}
+
+#[derive(Debug)]
+enum CompletedTurnAction {
+    Queue(SessionTurn),
+    Finished(StepOutput),
+    Failed(String),
+}
+
+fn handle_completed_turn(
+    turn: &SessionTurn,
+    extraction_context: &ExtractionContext,
+    runtime_verdict: Option<&serde_json::Value>,
+    output_text: &str,
+    repair_attempted: &mut bool,
+) -> CompletedTurnAction {
+    match turn.purpose {
+        TurnPurpose::Working => {
+            let extraction_prompt = crate::agent::extraction::build_extraction_prompt(
+                &extraction_context.step_name,
+                &extraction_context.issue_identifier,
+                &extraction_context.original_prompt,
+                output_text,
+            );
+            CompletedTurnAction::Queue(SessionTurn {
+                prompt: extraction_prompt,
+                visibility: TurnVisibility::Hidden,
+                purpose: TurnPurpose::Extraction,
+            })
+        }
+        TurnPurpose::Extraction | TurnPurpose::Repair => {
+            match crate::agent::extraction::validate_extraction_payload(
+                runtime_verdict,
+                output_text,
+            ) {
+                Ok(output) => CompletedTurnAction::Finished(output),
+                Err(error) if turn.purpose == TurnPurpose::Extraction && !*repair_attempted => {
+                    *repair_attempted = true;
+                    let previous_payload = runtime_verdict
+                        .map(serde_json::Value::to_string)
+                        .unwrap_or_else(|| output_text.to_string());
+                    CompletedTurnAction::Queue(SessionTurn {
+                        prompt: crate::agent::extraction::build_repair_prompt(
+                            &error.to_string(),
+                            &previous_payload,
+                        ),
+                        visibility: TurnVisibility::Hidden,
+                        purpose: TurnPurpose::Repair,
+                    })
+                }
+                Err(error) => {
+                    CompletedTurnAction::Failed(format!("verdict extraction failed: {error}"))
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -454,18 +552,12 @@ pub async fn discover_capabilities(
 
 pub async fn run_acp_session(
     config: AcpSessionConfig,
-    prompts: Vec<String>,
+    working_turn: SessionTurn,
+    extraction_context: ExtractionContext,
     issue_id: &str,
     step_name: &str,
     event_tx: &mpsc::Sender<WorkerEvent>,
-) -> Result<
-    (
-        Option<serde_json::Value>,
-        Vec<TurnResult>,
-        DiscoveredCapabilities,
-    ),
-    AgentError,
-> {
+) -> Result<AcpSessionOutcome, AgentError> {
     let agent = build_acp_agent(&config.command, &config.workspace_path);
     let permission_policy = config.permission_request_policy.clone();
     let issue_id_owned = issue_id.to_string();
@@ -473,11 +565,12 @@ pub async fn run_acp_session(
     let event_tx_clone = event_tx.clone();
 
     let turn_results: Arc<Mutex<Vec<TurnResult>>> = Arc::new(Mutex::new(Vec::new()));
-    let final_verdict: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+    let final_output: Arc<Mutex<Option<StepOutput>>> = Arc::new(Mutex::new(None));
     let session_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let discovered_capabilities: Arc<Mutex<DiscoveredCapabilities>> =
         Arc::new(Mutex::new(DiscoveredCapabilities::default()));
-    let prompts = Arc::new(prompts);
+    let working_turn = Arc::new(working_turn);
+    let extraction_context = Arc::new(extraction_context);
     let session_mode = config.session_mode.clone();
     let read_timeout_ms = config.read_timeout_ms;
     let turn_timeout_ms = config.turn_timeout_ms;
@@ -485,7 +578,7 @@ pub async fn run_acp_session(
     let cancel_token = config.cancel_token.clone();
 
     let turn_results_inner = turn_results.clone();
-    let final_verdict_inner = final_verdict.clone();
+    let final_output_inner = final_output.clone();
     let session_error_inner = session_error.clone();
     let session_error_outer = session_error.clone();
     let discovered_capabilities_inner = discovered_capabilities.clone();
@@ -653,23 +746,33 @@ pub async fn run_acp_session(
                 }
             }
 
-            for (i, prompt) in prompts.iter().enumerate() {
+            let mut turns = VecDeque::from([(*working_turn).clone()]);
+            let mut repair_attempted = false;
+            let mut turn_index = 0usize;
+
+            while let Some(turn) = turns.pop_front() {
+                turn_index += 1;
+                let visible = should_emit_turn_events(&turn);
                 if cancel_token.is_cancelled() {
-                    emit_event(
-                        event_tx,
-                        issue_id,
-                        step_name,
-                        AgentEvent::Cancelled { reason: None },
-                    )
-                    .await;
+                    if visible {
+                        emit_event(
+                            event_tx,
+                            issue_id,
+                            step_name,
+                            AgentEvent::Cancelled { reason: None },
+                        )
+                        .await;
+                    }
                     let mut err = session_error_inner.lock().await;
                     *err = Some("cancelled by user".to_string());
                     return Ok(());
                 }
 
-                emit_event(event_tx, issue_id, step_name, AgentEvent::PromptStarted).await;
+                if visible {
+                    emit_event(event_tx, issue_id, step_name, AgentEvent::PromptStarted).await;
+                }
 
-                if let Err(e) = session.send_prompt(prompt) {
+                if let Err(e) = session.send_prompt(&turn.prompt) {
                     let mut err = session_error_inner.lock().await;
                     *err = Some(format!("send_prompt failed: {e}"));
                     return Ok(());
@@ -677,6 +780,7 @@ pub async fn run_acp_session(
 
                 let mut last_usage: Option<TokenUsage> = None;
                 let mut last_runtime_verdict: Option<serde_json::Value> = None;
+                let mut output_text = String::new();
                 let mut timed_out = false;
 
                 let turn_future = async {
@@ -684,7 +788,12 @@ pub async fn run_acp_session(
                         match session.read_update().await {
                             Ok(SessionMessage::StopReason(stop)) => {
                                 let mapped = map_sdk_stop_reason(&stop);
-                                return Ok((mapped, last_usage, last_runtime_verdict));
+                                return Ok((
+                                    mapped,
+                                    last_usage,
+                                    last_runtime_verdict,
+                                    output_text,
+                                ));
                             }
                             Ok(SessionMessage::SessionMessage(dispatch)) => {
                                 if let Some(parsed) = parse_sdk_dispatch(dispatch)
@@ -698,16 +807,19 @@ pub async fn run_acp_session(
                                         last_runtime_verdict = Some(verdict);
                                     }
                                     if let Some(content) = parsed.output_text {
-                                        emit_event(
-                                            event_tx,
-                                            issue_id,
-                                            step_name,
-                                            AgentEvent::OutputChunk {
-                                                stream: RuntimeStream::Stdout,
-                                                content,
-                                            },
-                                        )
-                                        .await;
+                                        output_text.push_str(&content);
+                                        if visible {
+                                            emit_event(
+                                                event_tx,
+                                                issue_id,
+                                                step_name,
+                                                AgentEvent::OutputChunk {
+                                                    stream: RuntimeStream::Stdout,
+                                                    content,
+                                                },
+                                            )
+                                            .await;
+                                        }
                                     }
                                 }
                             }
@@ -722,13 +834,15 @@ pub async fn run_acp_session(
                 let cancel = cancel_token.clone();
                 let turn_result: TurnResult = tokio::select! {
                     _ = cancel.cancelled() => {
-                        emit_event(
-                            event_tx,
-                            issue_id,
-                            step_name,
-                            AgentEvent::Cancelled { reason: None },
-                        )
-                        .await;
+                        if visible {
+                            emit_event(
+                                event_tx,
+                                issue_id,
+                                step_name,
+                                AgentEvent::Cancelled { reason: None },
+                            )
+                            .await;
+                        }
                         let mut err = session_error_inner.lock().await;
                         *err = Some("cancelled by user".to_string());
                         return Ok(());
@@ -738,39 +852,45 @@ pub async fn run_acp_session(
                         turn_future,
                     ) => {
                         match result {
-                            Ok(Ok((stop_reason, usage, verdict))) => match stop_reason {
+                            Ok(Ok((stop_reason, usage, verdict, output_text))) => match stop_reason {
                                 super::events::StopReason::EndTurn
                                 | super::events::StopReason::MaxTokens => {
-                                    emit_event(
-                                        event_tx,
-                                        issue_id,
-                                        step_name,
-                                        AgentEvent::RunCompleted {
-                                            usage: usage.clone(),
-                                        },
-                                    )
-                                    .await;
+                                    if visible {
+                                        emit_event(
+                                            event_tx,
+                                            issue_id,
+                                            step_name,
+                                            AgentEvent::RunCompleted {
+                                                usage: usage.clone(),
+                                            },
+                                        )
+                                        .await;
+                                    }
                                     TurnResult::Completed {
                                         usage,
                                         runtime_verdict: verdict,
+                                        output_text,
                                     }
                                 }
                                 _ => {
                                     let reason = format!("stop reason: {:?}", stop_reason);
-                                    emit_event(
-                                        event_tx,
-                                        issue_id,
-                                        step_name,
-                                        AgentEvent::RunFailed {
-                                            reason: reason.clone(),
-                                            usage: usage.clone(),
-                                        },
-                                    )
-                                    .await;
+                                    if visible {
+                                        emit_event(
+                                            event_tx,
+                                            issue_id,
+                                            step_name,
+                                            AgentEvent::RunFailed {
+                                                reason: reason.clone(),
+                                                usage: usage.clone(),
+                                            },
+                                        )
+                                        .await;
+                                    }
                                     TurnResult::Failed {
                                         reason,
                                         usage,
                                         runtime_verdict: verdict,
+                                        output_text,
                                     }
                                 }
                             },
@@ -785,6 +905,7 @@ pub async fn run_acp_session(
                                     reason: format!("turn timeout after {turn_timeout_ms}ms"),
                                     usage: None,
                                     runtime_verdict: None,
+                                    output_text: String::new(),
                                 }
                             }
                         }
@@ -793,12 +914,25 @@ pub async fn run_acp_session(
 
                 if let TurnResult::Completed {
                     ref runtime_verdict,
+                    ref output_text,
                     ..
                 } = turn_result
                 {
-                    if runtime_verdict.is_some() {
-                        let mut v = final_verdict_inner.lock().await;
-                        *v = runtime_verdict.clone();
+                    match handle_completed_turn(
+                        &turn,
+                        &extraction_context,
+                        runtime_verdict.as_ref(),
+                        output_text,
+                        &mut repair_attempted,
+                    ) {
+                        CompletedTurnAction::Queue(next_turn) => turns.push_back(next_turn),
+                        CompletedTurnAction::Finished(output) => {
+                            *final_output_inner.lock().await = Some(output);
+                        }
+                        CompletedTurnAction::Failed(error) => {
+                            let mut err = session_error_inner.lock().await;
+                            *err = Some(error);
+                        }
                     }
                 }
 
@@ -809,26 +943,33 @@ pub async fn run_acp_session(
                         turn_results_inner.lock().await.push(turn_result);
                         return Ok(());
                     }
-                    if i < prompts.len() - 1 {
-                        warn!(
-                            issue_id = %issue_id,
-                            step = step_name,
-                            turn = i + 1,
-                            reason = %reason,
-                            "turn failed, stopping remaining turns"
-                        );
-                        turn_results_inner.lock().await.push(turn_result);
-                        return Ok(());
-                    }
+                    warn!(
+                        issue_id = %issue_id,
+                        step = step_name,
+                        turn = turn_index,
+                        purpose = ?turn.purpose,
+                        reason = %reason,
+                        "turn failed, stopping remaining turns"
+                    );
+                    turn_results_inner.lock().await.push(turn_result);
+                    return Ok(());
                 }
 
                 info!(
                     issue_id = %issue_id,
                     step = step_name,
-                    turn = i + 1,
+                    turn = turn_index,
+                    purpose = ?turn.purpose,
                     "turn completed successfully"
                 );
                 turn_results_inner.lock().await.push(turn_result);
+
+                if final_output_inner.lock().await.is_some() {
+                    break;
+                }
+                if session_error_inner.lock().await.is_some() {
+                    return Ok(());
+                }
             }
 
             Ok(())
@@ -871,10 +1012,20 @@ pub async fn run_acp_session(
         }
     }
 
-    let verdict = final_verdict.lock().await.take();
+    let output = final_output
+        .lock()
+        .await
+        .take()
+        .ok_or_else(|| AgentError::ResponseError {
+            reason: "verdict extraction did not produce a valid StepOutput".to_string(),
+        })?;
     let results = turn_results.lock().await.clone();
     let capabilities = discovered_capabilities.lock().await.clone();
-    Ok((verdict, results, capabilities))
+    Ok(AcpSessionOutcome {
+        output,
+        turn_results: results,
+        capabilities,
+    })
 }
 
 #[cfg(test)]
@@ -888,6 +1039,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::pipeline::verdict::StepResult;
 
     #[test]
     fn permission_option_event_kind_serializes_as_snake_case() {
@@ -1104,6 +1256,127 @@ mod tests {
         );
     }
 
+    fn extraction_context() -> ExtractionContext {
+        ExtractionContext {
+            step_name: "build".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            original_prompt: "Build it".to_string(),
+        }
+    }
+
+    fn hidden_extraction_turn() -> SessionTurn {
+        SessionTurn {
+            prompt: "extract".to_string(),
+            visibility: TurnVisibility::Hidden,
+            purpose: TurnPurpose::Extraction,
+        }
+    }
+
+    #[test]
+    fn hidden_extraction_validates_runtime_verdict_as_session_output() {
+        let mut repair_attempted = false;
+        let runtime_verdict = serde_json::json!({
+            "result": "concern",
+            "summary": "manual review needed",
+            "output": {"risk": "medium"}
+        });
+
+        let action = handle_completed_turn(
+            &hidden_extraction_turn(),
+            &extraction_context(),
+            Some(&runtime_verdict),
+            "not json",
+            &mut repair_attempted,
+        );
+
+        let CompletedTurnAction::Finished(output) = action else {
+            panic!("expected finished output, got {action:?}");
+        };
+        assert_eq!(
+            output.result,
+            StepResult::Concern {
+                summary: "manual review needed".to_string()
+            }
+        );
+        assert_eq!(output.output, Some(serde_json::json!({"risk": "medium"})));
+    }
+
+    #[test]
+    fn hidden_extraction_turns_do_not_emit_visible_events() {
+        assert!(!should_emit_turn_events(&hidden_extraction_turn()));
+        assert!(should_emit_turn_events(&SessionTurn {
+            prompt: "work".to_string(),
+            visibility: TurnVisibility::Visible,
+            purpose: TurnPurpose::Working,
+        }));
+    }
+
+    #[test]
+    fn invalid_extraction_then_valid_repair_succeeds() {
+        let mut repair_attempted = false;
+        let action = handle_completed_turn(
+            &hidden_extraction_turn(),
+            &extraction_context(),
+            None,
+            r#"{"result":"failed"}"#,
+            &mut repair_attempted,
+        );
+
+        let CompletedTurnAction::Queue(repair_turn) = action else {
+            panic!("expected repair turn, got {action:?}");
+        };
+        assert!(repair_attempted);
+        assert_eq!(repair_turn.visibility, TurnVisibility::Hidden);
+        assert_eq!(repair_turn.purpose, TurnPurpose::Repair);
+
+        let repair_action = handle_completed_turn(
+            &repair_turn,
+            &extraction_context(),
+            None,
+            r#"{"result":"failed","summary":"tests failed"}"#,
+            &mut repair_attempted,
+        );
+
+        let CompletedTurnAction::Finished(output) = repair_action else {
+            panic!("expected repaired output, got {repair_action:?}");
+        };
+        assert_eq!(
+            output.result,
+            StepResult::Failed {
+                summary: "tests failed".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_extraction_then_invalid_repair_fails() {
+        let mut repair_attempted = false;
+        let action = handle_completed_turn(
+            &hidden_extraction_turn(),
+            &extraction_context(),
+            None,
+            r#"{"result":"failed"}"#,
+            &mut repair_attempted,
+        );
+        let CompletedTurnAction::Queue(repair_turn) = action else {
+            panic!("expected repair turn, got {action:?}");
+        };
+
+        let repair_action = handle_completed_turn(
+            &repair_turn,
+            &extraction_context(),
+            None,
+            r#"{"result":"failed"}"#,
+            &mut repair_attempted,
+        );
+
+        let CompletedTurnAction::Failed(error) = repair_action else {
+            panic!("expected extraction failure, got {repair_action:?}");
+        };
+        assert!(error.contains("verdict extraction failed"));
+        assert!(error.contains("failed results require a non-empty summary"));
+    }
+
     #[tokio::test]
     async fn startup_initialize_uses_configured_read_timeout() {
         let workspace = TempDir::new().unwrap();
@@ -1124,7 +1397,22 @@ mod tests {
 
         let result = tokio::time::timeout(
             Duration::from_millis(500),
-            run_acp_session(config, vec!["hello".to_string()], "issue-1", "build", &tx),
+            run_acp_session(
+                config,
+                SessionTurn {
+                    prompt: "hello".to_string(),
+                    visibility: TurnVisibility::Visible,
+                    purpose: TurnPurpose::Working,
+                },
+                ExtractionContext {
+                    step_name: "build".to_string(),
+                    issue_identifier: "repo#1".to_string(),
+                    original_prompt: "hello".to_string(),
+                },
+                "issue-1",
+                "build",
+                &tx,
+            ),
         )
         .await;
 

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -20,9 +20,16 @@ pub struct AcpxCommandOptions<'a> {
     pub reasoning_level: Option<&'a str>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptVisibility {
+    Visible,
+    Hidden,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct PromptOutcome {
     pub runtime_verdict: Option<serde_json::Value>,
+    pub output_text: String,
 }
 
 impl AcpxCli {
@@ -91,6 +98,7 @@ impl AcpxCli {
         cwd: &Path,
         prompt: &str,
         options: AcpxCommandOptions<'_>,
+        visibility: PromptVisibility,
         mut on_event: F,
     ) -> Result<PromptOutcome, AgentError>
     where
@@ -221,6 +229,8 @@ impl AcpxCli {
             }
         });
 
+        let visible = visibility == PromptVisibility::Visible;
+        let mut output_text = String::new();
         let mut reader = BufReader::new(stdout).lines();
         let mut saw_terminal_event = false;
         let mut last_usage: Option<TokenUsage> = None;
@@ -242,24 +252,31 @@ impl AcpxCli {
                     last_runtime_verdict = Some(verdict);
                 }
                 if let Some(content) = update.output_text {
-                    on_event(AgentEvent::OutputChunk {
-                        stream: RuntimeStream::Stdout,
-                        content,
-                    })
-                    .await;
+                    output_text.push_str(&content);
+                    if visible {
+                        on_event(AgentEvent::OutputChunk {
+                            stream: RuntimeStream::Stdout,
+                            content,
+                        })
+                        .await;
+                    }
                 }
                 if let Some(permission) = update.permission_request {
-                    on_event(AgentEvent::Warning {
-                        message: format!(
-                            "permission requested ({}): {}",
-                            permission.permission_id, permission.description
-                        ),
-                    })
-                    .await;
+                    if visible {
+                        on_event(AgentEvent::Warning {
+                            message: format!(
+                                "permission requested ({}): {}",
+                                permission.permission_id, permission.description
+                            ),
+                        })
+                        .await;
+                    }
                 }
                 if let Some(stop_reason) = update.stop_reason {
                     saw_terminal_event = true;
-                    on_event(map_stop_reason(stop_reason, last_usage.clone())).await;
+                    if visible {
+                        on_event(map_stop_reason(stop_reason, last_usage.clone())).await;
+                    }
                 }
                 continue;
             }
@@ -270,21 +287,27 @@ impl AcpxCli {
                 .and_then(protocol::parse_stop_reason_from_result)
             {
                 saw_terminal_event = true;
-                on_event(map_stop_reason(stop_reason, last_usage.clone())).await;
+                if visible {
+                    on_event(map_stop_reason(stop_reason, last_usage.clone())).await;
+                }
                 continue;
             }
 
             if let Some(error) = message.error.as_ref() {
                 saw_terminal_event = true;
-                on_event(AgentEvent::RunFailed {
-                    reason: error.message.clone(),
-                    usage: last_usage.clone(),
-                })
-                .await;
+                if visible {
+                    on_event(AgentEvent::RunFailed {
+                        reason: error.message.clone(),
+                        usage: last_usage.clone(),
+                    })
+                    .await;
+                }
                 continue;
             }
 
-            on_event(AgentEvent::OtherMessage { raw: line }).await;
+            if visible {
+                on_event(AgentEvent::OtherMessage { raw: line }).await;
+            }
         }
 
         let status = child.wait().await.map_err(|e| AgentError::IoError {
@@ -306,6 +329,7 @@ impl AcpxCli {
 
         Ok(PromptOutcome {
             runtime_verdict: last_runtime_verdict,
+            output_text,
         })
     }
 
@@ -454,7 +478,7 @@ mod tests {
     use crate::agent::test_support::write_mock_acpx_script;
     use crate::error::AgentError;
 
-    use super::{AcpxCli, AcpxCommandOptions};
+    use super::{AcpxCli, AcpxCommandOptions, PromptVisibility};
 
     #[tokio::test]
     async fn ensure_session_uses_sessions_ensure_command() {
@@ -580,6 +604,7 @@ JSON
                 dir.path(),
                 "hi",
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |event| {
                     let events = Arc::clone(&events);
                     async move {
@@ -617,6 +642,7 @@ JSON
                 dir.path(),
                 "hi",
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |event| {
                     let events = Arc::clone(&events);
                     async move {
@@ -652,6 +678,7 @@ JSON
                 dir.path(),
                 "hi",
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |_| async {},
             )
             .await
@@ -686,6 +713,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":11,"result":{{"stopReason":"end_turn"}}}}'
             dir.path(),
             "hi",
             AcpxCommandOptions::default(),
+            PromptVisibility::Visible,
             |event| {
                 let tx = tx.clone();
                 async move {
@@ -737,6 +765,7 @@ JSON
                 dir.path(),
                 "hi",
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |_| async {},
             )
             .await
@@ -767,6 +796,7 @@ JSON
                 dir.path(),
                 "hi",
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |event| {
                     let events = Arc::clone(&events);
                     async move {
@@ -812,6 +842,7 @@ JSON
                 dir.path(),
                 "hi",
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |_| async {},
             )
             .await
@@ -824,6 +855,42 @@ JSON
                 "summary": "lint errors"
             }))
         );
+    }
+
+    #[tokio::test]
+    async fn hidden_prompt_captures_output_without_emitting_events() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            temp.path(),
+            r#"#!/usr/bin/env bash
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"result\":\"succeeded\"}"}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+"#,
+        );
+        let cli = AcpxCli::new(script);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_for_callback = events.clone();
+
+        let outcome = cli
+            .run_prompt(
+                "codex",
+                "session",
+                temp.path(),
+                "extract",
+                AcpxCommandOptions::default(),
+                PromptVisibility::Hidden,
+                move |event| {
+                    let events_for_callback = events_for_callback.clone();
+                    async move {
+                        events_for_callback.lock().unwrap().push(event);
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.output_text, "{\"result\":\"succeeded\"}");
+        assert!(events.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -847,6 +914,7 @@ JSON
                 dir.path(),
                 "hi",
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |event| {
                     let events = Arc::clone(&events);
                     async move {
@@ -928,6 +996,7 @@ exec 0<&-
                 dir.path(),
                 &prompt,
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |_| async {},
             ),
         )
@@ -969,6 +1038,7 @@ echo "stderr line 3" >&2
                 dir.path(),
                 "hi",
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |_| async {},
             )
             .await
@@ -1011,6 +1081,7 @@ JSON
                 dir.path(),
                 "hi",
                 AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
                 |_| async {},
             )
             .await

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -32,6 +32,16 @@ pub struct PromptOutcome {
     pub output_text: String,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct AcpxPromptRequest<'a> {
+    pub agent: &'a str,
+    pub session_name: &'a str,
+    pub cwd: &'a Path,
+    pub prompt: &'a str,
+    pub options: AcpxCommandOptions<'a>,
+    pub visibility: PromptVisibility,
+}
+
 impl AcpxCli {
     pub fn new(executable: String) -> Self {
         Self { executable }
@@ -93,32 +103,27 @@ impl AcpxCli {
 
     pub async fn run_prompt<F, Fut>(
         &self,
-        agent: &str,
-        session_name: &str,
-        cwd: &Path,
-        prompt: &str,
-        options: AcpxCommandOptions<'_>,
-        visibility: PromptVisibility,
+        request: AcpxPromptRequest<'_>,
         mut on_event: F,
     ) -> Result<PromptOutcome, AgentError>
     where
         F: FnMut(AgentEvent) -> Fut,
         Fut: Future<Output = ()> + Send,
     {
-        let mut command = self.base_command(agent, cwd, options);
+        let mut command = self.base_command(request.agent, request.cwd, request.options);
         command
-            .args(["prompt", "--session", session_name, "--file", "-"])
+            .args(["prompt", "--session", request.session_name, "--file", "-"])
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
-        debug!(agent, session_name, cwd = %cwd.display(), "running acpx prompt");
+        debug!(agent = request.agent, session_name = request.session_name, cwd = %request.cwd.display(), "running acpx prompt");
 
         let mut child = spawn_with_etxtbsy_retry(command).map_err(|e| AgentError::IoError {
             reason: format!("failed to run acpx prompt: {e}"),
         })?;
 
         if let Some(mut stdin) = child.stdin.take() {
-            if let Err(error) = stdin.write_all(prompt.as_bytes()).await {
+            if let Err(error) = stdin.write_all(request.prompt.as_bytes()).await {
                 if error.kind() != std::io::ErrorKind::BrokenPipe {
                     cleanup_prompt_child(&mut child).await;
                     return Err(AgentError::IoError {
@@ -162,9 +167,10 @@ impl AcpxCli {
             reason: "failed to capture acpx stderr".to_string(),
         })?;
 
-        let stderr_path = cwd
+        let stderr_path = request
+            .cwd
             .join(".ensemble")
-            .join(format!("acpx-stderr-{}.log", session_name));
+            .join(format!("acpx-stderr-{}.log", request.session_name));
         let parent = stderr_path.parent().ok_or_else(|| AgentError::IoError {
             reason: "stderr path has no parent".to_string(),
         })?;
@@ -181,9 +187,9 @@ impl AcpxCli {
                 })?;
 
         let stderr_path_clone = stderr_path.clone();
-        debug!(agent = %agent, session = %session_name, path = %stderr_path.display(), "acpx stderr -> {}", stderr_path.display());
+        debug!(agent = %request.agent, session = %request.session_name, path = %stderr_path.display(), "acpx stderr -> {}", stderr_path.display());
 
-        let agent_name = agent.to_string();
+        let agent_name = request.agent.to_string();
         let stderr_task = tokio::spawn(async move {
             let mut reader = BufReader::new(stderr).lines();
             let mut line_count: u64 = 0;
@@ -229,7 +235,7 @@ impl AcpxCli {
             }
         });
 
-        let visible = visibility == PromptVisibility::Visible;
+        let visible = request.visibility == PromptVisibility::Visible;
         let mut output_text = String::new();
         let mut reader = BufReader::new(stdout).lines();
         let mut saw_terminal_event = false;
@@ -345,9 +351,7 @@ impl AcpxCli {
         // Wait for the stderr sink to finish draining and flushing.
         let _ = tokio::time::timeout(std::time::Duration::from_secs(5), stderr_task).await;
 
-        if let Err(error) = read_result {
-            return Err(error);
-        }
+        read_result?;
 
         let status = status.expect("prompt status should be present when stdout read succeeds")?;
         if !status.success() {
@@ -358,7 +362,10 @@ impl AcpxCli {
         }
         if !saw_terminal_event {
             return Err(AgentError::AcpxFinalStatusMissing {
-                context: format!("session '{session_name}' ended without a terminal event"),
+                context: format!(
+                    "session '{}' ended without a terminal event",
+                    request.session_name
+                ),
             });
         }
 
@@ -507,13 +514,38 @@ fn map_stop_reason(stop_reason: StopReason, usage: Option<TokenUsage>) -> AgentE
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
     use std::sync::{Arc, Mutex};
 
     use crate::agent::events::{AgentEvent, TokenUsage};
     use crate::agent::test_support::write_mock_acpx_script;
     use crate::error::AgentError;
 
-    use super::{AcpxCli, AcpxCommandOptions, PromptVisibility};
+    use super::{AcpxCli, AcpxCommandOptions, AcpxPromptRequest, PromptVisibility};
+
+    fn prompt_request<'a>(
+        cwd: &'a Path,
+        prompt: &'a str,
+        visibility: PromptVisibility,
+    ) -> AcpxPromptRequest<'a> {
+        prompt_request_for("build-session", cwd, prompt, visibility)
+    }
+
+    fn prompt_request_for<'a>(
+        session_name: &'a str,
+        cwd: &'a Path,
+        prompt: &'a str,
+        visibility: PromptVisibility,
+    ) -> AcpxPromptRequest<'a> {
+        AcpxPromptRequest {
+            agent: "codex",
+            session_name,
+            cwd,
+            prompt,
+            options: AcpxCommandOptions::default(),
+            visibility,
+        }
+    }
 
     #[tokio::test]
     async fn ensure_session_uses_sessions_ensure_command() {
@@ -634,12 +666,7 @@ JSON
         let events = Arc::new(Mutex::new(Vec::new()));
         client
             .run_prompt(
-                "codex",
-                "build-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request(dir.path(), "hi", PromptVisibility::Visible),
                 |event| {
                     let events = Arc::clone(&events);
                     async move {
@@ -672,12 +699,7 @@ JSON
         let events = Arc::new(Mutex::new(Vec::new()));
         client
             .run_prompt(
-                "codex",
-                "build-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request(dir.path(), "hi", PromptVisibility::Visible),
                 |event| {
                     let events = Arc::clone(&events);
                     async move {
@@ -708,12 +730,7 @@ JSON
         let client = AcpxCli::new(script);
         let error = client
             .run_prompt(
-                "codex",
-                "build-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request(dir.path(), "hi", PromptVisibility::Visible),
                 |_| async {},
             )
             .await
@@ -743,12 +760,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":11,"result":{{"stopReason":"end_turn"}}}}'
         let client = AcpxCli::new(script);
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let run = client.run_prompt(
-            "codex",
-            "build-session",
-            dir.path(),
-            "hi",
-            AcpxCommandOptions::default(),
-            PromptVisibility::Visible,
+            prompt_request(dir.path(), "hi", PromptVisibility::Visible),
             |event| {
                 let tx = tx.clone();
                 async move {
@@ -795,12 +807,7 @@ JSON
         let client = AcpxCli::new(script);
         let error = client
             .run_prompt(
-                "codex",
-                "build-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request(dir.path(), "hi", PromptVisibility::Visible),
                 |_| async {},
             )
             .await
@@ -826,12 +833,7 @@ JSON
         let events = Arc::new(Mutex::new(Vec::new()));
         client
             .run_prompt(
-                "codex",
-                "build-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request(dir.path(), "hi", PromptVisibility::Visible),
                 |event| {
                     let events = Arc::clone(&events);
                     async move {
@@ -872,12 +874,7 @@ JSON
         let client = AcpxCli::new(script);
         let outcome = client
             .run_prompt(
-                "codex",
-                "build-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request(dir.path(), "hi", PromptVisibility::Visible),
                 |_| async {},
             )
             .await
@@ -908,12 +905,7 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
 
         let outcome = cli
             .run_prompt(
-                "codex",
-                "session",
-                temp.path(),
-                "extract",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Hidden,
+                prompt_request_for("session", temp.path(), "extract", PromptVisibility::Hidden),
                 move |event| {
                     let events_for_callback = events_for_callback.clone();
                     async move {
@@ -944,12 +936,7 @@ JSON
         let events = Arc::new(Mutex::new(Vec::new()));
         client
             .run_prompt(
-                "codex",
-                "build-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request(dir.path(), "hi", PromptVisibility::Visible),
                 |event| {
                     let events = Arc::clone(&events);
                     async move {
@@ -1026,12 +1013,7 @@ exec 0<&-
         let error = tokio::time::timeout(
             std::time::Duration::from_secs(10),
             client.run_prompt(
-                "codex",
-                "build-session",
-                dir.path(),
-                &prompt,
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request(dir.path(), &prompt, PromptVisibility::Visible),
                 |_| async {},
             ),
         )
@@ -1070,12 +1052,7 @@ printf '%s\n' 'not-jsonrpc'
         let error = tokio::time::timeout(
             std::time::Duration::from_secs(10),
             client.run_prompt(
-                "codex",
-                "build-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request(dir.path(), "hi", PromptVisibility::Visible),
                 |_| async {},
             ),
         )
@@ -1117,12 +1094,7 @@ echo "stderr line 3" >&2
         let client = AcpxCli::new(script);
         client
             .run_prompt(
-                "codex",
-                "test-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request_for("test-session", dir.path(), "hi", PromptVisibility::Visible),
                 |_| async {},
             )
             .await
@@ -1160,12 +1132,7 @@ JSON
         let client = AcpxCli::new(script);
         client
             .run_prompt(
-                "codex",
-                "empty-session",
-                dir.path(),
-                "hi",
-                AcpxCommandOptions::default(),
-                PromptVisibility::Visible,
+                prompt_request_for("empty-session", dir.path(), "hi", PromptVisibility::Visible),
                 |_| async {},
             )
             .await

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -236,15 +236,38 @@ impl AcpxCli {
         let mut last_usage: Option<TokenUsage> = None;
         let mut last_runtime_verdict: Option<serde_json::Value> = None;
 
-        while let Some(line) = reader.next_line().await.map_err(|e| AgentError::IoError {
-            reason: format!("failed to read acpx stdout: {e}"),
-        })? {
-            let message =
-                protocol::parse_jsonrpc(&line).ok_or_else(|| AgentError::ResponseError {
-                    reason: format!("invalid JSON-RPC message from acpx: {line}"),
-                })?;
+        let mut read_result = Ok(());
+        loop {
+            let line = match reader.next_line().await {
+                Ok(Some(line)) => line,
+                Ok(None) => break,
+                Err(error) => {
+                    read_result = Err(AgentError::IoError {
+                        reason: format!("failed to read acpx stdout: {error}"),
+                    });
+                    break;
+                }
+            };
 
-            if let Some(update) = parse_session_update_from_message(&message)? {
+            let message = match protocol::parse_jsonrpc(&line) {
+                Some(message) => message,
+                None => {
+                    read_result = Err(AgentError::ResponseError {
+                        reason: format!("invalid JSON-RPC message from acpx: {line}"),
+                    });
+                    break;
+                }
+            };
+
+            let update = match parse_session_update_from_message(&message) {
+                Ok(update) => update,
+                Err(error) => {
+                    read_result = Err(error);
+                    break;
+                }
+            };
+
+            if let Some(update) = update {
                 if let Some(usage) = update.usage {
                     last_usage = Some(usage);
                 }
@@ -310,11 +333,23 @@ impl AcpxCli {
             }
         }
 
-        let status = child.wait().await.map_err(|e| AgentError::IoError {
-            reason: format!("failed to wait for acpx prompt: {e}"),
-        })?;
+        let status = if read_result.is_err() {
+            cleanup_prompt_child(&mut child).await;
+            None
+        } else {
+            let wait_result = child.wait().await.map_err(|e| AgentError::IoError {
+                reason: format!("failed to wait for acpx prompt: {e}"),
+            });
+            Some(wait_result)
+        };
         // Wait for the stderr sink to finish draining and flushing.
         let _ = tokio::time::timeout(std::time::Duration::from_secs(5), stderr_task).await;
+
+        if let Err(error) = read_result {
+            return Err(error);
+        }
+
+        let status = status.expect("prompt status should be present when stdout read succeeds")?;
         if !status.success() {
             return Err(AgentError::AcpxCommandFailed {
                 command: "prompt".to_string(),
@@ -1011,6 +1046,55 @@ exec 0<&-
         assert!(
             !alive,
             "acpx child should be terminated after stdin write failure"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn prompt_protocol_error_kills_spawned_process() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let pid_path = dir.path().join("pid.txt");
+        let script = write_mock_acpx_script(
+            dir.path(),
+            &format!(
+                r#"#!/bin/bash
+printf '%s' "$$" > "{}"
+printf '%s\n' 'not-jsonrpc'
+/bin/sleep 30
+"#,
+                pid_path.display()
+            ),
+        );
+
+        let client = AcpxCli::new(script);
+        let error = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            client.run_prompt(
+                "codex",
+                "build-session",
+                dir.path(),
+                "hi",
+                AcpxCommandOptions::default(),
+                PromptVisibility::Visible,
+                |_| async {},
+            ),
+        )
+        .await
+        .expect("run_prompt should not hang after invalid stdout")
+        .unwrap_err();
+
+        assert!(matches!(error, AgentError::ResponseError { .. }));
+
+        let pid: i32 = std::fs::read_to_string(pid_path).unwrap().parse().unwrap();
+        let alive = unsafe { libc::kill(pid, 0) } == 0;
+        if alive {
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+        }
+        assert!(
+            !alive,
+            "acpx child should be terminated after stdout protocol error"
         );
     }
 

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -9,7 +9,7 @@ use crate::observability::events_contract::{
     elapsed_ms, ACPX_PROMPT_CANCELLED, ACPX_PROMPT_COMPLETED, ACPX_PROMPT_FAILED,
 };
 
-use super::acpx_cli::{AcpxCli, AcpxCommandOptions};
+use super::acpx_cli::{AcpxCli, AcpxCommandOptions, PromptVisibility};
 use super::events::{AgentEvent, WorkerEvent, WorkerResult};
 use super::{detect_worker_result_with_output, AgentRunRequest};
 
@@ -153,6 +153,7 @@ impl AcpxRuntime {
             request.workspace_path,
             prompt,
             command_options,
+            PromptVisibility::Visible,
             |event| {
                 cb_count.fetch_add(1, Ordering::Relaxed);
                 emit_event(
@@ -218,41 +219,87 @@ impl AcpxRuntime {
             }
         };
 
-        close_session(
-            &self.cli,
-            acpx_agent,
-            &session_name,
-            request.workspace_path,
-            command_options,
-        )
-        .await;
-
         let count = event_count.load(Ordering::Relaxed);
         let duration = elapsed_ms(prompt_start);
 
-        match prompt_result {
-            Ok(outcome) => {
-                info!(
-                    event = ACPX_PROMPT_COMPLETED,
-                    issue_id = %request.issue.id,
-                    step = request.step_name,
-                    session_name,
-                    event_count = count,
-                    duration_ms = duration,
-                    "acpx prompt completed"
-                );
-                let output = outcome
-                    .runtime_verdict
-                    .as_ref()
-                    .and_then(crate::pipeline::verdict::parse_step_output_from_value)
-                    .unwrap_or_else(super::transitional_succeeded_output);
+        let step_result = match prompt_result {
+            Ok(visible_outcome) => {
+                async {
+                    info!(
+                        event = ACPX_PROMPT_COMPLETED,
+                        issue_id = %request.issue.id,
+                        step = request.step_name,
+                        session_name,
+                        event_count = count,
+                        duration_ms = duration,
+                        "acpx prompt completed"
+                    );
 
-                Ok(detect_worker_result_with_output(
-                    request.workspace_path,
-                    output,
-                    request.step_name,
-                )
-                .await)
+                    let extraction_prompt = crate::agent::extraction::build_extraction_prompt(
+                        request.step_name,
+                        &request.issue.identifier,
+                        prompt,
+                        &visible_outcome.output_text,
+                    );
+                    let extraction_outcome = self
+                        .cli
+                        .run_prompt(
+                            acpx_agent,
+                            &session_name,
+                            request.workspace_path,
+                            &extraction_prompt,
+                            command_options,
+                            PromptVisibility::Hidden,
+                            |_| async {},
+                        )
+                        .await?;
+                    let output = match crate::agent::extraction::validate_extraction_payload(
+                        extraction_outcome.runtime_verdict.as_ref(),
+                        &extraction_outcome.output_text,
+                    ) {
+                        Ok(output) => output,
+                        Err(error) => {
+                            let previous_payload = extraction_outcome
+                                .runtime_verdict
+                                .as_ref()
+                                .map(serde_json::Value::to_string)
+                                .unwrap_or_else(|| extraction_outcome.output_text.clone());
+                            let repair_prompt = crate::agent::extraction::build_repair_prompt(
+                                &error.to_string(),
+                                &previous_payload,
+                            );
+                            let repair_outcome = self
+                                .cli
+                                .run_prompt(
+                                    acpx_agent,
+                                    &session_name,
+                                    request.workspace_path,
+                                    &repair_prompt,
+                                    command_options,
+                                    PromptVisibility::Hidden,
+                                    |_| async {},
+                                )
+                                .await?;
+                            crate::agent::extraction::validate_extraction_payload(
+                                repair_outcome.runtime_verdict.as_ref(),
+                                &repair_outcome.output_text,
+                            )
+                            .map_err(|error| {
+                                AgentError::ResponseError {
+                                    reason: format!("verdict extraction failed: {error}"),
+                                }
+                            })?
+                        }
+                    };
+
+                    Ok(detect_worker_result_with_output(
+                        request.workspace_path,
+                        output,
+                        request.step_name,
+                    )
+                    .await)
+                }
+                .await
             }
             Err(e) => {
                 warn!(
@@ -267,7 +314,18 @@ impl AcpxRuntime {
                 );
                 Err(e)
             }
-        }
+        };
+
+        close_session(
+            &self.cli,
+            acpx_agent,
+            &session_name,
+            request.workspace_path,
+            command_options,
+        )
+        .await;
+
+        step_result
     }
 }
 
@@ -406,10 +464,16 @@ case "$*" in
   exit 0
   ;;
   *" prompt --session "*)
-  cat > /dev/null
-  printf '%s\n' \
-    '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}' \
-    '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+  prompt=$(cat)
+  if [[ "$prompt" == Extract* ]]; then
+    printf '%s\n' \
+      '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"result\":\"succeeded\",\"output\":{\"artifact\":\"typed\"}}"}}}}' \
+      '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
+  else
+    printf '%s\n' \
+      '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}' \
+      '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+  fi
   exit 0
   ;;
   *" sessions close "*)
@@ -446,6 +510,7 @@ exit 1
                 output,
                 ..
             } if matches!(output.result, crate::pipeline::verdict::StepResult::Succeeded)
+                && output.output == Some(serde_json::json!({"artifact": "typed"}))
         ));
         let mut saw_output = false;
         while let Ok(event) = rx.try_recv() {
@@ -463,6 +528,139 @@ exit 1
     }
 
     #[tokio::test]
+    async fn acpx_runtime_repairs_invalid_hidden_extraction() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let script_path = write_mock_acpx_script(
+            workspace.path(),
+            r#"#!/usr/bin/env bash
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    prompt=$(cat)
+    if [[ "$prompt" == Extract* ]]; then
+      printf '%s\n' \
+        '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"result\":\"failed\"}"}}}}' \
+        '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
+    elif [[ "$prompt" == "The previous Ensemble step result was invalid."* ]]; then
+      printf '%s\n' \
+        '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"result\":\"concern\",\"summary\":\"needs follow-up\",\"output\":{\"fixed\":true}}"}}}}' \
+        '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}'
+    else
+      printf '%s\n' \
+        '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"visible"}}}}' \
+        '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+    fi
+    exit 0
+    ;;
+  *" sessions close "*)
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+        );
+
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path));
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let issue = test_issue("issue-1", "Todo");
+        let config = test_config();
+        let request = AgentRunRequest {
+            config,
+            issue: &issue,
+            agent_name: "builder",
+            step_name: "build",
+            step_kind: StepKind::Agent,
+            attempt: None,
+            interaction_response: None,
+            workspace_path: workspace.path(),
+            event_tx: tx,
+            cancel_token: CancellationToken::new(),
+            step_outputs: StepOutputTemplateContext::default(),
+        };
+
+        let result = runner.run_step(&request, "finish the task").await.unwrap();
+
+        assert!(matches!(
+            result,
+            WorkerResult::Success {
+                output,
+                ..
+            } if matches!(
+                output.result,
+                crate::pipeline::verdict::StepResult::Concern { ref summary }
+                    if summary == "needs follow-up"
+            ) && output.output == Some(serde_json::json!({"fixed": true}))
+        ));
+    }
+
+    #[tokio::test]
+    async fn acpx_runtime_returns_response_error_when_repair_is_invalid_and_closes_session() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let args_path = workspace.path().join("args.txt");
+        let script_path = write_mock_acpx_script(
+            workspace.path(),
+            &format!(
+                r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{}"
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    prompt=$(cat)
+    if [[ "$prompt" == Extract* || "$prompt" == "The previous Ensemble step result was invalid."* ]]; then
+      printf '%s\n' \
+        '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"{{\"result\":\"failed\"}}"}}}}}}}}' \
+        '{{"jsonrpc":"2.0","id":2,"result":{{"stopReason":"end_turn"}}}}'
+    else
+      printf '%s\n' '{{"jsonrpc":"2.0","id":1,"result":{{"stopReason":"end_turn"}}}}'
+    fi
+    exit 0
+    ;;
+  *" sessions close "*)
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+                args_path.display()
+            ),
+        );
+
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path));
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let issue = test_issue("issue-1", "Todo");
+        let config = test_config();
+        let request = AgentRunRequest {
+            config,
+            issue: &issue,
+            agent_name: "builder",
+            step_name: "build",
+            step_kind: StepKind::Agent,
+            attempt: None,
+            interaction_response: None,
+            workspace_path: workspace.path(),
+            event_tx: tx,
+            cancel_token: CancellationToken::new(),
+            step_outputs: StepOutputTemplateContext::default(),
+        };
+
+        let error = runner
+            .run_step(&request, "finish the task")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            AgentError::ResponseError { reason } if reason.contains("verdict extraction failed")
+        ));
+        let args = std::fs::read_to_string(args_path).unwrap();
+        assert!(args.contains("sessions close"));
+    }
+
+    #[tokio::test]
     async fn acpx_runtime_passes_reasoning_level_to_acpx_commands() {
         let workspace = tempfile::TempDir::new().unwrap();
         let args_path = workspace.path().join("args.txt");
@@ -477,7 +675,9 @@ case "$*" in
   ;;
   *" prompt --session "*)
   cat > /dev/null
-  printf '%s\n' '{{"jsonrpc":"2.0","id":1,"result":{{"stopReason":"end_turn"}}}}'
+  printf '%s\n' \
+    '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"{{\"result\":\"succeeded\"}}"}}}}}}}}' \
+    '{{"jsonrpc":"2.0","id":1,"result":{{"stopReason":"end_turn"}}}}'
   exit 0
   ;;
   *" sessions close "*)
@@ -556,7 +756,9 @@ case "$*" in
     ;;
   *" prompt --session "*)
     cat >/dev/null
-    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
+    printf '%s\n' \
+      '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"result\":\"succeeded\"}"}}}}' \
+      '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
     exit 0
     ;;
   *" sessions close "*)
@@ -666,7 +868,9 @@ case "$*" in
     ;;
   *" prompt --session "*)
     cat > /dev/null
-    printf '%s\n' '{{"jsonrpc":"2.0","id":3,"result":{{"stopReason":"end_turn"}}}}'
+    printf '%s\n' \
+      '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"{{\"result\":\"succeeded\"}}"}}}}}}}}' \
+      '{{"jsonrpc":"2.0","id":3,"result":{{"stopReason":"end_turn"}}}}'
     exit 0
     ;;
   *" sessions close "*)
@@ -829,7 +1033,9 @@ case "$*" in
     ;;
   *" prompt --session "*)
     cat > /dev/null
-    printf '%s\n' '{{"jsonrpc":"2.0","id":4,"result":{{"stopReason":"end_turn"}}}}'
+    printf '%s\n' \
+      '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"{{\"result\":\"succeeded\"}}"}}}}}}}}' \
+      '{{"jsonrpc":"2.0","id":4,"result":{{"stopReason":"end_turn"}}}}'
     exit 0
     ;;
   *" sessions close "*)
@@ -900,7 +1106,9 @@ case "$*" in
     ;;
   *" prompt --session "*)
     cat > /dev/null
-    printf '%s\n' '{{"jsonrpc":"2.0","id":100,"result":{{"stopReason":"end_turn"}}}}'
+    printf '%s\n' \
+      '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"{{\"result\":\"succeeded\"}}"}}}}}}}}' \
+      '{{"jsonrpc":"2.0","id":100,"result":{{"stopReason":"end_turn"}}}}'
     exit 0
     ;;
   *" sessions close "*)
@@ -959,7 +1167,9 @@ case "$*" in
     ;;
   *" prompt --session "*)
     cat > /dev/null
-    printf '%s\n' '{{"jsonrpc":"2.0","id":101,"result":{{"stopReason":"end_turn"}}}}'
+    printf '%s\n' \
+      '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"{{\"result\":\"succeeded\"}}"}}}}}}}}' \
+      '{{"jsonrpc":"2.0","id":101,"result":{{"stopReason":"end_turn"}}}}'
     exit 0
     ;;
   *" sessions close "*)

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -10,7 +10,7 @@ use crate::observability::events_contract::{
     elapsed_ms, ACPX_PROMPT_CANCELLED, ACPX_PROMPT_COMPLETED, ACPX_PROMPT_FAILED,
 };
 
-use super::acpx_cli::{AcpxCli, AcpxCommandOptions, PromptVisibility};
+use super::acpx_cli::{AcpxCli, AcpxCommandOptions, AcpxPromptRequest, PromptVisibility};
 use super::events::{AgentEvent, WorkerEvent, WorkerResult};
 use super::{detect_worker_result_with_output, AgentRunRequest};
 
@@ -24,6 +24,15 @@ use super::{detect_worker_result_with_output, AgentRunRequest};
 /// for the full session model rationale.
 pub struct AcpxRuntime {
     cli: AcpxCli,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RuntimePromptRequest<'a> {
+    acpx_agent: &'a str,
+    session_name: &'a str,
+    prompt: &'a str,
+    command_options: AcpxCommandOptions<'a>,
+    visibility: PromptVisibility,
 }
 
 impl AcpxRuntime {
@@ -151,11 +160,13 @@ impl AcpxRuntime {
         let prompt_result = self
             .run_prompt_with_cancellation(
                 request,
-                acpx_agent,
-                &session_name,
-                prompt,
-                command_options,
-                PromptVisibility::Visible,
+                RuntimePromptRequest {
+                    acpx_agent,
+                    session_name: &session_name,
+                    prompt,
+                    command_options,
+                    visibility: PromptVisibility::Visible,
+                },
                 |event| {
                     cb_count.fetch_add(1, Ordering::Relaxed);
                     emit_event(
@@ -193,11 +204,13 @@ impl AcpxRuntime {
                     let extraction_outcome = self
                         .run_prompt_with_cancellation(
                             request,
-                            acpx_agent,
-                            &session_name,
-                            &extraction_prompt,
-                            command_options,
-                            PromptVisibility::Hidden,
+                            RuntimePromptRequest {
+                                acpx_agent,
+                                session_name: &session_name,
+                                prompt: &extraction_prompt,
+                                command_options,
+                                visibility: PromptVisibility::Hidden,
+                            },
                             |_| async {},
                         )
                         .await?;
@@ -219,11 +232,13 @@ impl AcpxRuntime {
                             let repair_outcome = self
                                 .run_prompt_with_cancellation(
                                     request,
-                                    acpx_agent,
-                                    &session_name,
-                                    &repair_prompt,
-                                    command_options,
-                                    PromptVisibility::Hidden,
+                                    RuntimePromptRequest {
+                                        acpx_agent,
+                                        session_name: &session_name,
+                                        prompt: &repair_prompt,
+                                        command_options,
+                                        visibility: PromptVisibility::Hidden,
+                                    },
                                     |_| async {},
                                 )
                                 .await?;
@@ -290,11 +305,7 @@ impl AcpxRuntime {
     async fn run_prompt_with_cancellation<F, Fut>(
         &self,
         request: &AgentRunRequest<'_>,
-        acpx_agent: &str,
-        session_name: &str,
-        prompt: &str,
-        command_options: AcpxCommandOptions<'_>,
-        visibility: PromptVisibility,
+        prompt_request: RuntimePromptRequest<'_>,
         on_event: F,
     ) -> Result<super::acpx_cli::PromptOutcome, AgentError>
     where
@@ -302,12 +313,14 @@ impl AcpxRuntime {
         Fut: Future<Output = ()> + Send,
     {
         let run_prompt = self.cli.run_prompt(
-            acpx_agent,
-            session_name,
-            request.workspace_path,
-            prompt,
-            command_options,
-            visibility,
+            AcpxPromptRequest {
+                agent: prompt_request.acpx_agent,
+                session_name: prompt_request.session_name,
+                cwd: request.workspace_path,
+                prompt: prompt_request.prompt,
+                options: prompt_request.command_options,
+                visibility: prompt_request.visibility,
+            },
             on_event,
         );
         tokio::pin!(run_prompt);
@@ -318,19 +331,19 @@ impl AcpxRuntime {
                 debug!(
                     issue_id = %request.issue.id,
                     step = request.step_name,
-                    session_name,
+                    prompt_request.session_name,
                     "cancelling acpx prompt"
                 );
                 self.cli
                     .cancel(
-                        acpx_agent,
-                        session_name,
+                        prompt_request.acpx_agent,
+                        prompt_request.session_name,
                         request.workspace_path,
-                        command_options,
+                        prompt_request.command_options,
                     )
                     .await?;
 
-                if visibility == PromptVisibility::Visible {
+                if prompt_request.visibility == PromptVisibility::Visible {
                     emit_event(
                         &request.event_tx,
                         &request.issue.id,

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -147,77 +148,25 @@ impl AcpxRuntime {
         let event_count = Arc::new(AtomicUsize::new(0));
         let prompt_start = std::time::Instant::now();
         let cb_count = event_count.clone();
-        let run_prompt = self.cli.run_prompt(
-            acpx_agent,
-            &session_name,
-            request.workspace_path,
-            prompt,
-            command_options,
-            PromptVisibility::Visible,
-            |event| {
-                cb_count.fetch_add(1, Ordering::Relaxed);
-                emit_event(
-                    &request.event_tx,
-                    &request.issue.id,
-                    request.step_name,
-                    event,
-                )
-            },
-        );
-        tokio::pin!(run_prompt);
-
-        let prompt_result = tokio::select! {
-            result = &mut run_prompt => result,
-            _ = request.cancel_token.cancelled() => {
-                debug!(
-                    issue_id = %request.issue.id,
-                    step = request.step_name,
-                    session_name,
-                    "cancelling acpx prompt"
-                );
-                self.cli
-                    .cancel(
-                        acpx_agent,
-                        &session_name,
-                        request.workspace_path,
-                        command_options,
+        let prompt_result = self
+            .run_prompt_with_cancellation(
+                request,
+                acpx_agent,
+                &session_name,
+                prompt,
+                command_options,
+                PromptVisibility::Visible,
+                |event| {
+                    cb_count.fetch_add(1, Ordering::Relaxed);
+                    emit_event(
+                        &request.event_tx,
+                        &request.issue.id,
+                        request.step_name,
+                        event,
                     )
-                    .await?;
-
-                emit_event(
-                    &request.event_tx,
-                    &request.issue.id,
-                    request.step_name,
-                    AgentEvent::Cancelled {
-                        reason: Some("cancel requested".to_string()),
-                    },
-                )
-                .await;
-
-                // Wait for the prompt process to exit after cancellation, with a timeout
-                // to prevent hanging if acpx fails to exit gracefully.
-                let _ = tokio::time::timeout(std::time::Duration::from_secs(5), run_prompt).await;
-
-                close_session(
-                    &self.cli,
-                    acpx_agent,
-                    &session_name,
-                    request.workspace_path,
-                    command_options,
-                )
-                .await;
-                info!(
-                    event = ACPX_PROMPT_CANCELLED,
-                    issue_id = %request.issue.id,
-                    step = request.step_name,
-                    session_name,
-                    event_count = event_count.load(Ordering::Relaxed),
-                    duration_ms = elapsed_ms(prompt_start),
-                    "acpx prompt cancelled"
-                );
-                return Err(AgentError::TurnCancelled);
-            }
-        };
+                },
+            )
+            .await;
 
         let count = event_count.load(Ordering::Relaxed);
         let duration = elapsed_ms(prompt_start);
@@ -242,11 +191,10 @@ impl AcpxRuntime {
                         &visible_outcome.output_text,
                     );
                     let extraction_outcome = self
-                        .cli
-                        .run_prompt(
+                        .run_prompt_with_cancellation(
+                            request,
                             acpx_agent,
                             &session_name,
-                            request.workspace_path,
                             &extraction_prompt,
                             command_options,
                             PromptVisibility::Hidden,
@@ -269,11 +217,10 @@ impl AcpxRuntime {
                                 &previous_payload,
                             );
                             let repair_outcome = self
-                                .cli
-                                .run_prompt(
+                                .run_prompt_with_cancellation(
+                                    request,
                                     acpx_agent,
                                     &session_name,
-                                    request.workspace_path,
                                     &repair_prompt,
                                     command_options,
                                     PromptVisibility::Hidden,
@@ -302,16 +249,28 @@ impl AcpxRuntime {
                 .await
             }
             Err(e) => {
-                warn!(
-                    event = ACPX_PROMPT_FAILED,
-                    issue_id = %request.issue.id,
-                    step = request.step_name,
-                    session_name,
-                    event_count = count,
-                    duration_ms = duration,
-                    error = %e,
-                    "acpx prompt failed"
-                );
+                if matches!(e, AgentError::TurnCancelled) {
+                    info!(
+                        event = ACPX_PROMPT_CANCELLED,
+                        issue_id = %request.issue.id,
+                        step = request.step_name,
+                        session_name,
+                        event_count = count,
+                        duration_ms = duration,
+                        "acpx prompt cancelled"
+                    );
+                } else {
+                    warn!(
+                        event = ACPX_PROMPT_FAILED,
+                        issue_id = %request.issue.id,
+                        step = request.step_name,
+                        session_name,
+                        event_count = count,
+                        duration_ms = duration,
+                        error = %e,
+                        "acpx prompt failed"
+                    );
+                }
                 Err(e)
             }
         };
@@ -326,6 +285,68 @@ impl AcpxRuntime {
         .await;
 
         step_result
+    }
+
+    async fn run_prompt_with_cancellation<F, Fut>(
+        &self,
+        request: &AgentRunRequest<'_>,
+        acpx_agent: &str,
+        session_name: &str,
+        prompt: &str,
+        command_options: AcpxCommandOptions<'_>,
+        visibility: PromptVisibility,
+        on_event: F,
+    ) -> Result<super::acpx_cli::PromptOutcome, AgentError>
+    where
+        F: FnMut(AgentEvent) -> Fut,
+        Fut: Future<Output = ()> + Send,
+    {
+        let run_prompt = self.cli.run_prompt(
+            acpx_agent,
+            session_name,
+            request.workspace_path,
+            prompt,
+            command_options,
+            visibility,
+            on_event,
+        );
+        tokio::pin!(run_prompt);
+
+        tokio::select! {
+            result = &mut run_prompt => result,
+            _ = request.cancel_token.cancelled() => {
+                debug!(
+                    issue_id = %request.issue.id,
+                    step = request.step_name,
+                    session_name,
+                    "cancelling acpx prompt"
+                );
+                self.cli
+                    .cancel(
+                        acpx_agent,
+                        session_name,
+                        request.workspace_path,
+                        command_options,
+                    )
+                    .await?;
+
+                if visibility == PromptVisibility::Visible {
+                    emit_event(
+                        &request.event_tx,
+                        &request.issue.id,
+                        request.step_name,
+                        AgentEvent::Cancelled {
+                            reason: Some("cancel requested".to_string()),
+                        },
+                    )
+                    .await;
+                }
+
+                let _ = tokio::time::timeout(std::time::Duration::from_secs(5), run_prompt).await;
+
+                Err(AgentError::TurnCancelled)
+            }
+        }
     }
 }
 
@@ -657,6 +678,190 @@ exit 1
             AgentError::ResponseError { reason } if reason.contains("verdict extraction failed")
         ));
         let args = std::fs::read_to_string(args_path).unwrap();
+        assert!(args.contains("sessions close"));
+    }
+
+    #[tokio::test]
+    async fn acpx_runtime_cancels_hidden_extraction_and_closes_session() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let args_path = workspace.path().join("args.txt");
+        let extraction_started_path = workspace.path().join("extraction-started.flag");
+        let script_path = write_mock_acpx_script(
+            workspace.path(),
+            &format!(
+                r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{}"
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    prompt=$(cat)
+    if [[ "$prompt" == Extract* ]]; then
+      : > "{}"
+      while [ ! -f "{}/cancelled.flag" ]; do
+        /bin/sleep 0.05
+      done
+      printf '%s\n' '{{"jsonrpc":"2.0","id":2,"result":{{"stopReason":"cancelled"}}}}'
+    else
+      printf '%s\n' \
+        '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"visible"}}}}}}}}' \
+        '{{"jsonrpc":"2.0","id":1,"result":{{"stopReason":"end_turn"}}}}'
+    fi
+    exit 0
+    ;;
+  *" cancel --session "*)
+    : > "{}/cancelled.flag"
+    exit 0
+    ;;
+  *" sessions close "*)
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+                args_path.display(),
+                extraction_started_path.display(),
+                workspace.path().display(),
+                workspace.path().display()
+            ),
+        );
+
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path));
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let issue = test_issue("issue-1", "Todo");
+        let config = test_config();
+        let cancel_token = CancellationToken::new();
+        let request = AgentRunRequest {
+            config,
+            issue: &issue,
+            agent_name: "builder",
+            step_name: "build",
+            step_kind: StepKind::Agent,
+            attempt: None,
+            interaction_response: None,
+            workspace_path: workspace.path(),
+            event_tx: tx,
+            cancel_token: cancel_token.clone(),
+            step_outputs: StepOutputTemplateContext::default(),
+        };
+
+        let canceller = tokio::spawn({
+            let cancel_token = cancel_token.clone();
+            let extraction_started_path = extraction_started_path.clone();
+            async move {
+                while !extraction_started_path.exists() {
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+                cancel_token.cancel();
+            }
+        });
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            runner.run_step(&request, "finish the task"),
+        )
+        .await
+        .expect("hidden extraction cancellation should not hang");
+        canceller.await.unwrap();
+
+        assert!(matches!(result, Err(AgentError::TurnCancelled)));
+        let args = std::fs::read_to_string(args_path).unwrap();
+        assert!(args.contains("cancel --session"));
+        assert!(args.contains("sessions close"));
+    }
+
+    #[tokio::test]
+    async fn acpx_runtime_cancels_hidden_repair_and_closes_session() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let args_path = workspace.path().join("args.txt");
+        let repair_started_path = workspace.path().join("repair-started.flag");
+        let script_path = write_mock_acpx_script(
+            workspace.path(),
+            &format!(
+                r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{}"
+case "$*" in
+  *" sessions ensure --name "*)
+    exit 0
+    ;;
+  *" prompt --session "*)
+    prompt=$(cat)
+    if [[ "$prompt" == Extract* ]]; then
+      printf '%s\n' \
+        '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"{{\"result\":\"failed\"}}"}}}}}}}}' \
+        '{{"jsonrpc":"2.0","id":2,"result":{{"stopReason":"end_turn"}}}}'
+    elif [[ "$prompt" == "The previous Ensemble step result was invalid."* ]]; then
+      : > "{}"
+      while [ ! -f "{}/cancelled.flag" ]; do
+        /bin/sleep 0.05
+      done
+      printf '%s\n' '{{"jsonrpc":"2.0","id":3,"result":{{"stopReason":"cancelled"}}}}'
+    else
+      printf '%s\n' \
+        '{{"jsonrpc":"2.0","method":"session/update","params":{{"sessionId":"s1","update":{{"sessionUpdate":"agent_message_chunk","content":{{"type":"text","text":"visible"}}}}}}}}' \
+        '{{"jsonrpc":"2.0","id":1,"result":{{"stopReason":"end_turn"}}}}'
+    fi
+    exit 0
+    ;;
+  *" cancel --session "*)
+    : > "{}/cancelled.flag"
+    exit 0
+    ;;
+  *" sessions close "*)
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+                args_path.display(),
+                repair_started_path.display(),
+                workspace.path().display(),
+                workspace.path().display()
+            ),
+        );
+
+        let runner = AcpxRuntime::with_cli(AcpxCli::new(script_path));
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let issue = test_issue("issue-1", "Todo");
+        let config = test_config();
+        let cancel_token = CancellationToken::new();
+        let request = AgentRunRequest {
+            config,
+            issue: &issue,
+            agent_name: "builder",
+            step_name: "build",
+            step_kind: StepKind::Agent,
+            attempt: None,
+            interaction_response: None,
+            workspace_path: workspace.path(),
+            event_tx: tx,
+            cancel_token: cancel_token.clone(),
+            step_outputs: StepOutputTemplateContext::default(),
+        };
+
+        let canceller = tokio::spawn({
+            let cancel_token = cancel_token.clone();
+            let repair_started_path = repair_started_path.clone();
+            async move {
+                while !repair_started_path.exists() {
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+                cancel_token.cancel();
+            }
+        });
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            runner.run_step(&request, "finish the task"),
+        )
+        .await
+        .expect("hidden repair cancellation should not hang");
+        canceller.await.unwrap();
+
+        assert!(matches!(result, Err(AgentError::TurnCancelled)));
+        let args = std::fs::read_to_string(args_path).unwrap();
+        assert!(args.contains("cancel --session"));
         assert!(args.contains("sessions close"));
     }
 

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -11,7 +11,7 @@ use crate::observability::events_contract::{
 
 use super::acpx_cli::{AcpxCli, AcpxCommandOptions};
 use super::events::{AgentEvent, WorkerEvent, WorkerResult};
-use super::{detect_worker_result_with_runtime_verdict, AgentRunRequest};
+use super::{detect_worker_result_with_output, AgentRunRequest};
 
 /// Agent runtime backed by the `acpx` CLI tool.
 ///
@@ -241,9 +241,15 @@ impl AcpxRuntime {
                     duration_ms = duration,
                     "acpx prompt completed"
                 );
-                Ok(detect_worker_result_with_runtime_verdict(
+                let output = outcome
+                    .runtime_verdict
+                    .as_ref()
+                    .and_then(crate::pipeline::verdict::parse_step_output_from_value)
+                    .unwrap_or_else(super::transitional_succeeded_output);
+
+                Ok(detect_worker_result_with_output(
                     request.workspace_path,
-                    outcome.runtime_verdict,
+                    output,
                     request.step_name,
                 )
                 .await)
@@ -437,9 +443,9 @@ exit 1
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None,
+                output,
                 ..
-            }
+            } if matches!(output.result, crate::pipeline::verdict::StepResult::Succeeded)
         ));
         let mut saw_output = false;
         while let Ok(event) = rx.try_recv() {
@@ -584,9 +590,9 @@ exit 1
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None,
+                output,
                 ..
-            }
+            } if matches!(output.result, crate::pipeline::verdict::StepResult::Succeeded)
         ));
     }
 

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::interaction::InteractionKind;
+use crate::pipeline::verdict::StepOutput;
 
 /// Token usage reported by the ACP agent.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -225,7 +226,7 @@ pub enum WorkerEvent {
 #[derive(Debug, Clone)]
 pub enum WorkerResult {
     Success {
-        runtime_verdict: Option<serde_json::Value>,
+        output: StepOutput,
         approval_request: Option<StepApprovalRequestDraft>,
     },
     BlockedOnHuman {
@@ -351,7 +352,11 @@ mod tests {
     #[test]
     fn test_worker_result_is_success() {
         assert!(WorkerResult::Success {
-            runtime_verdict: None,
+            output: StepOutput {
+                result: crate::pipeline::verdict::StepResult::Succeeded,
+                summary: None,
+                output: None,
+            },
             approval_request: None,
         }
         .is_success());

--- a/crates/ensemble-core/src/agent/extraction.rs
+++ b/crates/ensemble-core/src/agent/extraction.rs
@@ -1,0 +1,133 @@
+use crate::error::AgentError;
+use crate::pipeline::verdict::{parse_step_output_json, validate_step_output_value, StepOutput};
+
+pub(crate) fn build_extraction_prompt(
+    step_name: &str,
+    issue_identifier: &str,
+    original_prompt: &str,
+    working_answer: &str,
+) -> String {
+    format!(
+        "Extract the Ensemble step result from the completed working turn.\n\n\
+         Step: {step_name}\n\
+         Issue: {issue_identifier}\n\n\
+         Original step prompt:\n\
+         ---\n\
+         {original_prompt}\n\
+         ---\n\n\
+         Visible working answer:\n\
+         ---\n\
+         {working_answer}\n\
+         ---\n\n\
+         Required JSON schema, expressed by example:\n\
+         {{\n\
+           \"result\": \"succeeded | failed | concern\",\n\
+           \"summary\": \"required for failed or concern; optional for succeeded\",\n\
+           \"output\": {{}}\n\
+         }}\n\n\
+         Rules:\n\
+         - Return only a JSON object.\n\
+         - Use result=succeeded only when the working answer completed the step.\n\
+         - Use result=failed for blocking failures and include a non-empty summary.\n\
+         - Use result=concern for non-blocking concerns and include a non-empty summary.\n\
+         - Omit output when there is no structured downstream data.\n\
+         - Do not include any keys other than result, summary, and output."
+    )
+}
+
+pub(crate) fn build_repair_prompt(validation_error: &str, previous_payload: &str) -> String {
+    format!(
+        "The previous Ensemble step result was invalid.\n\n\
+         Validation error:\n\
+         {validation_error}\n\n\
+         Previous payload:\n\
+         {previous_payload}\n\n\
+         Return only the corrected JSON object using exactly these keys: result, summary, output. \
+         The result value must be one of succeeded, failed, or concern. Failed and concern require a non-empty summary."
+    )
+}
+
+pub(crate) fn validate_extraction_payload(
+    runtime_payload: Option<&serde_json::Value>,
+    output_text: &str,
+) -> Result<StepOutput, AgentError> {
+    if let Some(value) = runtime_payload {
+        return validate_step_output_value(value).map_err(|error| AgentError::ResponseError {
+            reason: error.to_string(),
+        });
+    }
+
+    parse_step_output_json(output_text.trim()).map_err(|error| AgentError::ResponseError {
+        reason: error.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::verdict::StepResult;
+    use serde_json::json;
+
+    #[test]
+    fn extraction_prompt_contains_context_and_schema() {
+        let prompt = build_extraction_prompt(
+            "review",
+            "repo#184",
+            "Review this change",
+            "The implementation is sound.",
+        );
+
+        assert!(prompt.contains("Step: review"));
+        assert!(prompt.contains("Issue: repo#184"));
+        assert!(prompt.contains("Review this change"));
+        assert!(prompt.contains("The implementation is sound."));
+        assert!(prompt.contains("\"result\": \"succeeded | failed | concern\""));
+        assert!(prompt.contains("Return only a JSON object"));
+    }
+
+    #[test]
+    fn repair_prompt_contains_error_and_previous_payload() {
+        let prompt = build_repair_prompt(
+            "failed results require a non-empty summary",
+            "{\"result\":\"failed\"}",
+        );
+
+        assert!(prompt.contains("failed results require a non-empty summary"));
+        assert!(prompt.contains("{\"result\":\"failed\"}"));
+        assert!(prompt.contains("Return only the corrected JSON object"));
+    }
+
+    #[test]
+    fn validate_extraction_payload_prefers_runtime_payload() {
+        let output = validate_extraction_payload(
+            Some(&json!({"result":"failed","summary":"tests failed"})),
+            "{\"result\":\"succeeded\"}",
+        )
+        .unwrap();
+
+        assert_eq!(
+            output.result,
+            StepResult::Failed {
+                summary: "tests failed".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn validate_extraction_payload_parses_hidden_text_without_runtime_payload() {
+        let output = validate_extraction_payload(None, "{\"result\":\"succeeded\"}").unwrap();
+
+        assert_eq!(output.result, StepResult::Succeeded);
+    }
+
+    #[test]
+    fn validate_extraction_payload_reports_validation_error() {
+        let err = validate_extraction_payload(None, "{\"result\":\"failed\"}").unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("failed results require a non-empty summary"),
+            "{err}"
+        );
+    }
+}

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -468,9 +468,17 @@ async fn load_interaction_response(
     }
 }
 
-async fn detect_worker_result_with_runtime_verdict(
+pub(super) fn transitional_succeeded_output() -> crate::pipeline::verdict::StepOutput {
+    crate::pipeline::verdict::StepOutput {
+        result: crate::pipeline::verdict::StepResult::Succeeded,
+        summary: None,
+        output: None,
+    }
+}
+
+pub(super) async fn detect_worker_result_with_output(
     workspace_path: &Path,
-    runtime_verdict: Option<serde_json::Value>,
+    output: crate::pipeline::verdict::StepOutput,
     step_name: &str,
 ) -> WorkerResult {
     let interaction_path = workspace_path
@@ -537,7 +545,7 @@ async fn detect_worker_result_with_runtime_verdict(
         },
         Some(request) => WorkerResult::BlockedOnHuman { request },
         None => WorkerResult::Success {
-            runtime_verdict,
+            output,
             approval_request,
         },
     }
@@ -545,7 +553,8 @@ async fn detect_worker_result_with_runtime_verdict(
 
 #[cfg(test)]
 async fn detect_worker_result(workspace_path: &Path, step_name: &str) -> WorkerResult {
-    detect_worker_result_with_runtime_verdict(workspace_path, None, step_name).await
+    detect_worker_result_with_output(workspace_path, transitional_succeeded_output(), step_name)
+        .await
 }
 
 async fn write_interaction_response_file(
@@ -793,12 +802,15 @@ impl AcpAgentRunner {
             }
         }
 
-        Ok(detect_worker_result_with_runtime_verdict(
-            request.workspace_path,
-            final_verdict,
-            request.step_name,
+        let output = final_verdict
+            .as_ref()
+            .and_then(crate::pipeline::verdict::parse_step_output_from_value)
+            .unwrap_or_else(transitional_succeeded_output);
+
+        Ok(
+            detect_worker_result_with_output(request.workspace_path, output, request.step_name)
+                .await,
         )
-        .await)
     }
 }
 
@@ -890,7 +902,7 @@ mod tests {
 
             if self.should_succeed {
                 Ok(WorkerResult::Success {
-                    runtime_verdict: None,
+                    output: transitional_succeeded_output(),
                     approval_request: None,
                 })
             } else {
@@ -1112,9 +1124,9 @@ on_failure: Todo
         assert!(matches!(
             result,
             Ok(WorkerResult::Success {
-                runtime_verdict: None,
+                output,
                 ..
-            })
+            }) if matches!(output.result, crate::pipeline::verdict::StepResult::Succeeded)
         ));
 
         let evt = rx.try_recv().unwrap();
@@ -1217,9 +1229,9 @@ exit 1
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None,
+                output,
                 ..
-            }
+            } if matches!(output.result, crate::pipeline::verdict::StepResult::Succeeded)
         ));
         let event_names = collect_event_names(&mut rx);
         assert!(event_names.contains(&"output_chunk".to_string()));
@@ -1274,9 +1286,9 @@ exit 0
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None,
+                output,
                 ..
-            }
+            } if matches!(output.result, crate::pipeline::verdict::StepResult::Succeeded)
         ));
         let event_names = collect_event_names(&mut rx);
         assert!(event_names.contains(&"output_chunk".to_string()));
@@ -1683,9 +1695,9 @@ agent:
         assert!(matches!(
             result,
             WorkerResult::Success {
-                runtime_verdict: None,
+                output,
                 ..
-            }
+            } if matches!(output.result, crate::pipeline::verdict::StepResult::Succeeded)
         ));
     }
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -79,15 +79,6 @@ pub(crate) fn tokenize_command_string(command: &str) -> Result<ResolvedCommand, 
     })
 }
 
-fn verdict_fallback_instruction(step_name: &str) -> String {
-    format!(
-        "If you cannot return a structured runtime verdict, write .ensemble/verdict-{step_name}.json with:\n\
-         {{\"verdict\":\"approve\"}}\n\
-         or\n\
-         {{\"verdict\":\"reject\",\"summary\":\"<reason>\"}}"
-    )
-}
-
 const DEFAULT_INTERACTION_POLICY_INSTRUCTION: &str = "\
 When you need human input, prefer batching related questions into a single interaction request instead of asking one-by-one.\n\
 This is a soft preference: ask a single urgent question when sequential discovery or risk requires it.\n\
@@ -288,11 +279,7 @@ impl AcpAgentRunner {
                 rendered,
                 resolve_interaction_policy_instruction(config, agent_name, step_name).as_deref(),
             );
-            Ok(maybe_append_verdict_fallback_instruction(
-                rendered,
-                config.agent.inject_verdict_fallback_instructions,
-                step_name,
-            ))
+            Ok(rendered)
         } else {
             // Continuation turns: send guidance, not the full original prompt
             Ok(format!(
@@ -338,24 +325,6 @@ fn maybe_append_synthesis_instruction(rendered: String, step_kind: StepKind) -> 
          Merge, compare, or adjudicate those final structured outputs. Do not assume intermediate tool calls or hidden reasoning are available unless the prompt included them explicitly. \
          Return a normal Ensemble verdict with a concise `summary` and, when useful, a structured `output` JSON value describing the merged result."
     )
-}
-
-fn maybe_append_verdict_fallback_instruction(
-    prompt: String,
-    enabled: bool,
-    step_name: &str,
-) -> String {
-    let instruction = verdict_fallback_instruction(step_name);
-    if !enabled || prompt.contains(&instruction) {
-        return prompt;
-    }
-
-    let trimmed = prompt.trim_end();
-    if trimmed.is_empty() {
-        instruction
-    } else {
-        format!("{trimmed}\n\n{instruction}")
-    }
 }
 
 fn resolve_interaction_policy_instruction(
@@ -469,7 +438,7 @@ async fn load_interaction_response(
 }
 
 #[cfg(test)]
-pub(super) fn transitional_succeeded_output() -> crate::pipeline::verdict::StepOutput {
+pub(super) fn succeeded_step_output() -> crate::pipeline::verdict::StepOutput {
     crate::pipeline::verdict::StepOutput {
         result: crate::pipeline::verdict::StepResult::Succeeded,
         summary: None,
@@ -554,8 +523,7 @@ pub(super) async fn detect_worker_result_with_output(
 
 #[cfg(test)]
 async fn detect_worker_result(workspace_path: &Path, step_name: &str) -> WorkerResult {
-    detect_worker_result_with_output(workspace_path, transitional_succeeded_output(), step_name)
-        .await
+    detect_worker_result_with_output(workspace_path, succeeded_step_output(), step_name).await
 }
 
 async fn write_interaction_response_file(
@@ -906,7 +874,7 @@ mod tests {
 
             if self.should_succeed {
                 Ok(WorkerResult::Success {
-                    output: transitional_succeeded_output(),
+                    output: succeeded_step_output(),
                     approval_request: None,
                 })
             } else {
@@ -1189,6 +1157,16 @@ case "$*" in
     exit 0
     ;;
   *"prompt --session"*)
+    prompt=""
+    while IFS= read -r line; do
+      prompt="${prompt}${line}"
+    done
+    if [[ "$prompt" == *"Extract the Ensemble step result"* ]]; then
+      printf '%s\n' \
+        '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"result\":\"succeeded\"}"}}}}' \
+        '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+      exit 0
+    fi
     printf '%s\n' \
       '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}' \
       '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
@@ -1252,6 +1230,16 @@ exit 1
             r#"#!/bin/bash
 case "$*" in
   *"prompt --session"*)
+    prompt=""
+    while IFS= read -r line; do
+      prompt="${prompt}${line}"
+    done
+    if [[ "$prompt" == *"Extract the Ensemble step result"* ]]; then
+      printf '%s\n' \
+        '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"result\":\"succeeded\"}"}}}}' \
+        '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
+      exit 0
+    fi
     printf '%s\n' \
       '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}' \
       '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
@@ -1304,34 +1292,6 @@ exit 0
         tokio::fs::write(ensemble_dir.join(name), contents)
             .await
             .unwrap();
-    }
-
-    #[test]
-    fn injects_verdict_block_when_enabled() {
-        let prompt = "Do the work.".to_string();
-        let rendered = maybe_append_verdict_fallback_instruction(prompt, true, "build");
-        assert!(rendered.contains("write .ensemble/verdict-build.json"));
-    }
-
-    #[test]
-    fn does_not_inject_verdict_block_when_disabled() {
-        let prompt = "Do the work.".to_string();
-        let rendered = maybe_append_verdict_fallback_instruction(prompt.clone(), false, "build");
-        assert_eq!(rendered, prompt);
-    }
-
-    #[test]
-    fn does_not_duplicate_verdict_block_when_present() {
-        let instruction = verdict_fallback_instruction("build");
-        let prompt = format!("Do work.\n\n{instruction}");
-        let rendered = maybe_append_verdict_fallback_instruction(prompt.clone(), true, "build");
-        assert_eq!(rendered, prompt);
-        assert_eq!(
-            rendered
-                .matches("write .ensemble/verdict-build.json")
-                .count(),
-            1
-        );
     }
 
     #[test]
@@ -1797,7 +1757,7 @@ on_failure: Todo
             .unwrap();
 
         assert!(prompt.starts_with("question: Use staging"));
-        assert!(prompt.contains("write .ensemble/verdict-build.json"));
+        assert!(!prompt.contains("write .ensemble/verdict-build.json"));
     }
 
     #[tokio::test]
@@ -1862,7 +1822,7 @@ on_failure: Todo
             .unwrap();
 
         assert!(prompt.starts_with("hi"));
-        assert!(prompt.contains("write .ensemble/verdict-build.json"));
+        assert!(!prompt.contains("write .ensemble/verdict-build.json"));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -32,7 +32,7 @@ use tokio_util::sync::CancellationToken;
 
 use acp_client::{
     discover_capabilities, run_acp_session, AcpCapabilityDiscoveryConfig, AcpSessionConfig,
-    TurnResult,
+    ExtractionContext, SessionTurn, TurnPurpose, TurnResult, TurnVisibility,
 };
 use acpx_runtime::AcpxRuntime;
 
@@ -761,40 +761,46 @@ impl AcpAgentRunner {
             cancel_token: request.cancel_token.clone(),
         };
 
-        let max_turns = config.agent.max_turns.max(1);
-        let mut prompts = Vec::with_capacity(max_turns as usize);
-        for turn in 1..=max_turns {
-            let prompt = self
-                .build_prompt(
-                    config.as_ref(),
-                    BuildPromptRequest {
-                        issue: request.issue,
-                        agent_name: request.agent_name,
-                        step_name: request.step_name,
-                        step_kind: request.step_kind,
-                        attempt: request.attempt,
-                        workspace_path: request.workspace_path,
-                        turn_number: turn,
-                        step_outputs: &request.step_outputs,
-                    },
-                )
-                .await?;
-            prompts.push(prompt);
-        }
+        let working_prompt = self
+            .build_prompt(
+                config.as_ref(),
+                BuildPromptRequest {
+                    issue: request.issue,
+                    agent_name: request.agent_name,
+                    step_name: request.step_name,
+                    step_kind: request.step_kind,
+                    attempt: request.attempt,
+                    workspace_path: request.workspace_path,
+                    turn_number: 1,
+                    step_outputs: &request.step_outputs,
+                },
+            )
+            .await?;
+        let working_turn = SessionTurn {
+            prompt: working_prompt.clone(),
+            visibility: TurnVisibility::Visible,
+            purpose: TurnPurpose::Working,
+        };
+        let extraction_context = ExtractionContext {
+            step_name: request.step_name.to_string(),
+            issue_identifier: request.issue.identifier.clone(),
+            original_prompt: working_prompt,
+        };
 
-        let (final_verdict, turn_results, capabilities) = run_acp_session(
+        let outcome = run_acp_session(
             session_config,
-            prompts,
+            working_turn,
+            extraction_context,
             &request.issue.id,
             request.step_name,
             &request.event_tx,
         )
         .await?;
 
-        self.store_agent_capabilities(request.agent_name, capabilities)
+        self.store_agent_capabilities(request.agent_name, outcome.capabilities)
             .await;
 
-        for (i, result) in turn_results.iter().enumerate() {
+        for (i, result) in outcome.turn_results.iter().enumerate() {
             if let TurnResult::Failed { reason, .. } = result {
                 return Err(AgentError::TurnFailed {
                     reason: format!("turn {} failed: {}", i + 1, reason),
@@ -802,15 +808,12 @@ impl AcpAgentRunner {
             }
         }
 
-        let output = final_verdict
-            .as_ref()
-            .and_then(crate::pipeline::verdict::parse_step_output_from_value)
-            .unwrap_or_else(transitional_succeeded_output);
-
-        Ok(
-            detect_worker_result_with_output(request.workspace_path, output, request.step_name)
-                .await,
+        Ok(detect_worker_result_with_output(
+            request.workspace_path,
+            outcome.output,
+            request.step_name,
         )
+        .await)
     }
 }
 

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -468,6 +468,7 @@ async fn load_interaction_response(
     }
 }
 
+#[cfg(test)]
 pub(super) fn transitional_succeeded_output() -> crate::pipeline::verdict::StepOutput {
     crate::pipeline::verdict::StepOutput {
         result: crate::pipeline::verdict::StepResult::Succeeded,

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -3,6 +3,7 @@ pub mod acpx_cli;
 pub mod acpx_runtime;
 pub mod cancellation;
 pub mod events;
+pub mod extraction;
 pub mod protocol;
 pub mod runtime;
 

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -516,9 +516,6 @@ pub struct AgentRuntimeConfig {
     pub read_timeout_ms: u64,
     #[serde(default = "default_stall_timeout_ms")]
     pub stall_timeout_ms: i64,
-    #[serde(default = "default_inject_verdict_fallback_instructions")]
-    #[serde(alias = "inject_verdict_instructions")]
-    pub inject_verdict_fallback_instructions: bool,
     #[serde(default = "default_inject_interaction_policy_instructions")]
     pub inject_interaction_policy_instructions: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -634,10 +631,6 @@ fn default_stall_timeout_ms() -> i64 {
     300_000
 }
 
-fn default_inject_verdict_fallback_instructions() -> bool {
-    true
-}
-
 fn default_inject_interaction_policy_instructions() -> bool {
     true
 }
@@ -653,7 +646,6 @@ impl Default for AgentRuntimeConfig {
             turn_timeout_ms: default_turn_timeout_ms(),
             read_timeout_ms: default_read_timeout_ms(),
             stall_timeout_ms: default_stall_timeout_ms(),
-            inject_verdict_fallback_instructions: default_inject_verdict_fallback_instructions(),
             inject_interaction_policy_instructions: default_inject_interaction_policy_instructions(
             ),
             interaction_policy_text: None,
@@ -1583,7 +1575,6 @@ on_failure: Failed
         assert_eq!(config.agent.turn_timeout_ms, 3_600_000);
         assert_eq!(config.agent.read_timeout_ms, 5_000);
         assert_eq!(config.agent.stall_timeout_ms, 300_000);
-        assert!(config.agent.inject_verdict_fallback_instructions);
         assert!(config.agent.inject_interaction_policy_instructions);
         assert!(config.agent.interaction_policy_text.is_none());
         assert!(config.agent.interaction_policy_overrides.agents.is_empty());
@@ -2747,70 +2738,6 @@ on_failure: Failed
 
         assert_eq!(config.tracker.api_key, None);
         std::env::remove_var("GITHUB_TOKEN");
-    }
-
-    #[test]
-    fn test_agent_runtime_defaults_include_verdict_fallback_injection_enabled() {
-        let yaml = r#"
-tracker:
-  kind: todo_file
-agents:
-  builder:
-    acpx_agent: claude
-    prompt: "Build it."
-steps:
-  - name: implement
-    agent: builder
-on_success: Done
-on_failure: Failed
-"#;
-
-        let config = parse_config(yaml).unwrap();
-        assert!(config.agent.inject_verdict_fallback_instructions);
-    }
-
-    #[test]
-    fn test_parse_config_with_verdict_fallback_injection_disabled() {
-        let yaml = r#"
-tracker:
-  kind: todo_file
-agents:
-  builder:
-    acpx_agent: claude
-    prompt: "Build it."
-steps:
-  - name: implement
-    agent: builder
-on_success: Done
-on_failure: Failed
-agent:
-  inject_verdict_fallback_instructions: false
-"#;
-
-        let config = parse_config(yaml).unwrap();
-        assert!(!config.agent.inject_verdict_fallback_instructions);
-    }
-
-    #[test]
-    fn test_parse_config_with_short_verdict_injection_field_name() {
-        let yaml = r#"
-tracker:
-  kind: todo_file
-agents:
-  builder:
-    acpx_agent: claude
-    prompt: "Build it."
-steps:
-  - name: implement
-    agent: builder
-on_success: Done
-on_failure: Failed
-agent:
-  inject_verdict_instructions: false
-"#;
-
-        let config = parse_config(yaml).unwrap();
-        assert!(!config.agent.inject_verdict_fallback_instructions);
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -794,7 +794,7 @@ pub fn generate_template(step_name: &str) -> String {
              {{ issue.description }}\n\
              \n\
              Check for correctness, test coverage, and code quality.\n\
-             Write your verdict to `.ensemble/verdict.json`.\n"
+             Share your review findings in your final answer. Ensemble will extract the structured result afterward.\n"
             .to_string(),
         _ => "Solve the following issue:\n\
              \n\
@@ -1471,6 +1471,17 @@ mod tests {
             .templates
             .contains_key("templates/implement.liquid"));
         assert!(artifacts.todo_md.is_some());
+    }
+
+    #[test]
+    fn generated_review_template_uses_visible_review_answer() {
+        let template = generate_template("review");
+
+        assert!(template.contains("Review the changes made for:"));
+        assert!(template.contains("Share your review findings in your final answer."));
+        let legacy_name = String::from("verdict") + ".json";
+        assert!(!template.contains(&[".ensemble", &legacy_name].join("/")));
+        assert!(!template.contains(&["verdict", "file"].join(" ")));
     }
 
     #[test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -51,7 +51,7 @@ use crate::pipeline::engine::{
     DispatchRequest, PipelineAction, PipelineRun, PipelineRunSnapshot, StepOutputTemplateContext,
     StepState,
 };
-use crate::pipeline::verdict::{resolve_verdict_with_source, StepResult, VerdictSource};
+use crate::pipeline::verdict::StepResult;
 use crate::timeline::persistence::TimelinePersistence;
 use crate::tracker::model::{Issue, RetryEntry};
 use crate::tracker::IssueTracker;
@@ -1211,40 +1211,20 @@ impl Orchestrator {
 
         match result {
             WorkerResult::Success {
-                runtime_verdict,
+                output,
                 approval_request,
             } => {
                 let config = self.config.read().await;
                 info!(
                     issue_id = %issue_id,
                     step = step_name,
-                    "worker exited successfully, resolving verdict"
+                    "worker exited successfully"
                 );
 
                 let mut state = self.state.write().await;
 
-                // Resolve verdict from workspace
-                let workspace_path = self.workspace_mgr.workspace_path(
-                    issue_snapshot
-                        .as_ref()
-                        .map(|i| i.identifier.as_str())
-                        .unwrap_or(issue_id),
-                );
-                let resolved = match workspace_path {
-                    Some(wp) => {
-                        resolve_verdict_with_source(runtime_verdict.as_ref(), &wp, step_name).await
-                    }
-                    None => crate::pipeline::verdict::ResolvedResult {
-                        result: StepResult::Succeeded,
-                        output: crate::pipeline::verdict::StepOutput {
-                            result: StepResult::Succeeded,
-                            summary: None,
-                            output: None,
-                        },
-                        source: VerdictSource::Default,
-                    },
-                };
-                let verdict_value = match &resolved.result {
+                let resolved_output = output;
+                let verdict_value = match &resolved_output.result {
                     StepResult::Succeeded => "succeeded",
                     StepResult::Failed { .. } => "failed",
                     StepResult::Concern { .. } => "concern",
@@ -1252,22 +1232,14 @@ impl Orchestrator {
                 info!(
                     issue_id = %issue_id,
                     step = step_name,
-                    verdict_source = ?resolved.source,
                     verdict_value,
-                    "resolved step verdict"
+                    "received validated step result"
                 );
-                if matches!(resolved.source, VerdictSource::Default) {
-                    warn!(
-                        issue_id = %issue_id,
-                        step = step_name,
-                        "no runtime or file verdict found; defaulting to approve"
-                    );
-                }
 
                 // Drive the pipeline
                 let pipeline_action = if let Some(run) = state.get_pipeline_run_mut(issue_id) {
                     Some((
-                        run.step_completed(step_name, resolved.output, approval_request.is_some()),
+                        run.step_completed(step_name, resolved_output, approval_request.is_some()),
                         state.get_pipeline_config(issue_id).cloned(),
                     ))
                 } else {
@@ -4795,9 +4767,27 @@ mod tests {
                 return Err(AgentError::TurnCancelled);
             }
             Ok(WorkerResult::Success {
-                runtime_verdict: None,
+                output: succeeded_step_output(),
                 approval_request: None,
             })
+        }
+    }
+
+    fn succeeded_step_output() -> crate::pipeline::verdict::StepOutput {
+        crate::pipeline::verdict::StepOutput {
+            result: crate::pipeline::verdict::StepResult::Succeeded,
+            summary: None,
+            output: None,
+        }
+    }
+
+    fn failed_step_output(summary: &str) -> crate::pipeline::verdict::StepOutput {
+        crate::pipeline::verdict::StepOutput {
+            result: crate::pipeline::verdict::StepResult::Failed {
+                summary: summary.to_string(),
+            },
+            summary: Some(summary.to_string()),
+            output: None,
         }
     }
 
@@ -5387,10 +5377,7 @@ agent:
                 "1",
                 "build",
                 WorkerResult::Success {
-                    runtime_verdict: Some(serde_json::json!({
-                        "result": "failed",
-                        "summary": "tests failed"
-                    })),
+                    output: failed_step_output("tests failed"),
                     approval_request: None,
                 },
             )
@@ -5872,7 +5859,7 @@ agent:
                 "1",
                 "build",
                 WorkerResult::Success {
-                    runtime_verdict: None,
+                    output: succeeded_step_output(),
                     approval_request: None,
                 },
             )
@@ -5926,10 +5913,7 @@ agent:
                 "1",
                 "build",
                 WorkerResult::Success {
-                    runtime_verdict: Some(serde_json::json!({
-                        "result": "failed",
-                        "summary": "tests failed"
-                    })),
+                    output: failed_step_output("tests failed"),
                     approval_request: None,
                 },
             )
@@ -6007,10 +5991,7 @@ agent:
                 "1",
                 "fixup-review",
                 WorkerResult::Success {
-                    runtime_verdict: Some(serde_json::json!({
-                        "result": "failed",
-                        "summary": "fixup could not repair"
-                    })),
+                    output: failed_step_output("fixup could not repair"),
                     approval_request: None,
                 },
             )
@@ -6070,10 +6051,7 @@ agent:
                 "1",
                 "build",
                 WorkerResult::Success {
-                    runtime_verdict: Some(serde_json::json!({
-                        "result": "failed",
-                        "summary": "needs manual repair"
-                    })),
+                    output: failed_step_output("needs manual repair"),
                     approval_request: None,
                 },
             )
@@ -6104,8 +6082,8 @@ agent:
     }
 
     #[tokio::test]
-    async fn test_worker_exit_runtime_verdict_overrides_file_verdict() {
-        let config = Arc::new(RwLock::new(make_config()));
+    async fn test_worker_exit_uses_typed_step_output() {
+        let config = Arc::new(RwLock::new(make_halt_config()));
         let issues = Arc::new(RwLock::new(vec![]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
@@ -6156,78 +6134,20 @@ agent:
                 "1",
                 "build",
                 WorkerResult::Success {
-                    runtime_verdict: Some(serde_json::json!({"verdict":"approve"})),
+                    output: failed_step_output("tests failed"),
                     approval_request: None,
                 },
             )
             .await;
 
         let state = orchestrator.state.read().await;
-        assert!(state.completed.contains_key("1"));
+        assert!(matches!(
+            state
+                .get_pipeline_run("1")
+                .and_then(|run| run.step_states.get("build")),
+            Some(StepState::Failed { summary }) if summary == "tests failed"
+        ));
         assert!(!state.retry_attempts.contains_key("1"));
-    }
-
-    #[tokio::test]
-    async fn test_worker_exit_uses_file_verdict_when_runtime_missing() {
-        let config = Arc::new(RwLock::new(make_config()));
-        let issues = Arc::new(RwLock::new(vec![]));
-        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
-        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
-            delay_ms: 0,
-            observed_commands: None,
-            cancellation_probe: None,
-        });
-        let dir = tempfile::TempDir::new().unwrap();
-        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
-        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
-
-        let orchestrator = Orchestrator::new(
-            config.clone(),
-            tracker,
-            runner,
-            workspace_mgr,
-            dir.path(),
-            shutdown_rx,
-        );
-
-        {
-            let cfg = config.read().await;
-            let mut state = orchestrator.state.write().await;
-            state.add_running(&test_issue("1", "Todo"), None);
-            let dag = build_dag(&cfg.steps).unwrap();
-            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
-            pipeline_run.start();
-            pipeline_run.mark_running("build", "session-1".to_string());
-            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
-        }
-
-        let workspace = orchestrator
-            .workspace_mgr
-            .workspace_path("repo#1")
-            .expect("workspace path");
-        tokio::fs::create_dir_all(workspace.join(".ensemble"))
-            .await
-            .unwrap();
-        tokio::fs::write(
-            workspace.join(".ensemble").join("verdict-build.json"),
-            r#"{"verdict":"reject","summary":"broken"}"#,
-        )
-        .await
-        .unwrap();
-
-        orchestrator
-            .handle_worker_exit(
-                "1",
-                "build",
-                WorkerResult::Success {
-                    runtime_verdict: None,
-                    approval_request: None,
-                },
-            )
-            .await;
-
-        let state = orchestrator.state.read().await;
-        assert!(state.retry_attempts.contains_key("1"));
     }
 
     #[tokio::test]
@@ -6290,7 +6210,7 @@ agent:
                     "1",
                     "build",
                     WorkerResult::Success {
-                        runtime_verdict: None,
+                        output: failed_step_output("tests failed"),
                         approval_request: None,
                     },
                 )
@@ -6347,7 +6267,7 @@ agent:
                 "1",
                 "build",
                 WorkerResult::Success {
-                    runtime_verdict: None,
+                    output: succeeded_step_output(),
                     approval_request: None,
                 },
             )
@@ -7259,7 +7179,7 @@ agent:
                 "1",
                 "build",
                 WorkerResult::Success {
-                    runtime_verdict: None,
+                    output: succeeded_step_output(),
                     approval_request: Some(StepApprovalRequestDraft {
                         schema_version: 1,
                         title: "Approve plan".to_string(),
@@ -7921,7 +7841,7 @@ agent:
                 "1",
                 "docs",
                 WorkerResult::Success {
-                    runtime_verdict: None,
+                    output: succeeded_step_output(),
                     approval_request: None,
                 },
             )
@@ -9412,7 +9332,7 @@ agent:
                 "1",
                 "build",
                 WorkerResult::Success {
-                    runtime_verdict: None,
+                    output: succeeded_step_output(),
                     approval_request: None,
                 },
             )

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -1,8 +1,6 @@
 use std::fmt;
-use std::path::Path;
 
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 
 /// The result returned by an agent at the end of a pipeline step.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -16,35 +14,11 @@ pub enum StepResult {
     Concern { summary: String },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum VerdictSource {
-    Runtime,
-    File,
-    Default,
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StepOutput {
     pub result: StepResult,
     pub summary: Option<String>,
     pub output: Option<serde_json::Value>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct ResolvedResult {
-    pub result: StepResult,
-    pub output: StepOutput,
-    pub source: VerdictSource,
-}
-
-/// Internal deserialization type for both ACP JSON values and verdict files.
-#[derive(Debug, Deserialize)]
-struct VerdictPayload {
-    result: Option<String>,
-    verdict: Option<String>,
-    summary: Option<String>,
-    #[serde(default)]
-    output: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -96,9 +70,10 @@ pub fn parse_step_output_json(text: &str) -> Result<StepOutput, StepOutputValida
 pub fn validate_step_output_value(
     value: &serde_json::Value,
 ) -> Result<StepOutput, StepOutputValidationError> {
-    let payload: StrictStepOutputPayload = serde_json::from_value(value.clone()).map_err(|error| {
-        StepOutputValidationError::new(format!("invalid StepOutput payload: {error}"))
-    })?;
+    let payload: StrictStepOutputPayload =
+        serde_json::from_value(value.clone()).map_err(|error| {
+            StepOutputValidationError::new(format!("invalid StepOutput payload: {error}"))
+        })?;
 
     let summary = payload.summary.map(|value| value.trim().to_string());
     let result = match payload.result {
@@ -132,405 +107,10 @@ pub fn validate_step_output_value(
     })
 }
 
-/// Parse a [`StepResult`] from an arbitrary JSON value (e.g. an ACP event body).
-///
-/// Recognises `"approve"`/`"succeeded"` (case-insensitive) →
-/// [`StepResult::Succeeded`], `"reject"`/`"failed"` (case-insensitive) →
-/// [`StepResult::Failed`], and `"concern"` (case-insensitive) →
-/// [`StepResult::Concern`] with an optional `summary` field. Any other value or
-/// an absent/null `result`/`verdict` field returns `None`.
-pub fn parse_verdict_from_value(value: &serde_json::Value) -> Option<StepResult> {
-    let payload: VerdictPayload = serde_json::from_value(value.clone()).ok()?;
-    result_from_payload(&payload)
-}
-
-pub fn parse_step_output_from_value(value: &serde_json::Value) -> Option<StepOutput> {
-    let payload: VerdictPayload = serde_json::from_value(value.clone()).ok()?;
-    step_output_from_payload(&payload)
-}
-
-/// Read `.ensemble/verdict-{step_name}.json` from the given workspace directory.
-///
-/// Returns `Ok(None)` if the file does not exist. Returns `Ok(Some(verdict))`
-/// if the file exists and parses successfully. Returns an `Err` only on
-/// unexpected I/O failures (not "file not found").
-pub async fn read_verdict_file(
-    workspace: &Path,
-    step_name: &str,
-) -> Result<Option<StepResult>, std::io::Error> {
-    read_step_output_file(workspace, step_name)
-        .await
-        .map(|value| value.map(|output| output.result))
-}
-
-pub async fn read_step_output_file(
-    workspace: &Path,
-    step_name: &str,
-) -> Result<Option<StepOutput>, std::io::Error> {
-    let step_file = workspace
-        .join(".ensemble")
-        .join(format!("verdict-{step_name}.json"));
-    let legacy_file = workspace.join(".ensemble").join("verdict.json");
-
-    // Try step-scoped file first, fall back to legacy verdict.json.
-    for path in [&step_file, &legacy_file] {
-        match tokio::fs::read_to_string(path).await {
-            Ok(contents) => {
-                let payload: VerdictPayload = serde_json::from_str(&contents)
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-                return Ok(step_output_from_payload(&payload));
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(None)
-}
-
-/// Resolve the final verdict for a completed step.
-///
-/// Priority:
-/// 1. ACP event value (`acp_verdict`) — checked first.
-/// 2. `.ensemble/verdict-{step_name}.json` in the workspace — checked if ACP yields nothing.
-/// 3. `.ensemble/verdict.json` (legacy fallback) — checked if step-scoped file is absent.
-/// 4. Default to [`StepResult::Succeeded`] if no source provides a verdict.
-pub async fn resolve_verdict(
-    acp_verdict: Option<&serde_json::Value>,
-    workspace: &Path,
-    step_name: &str,
-) -> StepResult {
-    resolve_verdict_with_source(acp_verdict, workspace, step_name)
-        .await
-        .result
-}
-
-/// Resolve the final verdict for a completed step, including the source.
-pub async fn resolve_verdict_with_source(
-    acp_verdict: Option<&serde_json::Value>,
-    workspace: &Path,
-    step_name: &str,
-) -> ResolvedResult {
-    // 1. Try ACP event.
-    if let Some(value) = acp_verdict {
-        if let Some(output) = parse_step_output_from_value(value) {
-            return ResolvedResult {
-                result: output.result.clone(),
-                output,
-                source: VerdictSource::Runtime,
-            };
-        }
-    }
-
-    // 2. Try file.
-    match read_step_output_file(workspace, step_name).await {
-        Ok(Some(output)) => {
-            return ResolvedResult {
-                result: output.result.clone(),
-                output,
-                source: VerdictSource::File,
-            };
-        }
-        Ok(None) => {} // file doesn't exist — fall through to default
-        Err(e) => {
-            // Malformed verdict file — treat as rejection, not silent approval.
-            let msg = format!("failed to parse .ensemble/verdict-{step_name}.json: {e}");
-            let failed = StepResult::Failed {
-                summary: msg.clone(),
-            };
-            let output = StepOutput {
-                result: failed.clone(),
-                summary: Some(msg),
-                output: None,
-            };
-            return ResolvedResult {
-                result: failed,
-                output,
-                source: VerdictSource::File,
-            };
-        }
-    }
-
-    // 3. Default (no ACP verdict, no file).
-    warn!("no verdict source found for step, defaulting to Succeeded");
-    let output = StepOutput {
-        result: StepResult::Succeeded,
-        summary: None,
-        output: None,
-    };
-    ResolvedResult {
-        result: output.result.clone(),
-        output,
-        source: VerdictSource::Default,
-    }
-}
-
-/// Convert a [`VerdictPayload`] into an `Option<StepResult>`.
-fn result_from_payload(payload: &VerdictPayload) -> Option<StepResult> {
-    step_output_from_payload(payload).map(|output| output.result)
-}
-
-fn step_output_from_payload(payload: &VerdictPayload) -> Option<StepOutput> {
-    let result_value = payload.result.as_deref().or(payload.verdict.as_deref());
-    let result = match result_value {
-        Some(v) if v.eq_ignore_ascii_case("approve") || v.eq_ignore_ascii_case("succeeded") => {
-            StepResult::Succeeded
-        }
-        Some(v) if v.eq_ignore_ascii_case("reject") || v.eq_ignore_ascii_case("failed") => {
-            StepResult::Failed {
-                summary: payload.summary.clone().unwrap_or_default(),
-            }
-        }
-        Some(v) if v.eq_ignore_ascii_case("concern") => StepResult::Concern {
-            summary: payload.summary.clone().unwrap_or_default(),
-        },
-        _ => return None,
-    };
-
-    Some(StepOutput {
-        result,
-        summary: payload.summary.clone(),
-        output: payload.output.clone(),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
-    use tempfile::TempDir;
-
-    // -------------------------------------------------------------------------
-    // parse_verdict_from_value
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn test_parse_succeeded_result() {
-        let value = json!({ "result": "succeeded" });
-        assert_eq!(
-            parse_verdict_from_value(&value),
-            Some(StepResult::Succeeded)
-        );
-    }
-
-    #[test]
-    fn test_parse_legacy_approve_verdict() {
-        let value = json!({ "verdict": "approve" });
-        assert_eq!(
-            parse_verdict_from_value(&value),
-            Some(StepResult::Succeeded)
-        );
-    }
-
-    #[test]
-    fn test_parse_failed_result() {
-        let value = json!({ "result": "failed", "summary": "tests failed" });
-        assert_eq!(
-            parse_verdict_from_value(&value),
-            Some(StepResult::Failed {
-                summary: "tests failed".to_string()
-            })
-        );
-    }
-
-    #[test]
-    fn test_parse_legacy_reject_verdict() {
-        let value = json!({ "verdict": "reject", "summary": "tests failed" });
-        assert_eq!(
-            parse_verdict_from_value(&value),
-            Some(StepResult::Failed {
-                summary: "tests failed".to_string()
-            })
-        );
-    }
-
-    #[test]
-    fn test_parse_concern() {
-        let value = json!({ "result": "concern", "summary": "needs review" });
-        assert_eq!(
-            parse_verdict_from_value(&value),
-            Some(StepResult::Concern {
-                summary: "needs review".to_string()
-            })
-        );
-    }
-
-    #[test]
-    fn test_parse_result_preferred_over_legacy_verdict() {
-        let value = json!({
-            "result": "succeeded",
-            "verdict": "reject",
-            "summary": "legacy value should be ignored"
-        });
-        assert_eq!(
-            parse_verdict_from_value(&value),
-            Some(StepResult::Succeeded)
-        );
-    }
-
-    #[test]
-    fn test_parse_no_verdict_field() {
-        let value = json!({ "other_key": "something" });
-        assert_eq!(parse_verdict_from_value(&value), None);
-    }
-
-    #[test]
-    fn test_parse_null_verdict() {
-        let value = json!({ "verdict": null });
-        assert_eq!(parse_verdict_from_value(&value), None);
-    }
-
-    // -------------------------------------------------------------------------
-    // read_verdict_file
-    // -------------------------------------------------------------------------
-
-    async fn write_verdict_file(dir: &TempDir, contents: &str) {
-        write_step_verdict_file(dir, "build", contents).await;
-    }
-
-    async fn write_step_verdict_file(dir: &TempDir, step_name: &str, contents: &str) {
-        let ensemble_dir = dir.path().join(".ensemble");
-        tokio::fs::create_dir_all(&ensemble_dir).await.unwrap();
-        let filename = format!("verdict-{step_name}.json");
-        tokio::fs::write(ensemble_dir.join(&filename), contents)
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_read_verdict_file_approve() {
-        let dir = TempDir::new().unwrap();
-        write_verdict_file(&dir, r#"{"verdict":"approve"}"#).await;
-        let result = read_verdict_file(dir.path(), "build").await.unwrap();
-        assert_eq!(result, Some(StepResult::Succeeded));
-    }
-
-    #[tokio::test]
-    async fn test_read_verdict_file_reject() {
-        let dir = TempDir::new().unwrap();
-        write_verdict_file(&dir, r#"{"verdict":"reject","summary":"lint errors"}"#).await;
-        let result = read_verdict_file(dir.path(), "build").await.unwrap();
-        assert_eq!(
-            result,
-            Some(StepResult::Failed {
-                summary: "lint errors".to_string()
-            })
-        );
-    }
-
-    #[tokio::test]
-    async fn test_read_verdict_file_missing() {
-        let dir = TempDir::new().unwrap();
-        let result = read_verdict_file(dir.path(), "build").await.unwrap();
-        assert_eq!(result, None);
-    }
-
-    // -------------------------------------------------------------------------
-    // resolve_verdict
-    // -------------------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_resolve_verdict_acp_takes_priority() {
-        // ACP says approve, file says reject — ACP wins.
-        let dir = TempDir::new().unwrap();
-        write_verdict_file(&dir, r#"{"verdict":"reject","summary":"broken"}"#).await;
-
-        let acp = json!({ "result": "succeeded" });
-        let result = resolve_verdict(Some(&acp), dir.path(), "build").await;
-        assert_eq!(result, StepResult::Succeeded);
-    }
-
-    #[tokio::test]
-    async fn test_resolve_verdict_with_source_runtime_takes_priority() {
-        let dir = TempDir::new().unwrap();
-        write_verdict_file(&dir, r#"{"verdict":"reject","summary":"broken"}"#).await;
-
-        let acp = json!({ "result": "succeeded" });
-        let result = resolve_verdict_with_source(Some(&acp), dir.path(), "build").await;
-        assert_eq!(result.result, StepResult::Succeeded);
-        assert_eq!(result.source, VerdictSource::Runtime);
-    }
-
-    #[tokio::test]
-    async fn test_resolve_verdict_falls_back_to_file() {
-        // No ACP value — file provides the verdict.
-        let dir = TempDir::new().unwrap();
-        write_verdict_file(&dir, r#"{"verdict":"reject","summary":"compile error"}"#).await;
-
-        let result = resolve_verdict(None, dir.path(), "build").await;
-        assert_eq!(
-            result,
-            StepResult::Failed {
-                summary: "compile error".to_string()
-            }
-        );
-    }
-
-    #[tokio::test]
-    async fn test_resolve_verdict_with_source_falls_back_to_file() {
-        let dir = TempDir::new().unwrap();
-        write_verdict_file(&dir, r#"{"verdict":"reject","summary":"compile error"}"#).await;
-
-        let result = resolve_verdict_with_source(None, dir.path(), "build").await;
-        assert_eq!(
-            result.result,
-            StepResult::Failed {
-                summary: "compile error".to_string()
-            }
-        );
-        assert_eq!(result.source, VerdictSource::File);
-    }
-
-    #[tokio::test]
-    async fn test_resolve_verdict_no_source_is_approve() {
-        // No ACP, no file — defaults to Approve.
-        let dir = TempDir::new().unwrap();
-        let result = resolve_verdict(None, dir.path(), "build").await;
-        assert_eq!(result, StepResult::Succeeded);
-    }
-
-    #[tokio::test]
-    async fn test_resolve_verdict_with_source_no_source_is_default_approve() {
-        let dir = TempDir::new().unwrap();
-        let result = resolve_verdict_with_source(None, dir.path(), "build").await;
-        assert_eq!(result.result, StepResult::Succeeded);
-        assert_eq!(result.source, VerdictSource::Default);
-    }
-
-    #[tokio::test]
-    async fn test_read_verdict_file_malformed_json_is_error() {
-        let dir = TempDir::new().unwrap();
-        write_verdict_file(&dir, "this is not json").await;
-        let result = read_verdict_file(dir.path(), "build").await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_resolve_verdict_malformed_file_rejects() {
-        // Malformed verdict.json should reject, not silently approve.
-        let dir = TempDir::new().unwrap();
-        write_verdict_file(&dir, "not valid json").await;
-        let result = resolve_verdict(None, dir.path(), "build").await;
-        assert!(matches!(result, StepResult::Failed { .. }));
-    }
-
-    // -------------------------------------------------------------------------
-    // StepOutput and parse_step_output_from_value
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn test_parse_step_output_from_runtime_value() {
-        let value = json!({
-            "result": "succeeded",
-            "summary": "review passed",
-            "output": {"risk": "low", "findings": []}
-        });
-
-        let output = parse_step_output_from_value(&value).unwrap();
-
-        assert_eq!(output.result, StepResult::Succeeded);
-        assert_eq!(output.summary.as_deref(), Some("review passed"));
-        assert_eq!(output.output, Some(json!({"risk":"low","findings":[]})));
-    }
 
     #[test]
     fn validate_step_output_accepts_succeeded() {
@@ -580,10 +160,7 @@ mod tests {
         }))
         .unwrap_err();
 
-        assert!(
-            err.to_string().contains("unknown field `verdict`"),
-            "{err}"
-        );
+        assert!(err.to_string().contains("unknown field `verdict`"), "{err}");
     }
 
     #[test]
@@ -601,25 +178,9 @@ mod tests {
     fn parse_step_output_json_rejects_non_json_text() {
         let err = parse_step_output_json("approved, looks good").unwrap_err();
 
-        assert!(err.to_string().contains("invalid JSON step output"), "{err}");
-    }
-
-    #[tokio::test]
-    async fn test_read_step_output_file_preserves_approve_summary_and_output() {
-        let dir = TempDir::new().unwrap();
-        write_verdict_file(
-            &dir,
-            r#"{"verdict":"approve","summary":"ok","output":{"files":["src/lib.rs"]}}"#,
-        )
-        .await;
-
-        let output = read_step_output_file(dir.path(), "build")
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(output.result, StepResult::Succeeded);
-        assert_eq!(output.summary.as_deref(), Some("ok"));
-        assert_eq!(output.output, Some(json!({"files":["src/lib.rs"]})));
+        assert!(
+            err.to_string().contains("invalid JSON step output"),
+            "{err}"
+        );
     }
 }

--- a/crates/ensemble-core/src/pipeline/verdict.rs
+++ b/crates/ensemble-core/src/pipeline/verdict.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -44,6 +45,91 @@ struct VerdictPayload {
     summary: Option<String>,
     #[serde(default)]
     output: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepOutputValidationError {
+    message: String,
+}
+
+impl StepOutputValidationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for StepOutputValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StepOutputValidationError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictStepOutputPayload {
+    result: StrictStepResult,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    output: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StrictStepResult {
+    Succeeded,
+    Failed,
+    Concern,
+}
+
+pub fn parse_step_output_json(text: &str) -> Result<StepOutput, StepOutputValidationError> {
+    let value: serde_json::Value = serde_json::from_str(text).map_err(|error| {
+        StepOutputValidationError::new(format!("invalid JSON step output: {error}"))
+    })?;
+    validate_step_output_value(&value)
+}
+
+pub fn validate_step_output_value(
+    value: &serde_json::Value,
+) -> Result<StepOutput, StepOutputValidationError> {
+    let payload: StrictStepOutputPayload = serde_json::from_value(value.clone()).map_err(|error| {
+        StepOutputValidationError::new(format!("invalid StepOutput payload: {error}"))
+    })?;
+
+    let summary = payload.summary.map(|value| value.trim().to_string());
+    let result = match payload.result {
+        StrictStepResult::Succeeded => StepResult::Succeeded,
+        StrictStepResult::Failed => {
+            let Some(summary) = summary.as_ref().filter(|value| !value.is_empty()) else {
+                return Err(StepOutputValidationError::new(
+                    "failed results require a non-empty summary",
+                ));
+            };
+            StepResult::Failed {
+                summary: summary.clone(),
+            }
+        }
+        StrictStepResult::Concern => {
+            let Some(summary) = summary.as_ref().filter(|value| !value.is_empty()) else {
+                return Err(StepOutputValidationError::new(
+                    "concern results require a non-empty summary",
+                ));
+            };
+            StepResult::Concern {
+                summary: summary.clone(),
+            }
+        }
+    };
+
+    Ok(StepOutput {
+        result,
+        summary,
+        output: payload.output,
+    })
 }
 
 /// Parse a [`StepResult`] from an arbitrary JSON value (e.g. an ACP event body).
@@ -444,6 +530,78 @@ mod tests {
         assert_eq!(output.result, StepResult::Succeeded);
         assert_eq!(output.summary.as_deref(), Some("review passed"));
         assert_eq!(output.output, Some(json!({"risk":"low","findings":[]})));
+    }
+
+    #[test]
+    fn validate_step_output_accepts_succeeded() {
+        let output = validate_step_output_value(&json!({
+            "result": "succeeded",
+            "summary": "finished",
+            "output": {"branch": "issue-184"}
+        }))
+        .unwrap();
+
+        assert_eq!(output.result, StepResult::Succeeded);
+        assert_eq!(output.summary.as_deref(), Some("finished"));
+        assert_eq!(output.output, Some(json!({"branch": "issue-184"})));
+    }
+
+    #[test]
+    fn validate_step_output_requires_summary_for_failed() {
+        let err = validate_step_output_value(&json!({"result": "failed"})).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("failed results require a non-empty summary"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn validate_step_output_requires_summary_for_concern() {
+        let err = validate_step_output_value(&json!({
+            "result": "concern",
+            "summary": "   "
+        }))
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("concern results require a non-empty summary"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn validate_step_output_rejects_legacy_verdict_key() {
+        let err = validate_step_output_value(&json!({
+            "verdict": "approve",
+            "summary": "legacy"
+        }))
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("unknown field `verdict`"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn validate_step_output_rejects_unknown_keys() {
+        let err = validate_step_output_value(&json!({
+            "result": "succeeded",
+            "extra": true
+        }))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("unknown field `extra`"), "{err}");
+    }
+
+    #[test]
+    fn parse_step_output_json_rejects_non_json_text() {
+        let err = parse_step_output_json("approved, looks good").unwrap_err();
+
+        assert!(err.to_string().contains("invalid JSON step output"), "{err}");
     }
 
     #[tokio::test]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -89,7 +89,8 @@ Important boundary:
 
 5. `Pipeline Engine`
    - Builds a step DAG from `config.yaml` step definitions.
-   - Executes pipeline steps per issue, dispatching agents and collecting verdicts.
+   - Executes pipeline steps per issue, dispatching agents and collecting validated `StepOutput`
+     results.
    - Drives tracker state transitions at step boundaries.
    - Enforces concurrency limits (global and per-issue).
 
@@ -111,7 +112,7 @@ Important boundary:
    - Launches the coding agent via ACP over stdio from a structured command; implementations should
      avoid shell interpolation for agent command arguments.
    - Streams agent updates back to the orchestrator.
-   - Collects verdict (ACP protocol field or `.ensemble/verdict.json` fallback).
+   - Runs a hidden extraction turn in the same runtime session and collects a validated `StepOutput`.
 
 8. `Status Surface` (optional)
    - Presents human-readable runtime status (for example terminal output, dashboard, or other
@@ -266,9 +267,9 @@ Step states:
 - `Running` — agent dispatched, session active
 - `AwaitingApproval` — step completed but blocked on an approval gate. The orchestrator
   holds the pipeline here until a `approve_gate` or `reject_gate` signal is received.
-- `Passed` — agent exited successfully with approve verdict (or no verdict), or approved at an
-  approval gate
-- `Rejected` — agent exited successfully with reject verdict, or rejected at an approval gate
+- `Passed` — agent exited successfully with a `succeeded` or `concern` result, or was approved at
+  an approval gate
+- `Rejected` — agent exited successfully with a `failed` result, or was rejected at an approval gate
 - `Failed` — agent crashed, timed out, or errored
 
 **Post-step approval checkpoints:** When a step succeeds and has `approval` configured, the
@@ -291,26 +292,33 @@ Pipeline run recovery:
 - A `released` transition prevents older snapshots for the issue from being restored after
   completion, stop, terminal reconciliation, or whole-issue retry.
 
-#### 4.1.7 Verdict
+#### 4.1.7 StepOutput
 
-Agent judgment returned after a pipeline step completes:
+Structured result returned after a pipeline step completes:
 
-- `verdict` (string: `"approve"`, `"reject"`, or null)
-  - `"approve"` — step passed.
-  - `"reject"` — step failed quality/review check.
-  - null/absent — treated as `"approve"` (backwards compatible for non-review agents).
-- `summary` (string or null) — human-readable explanation of the verdict.
-- `output` (JSON value or null) — arbitrary structured data produced by a step for downstream
+- `result` (string: `"succeeded"`, `"failed"`, or `"concern"`)
+  - `"succeeded"` — step passed.
+  - `"failed"` — step failed quality/review checks or could not complete the requested work.
+  - `"concern"` — step passed with a non-blocking concern that downstream steps can inspect.
+- `summary` (string or null) — human-readable explanation of the result. Required and non-empty for
+  `failed` and `concern`; optional for `succeeded`.
+- `output` (JSON value or null) — optional structured data produced by a step for downstream
   prompt templates.
 
-Verdict sources (checked in priority order):
+Result extraction:
 
-1. ACP protocol: `verdict` field in the final `session/update` status event.
-2. File-based fallback: `.ensemble/verdict.json` in the workspace directory.
+1. The agent performs its visible working turn.
+2. Ensemble runs a hidden extraction turn in the same runtime session to produce `StepOutput`.
+3. If extraction produces invalid JSON or violates the result contract, Ensemble runs one hidden
+   repair turn.
+4. If repair also fails, the worker fails and the orchestrator applies the configured retry or
+   failure behavior.
+
+There is no default-success result. A step must produce valid `StepOutput` through extraction.
 
 Prompt templates for downstream steps receive:
 
-- `steps` — map of completed step name to `{ step, verdict, summary, output }`.
+- `steps` — map of completed step name to `{ step, result, summary, output }`.
 - `dependency_outputs` — ordered list of direct dependency outputs for the step being dispatched.
 
 #### 4.1.8 Run Attempt
@@ -684,7 +692,7 @@ Terminal tracker state to write when all pipeline steps pass. Required.
 
 #### 5.3.6 `on_failure` (string)
 
-Terminal tracker state to write when any pipeline step fails or a review agent rejects. Required.
+Terminal tracker state to write when any pipeline step fails or returns a failed result. Required.
 
 #### 5.3.7 `concurrency` (object)
 
@@ -812,11 +820,11 @@ Template input variables:
   - `null`/absent on first attempt.
   - Integer on retry or continuation run.
 - `steps` (map of string to object, optional)
-  - Present when upstream steps have completed. Each entry contains `step`, `verdict`, `summary`,
+  - Present when upstream steps have completed. Each entry contains `step`, `result`, `summary`,
     and `output` fields.
 - `dependency_outputs` (list of objects, optional)
   - Ordered list of outputs from the step's direct dependencies. Each entry has the same shape as
-    `steps` entries: `{ step, verdict, summary, output }`.
+    `steps` entries: `{ step, result, summary, output }`.
 
 Synthesis steps receive the same `steps` and `dependency_outputs` variables as normal steps. The
 runtime appends synthesis-specific guidance to the first turn prompt, instructing the agent to
@@ -1728,7 +1736,7 @@ Orchestrator-driven writes:
   to the tracker (for example "In Progress", "In Review").
 - **Pipeline success**: When all steps pass, the orchestrator writes `on_success` (for example
   "Done").
-- **Pipeline failure/rejection**: When any step fails or a review agent rejects, the orchestrator
+- **Pipeline failure/rejection**: When any step fails or returns a failed result, the orchestrator
   writes `on_failure` (for example "Needs Rework"). This is a terminal state from the pipeline's
   perspective — a human must intervene.
 
@@ -1791,7 +1799,7 @@ Implementations may append runtime-owned instruction blocks after template rende
 
 At minimum, Ensemble v1 appends:
 
-- verdict fallback instructions (enabled by default)
+- result extraction instructions for the hidden extraction turn
 - interaction-policy guidance (enabled by default), including:
   - prefer batched clarification requests instead of one-by-one ping-pong
   - this is a soft preference, not a strict prohibition

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -200,7 +200,7 @@ Parsed `config.yaml` payload:
 - `on_success` (string)
   - Terminal tracker state when all pipeline steps pass.
 - `on_failure` (string)
-  - Terminal tracker state when any pipeline step fails or rejects.
+  - Terminal tracker state when any pipeline step fails.
 - `concurrency` (ConcurrencyConfig)
   - `max_concurrent_agents` (global cap) and `max_step_parallelism` (per-issue cap).
 - `max_cycles` (integer, default 3)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2703,7 +2703,8 @@ Use the same validation profiles as Section 17:
 - Polling orchestrator with single-authority mutable state
 - Issue tracker client with candidate fetch + state refresh + terminal fetch + write operations
 - Pipeline engine with step DAG construction, validation, and per-issue execution
-- Verdict collection from ACP protocol and file-based fallback
+- Validated `StepOutput` extraction from the hidden extraction turn, with one repair attempt if
+  extraction is invalid
 - Workspace manager with sanitized per-issue workspaces
 - Workspace lifecycle hooks (`after_create`, `before_run`, `after_run`, `before_remove`)
 - Hook timeout config (`hooks.timeout_ms`, default `60000`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -390,6 +390,9 @@ Runtime settings for agent execution.
 
 This section configures Ensemble's runtime behavior after the agent is launched. It does not set per-agent ACPX launch flags; those belong in `agents.*`.
 
+Agent step results are extracted by Ensemble through a hidden second turn in the same runtime
+session. There is no config switch for this behavior.
+
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `max_turns` | integer | `20` | Maximum agent conversation turns per session |
@@ -401,15 +404,12 @@ This section configures Ensemble's runtime behavior after the agent is launched.
 | `turn_timeout_ms` | integer | `3600000` | Maximum time for a single agent turn (1 hour) |
 | `read_timeout_ms` | integer | `5000` | Timeout for reading agent output |
 | `stall_timeout_ms` | integer | `300000` | Timeout for detecting a stalled agent |
-| `inject_verdict_fallback_instructions` | boolean | `true` | Appends Ensemble-owned fallback instructions so agents can write `.ensemble/verdict.json` when no structured runtime verdict is emitted |
 | `inject_interaction_policy_instructions` | boolean | `true` | Automatically appends Ensemble interaction policy guidance to prompts (batched clarifications as a soft preference) |
 | `interaction_policy_text` | string | built-in default | Optional global replacement text for the injected interaction policy block |
 | `interaction_policy_overrides.agents.<agent>.mode` | string | `inherit` | Per-agent override mode: `inherit`, `custom`, or `off` |
 | `interaction_policy_overrides.agents.<agent>.text` | string | — | Required for useful `custom` overrides; policy text appended for that agent |
 | `interaction_policy_overrides.steps.<step>.mode` | string | `inherit` | Per-step override mode. Step override wins over agent override |
 | `interaction_policy_overrides.steps.<step>.text` | string | — | Required for useful `custom` per-step overrides |
-
-`agent.inject_verdict_instructions` is accepted as a shorter alias for `agent.inject_verdict_fallback_instructions`.
 
 Interaction policy override precedence is: `step override` → `agent override` → global `agent.*` defaults.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -345,7 +345,7 @@ steps:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `on_success` | string | *required* | Tracker state when all pipeline steps pass |
-| `on_failure` | string | *required* | Tracker state when any step fails or rejects |
+| `on_failure` | string | *required* | Tracker state when any step fails |
 
 ### concurrency
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -107,18 +107,23 @@ Todo → Building → In Review → Done
 
 ## Results
 
-After an agent finishes, Ensemble resolves results with this strict precedence:
+After an agent finishes its visible working turn, Ensemble runs a hidden extraction turn in the same
+runtime session. The extraction turn produces the step's structured result. Extraction messages are
+not shown in the timeline.
 
-1. **Runtime result (primary)** — if the runtime reports a parseable structured result, Ensemble uses it.
-2. **File fallback** — only when no runtime result is available, Ensemble checks `.ensemble/verdict-{step}.json`:
+Every successful agent step must produce:
 
 ```json
 {
-  "result": "succeeded"
+  "result": "succeeded",
+  "summary": "optional human-readable summary",
+  "output": {
+    "optional": "structured data for downstream steps"
+  }
 }
 ```
 
-or:
+Failed and concern results require a non-empty `summary`:
 
 ```json
 {
@@ -136,13 +141,11 @@ or:
 }
 ```
 
-3. **Default success** — if neither source provides a result, the step is treated as succeeded.
+If extraction produces invalid JSON or violates the result contract, Ensemble runs one hidden repair
+turn. If repair also fails, the worker fails and the orchestrator applies the configured retry or
+failure behavior.
 
-If both runtime and file results exist, the runtime result takes precedence and the file result is ignored.
-
-By default, Ensemble appends fallback result instructions to rendered prompts (`agent.inject_verdict_fallback_instructions: true`, alias `agent.inject_verdict_instructions`), so users do not need to manually add `.ensemble/verdict-{step}.json` instructions in their templates.
-
-For compatibility with older agent outputs, payloads that use `"verdict": "approve"` or `"verdict": "reject"` are still parsed. New templates and runtime payloads should use `result`.
+Verdict files and default-success fallback are not part of the runtime result contract.
 
 **Succeeded** means the step passed. The pipeline moves to the next step or completes.
 
@@ -284,7 +287,7 @@ Review B risk: {{ steps["review-b"].output.risk }}
 ```
 
 Steps can produce structured `output` data alongside their result. Set the `output` field in
-`.ensemble/verdict-{step}.json` or in the ACP runtime result:
+the extracted runtime `StepOutput`:
 
 ```json
 {

--- a/docs/superpowers/plans/2026-06-12-two-phase-verdict-extraction.md
+++ b/docs/superpowers/plans/2026-06-12-two-phase-verdict-extraction.md
@@ -1,0 +1,1644 @@
+# Two-phase Verdict Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every successful agent step produce one validated runtime `StepOutput` through a visible working turn followed by a hidden extraction turn.
+
+**Architecture:** Add a strict result validator and shared extraction prompt module, then change the worker/orchestrator contract from optional raw verdicts to typed `StepOutput`. Direct ACP and `acpx` both keep the same session open for a hidden extraction prompt and one hidden repair prompt; hidden turns collect output and usage but do not emit timeline events.
+
+**Tech Stack:** Rust 2021, Tokio, serde/serde_json, async-trait, existing ACP SDK, existing `acpx` CLI adapter, Markdown docs
+
+---
+
+## Scope Check
+
+The approved spec covers one coherent runtime contract change. It touches validation, worker results, both runtime adapters, tests, and docs, but those pieces all serve the same behavior: mandatory strict two-phase step results.
+
+## File Structure
+
+| Action | File | Responsibility |
+|---|---|---|
+| Modify | `crates/ensemble-core/src/pipeline/verdict.rs` | Add strict `StepOutput` validation and JSON parsing; later remove production fallback helpers. |
+| Create | `crates/ensemble-core/src/agent/extraction.rs` | Build extraction and repair prompts; convert hidden-turn runtime payload/text into validated `StepOutput`. |
+| Modify | `crates/ensemble-core/src/agent/mod.rs` | Export extraction module, remove verdict fallback prompt injection, change worker success wiring. |
+| Modify | `crates/ensemble-core/src/agent/events.rs` | Change `WorkerResult::Success` to carry typed `StepOutput`. |
+| Modify | `crates/ensemble-core/src/agent/acp_client.rs` | Add visible/hidden turn metadata, collect visible answer text, run extraction and repair hidden turns. |
+| Modify | `crates/ensemble-core/src/agent/acpx_cli.rs` | Add prompt visibility, capture prompt output text, suppress hidden prompt events. |
+| Modify | `crates/ensemble-core/src/agent/acpx_runtime.rs` | Keep `acpx` sessions open through visible prompt, extraction prompt, optional repair, and close. |
+| Modify | `crates/ensemble-core/src/orchestrator/mod.rs` | Consume typed `StepOutput` directly instead of resolving optional runtime/file/default verdicts. |
+| Modify | `crates/ensemble-core/src/config/ensemble.rs` | Remove verdict fallback injection config from typed runtime config. |
+| Modify | `docs/SPEC.md`, `docs/configuration.md`, `docs/pipelines.md` | Document mandatory two-phase runtime results and remove fallback/default result behavior. |
+
+## Task 1: Add Strict StepOutput Validation
+
+**Files:**
+- Modify: `crates/ensemble-core/src/pipeline/verdict.rs`
+
+- [ ] **Step 1: Add failing strict validation tests**
+
+Add these tests inside `#[cfg(test)] mod tests` in `crates/ensemble-core/src/pipeline/verdict.rs`:
+
+```rust
+#[test]
+fn validate_step_output_accepts_succeeded() {
+    let output = validate_step_output_value(&json!({
+        "result": "succeeded",
+        "summary": "finished",
+        "output": {"branch": "issue-184"}
+    }))
+    .unwrap();
+
+    assert_eq!(output.result, StepResult::Succeeded);
+    assert_eq!(output.summary.as_deref(), Some("finished"));
+    assert_eq!(output.output, Some(json!({"branch": "issue-184"})));
+}
+
+#[test]
+fn validate_step_output_requires_summary_for_failed() {
+    let err = validate_step_output_value(&json!({"result": "failed"})).unwrap_err();
+
+    assert!(
+        err.to_string().contains("failed results require a non-empty summary"),
+        "{err}"
+    );
+}
+
+#[test]
+fn validate_step_output_requires_summary_for_concern() {
+    let err = validate_step_output_value(&json!({
+        "result": "concern",
+        "summary": "   "
+    }))
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("concern results require a non-empty summary"),
+        "{err}"
+    );
+}
+
+#[test]
+fn validate_step_output_rejects_legacy_verdict_key() {
+    let err = validate_step_output_value(&json!({
+        "verdict": "approve",
+        "summary": "legacy"
+    }))
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("unknown field `verdict`"),
+        "{err}"
+    );
+}
+
+#[test]
+fn validate_step_output_rejects_unknown_keys() {
+    let err = validate_step_output_value(&json!({
+        "result": "succeeded",
+        "extra": true
+    }))
+    .unwrap_err();
+
+    assert!(err.to_string().contains("unknown field `extra`"), "{err}");
+}
+
+#[test]
+fn parse_step_output_json_rejects_non_json_text() {
+    let err = parse_step_output_json("approved, looks good").unwrap_err();
+
+    assert!(err.to_string().contains("invalid JSON step output"), "{err}");
+}
+```
+
+- [ ] **Step 2: Run strict validation tests and verify they fail**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core pipeline::verdict::tests::validate_step_output -- --nocapture
+rtk cargo test -p ensemble-core pipeline::verdict::tests::parse_step_output_json_rejects_non_json_text -- --exact
+```
+
+Expected: FAIL because `validate_step_output_value` and `parse_step_output_json` do not exist.
+
+- [ ] **Step 3: Add strict validation types and functions**
+
+In `crates/ensemble-core/src/pipeline/verdict.rs`, add `Display` import:
+
+```rust
+use std::fmt;
+```
+
+Add these types and functions after `VerdictPayload`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepOutputValidationError {
+    message: String,
+}
+
+impl StepOutputValidationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for StepOutputValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StepOutputValidationError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictStepOutputPayload {
+    result: StrictStepResult,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    output: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StrictStepResult {
+    Succeeded,
+    Failed,
+    Concern,
+}
+
+pub fn parse_step_output_json(text: &str) -> Result<StepOutput, StepOutputValidationError> {
+    let value: serde_json::Value = serde_json::from_str(text).map_err(|error| {
+        StepOutputValidationError::new(format!("invalid JSON step output: {error}"))
+    })?;
+    validate_step_output_value(&value)
+}
+
+pub fn validate_step_output_value(
+    value: &serde_json::Value,
+) -> Result<StepOutput, StepOutputValidationError> {
+    let payload: StrictStepOutputPayload = serde_json::from_value(value.clone()).map_err(|error| {
+        StepOutputValidationError::new(format!("invalid StepOutput payload: {error}"))
+    })?;
+
+    let summary = payload.summary.map(|value| value.trim().to_string());
+    let result = match payload.result {
+        StrictStepResult::Succeeded => StepResult::Succeeded,
+        StrictStepResult::Failed => {
+            let Some(summary) = summary.as_ref().filter(|value| !value.is_empty()) else {
+                return Err(StepOutputValidationError::new(
+                    "failed results require a non-empty summary",
+                ));
+            };
+            StepResult::Failed {
+                summary: summary.clone(),
+            }
+        }
+        StrictStepResult::Concern => {
+            let Some(summary) = summary.as_ref().filter(|value| !value.is_empty()) else {
+                return Err(StepOutputValidationError::new(
+                    "concern results require a non-empty summary",
+                ));
+            };
+            StepResult::Concern {
+                summary: summary.clone(),
+            }
+        }
+    };
+
+    Ok(StepOutput {
+        result,
+        summary,
+        output: payload.output,
+    })
+}
+```
+
+- [ ] **Step 4: Run strict validation tests and verify they pass**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core pipeline::verdict::tests::validate_step_output -- --nocapture
+rtk cargo test -p ensemble-core pipeline::verdict::tests::parse_step_output_json_rejects_non_json_text -- --exact
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit strict validator**
+
+Run:
+
+```bash
+rtk git add crates/ensemble-core/src/pipeline/verdict.rs
+rtk git commit -m "Add strict step output validation"
+```
+
+## Task 2: Add Shared Extraction Prompt Module
+
+**Files:**
+- Create: `crates/ensemble-core/src/agent/extraction.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+
+- [ ] **Step 1: Create failing extraction module tests**
+
+Create `crates/ensemble-core/src/agent/extraction.rs` with these tests and stub signatures:
+
+```rust
+use crate::error::AgentError;
+use crate::pipeline::verdict::{parse_step_output_json, validate_step_output_value, StepOutput};
+
+pub(crate) fn build_extraction_prompt(
+    _step_name: &str,
+    _issue_identifier: &str,
+    _original_prompt: &str,
+    _working_answer: &str,
+) -> String {
+    String::new()
+}
+
+pub(crate) fn build_repair_prompt(_validation_error: &str, _previous_payload: &str) -> String {
+    String::new()
+}
+
+pub(crate) fn validate_extraction_payload(
+    _runtime_payload: Option<&serde_json::Value>,
+    _output_text: &str,
+) -> Result<StepOutput, AgentError> {
+    Err(AgentError::ResponseError {
+        reason: "stubbed for failing extraction test".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::verdict::StepResult;
+    use serde_json::json;
+
+    #[test]
+    fn extraction_prompt_contains_context_and_schema() {
+        let prompt = build_extraction_prompt(
+            "review",
+            "repo#184",
+            "Review this change",
+            "The implementation is sound.",
+        );
+
+        assert!(prompt.contains("Step: review"));
+        assert!(prompt.contains("Issue: repo#184"));
+        assert!(prompt.contains("Review this change"));
+        assert!(prompt.contains("The implementation is sound."));
+        assert!(prompt.contains("\"result\": \"succeeded | failed | concern\""));
+        assert!(prompt.contains("Return only a JSON object"));
+    }
+
+    #[test]
+    fn repair_prompt_contains_error_and_previous_payload() {
+        let prompt = build_repair_prompt(
+            "failed results require a non-empty summary",
+            "{\"result\":\"failed\"}",
+        );
+
+        assert!(prompt.contains("failed results require a non-empty summary"));
+        assert!(prompt.contains("{\"result\":\"failed\"}"));
+        assert!(prompt.contains("Return only the corrected JSON object"));
+    }
+
+    #[test]
+    fn validate_extraction_payload_prefers_runtime_payload() {
+        let output = validate_extraction_payload(
+            Some(&json!({"result":"failed","summary":"tests failed"})),
+            "{\"result\":\"succeeded\"}",
+        )
+        .unwrap();
+
+        assert_eq!(
+            output.result,
+            StepResult::Failed {
+                summary: "tests failed".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn validate_extraction_payload_parses_hidden_text_without_runtime_payload() {
+        let output = validate_extraction_payload(None, "{\"result\":\"succeeded\"}").unwrap();
+
+        assert_eq!(output.result, StepResult::Succeeded);
+    }
+
+    #[test]
+    fn validate_extraction_payload_reports_validation_error() {
+        let err = validate_extraction_payload(None, "{\"result\":\"failed\"}").unwrap_err();
+
+        assert!(
+            err.to_string().contains("failed results require a non-empty summary"),
+            "{err}"
+        );
+    }
+}
+```
+
+In `crates/ensemble-core/src/agent/mod.rs`, add:
+
+```rust
+pub mod extraction;
+```
+
+- [ ] **Step 2: Run extraction tests and verify they fail**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core agent::extraction::tests -- --nocapture
+```
+
+Expected: FAIL because the extraction functions return stubs.
+
+- [ ] **Step 3: Implement extraction prompts and payload validation**
+
+Replace the stub bodies in `crates/ensemble-core/src/agent/extraction.rs` with:
+
+```rust
+pub(crate) fn build_extraction_prompt(
+    step_name: &str,
+    issue_identifier: &str,
+    original_prompt: &str,
+    working_answer: &str,
+) -> String {
+    format!(
+        "Extract the Ensemble step result from the completed working turn.\n\n\
+         Step: {step_name}\n\
+         Issue: {issue_identifier}\n\n\
+         Original step prompt:\n\
+         ---\n\
+         {original_prompt}\n\
+         ---\n\n\
+         Visible working answer:\n\
+         ---\n\
+         {working_answer}\n\
+         ---\n\n\
+         Required JSON schema, expressed by example:\n\
+         {{\n\
+           \"result\": \"succeeded | failed | concern\",\n\
+           \"summary\": \"required for failed or concern; optional for succeeded\",\n\
+           \"output\": {{}}\n\
+         }}\n\n\
+         Rules:\n\
+         - Return only a JSON object.\n\
+         - Use result=succeeded only when the working answer completed the step.\n\
+         - Use result=failed for blocking failures and include a non-empty summary.\n\
+         - Use result=concern for non-blocking concerns and include a non-empty summary.\n\
+         - Omit output when there is no structured downstream data.\n\
+         - Do not include any keys other than result, summary, and output."
+    )
+}
+
+pub(crate) fn build_repair_prompt(validation_error: &str, previous_payload: &str) -> String {
+    format!(
+        "The previous Ensemble step result was invalid.\n\n\
+         Validation error:\n\
+         {validation_error}\n\n\
+         Previous payload:\n\
+         {previous_payload}\n\n\
+         Return only the corrected JSON object using exactly these keys: result, summary, output. \
+         The result value must be one of succeeded, failed, or concern. Failed and concern require a non-empty summary."
+    )
+}
+
+pub(crate) fn validate_extraction_payload(
+    runtime_payload: Option<&serde_json::Value>,
+    output_text: &str,
+) -> Result<StepOutput, AgentError> {
+    if let Some(value) = runtime_payload {
+        return validate_step_output_value(value).map_err(|error| AgentError::ResponseError {
+            reason: error.to_string(),
+        });
+    }
+
+    parse_step_output_json(output_text.trim()).map_err(|error| AgentError::ResponseError {
+        reason: error.to_string(),
+    })
+}
+```
+
+- [ ] **Step 4: Run extraction tests and verify they pass**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core agent::extraction::tests -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit extraction prompt module**
+
+Run:
+
+```bash
+rtk git add crates/ensemble-core/src/agent/mod.rs crates/ensemble-core/src/agent/extraction.rs
+rtk git commit -m "Add verdict extraction prompts"
+```
+
+## Task 3: Change Worker Success to Typed StepOutput
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/events.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Modify: `crates/ensemble-core/src/agent/acpx_runtime.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Modify: affected tests in the same files
+
+- [ ] **Step 1: Change `WorkerResult::Success` shape**
+
+In `crates/ensemble-core/src/agent/events.rs`, add:
+
+```rust
+use crate::pipeline::verdict::StepOutput;
+```
+
+Change the enum variant to:
+
+```rust
+Success {
+    output: StepOutput,
+    approval_request: Option<StepApprovalRequestDraft>,
+},
+```
+
+- [ ] **Step 2: Add a temporary helper for current runtime paths**
+
+In `crates/ensemble-core/src/agent/mod.rs`, replace `detect_worker_result_with_runtime_verdict` with:
+
+```rust
+async fn detect_worker_result_with_output(
+    workspace_path: &Path,
+    output: crate::pipeline::verdict::StepOutput,
+    step_name: &str,
+) -> WorkerResult {
+    let interaction_path = workspace_path
+        .join(".ensemble")
+        .join("interaction-request.json");
+    let approval_path = workspace_path
+        .join(".ensemble")
+        .join("approval-request.json");
+
+    let interaction_request = match tokio::fs::read_to_string(&interaction_path).await {
+        Ok(contents) => match serde_json::from_str::<InteractionRequestDraft>(&contents) {
+            Ok(request) => Some(request),
+            Err(error) => {
+                return WorkerResult::Failed {
+                    error: format!("failed to parse .ensemble/interaction-request.json: {error}"),
+                }
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return WorkerResult::Failed {
+                error: format!("failed to read .ensemble/interaction-request.json: {error}"),
+            }
+        }
+    };
+
+    let approval_request = match tokio::fs::read_to_string(&approval_path).await {
+        Ok(contents) => match serde_json::from_str::<StepApprovalRequestDraft>(&contents) {
+            Ok(request) => Some(request),
+            Err(error) => {
+                return WorkerResult::Failed {
+                    error: format!("failed to parse .ensemble/approval-request.json: {error}"),
+                }
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return WorkerResult::Failed {
+                error: format!("failed to read .ensemble/approval-request.json: {error}"),
+            }
+        }
+    };
+
+    let step_verdict_path = workspace_path
+        .join(".ensemble")
+        .join(format!("verdict-{step_name}.json"));
+    let legacy_verdict_path = workspace_path.join(".ensemble").join("verdict.json");
+    let verdict_exists = tokio::fs::try_exists(&step_verdict_path)
+        .await
+        .unwrap_or(false)
+        || tokio::fs::try_exists(&legacy_verdict_path)
+            .await
+            .unwrap_or(false);
+
+    match interaction_request {
+        Some(_) if approval_request.is_some() => WorkerResult::Failed {
+            error: "agent produced both .ensemble/interaction-request.json and .ensemble/approval-request.json"
+                .to_string(),
+        },
+        Some(_) if verdict_exists => WorkerResult::Failed {
+            error:
+                "agent produced both .ensemble/interaction-request.json and .ensemble/verdict.json"
+                    .to_string(),
+        },
+        Some(request) => WorkerResult::BlockedOnHuman { request },
+        None => WorkerResult::Success {
+            output,
+            approval_request,
+        },
+    }
+}
+```
+
+Add this helper in the same file for temporary compile support:
+
+```rust
+fn transitional_succeeded_output() -> crate::pipeline::verdict::StepOutput {
+    crate::pipeline::verdict::StepOutput {
+        result: crate::pipeline::verdict::StepResult::Succeeded,
+        summary: None,
+        output: None,
+    }
+}
+```
+
+Update the test-only helper to:
+
+```rust
+#[cfg(test)]
+async fn detect_worker_result(workspace_path: &Path, step_name: &str) -> WorkerResult {
+    detect_worker_result_with_output(workspace_path, transitional_succeeded_output(), step_name)
+        .await
+}
+```
+
+- [ ] **Step 3: Update runtime call sites to compile**
+
+In `crates/ensemble-core/src/agent/mod.rs`, change the final direct runtime success construction from:
+
+```rust
+Ok(detect_worker_result_with_runtime_verdict(
+    request.workspace_path,
+    final_verdict,
+    request.step_name,
+)
+.await)
+```
+
+to:
+
+```rust
+let output = final_verdict
+    .as_ref()
+    .and_then(crate::pipeline::verdict::parse_step_output_from_value)
+    .unwrap_or_else(transitional_succeeded_output);
+
+Ok(detect_worker_result_with_output(request.workspace_path, output, request.step_name).await)
+```
+
+In `crates/ensemble-core/src/agent/acpx_runtime.rs`, change the import:
+
+```rust
+use super::{detect_worker_result_with_output, AgentRunRequest};
+```
+
+Change the success path to:
+
+```rust
+let output = outcome
+    .runtime_verdict
+    .as_ref()
+    .and_then(crate::pipeline::verdict::parse_step_output_from_value)
+    .unwrap_or_else(super::transitional_succeeded_output);
+
+Ok(detect_worker_result_with_output(request.workspace_path, output, request.step_name).await)
+```
+
+- [ ] **Step 4: Update orchestrator success handling**
+
+In `crates/ensemble-core/src/orchestrator/mod.rs`, remove these imports:
+
+```rust
+use crate::pipeline::verdict::{resolve_verdict_with_source, StepResult, VerdictSource};
+```
+
+Replace them with:
+
+```rust
+use crate::pipeline::verdict::StepResult;
+```
+
+In `handle_worker_exit`, replace:
+
+```rust
+WorkerResult::Success {
+    runtime_verdict,
+    approval_request,
+} => {
+```
+
+with:
+
+```rust
+WorkerResult::Success {
+    output,
+    approval_request,
+} => {
+```
+
+Replace the verdict resolution block with:
+
+```rust
+let resolved_output = output;
+let verdict_value = match &resolved_output.result {
+    StepResult::Succeeded => "succeeded",
+    StepResult::Failed { .. } => "failed",
+    StepResult::Concern { .. } => "concern",
+};
+info!(
+    issue_id = %issue_id,
+    step = step_name,
+    verdict_value,
+    "received validated step result"
+);
+```
+
+Replace later uses of `resolved.result` and `resolved.output` in this match arm with:
+
+```rust
+resolved_output.result
+resolved_output
+```
+
+Before calling the existing `run.step_completed` method, add:
+
+```rust
+let result = resolved_output.result.clone();
+```
+
+Use `result` for logging and failure-summary decisions that occur after `resolved_output` is moved
+into `run.step_completed`.
+
+- [ ] **Step 5: Update tests and mocks**
+
+Search for `runtime_verdict:` in `crates/ensemble-core/src` and replace each affected
+`WorkerResult::Success` test fixture with:
+
+```rust
+WorkerResult::Success {
+    output: crate::pipeline::verdict::StepOutput {
+        result: crate::pipeline::verdict::StepResult::Succeeded,
+        summary: None,
+        output: None,
+    },
+    approval_request: None,
+}
+```
+
+For tests that previously used a rejecting runtime verdict, use:
+
+```rust
+WorkerResult::Success {
+    output: crate::pipeline::verdict::StepOutput {
+        result: crate::pipeline::verdict::StepResult::Failed {
+            summary: "tests failed".to_string(),
+        },
+        summary: Some("tests failed".to_string()),
+        output: None,
+    },
+    approval_request: None,
+}
+```
+
+For tests that previously used runtime output JSON, preserve it under:
+
+```rust
+output: Some(serde_json::json!({"risk": "high"})),
+```
+
+- [ ] **Step 6: Run compile-focused tests**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core agent::events::tests
+rtk cargo test -p ensemble-core orchestrator::tests::test_worker_exit_runtime_verdict_overrides_file_verdict -- --exact
+```
+
+Expected: the old runtime-verdict override test will fail or need renaming because runtime/file precedence is no longer the contract. Replace that test with a typed-output test:
+
+```rust
+#[tokio::test]
+async fn test_worker_exit_uses_typed_step_output() {
+    let config = Arc::new(RwLock::new(make_config()));
+    let issues = Arc::new(RwLock::new(vec![]));
+    let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+    let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+        delay_ms: 0,
+        observed_commands: None,
+        cancellation_probe: None,
+    });
+    let dir = tempfile::TempDir::new().unwrap();
+    let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+    let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+    let orchestrator = Orchestrator::new(
+        config.clone(),
+        tracker,
+        runner,
+        workspace_mgr,
+        dir.path(),
+        shutdown_rx,
+    );
+
+    {
+        let cfg = config.read().await;
+        let mut state = orchestrator.state.write().await;
+        state.add_running(&test_issue("1", "Todo"), None);
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+        pipeline_run.start();
+        pipeline_run.mark_running("build", "session-1".to_string());
+        state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+    }
+
+    orchestrator
+        .handle_worker_exit(
+            "1",
+            "build",
+            WorkerResult::Success {
+                output: crate::pipeline::verdict::StepOutput {
+                    result: crate::pipeline::verdict::StepResult::Failed {
+                        summary: "tests failed".to_string(),
+                    },
+                    summary: Some("tests failed".to_string()),
+                    output: None,
+                },
+                approval_request: None,
+            },
+        )
+        .await;
+
+    let state = orchestrator.state.read().await;
+    let run = state.get_pipeline_run("1").unwrap();
+    assert!(matches!(
+        run.step_states.get("build"),
+        Some(crate::pipeline::engine::StepState::Failed { summary })
+            if summary == "tests failed"
+    ));
+}
+```
+
+Then run:
+
+```bash
+rtk cargo test -p ensemble-core orchestrator::tests -- --nocapture
+```
+
+Expected: PASS after updating all success variants.
+
+- [ ] **Step 7: Commit worker contract change**
+
+Run:
+
+```bash
+rtk git add crates/ensemble-core/src/agent/events.rs crates/ensemble-core/src/agent/mod.rs crates/ensemble-core/src/agent/acpx_runtime.rs crates/ensemble-core/src/orchestrator/mod.rs
+rtk git commit -m "Use typed step output for worker success"
+```
+
+## Task 4: Implement Two-phase Direct ACP Sessions
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+
+- [ ] **Step 1: Add direct ACP session turn types**
+
+In `crates/ensemble-core/src/agent/acp_client.rs`, add near `AcpSessionConfig`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnVisibility {
+    Visible,
+    Hidden,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnPurpose {
+    Working,
+    Extraction,
+    Repair,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionTurn {
+    pub prompt: String,
+    pub visibility: TurnVisibility,
+    pub purpose: TurnPurpose,
+}
+
+#[derive(Debug, Clone)]
+pub struct AcpSessionOutcome {
+    pub output: crate::pipeline::verdict::StepOutput,
+    pub turn_results: Vec<TurnResult>,
+    pub capabilities: DiscoveredCapabilities,
+}
+```
+
+Extend `TurnResult::Completed` and `TurnResult::Failed` to include captured output text:
+
+```rust
+Completed {
+    usage: Option<TokenUsage>,
+    runtime_verdict: Option<serde_json::Value>,
+    output_text: String,
+},
+Failed {
+    reason: String,
+    usage: Option<TokenUsage>,
+    runtime_verdict: Option<serde_json::Value>,
+    output_text: String,
+},
+```
+
+- [ ] **Step 2: Update `run_acp_session` signature**
+
+Change:
+
+```rust
+pub async fn run_acp_session(
+    config: AcpSessionConfig,
+    prompts: Vec<String>,
+    issue_id: &str,
+    step_name: &str,
+    event_tx: &mpsc::Sender<WorkerEvent>,
+) -> Result<
+    (
+        Option<serde_json::Value>,
+        Vec<TurnResult>,
+        DiscoveredCapabilities,
+    ),
+    AgentError,
+>
+```
+
+to:
+
+```rust
+pub async fn run_acp_session(
+    config: AcpSessionConfig,
+    turns: Vec<SessionTurn>,
+    issue_id: &str,
+    step_name: &str,
+    event_tx: &mpsc::Sender<WorkerEvent>,
+) -> Result<AcpSessionOutcome, AgentError>
+```
+
+- [ ] **Step 3: Capture output text and suppress hidden events**
+
+Inside the per-turn loop, replace `prompts.iter()` with `turns.iter()`.
+
+Before the `turn_future`, add:
+
+```rust
+let mut output_text = String::new();
+let visible = turn.visibility == TurnVisibility::Visible;
+```
+
+Change:
+
+```rust
+if let Some(content) = parsed.output_text {
+    emit_event(
+        event_tx,
+        issue_id,
+        step_name,
+        AgentEvent::OutputChunk {
+            stream: RuntimeStream::Stdout,
+            content,
+        },
+    )
+    .await;
+}
+```
+
+to:
+
+```rust
+if let Some(content) = parsed.output_text {
+    output_text.push_str(&content);
+    if visible {
+        emit_event(
+            event_tx,
+            issue_id,
+            step_name,
+            AgentEvent::OutputChunk {
+                stream: RuntimeStream::Stdout,
+                content,
+            },
+        )
+        .await;
+    }
+}
+```
+
+Wrap `PromptStarted`, `RunCompleted`, and `RunFailed` emissions with this shape:
+
+```rust
+if visible {
+    emit_event(event_tx, issue_id, step_name, AgentEvent::PromptStarted).await;
+}
+```
+
+Apply the same `if visible` guard to the existing `AgentEvent::RunCompleted` and
+`AgentEvent::RunFailed` emissions.
+
+- [ ] **Step 4: Validate extraction and repair results**
+
+After each completed hidden extraction or repair turn, validate the payload:
+
+```rust
+if matches!(turn.purpose, TurnPurpose::Extraction | TurnPurpose::Repair) {
+    match crate::agent::extraction::validate_extraction_payload(
+        runtime_verdict.as_ref(),
+        &output_text,
+    ) {
+        Ok(output) => {
+            let mut v = final_output_inner.lock().await;
+            *v = Some(output);
+        }
+        Err(error) if turn.purpose == TurnPurpose::Extraction => {
+            let repair_prompt = crate::agent::extraction::build_repair_prompt(
+                &error.to_string(),
+                runtime_verdict
+                    .as_ref()
+                    .map(serde_json::Value::to_string)
+                    .unwrap_or_else(|| output_text.clone())
+                    .as_str(),
+            );
+            queued_repair_turn = Some(SessionTurn {
+                prompt: repair_prompt,
+                visibility: TurnVisibility::Hidden,
+                purpose: TurnPurpose::Repair,
+            });
+        }
+        Err(error) => {
+            let mut err = session_error_inner.lock().await;
+            *err = Some(format!("verdict extraction failed: {error}"));
+            return Ok(());
+        }
+    }
+}
+```
+
+Implement this with a mutable turn queue, not a fixed `for` loop, so repair can be appended once:
+
+```rust
+let mut turns: std::collections::VecDeque<SessionTurn> = turns.iter().cloned().collect();
+while let Some(turn) = turns.pop_front() {
+    // existing turn body
+    if let Some(repair_turn) = queued_repair_turn.take() {
+        turns.push_back(repair_turn);
+    }
+}
+```
+
+Use `final_output: Arc<Mutex<Option<StepOutput>>>` instead of `final_verdict`.
+
+- [ ] **Step 5: Build direct ACP visible and extraction turns in `run_direct_step`**
+
+In `crates/ensemble-core/src/agent/mod.rs`, import:
+
+```rust
+use acp_client::{SessionTurn, TurnPurpose, TurnVisibility};
+```
+
+Replace the `max_turns` prompt vector construction with one working prompt:
+
+```rust
+let working_prompt = self
+    .build_prompt(
+        config.as_ref(),
+        BuildPromptRequest {
+            issue: request.issue,
+            agent_name: request.agent_name,
+            step_name: request.step_name,
+            step_kind: request.step_kind,
+            attempt: request.attempt,
+            workspace_path: request.workspace_path,
+            turn_number: 1,
+            step_outputs: &request.step_outputs,
+        },
+    )
+    .await?;
+
+let extraction_prompt = crate::agent::extraction::build_extraction_prompt(
+    request.step_name,
+    &request.issue.identifier,
+    &working_prompt,
+    "{{WORKING_ANSWER_FROM_VISIBLE_TURN}}",
+);
+```
+
+Do not keep the literal marker in production. Instead, construct the extraction prompt inside `run_acp_session` after the visible turn completes. Pass an extraction context:
+
+```rust
+pub struct ExtractionContext {
+    pub step_name: String,
+    pub issue_identifier: String,
+    pub original_prompt: String,
+}
+```
+
+Change `run_acp_session` to accept `working_turn: SessionTurn` plus `ExtractionContext`. After the
+visible turn completes, call:
+
+```rust
+let extraction_prompt = crate::agent::extraction::build_extraction_prompt(
+    &extraction_context.step_name,
+    &extraction_context.issue_identifier,
+    &extraction_context.original_prompt,
+    &visible_output_text,
+);
+```
+
+- [ ] **Step 6: Run direct ACP tests**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core agent::acp_client::tests -- --nocapture
+rtk cargo test -p ensemble-core agent::tests::build_prompt -- --nocapture
+```
+
+Expected: PASS after updating expected `TurnResult` patterns to include `output_text`.
+
+- [ ] **Step 7: Commit direct ACP extraction**
+
+Run:
+
+```bash
+rtk git add crates/ensemble-core/src/agent/acp_client.rs crates/ensemble-core/src/agent/mod.rs
+rtk git commit -m "Run hidden verdict extraction for direct ACP"
+```
+
+## Task 5: Implement Two-phase `acpx` Runtime
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/acpx_cli.rs`
+- Modify: `crates/ensemble-core/src/agent/acpx_runtime.rs`
+
+- [ ] **Step 1: Add prompt visibility to `AcpxCli`**
+
+In `crates/ensemble-core/src/agent/acpx_cli.rs`, add:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptVisibility {
+    Visible,
+    Hidden,
+}
+```
+
+Change `PromptOutcome` to:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct PromptOutcome {
+    pub runtime_verdict: Option<serde_json::Value>,
+    pub output_text: String,
+}
+```
+
+Add a `visibility: PromptVisibility` parameter to `run_prompt`.
+
+- [ ] **Step 2: Capture output text and suppress hidden events**
+
+Inside `run_prompt`, add:
+
+```rust
+let mut output_text = String::new();
+let visible = visibility == PromptVisibility::Visible;
+```
+
+Change output handling to:
+
+```rust
+if let Some(content) = update.output_text {
+    output_text.push_str(&content);
+    if visible {
+        on_event(AgentEvent::OutputChunk {
+            stream: RuntimeStream::Stdout,
+            content,
+        })
+        .await;
+    }
+}
+```
+
+Wrap permission warnings, stop reason events, error events, and `OtherMessage` events in `if visible`.
+
+Return:
+
+```rust
+Ok(PromptOutcome {
+    runtime_verdict: last_runtime_verdict,
+    output_text,
+})
+```
+
+- [ ] **Step 3: Run existing `acpx_cli` tests and update call sites**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core agent::acpx_cli::tests -- --nocapture
+```
+
+Expected: FAIL at compile because tests and callers need the new visibility argument.
+
+Add `PromptVisibility::Visible` to existing visible prompt calls in tests and runtime code.
+
+Add this test:
+
+```rust
+#[tokio::test]
+async fn hidden_prompt_captures_output_without_emitting_events() {
+    let temp = TempDir::new().unwrap();
+    let script = write_mock_acpx_script(
+        temp.path(),
+        r#"
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"result\":\"succeeded\"}"}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+"#,
+    );
+    let cli = AcpxCli::new(script);
+    let mut events = Vec::new();
+
+    let outcome = cli
+        .run_prompt(
+            "codex",
+            "session",
+            temp.path(),
+            "extract",
+            AcpxCommandOptions::default(),
+            PromptVisibility::Hidden,
+            |event| {
+                events.push(event);
+                async {}
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.output_text, "{\"result\":\"succeeded\"}");
+    assert!(events.is_empty());
+}
+```
+
+- [ ] **Step 4: Update `AcpxRuntime::run_step` flow**
+
+In `crates/ensemble-core/src/agent/acpx_runtime.rs`, after the visible prompt succeeds, build the extraction prompt:
+
+```rust
+let extraction_prompt = crate::agent::extraction::build_extraction_prompt(
+    request.step_name,
+    &request.issue.identifier,
+    prompt,
+    &outcome.output_text,
+);
+```
+
+Run a hidden extraction prompt before closing the session:
+
+```rust
+let extraction_outcome = self
+    .cli
+    .run_prompt(
+        acpx_agent,
+        &session_name,
+        request.workspace_path,
+        &extraction_prompt,
+        command_options,
+        PromptVisibility::Hidden,
+        |_| async {},
+    )
+    .await?;
+```
+
+Validate it:
+
+```rust
+let output = match crate::agent::extraction::validate_extraction_payload(
+    extraction_outcome.runtime_verdict.as_ref(),
+    &extraction_outcome.output_text,
+) {
+    Ok(output) => output,
+    Err(error) => {
+        let previous_payload = extraction_outcome
+            .runtime_verdict
+            .as_ref()
+            .map(serde_json::Value::to_string)
+            .unwrap_or_else(|| extraction_outcome.output_text.clone());
+        let repair_prompt =
+            crate::agent::extraction::build_repair_prompt(&error.to_string(), &previous_payload);
+        let repair_outcome = self
+            .cli
+            .run_prompt(
+                acpx_agent,
+                &session_name,
+                request.workspace_path,
+                &repair_prompt,
+                command_options,
+                PromptVisibility::Hidden,
+                |_| async {},
+            )
+            .await?;
+        crate::agent::extraction::validate_extraction_payload(
+            repair_outcome.runtime_verdict.as_ref(),
+            &repair_outcome.output_text,
+        )
+        .map_err(|error| AgentError::ResponseError {
+            reason: format!("verdict extraction failed: {error}"),
+        })?
+    }
+};
+```
+
+Pass `output` to:
+
+```rust
+detect_worker_result_with_output(request.workspace_path, output, request.step_name).await
+```
+
+- [ ] **Step 5: Ensure sessions close after extraction errors**
+
+Keep the existing `close_session` helper call in a path that runs after visible prompt success, extraction success,
+extraction validation failure, and repair validation failure. Use this structure:
+
+```rust
+let step_result = async {
+    let visible_outcome = self
+        .cli
+        .run_prompt(
+            acpx_agent,
+            &session_name,
+            request.workspace_path,
+            prompt,
+            command_options,
+            PromptVisibility::Visible,
+            |event| {
+                cb_count.fetch_add(1, Ordering::Relaxed);
+                emit_event(&request.event_tx, &request.issue.id, request.step_name, event)
+            },
+        )
+        .await?;
+
+    let extraction_prompt = crate::agent::extraction::build_extraction_prompt(
+        request.step_name,
+        &request.issue.identifier,
+        prompt,
+        &visible_outcome.output_text,
+    );
+
+    let extraction_outcome = self
+        .cli
+        .run_prompt(
+            acpx_agent,
+            &session_name,
+            request.workspace_path,
+            &extraction_prompt,
+            command_options,
+            PromptVisibility::Hidden,
+            |_| async {},
+        )
+        .await?;
+
+    crate::agent::extraction::validate_extraction_payload(
+        extraction_outcome.runtime_verdict.as_ref(),
+        &extraction_outcome.output_text,
+    )
+    .map_err(|error| AgentError::ResponseError {
+        reason: format!("verdict extraction failed: {error}"),
+    })
+}
+.await;
+
+close_session(
+    &self.cli,
+    acpx_agent,
+    &session_name,
+    request.workspace_path,
+    command_options,
+)
+.await;
+
+let output = step_result?;
+```
+
+Then extend the `Err(error)` branch inside `step_result` to run the one repair prompt before
+returning `AgentError::ResponseError`.
+
+- [ ] **Step 6: Run `acpx` runtime tests**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core agent::acpx_cli::tests -- --nocapture
+rtk cargo test -p ensemble-core agent::acpx_runtime::tests -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit `acpx` extraction**
+
+Run:
+
+```bash
+rtk git add crates/ensemble-core/src/agent/acpx_cli.rs crates/ensemble-core/src/agent/acpx_runtime.rs
+rtk git commit -m "Run hidden verdict extraction for acpx"
+```
+
+## Task 6: Remove Production Fallback Verdict Paths
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/mod.rs`
+- Modify: `crates/ensemble-core/src/config/ensemble.rs`
+- Modify: `crates/ensemble-core/src/pipeline/verdict.rs`
+- Modify: tests in those files
+
+- [ ] **Step 1: Remove verdict fallback prompt injection**
+
+In `crates/ensemble-core/src/agent/mod.rs`, remove the whole `verdict_fallback_instruction`
+function and the whole `maybe_append_verdict_fallback_instruction` function.
+
+In `build_prompt`, replace:
+
+```rust
+Ok(maybe_append_verdict_fallback_instruction(
+    rendered,
+    config.agent.inject_verdict_fallback_instructions,
+    step_name,
+))
+```
+
+with:
+
+```rust
+Ok(rendered)
+```
+
+Remove prompt-injection tests that assert `.ensemble/verdict-{step}.json` instructions are appended or disabled.
+
+- [ ] **Step 2: Remove config field**
+
+In `crates/ensemble-core/src/config/ensemble.rs`, remove from `AgentRuntimeConfig`:
+
+```rust
+#[serde(default = "default_inject_verdict_fallback_instructions")]
+#[serde(alias = "inject_verdict_instructions")]
+pub inject_verdict_fallback_instructions: bool,
+```
+
+Remove `default_inject_verdict_fallback_instructions()` and remove the field from `Default for AgentRuntimeConfig`.
+
+Update config tests that expected `agent.inject_verdict_fallback_instructions`.
+
+- [ ] **Step 3: Remove production resolver usage**
+
+In `crates/ensemble-core/src/pipeline/verdict.rs`, keep these strict functions:
+
+```rust
+parse_step_output_json
+validate_step_output_value
+```
+
+Keep `StepResult`, `StepOutput`, and `ResolvedResult` only if tests or public API still need them. Remove production use of:
+
+```rust
+read_verdict_file
+read_step_output_file
+resolve_verdict
+resolve_verdict_with_source
+VerdictSource
+parse_verdict_from_value
+parse_step_output_from_value
+```
+
+If removing all at once creates broad test churn, mark legacy file helpers with `#[cfg(test)]` first, then remove tests that exercise production fallback behavior.
+
+- [ ] **Step 4: Remove transitional success helper**
+
+In `crates/ensemble-core/src/agent/mod.rs`, delete:
+
+```rust
+fn transitional_succeeded_output() -> crate::pipeline::verdict::StepOutput
+```
+
+No production runtime should construct success without validated extraction output after Tasks 4 and 5.
+
+- [ ] **Step 5: Run fallback-removal tests**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core pipeline::verdict::tests -- --nocapture
+rtk cargo test -p ensemble-core agent::tests -- --nocapture
+rtk cargo test -p ensemble-core config::ensemble::tests -- --nocapture
+```
+
+Expected: PASS after removing or replacing fallback-specific tests.
+
+- [ ] **Step 6: Commit fallback removal**
+
+Run:
+
+```bash
+rtk git add crates/ensemble-core/src/agent/mod.rs crates/ensemble-core/src/config/ensemble.rs crates/ensemble-core/src/pipeline/verdict.rs
+rtk git commit -m "Remove verdict fallback result paths"
+```
+
+## Task 7: Update Documentation
+
+**Files:**
+- Modify: `docs/SPEC.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/pipelines.md`
+
+- [ ] **Step 1: Update pipeline result docs**
+
+In `docs/pipelines.md`, replace the “Results” section with:
+
+```markdown
+## Results
+
+After an agent finishes its visible working turn, Ensemble runs a hidden extraction turn in the same
+runtime session. The extraction turn produces the step's structured result. Extraction messages are
+not shown in the timeline.
+
+Every successful agent step must produce:
+
+```json
+{
+  "result": "succeeded",
+  "summary": "optional human-readable summary",
+  "output": {
+    "optional": "structured data for downstream steps"
+  }
+}
+```
+
+Failed and concern results require a non-empty `summary`:
+
+```json
+{
+  "result": "failed",
+  "summary": "Tests are failing - 3 test cases need fixes"
+}
+```
+
+```json
+{
+  "result": "concern",
+  "summary": "Naming is inconsistent, but the implementation is usable"
+}
+```
+
+If extraction produces invalid JSON or violates the result contract, Ensemble runs one hidden repair
+turn. If repair also fails, the worker fails and the orchestrator applies the configured retry or
+failure behavior.
+
+Verdict files and default-success fallback are not part of the runtime result contract.
+```
+```
+
+- [ ] **Step 2: Update configuration docs**
+
+In `docs/configuration.md`, remove the `agent.inject_verdict_fallback_instructions` row and the alias note:
+
+```markdown
+| `inject_verdict_fallback_instructions` | boolean | `true` |
+```
+
+Remove:
+
+```markdown
+`agent.inject_verdict_instructions` is accepted as a shorter alias for `agent.inject_verdict_fallback_instructions`.
+```
+
+Add under `### agent`:
+
+```markdown
+Agent step results are extracted by Ensemble through a hidden second turn in the same runtime
+session. There is no config switch for this behavior.
+```
+
+- [ ] **Step 3: Update SPEC runtime result sections**
+
+In `docs/SPEC.md`, replace references to:
+
+```markdown
+Collects verdict (ACP protocol field or `.ensemble/verdict.json` fallback).
+```
+
+with:
+
+```markdown
+Collects a validated `StepOutput` from Ensemble's hidden extraction turn.
+```
+
+Replace any result precedence list that mentions ACP, file fallback, and default success with:
+
+```markdown
+Agent-backed steps produce results through two runtime turns:
+
+1. A visible working turn where the agent reasons freely.
+2. A hidden extraction turn where Ensemble extracts a strict `StepOutput`.
+
+The extraction payload is validated before the pipeline state machine sees it. Invalid extraction
+gets one hidden repair turn. If repair fails, the worker fails; Ensemble does not default the step
+to success.
+```
+
+- [ ] **Step 4: Run documentation search**
+
+Run:
+
+```bash
+rtk rg -n "verdict.json|verdict-\\{|default.*success|inject_verdict|approve|reject" docs crates/ensemble-core/src
+```
+
+Expected: no matches in current production code for `inject_verdict`, `.ensemble/verdict`, or
+default-success result resolution. Matches in old design documents under `docs/superpowers/specs/`
+and `docs/superpowers/plans/` can remain.
+
+- [ ] **Step 5: Commit docs**
+
+Run:
+
+```bash
+rtk git add docs/SPEC.md docs/configuration.md docs/pipelines.md
+rtk git commit -m "Document two-phase verdict extraction"
+```
+
+## Task 8: Final Verification
+
+**Files:**
+- No direct edits unless verification finds failures.
+
+- [ ] **Step 1: Run core tests**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run non-desktop workspace tests**
+
+Run:
+
+```bash
+rtk cargo test --workspace --exclude ensemble-desktop
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run CLI web-ui checks**
+
+Run:
+
+```bash
+rtk SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
+rtk SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run clippy and formatting**
+
+Run:
+
+```bash
+rtk cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+rtk cargo fmt --all -- --check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Check final git state**
+
+Run:
+
+```bash
+rtk git status --short --branch
+```
+
+Expected: clean working tree. If verification produced edits, return to the task that owns those
+files, apply the concrete fix there, rerun that task's verification command, and commit with that
+task's commit pattern.

--- a/docs/superpowers/specs/2026-06-12-two-phase-verdict-extraction-design.md
+++ b/docs/superpowers/specs/2026-06-12-two-phase-verdict-extraction-design.md
@@ -1,0 +1,285 @@
+# Two-phase verdict extraction
+
+**Date:** 2026-06-12
+**Issue:** [#184](https://github.com/chrisbanes/ensemble/issues/184)
+**Status:** Design
+
+## Context
+
+Ensemble currently lets agent runtimes return an optional structured result. If the runtime result
+is missing or unparsable, the orchestrator falls back to `.ensemble/verdict-{step}.json`, then
+defaults the step to success. This made early integrations forgiving, but it also allows malformed
+or absent verdicts to silently pass.
+
+Agents also have to reason about the task and format the final result in the same turn. That is a
+poor fit for review and synthesis steps: schema pressure can reduce reasoning quality, and one bad
+JSON shape can turn a useful answer into an unreliable pipeline signal.
+
+Both supported runtime paths can continue a session for another prompt. The direct ACP path already
+accepts a vector of prompts. The `acpx` runtime creates a named session, runs one prompt, then closes
+it; it can keep that session open for a hidden extraction prompt before closing.
+
+## Problem
+
+1. **Reasoning and formatting are coupled.** Agents must solve the task and produce structured JSON
+   in one response.
+2. **Bad runtime results are not strict failures.** Invalid runtime payloads can fall through to file
+   fallback or default success.
+3. **File fallback and default success hide contract bugs.** A missing result should be a runtime
+   problem, not an approved step.
+4. **Extraction visibility needs a clear boundary.** The second turn is an implementation detail and
+   should not appear as agent work in the operator timeline.
+
+## Goal
+
+- Make every successful agent step produce exactly one validated runtime `StepOutput`.
+- Split agent execution into a visible working turn and a hidden extraction turn.
+- Validate extracted results in Ensemble before the pipeline state machine sees them.
+- Retry extraction once with a corrective hidden prompt when validation fails.
+- Remove normal runtime dependence on verdict files and default-success resolution.
+
+## Non-Goals
+
+- Preserving legacy `verdict: approve/reject` payloads.
+- Preserving `.ensemble/verdict.json` or `.ensemble/verdict-{step}.json` as a normal result path.
+- Adding per-agent opt-in controls for two-phase extraction.
+- Introducing a separate external extractor service.
+- Surfacing extraction messages, chunks, or repair prompts in the user-facing timeline.
+
+---
+
+## Design
+
+### 1. Strict Result Contract
+
+The runtime contract becomes:
+
+```rust
+pub struct StepOutput {
+    pub result: StepResult,
+    pub summary: Option<String>,
+    pub output: Option<serde_json::Value>,
+}
+```
+
+Allowed `result` values:
+
+| Value | Meaning |
+|-------|---------|
+| `succeeded` | Step passed. Pipeline continues. |
+| `failed` | Step failed. `summary` is required. |
+| `concern` | Step raised a non-blocking concern. `summary` is required. |
+
+`output` remains optional arbitrary JSON for downstream prompts. `summary` is optional only for
+`succeeded`.
+
+Legacy `verdict` keys and `approve`/`reject` values are rejected. A successful worker exit without a
+valid `StepOutput` is impossible by contract; the worker returns `WorkerResult::Failed` instead.
+
+### 2. Runtime Flow
+
+Each agent-backed step runs these phases in the same runtime session:
+
+1. **Working turn**: the configured prompt is rendered and sent normally. The agent has the same tool
+   access, permissions, hooks, and event visibility it has today.
+2. **Extraction turn**: Ensemble sends a hidden prompt that includes the working answer and the
+   required result schema. Tool use is disabled or denied. Events from this turn are not published to
+   the timeline or normal agent state.
+3. **Repair turn**: if validation fails, Ensemble sends one hidden corrective prompt containing the
+   validation error and the required schema. A second failure makes the worker fail.
+
+The working turn should not be asked to format JSON. Its prompt should make clear that it can answer
+freely and that Ensemble will extract the final result separately.
+
+Extraction uses the same session and configured model as the working turn. A future dedicated
+extractor model can be added later, but the first implementation keeps extraction in-session so it
+has the same conversation context across ACP backends.
+
+### 3. Capturing the Working Answer
+
+Extraction needs the visible answer, not only the original prompt. Runtime adapters should collect
+the text emitted by the working turn into an internal buffer while still streaming it to the
+timeline.
+
+The extraction prompt receives:
+
+- The step name and issue identifier.
+- The original rendered step prompt.
+- The visible working answer captured from the first turn.
+- The strict `StepOutput` schema and semantic rules.
+- A clear instruction to return only the structured result.
+
+If the working answer is empty but the runtime completed successfully, extraction still runs. The
+extractor may return `succeeded` only if the answer gives enough evidence; otherwise it should return
+`failed` with a summary explaining the missing usable answer.
+
+### 4. Direct ACP Runtime
+
+The direct ACP implementation should replace the plain `Vec<String>` prompt list with turn metadata:
+
+```rust
+pub enum TurnVisibility {
+    Visible,
+    Hidden,
+}
+
+pub struct SessionTurn {
+    pub prompt: String,
+    pub visibility: TurnVisibility,
+    pub purpose: TurnPurpose,
+}
+```
+
+`run_acp_session` keeps the existing session open across all turns. Visible turns emit `AgentEvent`s
+as they do today. Hidden turns still update internal usage and diagnostics, but do not send timeline
+events or mutate the operator-visible `last_agent_event`.
+
+The final return type should carry a validated `StepOutput`, not an optional raw verdict value.
+
+### 5. `acpx` Runtime
+
+`AcpxRuntime::run_step` should keep the named session open until extraction is complete:
+
+1. `sessions ensure`
+2. visible `prompt --session <name>` for the working turn
+3. hidden `prompt --session <name>` for extraction
+4. optional hidden repair prompt
+5. `sessions close`
+
+`AcpxCli::run_prompt` should accept an event visibility setting. For hidden prompts it parses stdout
+for runtime verdicts and usage, but suppresses `AgentEvent` emission.
+
+Cancellation still cancels the active `acpx` prompt and closes the session best-effort.
+
+### 6. Validation
+
+Add a dedicated validator in `pipeline/verdict.rs` or a new `pipeline/result_contract.rs` module.
+The validator should return either a typed `StepOutput` or a diagnostic suitable for the repair
+prompt and worker error.
+
+Validation rules:
+
+- Payload must be a JSON object.
+- `result` must be one of `succeeded`, `failed`, or `concern`.
+- `failed` and `concern` require a non-empty `summary`.
+- `succeeded` may include `summary`, but it is not required.
+- `output`, when present, may be any JSON value.
+- Unknown top-level keys are errors.
+- Legacy `verdict` keys are errors.
+
+The orchestrator should no longer call a resolver that can default to success for normal worker
+success. It should receive the validated `StepOutput` directly and pass it to `PipelineRun`.
+
+### 7. Worker and Orchestrator Contract
+
+Change worker success from:
+
+```rust
+WorkerResult::Success {
+    runtime_verdict: Option<serde_json::Value>,
+    approval_request: Option<StepApprovalRequestDraft>,
+}
+```
+
+to:
+
+```rust
+WorkerResult::Success {
+    output: StepOutput,
+    approval_request: Option<StepApprovalRequestDraft>,
+}
+```
+
+`approval_request` remains mutually exclusive with human interaction requests. A step that blocks on
+human input does not run extraction yet; after the user response resumes the step, the normal visible
+turn and extraction contract apply to the resumed run.
+
+The pipeline state machine receives validated data only. Missing or invalid extraction output becomes
+`WorkerResult::Failed`, which follows existing agent error retry behavior.
+
+### 8. Removing Fallbacks
+
+Remove prompt injection that tells agents to write `.ensemble/verdict-{step}.json`. Remove normal
+runtime reads of verdict files and the default-success path.
+
+Tests may still create `StepOutput` values directly. If a local fixture helper for verdict files
+remains useful during transition, keep it test-only and outside the production resolution path.
+
+### 9. Observability
+
+Extraction is hidden from the timeline but should remain debuggable through structured logs:
+
+- `verdict_extraction_started`
+- `verdict_extraction_completed`
+- `verdict_extraction_repair_started`
+- `verdict_extraction_failed`
+
+Include issue id, step name, runtime, validation diagnostics, and token usage when available. Do not
+log full hidden prompts by default.
+
+Timeline records should continue to show the visible working answer and the final step result. They
+should not show extraction prompt text, extraction output chunks, or repair details.
+
+Hidden-turn token usage counts toward the step and aggregate runtime totals because it is real agent
+work. It is not shown as a separate timeline turn.
+
+## Testing Strategy
+
+Unit tests:
+
+- Strict validator accepts valid `succeeded`, `failed`, and `concern` payloads.
+- Validator rejects legacy `verdict`, unknown keys, invalid result strings, and missing summaries.
+- Extraction prompt builder includes the working answer and schema.
+- Hidden turns suppress `AgentEvent` emission while preserving internal verdict capture.
+
+Runtime tests:
+
+- Direct ACP returns `WorkerResult::Success { output }` from the hidden extraction turn.
+- Direct ACP runs one repair turn after invalid extraction and succeeds when repair is valid.
+- Direct ACP fails the worker after two invalid extraction payloads.
+- `acpx` runs visible prompt, hidden extraction prompt, optional repair prompt, then closes the
+  session.
+- `acpx` hidden prompt output is not emitted to the timeline.
+
+Orchestrator tests:
+
+- Worker success passes validated `StepOutput` directly to `PipelineRun`.
+- Worker extraction failure follows existing agent error retry behavior.
+- No-runtime-result no longer defaults to success.
+- Verdict file artifacts do not affect step outcomes.
+
+Docs tests/checks:
+
+- Update `docs/SPEC.md`, `docs/configuration.md`, and `docs/pipelines.md` to remove fallback/default
+  result behavior and document mandatory two-phase extraction.
+
+## Rollout
+
+This is a breaking contract cleanup. No compatibility migration is required.
+
+Implementation should land in small pieces:
+
+1. Add strict validation and extraction prompt construction.
+2. Change `WorkerResult::Success` to carry `StepOutput`.
+3. Update direct ACP for visible/hidden turn metadata.
+4. Update `acpx` to run hidden extraction before closing the session.
+5. Remove production verdict-file/default-success resolution.
+6. Update docs and tests.
+
+## Risks and Mitigations
+
+Risk: Hidden extraction increases token usage and latency.
+- Mitigation: Keep extraction prompt compact and schema-only. Do not include full session logs beyond
+  the original prompt and visible working answer.
+
+Risk: Some runtimes cannot truly disable tools for a hidden turn.
+- Mitigation: Deny permission callbacks during hidden turns and instruct no tool use. Treat tool
+  requests as extraction failure.
+
+Risk: Suppressing hidden events makes failures harder to debug.
+- Mitigation: Add structured logs with validation diagnostics and runtime metadata, while keeping
+  hidden prompt contents out of normal timeline views.
+
+Risk: Removing default success can reveal existing prompts that never produced real results.
+- Mitigation: This is intentional. Failed extraction should retry or fail loudly instead of silently
+  approving work.


### PR DESCRIPTION
## Summary

Implements issue #184 by moving verdict handling to a strict two-phase flow:

- agents run the normal visible task prompt first
- Ensemble then performs hidden structured extraction into `StepOutput`
- malformed extraction gets one hidden repair attempt
- invalid output fails the step explicitly instead of falling back to verdict files or prompt text

This also removes the old production fallback result paths and updates setup/init templates plus the verdict/configuration docs to describe the new contract.

## Validation

- `rtk cargo test --workspace --exclude ensemble-desktop` - 936 passed, 1 ignored
- `rtk cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `rtk cargo fmt --all -- --check`
- `rtk env SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `rtk env SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`

The full workspace and product E2E test commands required unsandboxed execution because they bind local ports.

Fixes #184