### PR TITLE
Make Renovate wait for stable releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
   ],
   "labels": ["dependencies"],
   "prConcurrentLimit": 5,
+  "minimumReleaseAge": "1 day",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "internalChecksFilter": "strict",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 6am"]


### PR DESCRIPTION
## Summary
- add Renovate minimum release age settings matching pnpm's 24h stability window
- require timestamps and strict internal checks before PR creation
- delay PR creation while Renovate's stability check is pending

## Why
Recent Renovate PRs opened before pnpm's minimum release age policy would accept the packages, so CI failed until the package age window elapsed.

## Validation
- jq empty renovate.json