### PR TITLE
Add per-step conversation transcripts

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -92,6 +92,10 @@ async fn web_cli_runs_todo_issue_to_completion_with_mock_acpx() {
         .await
         .expect("timeline artifact should be persisted");
 
+    wait_for_transcript_artifact(&fixture.workspace_root)
+        .await
+        .expect("step transcript artifact should be persisted");
+
     let todo = fs::read_to_string(&fixture.todo_path).expect("read TODO.md");
     assert!(
         section_contains_issue(&todo, "Done", ISSUE_ID),
@@ -246,6 +250,7 @@ if [[ " $* " == *" prompt "* ]]; then
 JSON
 
   printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"mock agent completed"}}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-1","status":"completed","content":{"type":"tool_call","name":"read_file","arguments":{"path":"Cargo.toml"}}}}}'
   printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"turn_complete","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7},"verdict":{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}},"stopReason":"end_turn"}}}'
   exit 0
 fi
@@ -373,6 +378,65 @@ fn read_first_timeline_file(workspace_root: &Path) -> Result<Option<String>, Str
         let path = entry.path().join("events.jsonl");
         match fs::read_to_string(&path) {
             Ok(contents) => return Ok(Some(contents)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+
+    Ok(None)
+}
+
+async fn wait_for_transcript_artifact(workspace_root: &Path) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+
+    loop {
+        match read_first_transcript_file(workspace_root)? {
+            Some((_, contents))
+                if contents.contains("\"assistant_message\"")
+                    && contents.contains("\"tool_call\"")
+                    && contents.contains("\"read_file\"") =>
+            {
+                return Ok(());
+            }
+            Some((path, contents)) => {
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "transcript did not contain expected records at {}:\n{contents}",
+                        path.display()
+                    ));
+                }
+            }
+            None => {
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "transcript artifact not found under {}",
+                        workspace_root.display()
+                    ));
+                }
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn read_first_transcript_file(workspace_root: &Path) -> Result<Option<(PathBuf, String)>, String> {
+    let runs_dir = workspace_root.join(".ensemble").join("runs");
+    let entries = match fs::read_dir(&runs_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry
+            .path()
+            .join("steps")
+            .join("implement")
+            .join("transcript.jsonl");
+        match fs::read_to_string(&path) {
+            Ok(contents) => return Ok(Some((path, contents))),
             Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
             Err(error) => return Err(error.to_string()),
         }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -27,6 +27,7 @@ use super::events::{
     AgentEvent, AgentPermissionOption, AgentPermissionOptionKind, AgentPermissionOutcome,
     RuntimeStream, TokenUsage, WorkerEvent,
 };
+use super::protocol::{self, TranscriptBlock};
 use super::ResolvedCommand;
 
 /// Build an `AcpAgent` from a structured `ResolvedCommand`. The SDK's
@@ -374,14 +375,39 @@ struct ParsedSdkDispatch {
     output_text: Option<String>,
     usage: Option<TokenUsage>,
     verdict: Option<serde_json::Value>,
+    transcript_blocks: Vec<TranscriptBlock>,
 }
 
 fn parse_session_notification(notification: SessionNotification) -> ParsedSdkDispatch {
+    let update_value = serde_json::to_value(&notification.update).ok();
+    let transcript_blocks = update_value
+        .as_ref()
+        .and_then(|update| protocol::parse_session_update(&serde_json::json!({ "update": update })))
+        .map(|parsed| parsed.transcript_blocks)
+        .unwrap_or_default();
+
     match notification.update {
-        SessionUpdate::AgentMessageChunk(chunk) => ParsedSdkDispatch {
-            output_text: text_from_content(&chunk.content),
-            ..ParsedSdkDispatch::default()
-        },
+        SessionUpdate::AgentMessageChunk(chunk) => {
+            let output_text = text_from_content(&chunk.content);
+            let transcript_blocks = if transcript_blocks.is_empty() {
+                output_text
+                    .as_ref()
+                    .map(|text| {
+                        vec![TranscriptBlock {
+                            kind: protocol::TranscriptBlockKind::AssistantMessage,
+                            payload: serde_json::json!({ "text": text }),
+                        }]
+                    })
+                    .unwrap_or_default()
+            } else {
+                transcript_blocks
+            };
+            ParsedSdkDispatch {
+                output_text,
+                transcript_blocks,
+                ..ParsedSdkDispatch::default()
+            }
+        }
         update => {
             let value = serde_json::to_value(update).ok();
             ParsedSdkDispatch {
@@ -392,6 +418,7 @@ fn parse_session_notification(notification: SessionNotification) -> ParsedSdkDis
                     .and_then(token_usage_from_value),
                 verdict: value.as_ref().and_then(runtime_verdict_from_value),
                 output_text: None,
+                transcript_blocks,
             }
         }
     }
@@ -847,6 +874,20 @@ pub async fn run_acp_session(
                                     .await
                                     .map_err(|e| e.to_string())?
                                 {
+                                    for block in parsed.transcript_blocks.clone() {
+                                        if visible {
+                                            emit_event(
+                                                event_tx,
+                                                issue_id,
+                                                step_name,
+                                                AgentEvent::TranscriptBlock {
+                                                    kind: block.kind,
+                                                    payload: block.payload,
+                                                },
+                                            )
+                                            .await;
+                                        }
+                                    }
                                     if let Some(usage) = parsed.usage {
                                         last_usage = Some(usage);
                                     }

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -274,6 +274,15 @@ impl AcpxCli {
             };
 
             if let Some(update) = update {
+                for block in update.transcript_blocks.clone() {
+                    if visible {
+                        on_event(AgentEvent::TranscriptBlock {
+                            kind: block.kind,
+                            payload: block.payload,
+                        })
+                        .await;
+                    }
+                }
                 if let Some(usage) = update.usage {
                     last_usage = Some(usage);
                 }
@@ -713,6 +722,44 @@ JSON
 
         assert!(matches!(events[0], AgentEvent::OutputChunk { .. }));
         assert!(matches!(events[1], AgentEvent::RunCompleted { .. }));
+    }
+
+    #[tokio::test]
+    async fn prompt_emits_transcript_blocks_for_visible_updates() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = write_mock_acpx_script(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+cat <<'JSON'
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"turn_complete","stopReason":"end_turn"}}}
+JSON
+"#,
+        );
+
+        let client = AcpxCli::new(script);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        client
+            .run_prompt(
+                prompt_request(dir.path(), "hi", PromptVisibility::Visible),
+                |event| {
+                    let events = Arc::clone(&events);
+                    async move {
+                        events.lock().unwrap().push(event);
+                    }
+                },
+            )
+            .await
+            .unwrap();
+        let events = events.lock().unwrap();
+
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::TranscriptBlock {
+                kind: crate::agent::protocol::TranscriptBlockKind::AssistantMessage,
+                ..
+            }
+        )));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/acpx_cli.rs
+++ b/crates/ensemble-core/src/agent/acpx_cli.rs
@@ -687,8 +687,12 @@ JSON
             .unwrap();
         let events = events.lock().unwrap();
 
-        assert!(matches!(events[0], AgentEvent::OutputChunk { .. }));
-        assert!(matches!(events[1], AgentEvent::RunCompleted { .. }));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::OutputChunk { .. })));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::RunCompleted { .. })));
     }
 
     #[tokio::test]
@@ -720,8 +724,12 @@ JSON
             .unwrap();
         let events = events.lock().unwrap();
 
-        assert!(matches!(events[0], AgentEvent::OutputChunk { .. }));
-        assert!(matches!(events[1], AgentEvent::RunCompleted { .. }));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::OutputChunk { .. })));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::RunCompleted { .. })));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::agent::protocol::TranscriptBlockKind;
 use crate::interaction::InteractionKind;
 use crate::pipeline::verdict::StepOutput;
 
@@ -133,6 +134,10 @@ pub enum AgentEvent {
         selected_option_kind: Option<AgentPermissionOptionKind>,
         allowed: bool,
     },
+    TranscriptBlock {
+        kind: TranscriptBlockKind,
+        payload: serde_json::Value,
+    },
     Notification {
         message: String,
     },
@@ -161,6 +166,7 @@ impl AgentEvent {
             AgentEvent::TurnFailed { .. } => "turn_failed",
             AgentEvent::PermissionRequested { .. } => "permission_requested",
             AgentEvent::PermissionResolved { .. } => "permission_resolved",
+            AgentEvent::TranscriptBlock { .. } => "transcript_block",
             AgentEvent::Notification { .. } => "notification",
             AgentEvent::OtherMessage { .. } => "other_message",
             AgentEvent::Malformed { .. } => "malformed",
@@ -187,6 +193,10 @@ impl AgentEvent {
                 Some(option_id) => format!("permission {outcome:?}: {option_id}"),
                 None => format!("permission {outcome:?}"),
             })),
+            AgentEvent::TranscriptBlock { payload, .. } => payload
+                .get("text")
+                .and_then(|value| value.as_str())
+                .map(truncate_for_state),
             AgentEvent::Notification { message } => Some(truncate_for_state(message)),
             AgentEvent::OtherMessage { raw } => Some(truncate_for_state(raw)),
             AgentEvent::Malformed { line } => Some(truncate_for_state(line)),
@@ -354,6 +364,17 @@ mod tests {
         assert!(StopReason::MaxTurnRequests.is_failure());
         assert!(!StopReason::MaxTokens.is_success());
         assert!(!StopReason::MaxTokens.is_failure());
+    }
+
+    #[test]
+    fn transcript_block_event_has_stable_name() {
+        let event = AgentEvent::TranscriptBlock {
+            kind: crate::agent::protocol::TranscriptBlockKind::AssistantMessage,
+            payload: serde_json::json!({"text": "hello"}),
+        };
+
+        assert_eq!(event.event_name(), "transcript_block");
+        assert_eq!(event.message_for_state().as_deref(), Some("hello"));
     }
 
     #[test]

--- a/crates/ensemble-core/src/agent/protocol.rs
+++ b/crates/ensemble-core/src/agent/protocol.rs
@@ -7,6 +7,23 @@ pub struct PermissionRequest {
     pub description: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum TranscriptBlockKind {
+    AssistantMessage,
+    Reasoning,
+    ToolCall,
+    ToolResult,
+    PermissionRequest,
+    TurnComplete,
+    Raw,
+}
+
+#[derive(Debug, Clone)]
+pub struct TranscriptBlock {
+    pub kind: TranscriptBlockKind,
+    pub payload: serde_json::Value,
+}
+
 /// Normalized data extracted from ACP `session/update` payloads.
 ///
 /// `permission_request` is currently consumed by the acpx runtime path when
@@ -19,6 +36,7 @@ pub struct ParsedSessionUpdate {
     pub stop_reason: Option<StopReason>,
     pub permission_request: Option<PermissionRequest>,
     pub verdict: Option<serde_json::Value>,
+    pub transcript_blocks: Vec<TranscriptBlock>,
 }
 
 /// Parse one stdout line as a JSON-RPC message.
@@ -71,6 +89,7 @@ pub fn parse_session_update(value: &serde_json::Value) -> Option<ParsedSessionUp
     let stop_reason = extract_stop_reason(params, update);
     let permission_request = extract_permission_request(params, update);
     let verdict = extract_verdict(params, update);
+    let transcript_blocks = extract_transcript_blocks(params, update, output_text.as_deref());
 
     let parsed = ParsedSessionUpdate {
         output_text,
@@ -78,6 +97,7 @@ pub fn parse_session_update(value: &serde_json::Value) -> Option<ParsedSessionUp
         stop_reason,
         permission_request,
         verdict,
+        transcript_blocks,
     };
 
     if parsed.output_text.is_none()
@@ -85,6 +105,7 @@ pub fn parse_session_update(value: &serde_json::Value) -> Option<ParsedSessionUp
         && parsed.stop_reason.is_none()
         && parsed.permission_request.is_none()
         && parsed.verdict.is_none()
+        && parsed.transcript_blocks.is_empty()
     {
         return None;
     }
@@ -121,6 +142,74 @@ fn content_text(value: &serde_json::Value) -> Option<String> {
         .get("text")
         .and_then(|v| v.as_str())
         .map(ToString::to_string)
+}
+
+fn extract_transcript_blocks(
+    params: &serde_json::Value,
+    update: Option<&serde_json::Value>,
+    output_text: Option<&str>,
+) -> Vec<TranscriptBlock> {
+    let source = update.unwrap_or(params);
+    let session_update = source
+        .get("sessionUpdate")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let content = source.get("content").or_else(|| params.get("content"));
+
+    if session_update.contains("reasoning") {
+        if let Some(text) = content.and_then(content_text) {
+            return vec![TranscriptBlock {
+                kind: TranscriptBlockKind::Reasoning,
+                payload: serde_json::json!({"text": text}),
+            }];
+        }
+    }
+
+    if session_update == "tool_call_update" {
+        let tool_call_id = source
+            .get("toolCallId")
+            .or_else(|| source.get("tool_call_id"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let name = content
+            .and_then(|value| value.get("name"))
+            .cloned()
+            .or_else(|| source.get("name").cloned())
+            .unwrap_or(serde_json::Value::Null);
+        let arguments = content
+            .and_then(|value| value.get("arguments"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        return vec![TranscriptBlock {
+            kind: TranscriptBlockKind::ToolCall,
+            payload: serde_json::json!({
+                "tool_call_id": tool_call_id,
+                "name": name,
+                "arguments": arguments,
+                "status": source.get("status").cloned().unwrap_or(serde_json::Value::Null),
+                "title": source.get("title").cloned().unwrap_or(serde_json::Value::Null)
+            }),
+        }];
+    }
+
+    if session_update.contains("tool_result") || session_update.contains("tool_output") {
+        return vec![TranscriptBlock {
+            kind: TranscriptBlockKind::ToolResult,
+            payload: serde_json::json!({
+                "tool_call_id": source.get("toolCallId").or_else(|| source.get("tool_call_id")).cloned(),
+                "content": content.cloned().unwrap_or(serde_json::Value::Null)
+            }),
+        }];
+    }
+
+    if let Some(text) = output_text {
+        return vec![TranscriptBlock {
+            kind: TranscriptBlockKind::AssistantMessage,
+            payload: serde_json::json!({"text": text}),
+        }];
+    }
+
+    vec![]
 }
 
 fn extract_usage(
@@ -214,6 +303,143 @@ mod tests {
 
         let parsed = parse_session_update(&line).unwrap();
         assert_eq!(parsed.output_text.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn parse_session_update_extracts_transcript_tool_call() {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "s1",
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "call-1",
+                    "title": "Read file",
+                    "kind": "read",
+                    "status": "pending",
+                    "content": {
+                        "type": "tool_call",
+                        "name": "read_file",
+                        "arguments": {"path": "Cargo.toml"}
+                    }
+                }
+            }
+        });
+
+        let parsed = parse_session_update(&line).unwrap();
+        assert_eq!(parsed.transcript_blocks.len(), 1);
+        assert_eq!(
+            parsed.transcript_blocks[0].kind,
+            TranscriptBlockKind::ToolCall
+        );
+        assert_eq!(
+            parsed.transcript_blocks[0].payload["tool_call_id"],
+            "call-1"
+        );
+        assert_eq!(parsed.transcript_blocks[0].payload["name"], "read_file");
+    }
+
+    #[test]
+    fn parse_session_update_extracts_tool_result_block() {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "s1",
+                "update": {
+                    "sessionUpdate": "tool_result",
+                    "toolCallId": "call-1",
+                    "content": {"type": "text", "text": "Cargo.toml contents"}
+                }
+            }
+        });
+
+        let parsed = parse_session_update(&line).unwrap();
+        assert_eq!(parsed.output_text.as_deref(), Some("Cargo.toml contents"));
+        assert_eq!(parsed.transcript_blocks.len(), 1);
+        assert_eq!(
+            parsed.transcript_blocks[0].kind,
+            TranscriptBlockKind::ToolResult
+        );
+        assert_eq!(
+            parsed.transcript_blocks[0].payload["tool_call_id"],
+            "call-1"
+        );
+        assert_eq!(
+            parsed.transcript_blocks[0].payload["content"],
+            json!({"type": "text", "text": "Cargo.toml contents"})
+        );
+    }
+
+    #[test]
+    fn parse_session_update_extracts_reasoning_block() {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "s1",
+                "update": {
+                    "sessionUpdate": "reasoning_chunk",
+                    "content": {"type": "reasoning", "text": "thinking"}
+                }
+            }
+        });
+
+        let parsed = parse_session_update(&line).unwrap();
+        assert_eq!(parsed.transcript_blocks.len(), 1);
+        assert_eq!(
+            parsed.transcript_blocks[0].kind,
+            TranscriptBlockKind::Reasoning
+        );
+        assert_eq!(parsed.transcript_blocks[0].payload["text"], "thinking");
+    }
+
+    #[test]
+    fn parse_session_update_preserves_output_text_for_reasoning_block() {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "s1",
+                "update": {
+                    "sessionUpdate": "reasoning_chunk",
+                    "content": {"type": "reasoning", "text": "thinking"}
+                }
+            }
+        });
+
+        let parsed = parse_session_update(&line).unwrap();
+        assert_eq!(parsed.output_text.as_deref(), Some("thinking"));
+        assert_eq!(parsed.transcript_blocks.len(), 1);
+        assert_eq!(
+            parsed.transcript_blocks[0].kind,
+            TranscriptBlockKind::Reasoning
+        );
+        assert_eq!(parsed.transcript_blocks[0].payload["text"], "thinking");
+    }
+
+    #[test]
+    fn parse_session_update_keeps_assistant_text_as_transcript_block() {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "s1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "hello"}
+                }
+            }
+        });
+
+        let parsed = parse_session_update(&line).unwrap();
+        assert_eq!(parsed.output_text.as_deref(), Some("hello"));
+        assert_eq!(
+            parsed.transcript_blocks[0].kind,
+            TranscriptBlockKind::AssistantMessage
+        );
+        assert_eq!(parsed.transcript_blocks[0].payload["text"], "hello");
     }
 
     #[test]

--- a/crates/ensemble-core/src/api/conversation.rs
+++ b/crates/ensemble-core/src/api/conversation.rs
@@ -1,381 +1,143 @@
 use crate::api::handlers::{api_error, ApiError};
 use crate::api::router::AppState;
 use crate::tracker::model::sanitize_workspace_key;
+use crate::transcript::model::TranscriptRecord;
+use crate::transcript::reader::{read_transcript_page, read_transcript_record, TranscriptResponse};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use serde::{Deserialize, Serialize};
-use std::path::{Path as FsPath, PathBuf};
+use serde::Deserialize;
+use std::path::PathBuf;
 
-fn conversation_path(workspace_root: &str, workspace_key: &str) -> PathBuf {
-    PathBuf::from(workspace_root)
-        .join(workspace_key)
-        .join(".ensemble")
-        .join("conversation.jsonl")
-}
-
-async fn read_conversation_file(path: &FsPath) -> Result<Option<String>, std::io::Error> {
-    match tokio::fs::read_to_string(path).await {
-        Ok(contents) => Ok(Some(contents)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error),
-    }
-}
-
-fn parse_conversation_messages(
-    contents: &str,
-) -> Result<Vec<ConversationMessage>, serde_json::Error> {
-    contents.lines().map(serde_json::from_str).collect()
-}
-
-async fn load_conversation_messages(
-    path: &FsPath,
-) -> Result<Option<Vec<ConversationMessage>>, ApiError> {
-    let Some(contents) = read_conversation_file(path).await.map_err(|e| {
-        ApiError::new(
-            "conversation_read_error",
-            &format!("failed to read conversation: {e}"),
-        )
-    })?
-    else {
-        return Ok(None);
-    };
-
-    let messages = parse_conversation_messages(&contents).map_err(|e| {
-        ApiError::new(
-            "conversation_parse_error",
-            &format!("failed to parse conversation: {e}"),
-        )
-    })?;
-
-    Ok(Some(messages))
-}
-
-/// Query parameters for conversation pagination.
 #[derive(Debug, Default, Deserialize, utoipa::IntoParams)]
 pub struct ConversationQuery {
-    /// Cursor-based pagination: skip messages before this 0-based index.
     pub cursor: Option<usize>,
-    /// Maximum number of messages to return (default: 50).
     pub limit: Option<usize>,
 }
 
-/// A single conversation message.
-#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
-pub struct ConversationMessage {
-    pub index: u64,
-    pub role: String,
-    pub content: String,
-    #[serde(default)]
-    pub tool_calls: Option<serde_json::Value>,
-    #[serde(default)]
-    pub tool_output: Option<serde_json::Value>,
+fn workspace_path(workspace_root: &str, identifier: &str) -> Result<PathBuf, ApiError> {
+    let workspace_key = sanitize_workspace_key(identifier).ok_or_else(|| {
+        ApiError::new(
+            "invalid_identifier",
+            "identifier cannot be sanitized to a workspace key",
+        )
+    })?;
+    Ok(PathBuf::from(workspace_root).join(workspace_key))
 }
 
-/// Response envelope for conversation queries.
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ConversationResponse {
-    pub messages: Vec<ConversationMessage>,
-    pub total: usize,
-    pub next_cursor: Option<usize>,
-}
-
-/// GET /api/v1/{identifier}/conversation
-///
-/// Returns paginated conversation messages from the workspace's conversation.jsonl file.
 #[utoipa::path(
     get,
-    path = "/api/v1/{identifier}/conversation",
-    operation_id = "getConversation",
+    path = "/api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation",
+    operation_id = "getStepConversation",
     params(
         ("identifier" = String, Path, description = "Issue identifier"),
+        ("run_id" = String, Path, description = "Run id"),
+        ("step_name" = String, Path, description = "Step name"),
         ConversationQuery,
     ),
     responses(
-        (status = 200, description = "Conversation messages", body = ConversationResponse),
-        (status = 400, description = "Invalid identifier", body = ApiError)
+        (status = 200, description = "Step transcript records", body = TranscriptResponse),
+        (status = 400, description = "Invalid path", body = ApiError)
     ),
     tag = "conversation"
 )]
 pub async fn get_conversation(
     State(state): State<AppState>,
-    Path(identifier): Path<String>,
+    Path((identifier, run_id, step_name)): Path<(String, String, String)>,
     Query(query): Query<ConversationQuery>,
 ) -> impl IntoResponse {
-    let workspace_key = match sanitize_workspace_key(&identifier) {
-        Some(key) => key,
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                api_error(
-                    "invalid_identifier",
-                    "identifier cannot be sanitized to a workspace key",
-                ),
-            )
-                .into_response();
-        }
+    let workspace_path = match workspace_path(&state.workspace_root, &identifier) {
+        Ok(path) => path,
+        Err(error) => return (StatusCode::BAD_REQUEST, Json(error)).into_response(),
     };
 
-    let conversation_path = conversation_path(&state.workspace_root, &workspace_key);
-
-    let all_messages = match load_conversation_messages(&conversation_path).await {
-        Ok(Some(messages)) => messages,
-        Ok(None) => {
-            return (
-                StatusCode::OK,
-                Json(ConversationResponse {
-                    messages: vec![],
-                    total: 0,
-                    next_cursor: None,
-                }),
-            )
-                .into_response();
-        }
-        Err(error) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response();
-        }
-    };
-
-    let total = all_messages.len();
-    let cursor = query.cursor.unwrap_or(0);
-    let limit = query.limit.unwrap_or(50).min(200);
-
-    let page: Vec<ConversationMessage> =
-        all_messages.into_iter().skip(cursor).take(limit).collect();
-
-    let next_cursor = if cursor + page.len() < total {
-        Some(cursor + page.len())
-    } else {
-        None
-    };
-
-    (
-        StatusCode::OK,
-        Json(ConversationResponse {
-            messages: page,
-            total,
-            next_cursor,
-        }),
+    match read_transcript_page(
+        &workspace_path,
+        &run_id,
+        &step_name,
+        query.cursor,
+        query.limit,
     )
-        .into_response()
-}
-
-/// GET /api/v1/{identifier}/conversation/{index}
-///
-/// Returns a single conversation message by its index.
-#[utoipa::path(
-    get,
-    path = "/api/v1/{identifier}/conversation/{index}",
-    operation_id = "getConversationMessage",
-    params(
-        ("identifier" = String, Path, description = "Issue identifier"),
-        ("index" = u64, Path, description = "Message index"),
-    ),
-    responses(
-        (status = 200, description = "Single message", body = ConversationMessage),
-        (status = 404, description = "Message not found", body = ApiError)
-    ),
-    tag = "conversation"
-)]
-pub async fn get_conversation_message(
-    State(state): State<AppState>,
-    Path((identifier, index)): Path<(String, u64)>,
-) -> impl IntoResponse {
-    let workspace_key = match sanitize_workspace_key(&identifier) {
-        Some(key) => key,
-        None => {
-            return (
+    .await
+    {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error)
+            if error
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|e| e.kind() == std::io::ErrorKind::InvalidInput) =>
+        {
+            (
                 StatusCode::BAD_REQUEST,
-                api_error(
-                    "invalid_identifier",
-                    "identifier cannot be sanitized to a workspace key",
-                ),
+                api_error("invalid_path", "run id or step name is invalid"),
             )
-                .into_response();
+                .into_response()
         }
-    };
-
-    let conversation_path = conversation_path(&state.workspace_root, &workspace_key);
-
-    let messages = match load_conversation_messages(&conversation_path).await {
-        Ok(Some(messages)) => messages,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                api_error(
-                    "conversation_not_found",
-                    "no conversation file found for this issue",
-                ),
-            )
-                .into_response();
-        }
-        Err(error) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response();
-        }
-    };
-
-    let message = messages.into_iter().find(|m| m.index == index);
-
-    match message {
-        Some(msg) => (StatusCode::OK, Json(msg)).into_response(),
-        None => (
-            StatusCode::NOT_FOUND,
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
             api_error(
-                "message_not_found",
-                format!("no message at index {}", index),
+                "conversation_read_error",
+                format!("failed to read transcript: {error}"),
             ),
         )
             .into_response(),
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
-    use crate::tracker::model::sanitize_workspace_key;
-    use axum::body::to_bytes;
-    use tempfile::TempDir;
+#[utoipa::path(
+    get,
+    path = "/api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation/{sequence}",
+    operation_id = "getStepConversationRecord",
+    params(
+        ("identifier" = String, Path, description = "Issue identifier"),
+        ("run_id" = String, Path, description = "Run id"),
+        ("step_name" = String, Path, description = "Step name"),
+        ("sequence" = u64, Path, description = "Transcript sequence"),
+    ),
+    responses(
+        (status = 200, description = "Transcript record", body = TranscriptRecord),
+        (status = 400, description = "Invalid path", body = ApiError),
+        (status = 404, description = "Record not found", body = ApiError)
+    ),
+    tag = "conversation"
+)]
+pub async fn get_conversation_message(
+    State(state): State<AppState>,
+    Path((identifier, run_id, step_name, sequence)): Path<(String, String, String, u64)>,
+) -> impl IntoResponse {
+    let workspace_path = match workspace_path(&state.workspace_root, &identifier) {
+        Ok(path) => path,
+        Err(error) => return (StatusCode::BAD_REQUEST, Json(error)).into_response(),
+    };
 
-    fn test_app_state(workspace_root: String) -> AppState {
-        let mut app_state = app_state_with_document_state(parsed_document_state());
-        app_state.workspace_root = workspace_root;
-        app_state
-    }
-
-    async fn write_conversation_file(root: &std::path::Path, contents: &str) {
-        let workspace_key = sanitize_workspace_key("my-repo#42").unwrap();
-        let path = conversation_path(root.to_str().unwrap(), &workspace_key);
-        tokio::fs::create_dir_all(path.parent().unwrap())
-            .await
-            .unwrap();
-        tokio::fs::write(path, contents).await.unwrap();
-    }
-
-    async fn response_json(response: axum::response::Response) -> serde_json::Value {
-        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        serde_json::from_slice(&body).unwrap()
-    }
-
-    #[test]
-    fn conversation_path_uses_workspace_root_and_key() {
-        let path = conversation_path("/tmp/workspaces", "my-repo-42");
-        assert_eq!(
-            path,
-            std::path::PathBuf::from("/tmp/workspaces")
-                .join("my-repo-42")
-                .join(".ensemble")
-                .join("conversation.jsonl")
-        );
-    }
-
-    #[tokio::test]
-    async fn read_conversation_file_returns_none_for_missing_file() {
-        let tempdir = TempDir::new().unwrap();
-        let path = tempdir.path().join("missing.jsonl");
-
-        let contents = read_conversation_file(&path).await.unwrap();
-
-        assert!(contents.is_none());
-    }
-
-    #[tokio::test]
-    async fn get_conversation_returns_empty_result_when_file_is_missing() {
-        let tempdir = TempDir::new().unwrap();
-        let state = test_app_state(tempdir.path().display().to_string());
-
-        let response = get_conversation(
-            State(state),
-            Path("my-repo#42".to_string()),
-            Query(ConversationQuery::default()),
+    match read_transcript_record(&workspace_path, &run_id, &step_name, sequence).await {
+        Ok(Some(record)) => (StatusCode::OK, Json(record)).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            api_error(
+                "transcript_record_not_found",
+                format!("no transcript record at sequence {sequence}"),
+            ),
         )
-        .await
-        .into_response();
-
-        assert_eq!(response.status(), StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn get_conversation_message_returns_not_found_when_file_is_missing() {
-        let tempdir = TempDir::new().unwrap();
-        let state = test_app_state(tempdir.path().display().to_string());
-
-        let response = get_conversation_message(State(state), Path(("my-repo#42".to_string(), 0)))
-            .await
-            .into_response();
-
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn get_conversation_returns_internal_error_for_malformed_jsonl() {
-        let tempdir = TempDir::new().unwrap();
-        write_conversation_file(tempdir.path(), "{invalid json}\n").await;
-        let state = test_app_state(tempdir.path().display().to_string());
-
-        let response = get_conversation(
-            State(state),
-            Path("my-repo#42".to_string()),
-            Query(ConversationQuery::default()),
+            .into_response(),
+        Err(error)
+            if error
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|e| e.kind() == std::io::ErrorKind::InvalidInput) =>
+        {
+            (
+                StatusCode::BAD_REQUEST,
+                api_error("invalid_path", "run id or step name is invalid"),
+            )
+                .into_response()
+        }
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            api_error(
+                "conversation_read_error",
+                format!("failed to read transcript: {error}"),
+            ),
         )
-        .await
-        .into_response();
-
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-
-        let body = response_json(response).await;
-        assert_eq!(body["error"]["code"], "conversation_parse_error");
-        assert!(body["error"]["message"]
-            .as_str()
-            .unwrap()
-            .starts_with("failed to parse conversation:"));
-    }
-
-    #[tokio::test]
-    async fn get_conversation_message_returns_error_for_malformed_jsonl() {
-        let tempdir = TempDir::new().unwrap();
-        write_conversation_file(tempdir.path(), "{invalid json}\n").await;
-        let state = test_app_state(tempdir.path().display().to_string());
-
-        let response = get_conversation_message(State(state), Path(("my-repo#42".to_string(), 0)))
-            .await
-            .into_response();
-
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-
-        let body = response_json(response).await;
-        assert_eq!(body["error"]["code"], "conversation_parse_error");
-        assert!(body["error"]["message"]
-            .as_str()
-            .unwrap()
-            .starts_with("failed to parse conversation:"));
-    }
-
-    #[test]
-    fn test_conversation_message_deserialize() {
-        let json = r#"{"index":0,"role":"user","content":"hello"}"#;
-        let msg: ConversationMessage = serde_json::from_str(json).unwrap();
-        assert_eq!(msg.index, 0);
-        assert_eq!(msg.role, "user");
-        assert_eq!(msg.content, "hello");
-    }
-
-    #[test]
-    fn conversation_response_serializes_total_and_next_cursor() {
-        let response = ConversationResponse {
-            messages: vec![],
-            total: 0,
-            next_cursor: None,
-        };
-        let json = serde_json::to_value(&response).unwrap();
-        assert_eq!(json["total"], 0);
-        assert!(json["next_cursor"].is_null());
-    }
-
-    #[test]
-    fn parse_conversation_messages_returns_error_for_malformed_jsonl() {
-        let error = parse_conversation_messages("{invalid json}\n").unwrap_err();
-        assert!(error.is_syntax());
+            .into_response(),
     }
 }

--- a/crates/ensemble-core/src/api/conversation.rs
+++ b/crates/ensemble-core/src/api/conversation.rs
@@ -1,6 +1,5 @@
 use crate::api::handlers::{api_error, ApiError};
 use crate::api::router::AppState;
-use crate::tracker::model::sanitize_workspace_key;
 use crate::transcript::model::TranscriptRecord;
 use crate::transcript::reader::{read_transcript_page, read_transcript_record, TranscriptResponse};
 use axum::extract::{Path, Query, State};
@@ -8,22 +7,12 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::Path as FsPath;
 
 #[derive(Debug, Default, Deserialize, utoipa::IntoParams)]
 pub struct ConversationQuery {
     pub cursor: Option<usize>,
     pub limit: Option<usize>,
-}
-
-fn workspace_path(workspace_root: &str, identifier: &str) -> Result<PathBuf, ApiError> {
-    let workspace_key = sanitize_workspace_key(identifier).ok_or_else(|| {
-        ApiError::new(
-            "invalid_identifier",
-            "identifier cannot be sanitized to a workspace key",
-        )
-    })?;
-    Ok(PathBuf::from(workspace_root).join(workspace_key))
 }
 
 #[utoipa::path(
@@ -44,16 +33,11 @@ fn workspace_path(workspace_root: &str, identifier: &str) -> Result<PathBuf, Api
 )]
 pub async fn get_conversation(
     State(state): State<AppState>,
-    Path((identifier, run_id, step_name)): Path<(String, String, String)>,
+    Path((_identifier, run_id, step_name)): Path<(String, String, String)>,
     Query(query): Query<ConversationQuery>,
 ) -> impl IntoResponse {
-    let workspace_path = match workspace_path(&state.workspace_root, &identifier) {
-        Ok(path) => path,
-        Err(error) => return (StatusCode::BAD_REQUEST, Json(error)).into_response(),
-    };
-
     match read_transcript_page(
-        &workspace_path,
+        FsPath::new(&state.workspace_root),
         &run_id,
         &step_name,
         query.cursor,
@@ -103,14 +87,16 @@ pub async fn get_conversation(
 )]
 pub async fn get_conversation_message(
     State(state): State<AppState>,
-    Path((identifier, run_id, step_name, sequence)): Path<(String, String, String, u64)>,
+    Path((_identifier, run_id, step_name, sequence)): Path<(String, String, String, u64)>,
 ) -> impl IntoResponse {
-    let workspace_path = match workspace_path(&state.workspace_root, &identifier) {
-        Ok(path) => path,
-        Err(error) => return (StatusCode::BAD_REQUEST, Json(error)).into_response(),
-    };
-
-    match read_transcript_record(&workspace_path, &run_id, &step_name, sequence).await {
+    match read_transcript_record(
+        FsPath::new(&state.workspace_root),
+        &run_id,
+        &step_name,
+        sequence,
+    )
+    .await
+    {
         Ok(Some(record)) => (StatusCode::OK, Json(record)).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,

--- a/crates/ensemble-core/src/api/openapi.rs
+++ b/crates/ensemble-core/src/api/openapi.rs
@@ -125,8 +125,10 @@ use utoipa::OpenApi;
         crate::timeline::model::TimelineEventRecord,
         crate::timeline::TimelineResponse,
         // Conversation types
-        crate::api::conversation::ConversationResponse,
-        crate::api::conversation::ConversationMessage,
+        crate::transcript::reader::TranscriptResponse,
+        crate::transcript::model::TranscriptRecord,
+        crate::transcript::model::TranscriptRecordKind,
+        crate::transcript::model::TranscriptTruncation,
         // Filesystem types
         crate::api::fs_handler::ListResponse,
         crate::api::fs_handler::FsEntry,

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -66,8 +66,8 @@ pub struct AppState {
 /// - `POST /api/v1/refresh` — trigger immediate poll+reconcile
 /// - `GET /api/v1/history` — query history records
 /// - `GET /api/v1/{identifier}` — issue-specific detail
-/// - `GET /api/v1/{identifier}/conversation` — paginated conversation
-/// - `GET /api/v1/{identifier}/conversation/{index}` — single conversation message
+/// - `GET /api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation` — paginated step transcript records
+/// - `GET /api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation/{sequence}` — single transcript record
 /// - `POST /api/v1/{identifier}/stop` — stop a running agent
 /// - `POST /api/v1/{identifier}/retry` — retry a failed issue
 /// - `GET /ws/events/{identifier}` — WebSocket live event stream
@@ -140,11 +140,11 @@ pub fn create_api_router(state: AppState) -> Router {
             post(config_edit_handler::save_guided_form),
         )
         .route(
-            "/{identifier}/conversation",
+            "/{identifier}/runs/{run_id}/steps/{step_name}/conversation",
             get(conversation::get_conversation),
         )
         .route(
-            "/{identifier}/conversation/{index}",
+            "/{identifier}/runs/{run_id}/steps/{step_name}/conversation/{sequence}",
             get(conversation::get_conversation_message),
         )
         .route(

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod orchestrator;
 pub mod pipeline;
 pub mod timeline;
 pub mod tracker;
+pub mod transcript;
 pub mod ui;
 pub mod workspace;
 

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -10631,6 +10631,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            observed_timeouts: None,
             cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
@@ -10689,6 +10690,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            observed_timeouts: None,
             cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();
@@ -10757,6 +10759,7 @@ agent:
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
+            observed_timeouts: None,
             cancellation_probe: None,
         });
         let dir = tempfile::TempDir::new().unwrap();

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -56,6 +56,8 @@ use crate::pipeline::verdict::StepResult;
 use crate::timeline::persistence::TimelinePersistence;
 use crate::tracker::model::{Issue, RetryEntry};
 use crate::tracker::IssueTracker;
+use crate::transcript::model::TranscriptRecordKind;
+use crate::transcript::persistence::{TranscriptPersistRequest, TranscriptPersistence};
 use crate::workspace::finalize::FinalizeMode;
 use crate::workspace::manager::WorkspaceManager;
 
@@ -115,6 +117,7 @@ pub struct Orchestrator {
     pipeline_journal: PipelineRunJournal,
     event_bus: EventBus,
     timeline_persistence: Option<TimelinePersistence>,
+    transcript_persistence: Option<TranscriptPersistence>,
     worker_tx: mpsc::Sender<WorkerEvent>,
     worker_rx: mpsc::Receiver<WorkerEvent>,
     shutdown_rx: mpsc::Receiver<()>,
@@ -208,7 +211,8 @@ impl Orchestrator {
             .ok(),
             pipeline_journal: PipelineRunJournal::new(config_dir.to_path_buf()),
             event_bus: parts.event_bus,
-            timeline_persistence: Some(TimelinePersistence::new(parts.workspace_root)),
+            timeline_persistence: Some(TimelinePersistence::new(parts.workspace_root.clone())),
+            transcript_persistence: Some(TranscriptPersistence::new(parts.workspace_root)),
             worker_tx,
             worker_rx,
             shutdown_rx,
@@ -327,6 +331,11 @@ impl Orchestrator {
             persistence.flush().await;
         }
         info!("timeline persistence flushed");
+        info!("orchestrator stopped, flushing transcript persistence");
+        if let Some(mut persistence) = self.transcript_persistence.take() {
+            persistence.flush().await;
+        }
+        info!("transcript persistence flushed");
 
         info!("orchestrator stopped");
     }
@@ -1135,7 +1144,22 @@ impl Orchestrator {
             .get(issue_id)
             .map(|entry| entry.identifier.clone())
             .unwrap_or_else(|| issue_id.to_string());
-        let (run_id, sequence, attempt_num) = Self::run_context_for_issue(&mut state, issue_id);
+        let (run_id, attempt_num) = Self::run_metadata_for_issue(&state, issue_id);
+        let transcript_request = match &event {
+            AgentEvent::TranscriptBlock { kind, payload } => {
+                run_id.as_ref().map(|run_id| TranscriptPersistRequest {
+                    run_id: run_id.clone(),
+                    issue_identifier: issue_identifier.clone(),
+                    step_name: step_name.to_string(),
+                    attempt: attempt_num,
+                    timestamp,
+                    kind: transcript_kind_from_agent_kind(*kind),
+                    payload: payload.clone(),
+                    truncated: None,
+                })
+            }
+            _ => None,
+        };
         let mut pipeline_event: Option<PipelineEvent> = None;
 
         // Handle special cases
@@ -1201,6 +1225,11 @@ impl Orchestrator {
             _ => {}
         }
 
+        let sequence = pipeline_event
+            .as_ref()
+            .and_then(|_| run_id.as_ref())
+            .map(|run_id| state.next_timeline_sequence(run_id));
+
         // Common path: update agent event
         state.update_agent_event(
             issue_id,
@@ -1209,6 +1238,12 @@ impl Orchestrator {
             timestamp,
         );
         drop(state);
+
+        if let Some(request) = transcript_request {
+            if let Some(ref persistence) = self.transcript_persistence {
+                persistence.send(request);
+            }
+        }
 
         if let Some(event) = pipeline_event {
             self.publish_pipeline_event(run_id, sequence, attempt_num, event)
@@ -4701,19 +4736,24 @@ impl Orchestrator {
         state: &mut OrchestratorState,
         issue_id: &str,
     ) -> (Option<String>, Option<u64>, u32) {
+        let (run_id, attempt) = Self::run_metadata_for_issue(state, issue_id);
+        let sequence = run_id
+            .as_ref()
+            .map(|run_id| state.next_timeline_sequence(run_id));
+        (run_id, sequence, attempt)
+    }
+
+    fn run_metadata_for_issue(state: &OrchestratorState, issue_id: &str) -> (Option<String>, u32) {
         let run_id = state
             .running
             .get(issue_id)
             .and_then(|entry| entry.run_id.clone());
-        let sequence = run_id
-            .as_ref()
-            .map(|run_id| state.next_timeline_sequence(run_id));
         let attempt = state
             .running
             .get(issue_id)
             .and_then(|entry| entry.retry_attempt)
             .unwrap_or(1);
-        (run_id, sequence, attempt)
+        (run_id, attempt)
     }
 }
 
@@ -4741,6 +4781,26 @@ where
                 kind: WorkerFailureKind::Runtime,
             }
         }
+    }
+}
+
+fn transcript_kind_from_agent_kind(
+    kind: crate::agent::protocol::TranscriptBlockKind,
+) -> TranscriptRecordKind {
+    match kind {
+        crate::agent::protocol::TranscriptBlockKind::AssistantMessage => {
+            TranscriptRecordKind::AssistantMessage
+        }
+        crate::agent::protocol::TranscriptBlockKind::Reasoning => TranscriptRecordKind::Reasoning,
+        crate::agent::protocol::TranscriptBlockKind::ToolCall => TranscriptRecordKind::ToolCall,
+        crate::agent::protocol::TranscriptBlockKind::ToolResult => TranscriptRecordKind::ToolResult,
+        crate::agent::protocol::TranscriptBlockKind::PermissionRequest => {
+            TranscriptRecordKind::PermissionRequest
+        }
+        crate::agent::protocol::TranscriptBlockKind::TurnComplete => {
+            TranscriptRecordKind::TurnComplete
+        }
+        crate::agent::protocol::TranscriptBlockKind::Raw => TranscriptRecordKind::Raw,
     }
 }
 
@@ -10541,6 +10601,138 @@ agent:
         assert_eq!(record.attempt, 3);
         assert_eq!(record.event_type, "output");
         assert_eq!(record.step_name.as_deref(), Some("build"));
+    }
+
+    #[tokio::test]
+    async fn handle_agent_update_persists_transcript_block() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let mut orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("issue-1", "Todo"), None);
+            let entry = state.running.get_mut("issue-1").unwrap();
+            entry.identifier = "repo#1".to_string();
+            entry.run_id = Some("run-1".to_string());
+        }
+
+        orchestrator
+            .handle_worker_event(WorkerEvent::AgentUpdate {
+                issue_id: "issue-1".to_string(),
+                step_name: "build".to_string(),
+                event: AgentEvent::TranscriptBlock {
+                    kind: crate::agent::protocol::TranscriptBlockKind::AssistantMessage,
+                    payload: serde_json::json!({"text": "hello"}),
+                },
+                timestamp: chrono::Utc::now(),
+            })
+            .await;
+
+        if let Some(ref mut persistence) = orchestrator.transcript_persistence {
+            persistence.flush().await;
+        }
+
+        let contents = tokio::fs::read_to_string(
+            dir.path()
+                .join(".ensemble/runs/run-1/steps/build/transcript.jsonl"),
+        )
+        .await
+        .unwrap();
+        assert!(contents.contains("\"assistant_message\""));
+        assert!(contents.contains("\"hello\""));
+    }
+
+    #[tokio::test]
+    async fn transcript_block_does_not_advance_timeline_sequence() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let mut orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("issue-1", "Todo"), None);
+            let entry = state.running.get_mut("issue-1").unwrap();
+            entry.identifier = "repo#1".to_string();
+            entry.run_id = Some("run-1".to_string());
+        }
+
+        orchestrator
+            .handle_worker_event(WorkerEvent::AgentUpdate {
+                issue_id: "issue-1".to_string(),
+                step_name: "build".to_string(),
+                event: AgentEvent::TranscriptBlock {
+                    kind: crate::agent::protocol::TranscriptBlockKind::AssistantMessage,
+                    payload: serde_json::json!({"text": "hello"}),
+                },
+                timestamp: chrono::Utc::now(),
+            })
+            .await;
+
+        if let Some(ref mut persistence) = orchestrator.transcript_persistence {
+            persistence.flush().await;
+        }
+
+        orchestrator
+            .handle_worker_event(WorkerEvent::AgentUpdate {
+                issue_id: "issue-1".to_string(),
+                step_name: "build".to_string(),
+                event: AgentEvent::OutputChunk {
+                    stream: crate::agent::events::RuntimeStream::Stdout,
+                    content: "visible output".to_string(),
+                },
+                timestamp: chrono::Utc::now(),
+            })
+            .await;
+
+        if let Some(ref mut persistence) = orchestrator.timeline_persistence {
+            persistence.flush().await;
+        }
+
+        let contents =
+            tokio::fs::read_to_string(dir.path().join(".ensemble/runs/run-1/events.jsonl"))
+                .await
+                .unwrap();
+        let record: crate::timeline::model::TimelineEventRecord =
+            serde_json::from_str(contents.lines().next().unwrap()).unwrap();
+        assert_eq!(record.sequence, 1);
+        assert_eq!(record.event_type, "output");
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1227,7 +1227,7 @@ impl Orchestrator {
 
         let sequence = pipeline_event
             .as_ref()
-            .and_then(|_| run_id.as_ref())
+            .and(run_id.as_ref())
             .map(|run_id| state.next_timeline_sequence(run_id));
 
         // Common path: update agent event

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1160,6 +1160,20 @@ impl Orchestrator {
             }
             _ => None,
         };
+        let flush_transcript_step = matches!(
+            &event,
+            AgentEvent::RunCompleted { .. }
+                | AgentEvent::RunFailed { .. }
+                | AgentEvent::TurnCompleted { .. }
+                | AgentEvent::TurnFailed { .. }
+                | AgentEvent::Cancelled { .. }
+        )
+        .then(|| {
+            run_id
+                .as_ref()
+                .map(|run_id| (run_id.clone(), step_name.to_string()))
+        })
+        .flatten();
         let mut pipeline_event: Option<PipelineEvent> = None;
 
         // Handle special cases
@@ -1242,6 +1256,11 @@ impl Orchestrator {
         if let Some(request) = transcript_request {
             if let Some(ref persistence) = self.transcript_persistence {
                 persistence.send(request);
+            }
+        }
+        if let Some((run_id, step_name)) = flush_transcript_step {
+            if let Some(ref persistence) = self.transcript_persistence {
+                persistence.flush_step(run_id, step_name);
             }
         }
 
@@ -10657,6 +10676,74 @@ agent:
         )
         .await
         .unwrap();
+        assert!(contents.contains("\"assistant_message\""));
+        assert!(contents.contains("\"hello\""));
+    }
+
+    #[tokio::test]
+    async fn run_completed_flushes_coalesced_transcript_block() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("issue-1", "Todo"), None);
+            let entry = state.running.get_mut("issue-1").unwrap();
+            entry.identifier = "repo#1".to_string();
+            entry.run_id = Some("run-1".to_string());
+        }
+
+        orchestrator
+            .handle_worker_event(WorkerEvent::AgentUpdate {
+                issue_id: "issue-1".to_string(),
+                step_name: "build".to_string(),
+                event: AgentEvent::TranscriptBlock {
+                    kind: crate::agent::protocol::TranscriptBlockKind::AssistantMessage,
+                    payload: serde_json::json!({"text": "hello"}),
+                },
+                timestamp: chrono::Utc::now(),
+            })
+            .await;
+
+        orchestrator
+            .handle_worker_event(WorkerEvent::AgentUpdate {
+                issue_id: "issue-1".to_string(),
+                step_name: "build".to_string(),
+                event: AgentEvent::RunCompleted { usage: None },
+                timestamp: chrono::Utc::now(),
+            })
+            .await;
+
+        let transcript_path = dir
+            .path()
+            .join(".ensemble/runs/run-1/steps/build/transcript.jsonl");
+        for _ in 0..20 {
+            if transcript_path.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let contents = tokio::fs::read_to_string(transcript_path).await.unwrap();
         assert!(contents.contains("\"assistant_message\""));
         assert!(contents.contains("\"hello\""));
     }

--- a/crates/ensemble-core/src/transcript/mod.rs
+++ b/crates/ensemble-core/src/transcript/mod.rs
@@ -1,0 +1,3 @@
+pub mod model;
+pub mod reader;
+pub mod writer;

--- a/crates/ensemble-core/src/transcript/mod.rs
+++ b/crates/ensemble-core/src/transcript/mod.rs
@@ -1,3 +1,4 @@
 pub mod model;
+pub mod persistence;
 pub mod reader;
 pub mod writer;

--- a/crates/ensemble-core/src/transcript/model.rs
+++ b/crates/ensemble-core/src/transcript/model.rs
@@ -1,0 +1,108 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptRecordKind {
+    Prompt,
+    AssistantMessage,
+    Reasoning,
+    ToolCall,
+    ToolResult,
+    PermissionRequest,
+    PermissionResolution,
+    TurnComplete,
+    Error,
+    Raw,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TranscriptTruncation {
+    pub original_bytes: usize,
+    pub retained_head_bytes: usize,
+    pub retained_tail_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TranscriptRecord {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub issue_identifier: String,
+    pub step_name: String,
+    pub attempt: u32,
+    pub sequence: u64,
+    pub timestamp: DateTime<Utc>,
+    pub kind: TranscriptRecordKind,
+    pub payload: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<TranscriptTruncation>,
+}
+
+pub fn sanitize_step_path_segment(value: &str) -> Option<String> {
+    if value.is_empty() || value == "." || value == ".." {
+        return None;
+    }
+
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        Some(value.to_string())
+    } else {
+        None
+    }
+}
+
+pub fn sanitize_run_path_segment(value: &str) -> Option<String> {
+    sanitize_step_path_segment(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_step_path_segment_accepts_pipeline_names() {
+        assert_eq!(sanitize_step_path_segment("build").unwrap(), "build");
+        assert_eq!(
+            sanitize_step_path_segment("review-step").unwrap(),
+            "review-step"
+        );
+        assert_eq!(
+            sanitize_step_path_segment("review_step.2").unwrap(),
+            "review_step.2"
+        );
+    }
+
+    #[test]
+    fn sanitize_step_path_segment_rejects_traversal() {
+        assert!(sanitize_step_path_segment("../build").is_none());
+        assert!(sanitize_step_path_segment("build/review").is_none());
+        assert!(sanitize_step_path_segment("").is_none());
+    }
+
+    #[test]
+    fn transcript_record_round_trips() {
+        let record = TranscriptRecord {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION,
+            run_id: "run-1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            step_name: "build".to_string(),
+            attempt: 1,
+            sequence: 7,
+            timestamp: chrono::Utc::now(),
+            kind: TranscriptRecordKind::AssistantMessage,
+            payload: serde_json::json!({"text": "hello"}),
+            truncated: None,
+        };
+
+        let encoded = serde_json::to_string(&record).unwrap();
+        let decoded: TranscriptRecord = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded.schema_version, TRANSCRIPT_SCHEMA_VERSION);
+        assert_eq!(decoded.kind, TranscriptRecordKind::AssistantMessage);
+        assert_eq!(decoded.payload["text"], "hello");
+    }
+}

--- a/crates/ensemble-core/src/transcript/persistence.rs
+++ b/crates/ensemble-core/src/transcript/persistence.rs
@@ -1,0 +1,435 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::warn;
+
+use super::model::{
+    TranscriptRecord, TranscriptRecordKind, TranscriptTruncation, TRANSCRIPT_SCHEMA_VERSION,
+};
+use super::writer::TranscriptWriter;
+
+pub const COALESCE_MAX_BYTES: usize = 16 * 1024;
+pub const TOOL_RESULT_MAX_BYTES: usize = 128 * 1024;
+pub const TOOL_RESULT_HEAD_BYTES: usize = 96 * 1024;
+pub const TOOL_RESULT_TAIL_BYTES: usize = 32 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct TranscriptPersistRequest {
+    pub run_id: String,
+    pub issue_identifier: String,
+    pub step_name: String,
+    pub attempt: u32,
+    pub timestamp: DateTime<Utc>,
+    pub kind: TranscriptRecordKind,
+    pub payload: serde_json::Value,
+    pub truncated: Option<TranscriptTruncation>,
+}
+
+pub struct TranscriptPersistence {
+    sender: Option<mpsc::Sender<TranscriptPersistRequest>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl TranscriptPersistence {
+    pub fn new(workspace_root: PathBuf) -> Self {
+        let writer = TranscriptWriter::new(workspace_root);
+        let (sender, mut receiver) = mpsc::channel::<TranscriptPersistRequest>(10_000);
+
+        let handle = tokio::spawn(async move {
+            let mut state = PersistState::default();
+            while let Some(req) = receiver.recv().await {
+                state.write_request(&writer, req).await;
+            }
+            state.flush_all(&writer).await;
+        });
+
+        Self {
+            sender: Some(sender),
+            handle: Some(handle),
+        }
+    }
+
+    pub fn send(&self, request: TranscriptPersistRequest) {
+        if let Some(sender) = &self.sender {
+            match sender.try_send(request) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    warn!("transcript persist channel full; transcript record dropped");
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    warn!("transcript persist channel closed; transcript record dropped");
+                }
+            }
+        }
+    }
+
+    pub async fn flush(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            drop(sender);
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for TranscriptPersistence {
+    fn drop(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            drop(sender);
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[derive(Default)]
+struct PersistState {
+    sequences: HashMap<(String, String), u64>,
+    coalesced: HashMap<(String, String), TranscriptPersistRequest>,
+}
+
+impl PersistState {
+    async fn write_request(
+        &mut self,
+        writer: &TranscriptWriter,
+        mut req: TranscriptPersistRequest,
+    ) {
+        if should_coalesce(req.kind) {
+            let key = (req.run_id.clone(), req.step_name.clone());
+            if let Some(existing) = self.coalesced.get_mut(&key) {
+                if can_merge_coalesced(existing, &req)
+                    && merge_text_payload(&mut existing.payload, &req.payload)
+                {
+                    return;
+                }
+            }
+            self.flush_key(writer, key.clone()).await;
+            self.coalesced.insert(key, req);
+            return;
+        }
+
+        self.flush_step(writer, &req.run_id, &req.step_name).await;
+        if req.kind == TranscriptRecordKind::ToolResult {
+            let (payload, truncation) = truncate_tool_result_payload(req.payload);
+            req.payload = payload;
+            req.truncated = req.truncated.or(truncation);
+        }
+        self.append(writer, req).await;
+    }
+
+    async fn flush_key(&mut self, writer: &TranscriptWriter, key: (String, String)) {
+        if let Some(req) = self.coalesced.remove(&key) {
+            self.append(writer, req).await;
+        }
+    }
+
+    async fn flush_step(&mut self, writer: &TranscriptWriter, run_id: &str, step_name: &str) {
+        let keys: Vec<_> = self
+            .coalesced
+            .keys()
+            .filter(|(run, step)| run == run_id && step == step_name)
+            .cloned()
+            .collect();
+        for key in keys {
+            self.flush_key(writer, key).await;
+        }
+    }
+
+    async fn flush_all(&mut self, writer: &TranscriptWriter) {
+        let keys: Vec<_> = self.coalesced.keys().cloned().collect();
+        for key in keys {
+            self.flush_key(writer, key).await;
+        }
+    }
+
+    async fn append(&mut self, writer: &TranscriptWriter, req: TranscriptPersistRequest) {
+        let sequence_key = (req.run_id.clone(), req.step_name.clone());
+        let sequence = self.sequences.entry(sequence_key).or_insert(0);
+        *sequence += 1;
+
+        let record = TranscriptRecord {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION,
+            run_id: req.run_id,
+            issue_identifier: req.issue_identifier,
+            step_name: req.step_name,
+            attempt: req.attempt,
+            sequence: *sequence,
+            timestamp: req.timestamp,
+            kind: req.kind,
+            payload: req.payload,
+            truncated: req.truncated,
+        };
+
+        if let Err(error) = writer.append(&record).await {
+            warn!(
+                event = "transcript_persist_failed",
+                run_id = %record.run_id,
+                step_name = %record.step_name,
+                error = %error,
+                "failed to persist transcript record"
+            );
+        }
+    }
+}
+
+fn should_coalesce(kind: TranscriptRecordKind) -> bool {
+    matches!(
+        kind,
+        TranscriptRecordKind::AssistantMessage | TranscriptRecordKind::Reasoning
+    )
+}
+
+fn can_merge_coalesced(
+    existing: &TranscriptPersistRequest,
+    next: &TranscriptPersistRequest,
+) -> bool {
+    existing.run_id == next.run_id
+        && existing.step_name == next.step_name
+        && existing.kind == next.kind
+        && existing.attempt == next.attempt
+        && existing.issue_identifier == next.issue_identifier
+}
+
+fn merge_text_payload(existing: &mut serde_json::Value, next: &serde_json::Value) -> bool {
+    if !is_text_only_payload(existing) || !is_text_only_payload(next) {
+        return false;
+    }
+
+    let existing_text = existing["text"].as_str().unwrap().to_string();
+    let Some(next_text) = next.get("text").and_then(|value| value.as_str()) else {
+        return false;
+    };
+    if existing_text.len() + next_text.len() > COALESCE_MAX_BYTES {
+        return false;
+    }
+
+    existing["text"] = serde_json::Value::String(format!("{existing_text}{next_text}"));
+    true
+}
+
+fn is_text_only_payload(payload: &serde_json::Value) -> bool {
+    let Some(object) = payload.as_object() else {
+        return false;
+    };
+
+    object.len() == 1 && object.get("text").is_some_and(|value| value.is_string())
+}
+
+pub fn truncate_tool_result_payload(
+    payload: serde_json::Value,
+) -> (serde_json::Value, Option<TranscriptTruncation>) {
+    let text = match payload.get("text").and_then(|value| value.as_str()) {
+        Some(text) => text,
+        None => return (payload, None),
+    };
+    if text.len() <= TOOL_RESULT_MAX_BYTES {
+        return (payload, None);
+    }
+
+    let head_end = floor_char_boundary(text, TOOL_RESULT_HEAD_BYTES.min(text.len()));
+    let tail_start = ceil_char_boundary(text, text.len().saturating_sub(TOOL_RESULT_TAIL_BYTES));
+    let head = &text[..head_end];
+    let tail = &text[tail_start..];
+    let retained = format!("{head}\n\n[truncated]\n\n{tail}");
+    let truncation = TranscriptTruncation {
+        original_bytes: text.len(),
+        retained_head_bytes: head.len(),
+        retained_tail_bytes: tail.len(),
+    };
+
+    let mut wrapper = payload;
+    wrapper["text"] = serde_json::Value::String(retained);
+    (wrapper, Some(truncation))
+}
+
+fn floor_char_boundary(value: &str, mut index: usize) -> usize {
+    while !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn ceil_char_boundary(value: &str, mut index: usize) -> usize {
+    while index < value.len() && !value.is_char_boundary(index) {
+        index += 1;
+    }
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::model::TranscriptRecordKind;
+    use tempfile::TempDir;
+
+    fn request(kind: TranscriptRecordKind, text: &str) -> TranscriptPersistRequest {
+        TranscriptPersistRequest {
+            run_id: "run-1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            step_name: "build".to_string(),
+            attempt: 1,
+            timestamp: chrono::Utc::now(),
+            kind,
+            payload: serde_json::json!({"text": text}),
+            truncated: None,
+        }
+    }
+
+    async fn read_records(temp_dir: &TempDir) -> Vec<crate::transcript::model::TranscriptRecord> {
+        let contents = tokio::fs::read_to_string(
+            temp_dir
+                .path()
+                .join(".ensemble/runs/run-1/steps/build/transcript.jsonl"),
+        )
+        .await
+        .unwrap();
+        contents
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn persistence_assigns_sequence_numbers() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+
+        persistence.send(request(TranscriptRecordKind::AssistantMessage, "one"));
+        persistence.send(request(TranscriptRecordKind::ToolCall, "tool"));
+        persistence.flush().await;
+
+        let records = read_records(&temp_dir).await;
+
+        assert_eq!(records[0].sequence, 1);
+        assert_eq!(records[1].sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn persistence_coalesces_adjacent_assistant_messages() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+
+        persistence.send(request(TranscriptRecordKind::AssistantMessage, "hel"));
+        persistence.send(request(TranscriptRecordKind::AssistantMessage, "lo"));
+        persistence.flush().await;
+
+        let records = read_records(&temp_dir).await;
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].payload["text"], "hello");
+    }
+
+    #[tokio::test]
+    async fn persistence_does_not_coalesce_when_attempt_differs() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+        let mut retry_request = request(TranscriptRecordKind::AssistantMessage, "two");
+        retry_request.attempt = 2;
+
+        persistence.send(request(TranscriptRecordKind::AssistantMessage, "one"));
+        persistence.send(retry_request);
+        persistence.flush().await;
+
+        let records = read_records(&temp_dir).await;
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].attempt, 1);
+        assert_eq!(records[0].payload["text"], "one");
+        assert_eq!(records[1].attempt, 2);
+        assert_eq!(records[1].payload["text"], "two");
+    }
+
+    #[tokio::test]
+    async fn persistence_does_not_coalesce_when_issue_identifier_differs() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+        let mut other_issue_request = request(TranscriptRecordKind::Reasoning, "second");
+        other_issue_request.issue_identifier = "repo#2".to_string();
+
+        persistence.send(request(TranscriptRecordKind::Reasoning, "first"));
+        persistence.send(other_issue_request);
+        persistence.flush().await;
+
+        let records = read_records(&temp_dir).await;
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].issue_identifier, "repo#1");
+        assert_eq!(records[0].payload["text"], "first");
+        assert_eq!(records[1].issue_identifier, "repo#2");
+        assert_eq!(records[1].payload["text"], "second");
+    }
+
+    #[tokio::test]
+    async fn persistence_does_not_coalesce_when_next_payload_has_extra_fields() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+        let mut metadata_request = request(TranscriptRecordKind::AssistantMessage, "lo");
+        metadata_request.payload = serde_json::json!({
+            "text": "lo",
+            "source": "tool"
+        });
+
+        persistence.send(request(TranscriptRecordKind::AssistantMessage, "hel"));
+        persistence.send(metadata_request);
+        persistence.flush().await;
+
+        let records = read_records(&temp_dir).await;
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].payload, serde_json::json!({"text": "hel"}));
+        assert_eq!(
+            records[1].payload,
+            serde_json::json!({"text": "lo", "source": "tool"})
+        );
+    }
+
+    #[tokio::test]
+    async fn persistence_does_not_coalesce_when_payload_metadata_values_differ() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+        let mut first_request = request(TranscriptRecordKind::Reasoning, "first");
+        first_request.payload = serde_json::json!({
+            "text": "first",
+            "source": "model"
+        });
+        let mut second_request = request(TranscriptRecordKind::Reasoning, "second");
+        second_request.payload = serde_json::json!({
+            "text": "second",
+            "source": "tool"
+        });
+
+        persistence.send(first_request);
+        persistence.send(second_request);
+        persistence.flush().await;
+
+        let records = read_records(&temp_dir).await;
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(
+            records[0].payload,
+            serde_json::json!({"text": "first", "source": "model"})
+        );
+        assert_eq!(
+            records[1].payload,
+            serde_json::json!({"text": "second", "source": "tool"})
+        );
+    }
+
+    #[test]
+    fn truncate_large_payload_keeps_head_and_tail() {
+        let input = "a".repeat(96 * 1024) + &"b".repeat(64 * 1024);
+        let (payload, truncation) =
+            truncate_tool_result_payload(serde_json::json!({"text": input}));
+
+        let truncation = truncation.expect("large payload should be truncated");
+        assert!(payload["text"].as_str().unwrap().starts_with("aaaa"));
+        assert!(payload["text"].as_str().unwrap().ends_with("bbbb"));
+        assert!(truncation.original_bytes > truncation.retained_head_bytes);
+        assert_eq!(truncation.retained_tail_bytes, TOOL_RESULT_TAIL_BYTES);
+    }
+}

--- a/crates/ensemble-core/src/transcript/persistence.rs
+++ b/crates/ensemble-core/src/transcript/persistence.rs
@@ -29,19 +29,26 @@ pub struct TranscriptPersistRequest {
 }
 
 pub struct TranscriptPersistence {
-    sender: Option<mpsc::Sender<TranscriptPersistRequest>>,
+    sender: Option<mpsc::Sender<TranscriptPersistCommand>>,
     handle: Option<JoinHandle<()>>,
 }
 
 impl TranscriptPersistence {
     pub fn new(workspace_root: PathBuf) -> Self {
         let writer = TranscriptWriter::new(workspace_root);
-        let (sender, mut receiver) = mpsc::channel::<TranscriptPersistRequest>(10_000);
+        let (sender, mut receiver) = mpsc::channel::<TranscriptPersistCommand>(10_000);
 
         let handle = tokio::spawn(async move {
             let mut state = PersistState::default();
-            while let Some(req) = receiver.recv().await {
-                state.write_request(&writer, req).await;
+            while let Some(command) = receiver.recv().await {
+                match command {
+                    TranscriptPersistCommand::Record(req) => {
+                        state.write_request(&writer, req).await;
+                    }
+                    TranscriptPersistCommand::FlushStep { run_id, step_name } => {
+                        state.flush_step(&writer, &run_id, &step_name).await;
+                    }
+                }
             }
             state.flush_all(&writer).await;
         });
@@ -53,8 +60,16 @@ impl TranscriptPersistence {
     }
 
     pub fn send(&self, request: TranscriptPersistRequest) {
+        self.send_command(TranscriptPersistCommand::Record(request));
+    }
+
+    pub fn flush_step(&self, run_id: String, step_name: String) {
+        self.send_command(TranscriptPersistCommand::FlushStep { run_id, step_name });
+    }
+
+    fn send_command(&self, command: TranscriptPersistCommand) {
         if let Some(sender) = &self.sender {
-            match sender.try_send(request) {
+            match sender.try_send(command) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Full(_)) => {
                     warn!("transcript persist channel full; transcript record dropped");
@@ -74,6 +89,11 @@ impl TranscriptPersistence {
             let _ = handle.await;
         }
     }
+}
+
+enum TranscriptPersistCommand {
+    Record(TranscriptPersistRequest),
+    FlushStep { run_id: String, step_name: String },
 }
 
 impl Drop for TranscriptPersistence {
@@ -223,7 +243,11 @@ fn is_text_only_payload(payload: &serde_json::Value) -> bool {
 pub fn truncate_tool_result_payload(
     payload: serde_json::Value,
 ) -> (serde_json::Value, Option<TranscriptTruncation>) {
-    let text = match payload.get("text").and_then(|value| value.as_str()) {
+    let text_path = match tool_result_text_path(&payload) {
+        Some(path) => path,
+        None => return (payload, None),
+    };
+    let text = match text_path.get(&payload) {
         Some(text) => text,
         None => return (payload, None),
     };
@@ -243,8 +267,52 @@ pub fn truncate_tool_result_payload(
     };
 
     let mut wrapper = payload;
-    wrapper["text"] = serde_json::Value::String(retained);
+    text_path.set(&mut wrapper, retained);
     (wrapper, Some(truncation))
+}
+
+#[derive(Clone, Copy)]
+enum ToolResultTextPath {
+    TopLevel,
+    Content,
+}
+
+impl ToolResultTextPath {
+    fn get<'a>(&self, payload: &'a serde_json::Value) -> Option<&'a str> {
+        match self {
+            Self::TopLevel => payload.get("text").and_then(|value| value.as_str()),
+            Self::Content => payload
+                .get("content")
+                .and_then(|content| content.get("text"))
+                .and_then(|value| value.as_str()),
+        }
+    }
+
+    fn set(&self, payload: &mut serde_json::Value, text: String) {
+        match self {
+            Self::TopLevel => payload["text"] = serde_json::Value::String(text),
+            Self::Content => payload["content"]["text"] = serde_json::Value::String(text),
+        }
+    }
+}
+
+fn tool_result_text_path(payload: &serde_json::Value) -> Option<ToolResultTextPath> {
+    if payload
+        .get("text")
+        .and_then(|value| value.as_str())
+        .is_some()
+    {
+        return Some(ToolResultTextPath::TopLevel);
+    }
+    if payload
+        .get("content")
+        .and_then(|content| content.get("text"))
+        .and_then(|value| value.as_str())
+        .is_some()
+    {
+        return Some(ToolResultTextPath::Content);
+    }
+    None
 }
 
 fn floor_char_boundary(value: &str, mut index: usize) -> usize {
@@ -322,6 +390,24 @@ mod tests {
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].payload["text"], "hello");
+    }
+
+    #[tokio::test]
+    async fn flush_step_persists_coalesced_message_without_closing_worker() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+
+        persistence.send(request(TranscriptRecordKind::AssistantMessage, "hello"));
+        persistence.flush_step("run-1".to_string(), "build".to_string());
+        persistence.send(request(TranscriptRecordKind::ToolCall, "tool"));
+        persistence.flush().await;
+
+        let records = read_records(&temp_dir).await;
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].kind, TranscriptRecordKind::AssistantMessage);
+        assert_eq!(records[0].payload["text"], "hello");
+        assert_eq!(records[1].kind, TranscriptRecordKind::ToolCall);
     }
 
     #[tokio::test]
@@ -431,5 +517,25 @@ mod tests {
         assert!(payload["text"].as_str().unwrap().ends_with("bbbb"));
         assert!(truncation.original_bytes > truncation.retained_head_bytes);
         assert_eq!(truncation.retained_tail_bytes, TOOL_RESULT_TAIL_BYTES);
+    }
+
+    #[test]
+    fn truncate_large_nested_content_payload_keeps_shape() {
+        let input = "a".repeat(96 * 1024) + &"b".repeat(64 * 1024);
+        let (payload, truncation) = truncate_tool_result_payload(serde_json::json!({
+            "tool_call_id": "call-1",
+            "content": {
+                "type": "text",
+                "text": input
+            }
+        }));
+
+        let truncation = truncation.expect("large nested payload should be truncated");
+        let text = payload["content"]["text"].as_str().unwrap();
+        assert!(text.starts_with("aaaa"));
+        assert!(text.contains("[truncated]"));
+        assert!(text.ends_with("bbbb"));
+        assert_eq!(payload["content"]["type"], "text");
+        assert_eq!(truncation.original_bytes, 160 * 1024);
     }
 }

--- a/crates/ensemble-core/src/transcript/reader.rs
+++ b/crates/ensemble-core/src/transcript/reader.rs
@@ -1,0 +1,181 @@
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::model::TranscriptRecord;
+use super::writer::TranscriptWriter;
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct TranscriptResponse {
+    pub records: Vec<TranscriptRecord>,
+    pub total: usize,
+    pub next_cursor: Option<usize>,
+}
+
+async fn read_transcript_file(path: &Path) -> Result<Option<String>, std::io::Error> {
+    match tokio::fs::read_to_string(path).await {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn parse_transcript_records(contents: &str) -> Result<Vec<TranscriptRecord>, serde_json::Error> {
+    contents.lines().map(serde_json::from_str).collect()
+}
+
+pub async fn read_transcript_page(
+    workspace_root: &Path,
+    run_id: &str,
+    step_name: &str,
+    cursor: Option<usize>,
+    limit: Option<usize>,
+) -> Result<TranscriptResponse, Box<dyn std::error::Error + Send + Sync>> {
+    let writer = TranscriptWriter::new(workspace_root.to_path_buf());
+    let path = writer.transcript_path(run_id, step_name)?;
+    let Some(contents) = read_transcript_file(&path).await? else {
+        return Ok(TranscriptResponse {
+            records: vec![],
+            total: 0,
+            next_cursor: None,
+        });
+    };
+
+    let records = parse_transcript_records(&contents)?;
+    let total = records.len();
+    let cursor = cursor.unwrap_or(0);
+    let limit = limit.unwrap_or(50).clamp(1, 200);
+    let page: Vec<TranscriptRecord> = records.into_iter().skip(cursor).take(limit).collect();
+    let next_cursor = if cursor + page.len() < total {
+        Some(cursor + page.len())
+    } else {
+        None
+    };
+
+    Ok(TranscriptResponse {
+        records: page,
+        total,
+        next_cursor,
+    })
+}
+
+pub async fn read_transcript_record(
+    workspace_root: &Path,
+    run_id: &str,
+    step_name: &str,
+    sequence: u64,
+) -> Result<Option<TranscriptRecord>, Box<dyn std::error::Error + Send + Sync>> {
+    let writer = TranscriptWriter::new(workspace_root.to_path_buf());
+    let path = writer.transcript_path(run_id, step_name)?;
+    let Some(contents) = read_transcript_file(&path).await? else {
+        return Ok(None);
+    };
+
+    let records = parse_transcript_records(&contents)?;
+    Ok(records
+        .into_iter()
+        .find(|record| record.sequence == sequence))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::model::{
+        TranscriptRecord, TranscriptRecordKind, TRANSCRIPT_SCHEMA_VERSION,
+    };
+    use crate::transcript::writer::TranscriptWriter;
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn sample_record(sequence: u64) -> TranscriptRecord {
+        TranscriptRecord {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION,
+            run_id: "run-1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            step_name: "build".to_string(),
+            attempt: 1,
+            sequence,
+            timestamp: Utc::now(),
+            kind: TranscriptRecordKind::AssistantMessage,
+            payload: serde_json::json!({"text": format!("message-{sequence}")}),
+            truncated: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_transcript_paginates_records() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer.append(&sample_record(1)).await.unwrap();
+        writer.append(&sample_record(2)).await.unwrap();
+        writer.append(&sample_record(3)).await.unwrap();
+
+        let response = read_transcript_page(temp_dir.path(), "run-1", "build", Some(1), Some(1))
+            .await
+            .unwrap();
+
+        assert_eq!(response.records.len(), 1);
+        assert_eq!(response.records[0].sequence, 2);
+        assert_eq!(response.total, 3);
+        assert_eq!(response.next_cursor, Some(2));
+    }
+
+    #[tokio::test]
+    async fn read_transcript_page_clamps_zero_limit_to_one() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer.append(&sample_record(1)).await.unwrap();
+        writer.append(&sample_record(2)).await.unwrap();
+
+        let response = read_transcript_page(temp_dir.path(), "run-1", "build", Some(0), Some(0))
+            .await
+            .unwrap();
+
+        assert_eq!(response.records.len(), 1);
+        assert_eq!(response.records[0].sequence, 1);
+        assert_eq!(response.total, 2);
+        assert_eq!(response.next_cursor, Some(1));
+    }
+
+    #[tokio::test]
+    async fn read_transcript_returns_empty_for_missing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let response = read_transcript_page(temp_dir.path(), "run-1", "build", None, None)
+            .await
+            .unwrap();
+
+        assert!(response.records.is_empty());
+        assert_eq!(response.total, 0);
+        assert_eq!(response.next_cursor, None);
+    }
+
+    #[tokio::test]
+    async fn read_transcript_record_finds_sequence() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer.append(&sample_record(9)).await.unwrap();
+
+        let record = read_transcript_record(temp_dir.path(), "run-1", "build", 9)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(record.sequence, 9);
+    }
+
+    #[tokio::test]
+    async fn read_transcript_record_finds_sequence_beyond_page_limit() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        for sequence in 1..=201 {
+            writer.append(&sample_record(sequence)).await.unwrap();
+        }
+
+        let record = read_transcript_record(temp_dir.path(), "run-1", "build", 201)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(record.sequence, 201);
+    }
+}

--- a/crates/ensemble-core/src/transcript/writer.rs
+++ b/crates/ensemble-core/src/transcript/writer.rs
@@ -1,0 +1,112 @@
+use std::path::{Path, PathBuf};
+
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+
+use super::model::{sanitize_run_path_segment, sanitize_step_path_segment, TranscriptRecord};
+
+#[derive(Debug, Clone)]
+pub struct TranscriptWriter {
+    workspace_root: PathBuf,
+}
+
+impl TranscriptWriter {
+    pub fn new(workspace_root: PathBuf) -> Self {
+        Self { workspace_root }
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+
+    pub fn transcript_path(
+        &self,
+        run_id: &str,
+        step_name: &str,
+    ) -> Result<PathBuf, std::io::Error> {
+        let run_id = sanitize_run_path_segment(run_id).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid run id")
+        })?;
+        let step_name = sanitize_step_path_segment(step_name).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid step name")
+        })?;
+
+        Ok(self
+            .workspace_root
+            .join(".ensemble")
+            .join("runs")
+            .join(run_id)
+            .join("steps")
+            .join(step_name)
+            .join("transcript.jsonl"))
+    }
+
+    pub async fn append(&self, record: &TranscriptRecord) -> Result<(), std::io::Error> {
+        let path = self.transcript_path(&record.run_id, &record.step_name)?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let mut line = serde_json::to_string(record)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        line.push('\n');
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        file.write_all(line.as_bytes()).await?;
+        file.flush().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::model::{
+        TranscriptRecord, TranscriptRecordKind, TRANSCRIPT_SCHEMA_VERSION,
+    };
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn sample_record(sequence: u64) -> TranscriptRecord {
+        TranscriptRecord {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION,
+            run_id: "run-1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            step_name: "build".to_string(),
+            attempt: 1,
+            sequence,
+            timestamp: Utc::now(),
+            kind: TranscriptRecordKind::AssistantMessage,
+            payload: serde_json::json!({"text": "hello"}),
+            truncated: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn append_writes_step_transcript_jsonl() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+
+        writer.append(&sample_record(1)).await.unwrap();
+
+        let path = writer.transcript_path("run-1", "build").unwrap();
+        let contents = tokio::fs::read_to_string(path).await.unwrap();
+        let parsed: TranscriptRecord =
+            serde_json::from_str(contents.lines().next().unwrap()).unwrap();
+        assert_eq!(parsed.sequence, 1);
+        assert_eq!(parsed.step_name, "build");
+    }
+
+    #[test]
+    fn transcript_path_rejects_unsafe_segments() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+
+        assert!(writer.transcript_path("../run", "build").is_err());
+        assert!(writer.transcript_path("run-1", "../build").is_err());
+    }
+}

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -448,11 +448,7 @@ async fn test_app_with_workspace_root(workspace_root: &std::path::Path) -> Strin
 async fn get_step_conversation_returns_transcript_records() {
     let temp = tempfile::TempDir::new().unwrap();
     let base_url = test_app_with_workspace_root(temp.path()).await;
-    let workspace_key = ensemble_core::tracker::model::sanitize_workspace_key("repo#1").unwrap();
-    let transcript_dir = temp
-        .path()
-        .join(workspace_key)
-        .join(".ensemble/runs/run-1/steps/build");
+    let transcript_dir = temp.path().join(".ensemble/runs/run-1/steps/build");
     tokio::fs::create_dir_all(&transcript_dir).await.unwrap();
     tokio::fs::write(
         transcript_dir.join("transcript.jsonl"),

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -438,6 +438,70 @@ fn build_empty_app_state() -> (AppState, TempDir) {
     (app_state, temp_dir)
 }
 
+async fn test_app_with_workspace_root(workspace_root: &std::path::Path) -> String {
+    let (mut app_state, _temp_dir) = build_empty_app_state();
+    app_state.workspace_root = workspace_root.display().to_string();
+    start_test_server(app_state).await
+}
+
+#[tokio::test]
+async fn get_step_conversation_returns_transcript_records() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let base_url = test_app_with_workspace_root(temp.path()).await;
+    let workspace_key = ensemble_core::tracker::model::sanitize_workspace_key("repo#1").unwrap();
+    let transcript_dir = temp
+        .path()
+        .join(workspace_key)
+        .join(".ensemble/runs/run-1/steps/build");
+    tokio::fs::create_dir_all(&transcript_dir).await.unwrap();
+    tokio::fs::write(
+        transcript_dir.join("transcript.jsonl"),
+        r#"{"schema_version":1,"run_id":"run-1","issue_identifier":"repo#1","step_name":"build","attempt":1,"sequence":1,"timestamp":"2026-06-14T00:00:00Z","kind":"assistant_message","payload":{"text":"hello"}}"#,
+    )
+    .await
+    .unwrap();
+
+    let response = reqwest::get(format!(
+        "{base_url}/api/v1/repo%231/runs/run-1/steps/build/conversation"
+    ))
+    .await
+    .unwrap();
+
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(body["records"][0]["kind"], "assistant_message");
+    assert_eq!(body["records"][0]["payload"]["text"], "hello");
+}
+
+#[tokio::test]
+async fn old_issue_conversation_route_is_removed() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let base_url = test_app_with_workspace_root(temp.path()).await;
+
+    let response = reqwest::get(format!("{base_url}/api/v1/repo%231/conversation"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_step_conversation_record_returns_not_found_for_missing_sequence() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let base_url = test_app_with_workspace_root(temp.path()).await;
+
+    let response = reqwest::get(format!(
+        "{base_url}/api/v1/repo%231/runs/run-1/steps/build/conversation/99"
+    ))
+    .await
+    .unwrap();
+    let status = response.status();
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+    assert_eq!(body["error"]["code"], "transcript_record_not_found");
+}
+
 #[tokio::test]
 async fn test_api_unknown_route_returns_json_404() {
     let (app_state, _temp_dir) = build_empty_app_state();

--- a/crates/ensemble-core/tests/openapi_spec.rs
+++ b/crates/ensemble-core/tests/openapi_spec.rs
@@ -2,6 +2,23 @@ use ensemble_core::api::openapi::ApiDoc;
 use utoipa::OpenApi;
 
 #[test]
+fn openapi_documents_step_conversation_routes() {
+    let spec: serde_json::Value =
+        serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+
+    assert!(
+        spec["paths"]["/api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation"]["get"]
+            .is_object()
+    );
+    assert!(spec["paths"]
+        ["/api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation/{sequence}"]["get"]
+        .is_object());
+    assert!(spec["paths"]["/api/v1/{identifier}/conversation"].is_null());
+    assert!(spec["components"]["schemas"]["TranscriptResponse"].is_object());
+    assert!(spec["components"]["schemas"]["TranscriptRecord"].is_object());
+}
+
+#[test]
 #[ignore = "writes generated OpenAPI output for frontend codegen"]
 fn write_openapi_spec() {
     let spec = ApiDoc::openapi().to_pretty_json().unwrap();

--- a/crates/ensemble-ui/src-ui/src/components/ConversationViewer.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ConversationViewer.tsx
@@ -1,45 +1,62 @@
 import { useState } from "react";
-import { useConversationQuery } from "@/hooks";
-import type { ConversationMessage } from "@/generated/models";
+import { useStepConversationQuery } from "@/hooks";
+import type { TranscriptRecord } from "@/generated/models";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface ConversationViewerProps {
   identifier: string;
+  runId: string;
+  stepName: string;
   scrollToIndex?: number;
 }
 
-function MessageBubble({ msg, highlight }: { msg: ConversationMessage; highlight?: boolean }) {
+function recordText(record: TranscriptRecord): string {
+  if (typeof record.payload === "object" && record.payload != null && "text" in record.payload) {
+    return String((record.payload as { text?: unknown }).text ?? "");
+  }
+  return JSON.stringify(record.payload);
+}
+
+function MessageBubble({ record, highlight }: { record: TranscriptRecord; highlight?: boolean }) {
   return (
     <div
-      id={`msg-${msg.index}`}
+      id={`msg-${record.sequence}`}
       className={cn(
         "rounded-lg p-3 border bg-card",
         highlight && "ring-2 ring-primary",
       )}
     >
       <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
-        <span className="font-medium capitalize">{msg.role}</span>
-        <span>#{msg.index}</span>
+        <span className="font-medium capitalize">{record.kind.replace(/_/g, " ")}</span>
+        <span>#{record.sequence}</span>
       </div>
-      <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
-      {msg.tool_calls != null && (
+      <p className="text-sm whitespace-pre-wrap">{recordText(record)}</p>
+      {record.payload != null && record.kind !== "assistant_message" ? (
         <details className="mt-2">
           <summary className="text-xs text-muted-foreground cursor-pointer hover:underline">
-            Tool calls
+            Payload
           </summary>
           <pre className="mt-1 text-xs bg-muted rounded p-2 overflow-x-auto whitespace-pre-wrap">
-            {JSON.stringify(msg.tool_calls, null, 2)}
+            {JSON.stringify(record.payload, null, 2)}
           </pre>
         </details>
-      )}
+      ) : null}
     </div>
   );
 }
 
-export default function ConversationViewer({ identifier, scrollToIndex }: ConversationViewerProps) {
+export default function ConversationViewer({
+  identifier,
+  runId,
+  stepName,
+  scrollToIndex,
+}: ConversationViewerProps) {
   const [cursor, setCursor] = useState<string | undefined>();
-  const { data, isLoading, isError } = useConversationQuery(identifier, cursor);
+  const { data, isLoading, isError } = useStepConversationQuery(identifier, runId, stepName, {
+    cursor: cursor ? Number(cursor) : undefined,
+    limit: 50,
+  });
 
   if (isLoading) {
     return <div className="text-center py-8 text-muted-foreground">Loading conversation...</div>;
@@ -49,17 +66,17 @@ export default function ConversationViewer({ identifier, scrollToIndex }: Conver
     return <div className="text-center py-8 text-destructive">Failed to load conversation.</div>;
   }
 
-  if (!data || data.messages.length === 0) {
+  if (!data || data.records.length === 0) {
     return <div className="text-center py-8 text-muted-foreground">No conversation data.</div>;
   }
 
   return (
     <div className="space-y-3">
-      {data.messages.map((msg) => (
+      {data.records.map((record) => (
         <MessageBubble
-          key={msg.index}
-          msg={msg}
-          highlight={scrollToIndex === msg.index}
+          key={record.sequence}
+          record={record}
+          highlight={scrollToIndex === record.sequence}
         />
       ))}
 

--- a/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.test.ts
+++ b/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.test.ts
@@ -85,6 +85,106 @@ describe("buildTranscriptEntries", () => {
     });
   });
 
+  it("maps transcript records into agent and tool activity entries", () => {
+    const entries = buildTranscriptEntries({
+      conversation: [],
+      transcriptRecords: [
+        {
+          schema_version: 1,
+          run_id: "run-1",
+          issue_identifier: "repo#1",
+          step_name: "build",
+          attempt: 1,
+          sequence: 1,
+          timestamp: "2026-06-14T00:00:00Z",
+          kind: "assistant_message",
+          payload: { text: "hello" },
+        },
+        {
+          schema_version: 1,
+          run_id: "run-1",
+          issue_identifier: "repo#1",
+          step_name: "build",
+          attempt: 1,
+          sequence: 2,
+          timestamp: "2026-06-14T00:00:01Z",
+          kind: "tool_call",
+          payload: { name: "read_file", arguments: { path: "Cargo.toml" } },
+        },
+      ],
+      interactions: [],
+      events: [],
+    });
+
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "agent_message" }),
+        expect.objectContaining({ kind: "tool_activity" }),
+      ]),
+    );
+  });
+
+  it("maps non-message transcript records into visible entries", () => {
+    const entries = buildTranscriptEntries({
+      conversation: [],
+      transcriptRecords: [
+        {
+          schema_version: 1,
+          run_id: "run-1",
+          issue_identifier: "repo#1",
+          step_name: "build",
+          attempt: 1,
+          sequence: 1,
+          timestamp: "2026-06-14T00:00:00Z",
+          kind: "error",
+          payload: { text: "tool failed" },
+        },
+        {
+          schema_version: 1,
+          run_id: "run-1",
+          issue_identifier: "repo#1",
+          step_name: "build",
+          attempt: 1,
+          sequence: 2,
+          timestamp: "2026-06-14T00:00:01Z",
+          kind: "permission_request",
+          payload: { text: "May I write files?" },
+        },
+        {
+          schema_version: 1,
+          run_id: "run-1",
+          issue_identifier: "repo#1",
+          step_name: "build",
+          attempt: 1,
+          sequence: 3,
+          timestamp: "2026-06-14T00:00:02Z",
+          kind: "turn_complete",
+          payload: { text: "turn finished" },
+        },
+      ],
+      interactions: [],
+      events: [],
+    });
+
+    expect(entries).toEqual([
+      expect.objectContaining({ kind: "error", message: "tool failed" }),
+      expect.objectContaining({
+        kind: "tool_activity",
+        event: expect.objectContaining({
+          type: "permission_request",
+          detail: "May I write files?",
+        }),
+      }),
+      expect.objectContaining({
+        kind: "workflow_event",
+        event: expect.objectContaining({
+          type: "turn_complete",
+          detail: "turn finished",
+        }),
+      }),
+    ]);
+  });
+
   it("classifies workflow and error events distinctly", () => {
     const source: TranscriptSource = {
       conversation: [],

--- a/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.ts
+++ b/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.ts
@@ -1,8 +1,17 @@
-import type { ConversationMessage, InteractionDetail } from "@/generated/models";
+import type { InteractionDetail, TranscriptRecord } from "@/generated/models";
 import type { WsEventData } from "@/ws-types";
+
+export interface ConversationMessage {
+  index: number;
+  role: string;
+  content: string;
+  tool_calls: unknown;
+  tool_output?: unknown;
+}
 
 export interface TranscriptSource {
   conversation: ConversationMessage[];
+  transcriptRecords?: TranscriptRecord[];
   interactions: InteractionDetail[];
   events: WsEventData[];
 }
@@ -129,6 +138,80 @@ function eventPriority(eventType: string): number {
 
 function interactionSequence(index: number): number {
   return index;
+}
+
+function payloadText(payload: unknown): string {
+  if (typeof payload === "object" && payload != null && "text" in payload) {
+    return String((payload as { text?: unknown }).text ?? "");
+  }
+  const json = JSON.stringify(payload);
+  return json ?? "";
+}
+
+function transcriptRecordEvent(record: TranscriptRecord, detail: string): WsEventData {
+  return {
+    type: record.kind,
+    timestamp: record.timestamp,
+    detail,
+    runId: record.run_id,
+    sequence: record.sequence,
+    stepName: record.step_name,
+    attempt: record.attempt,
+  };
+}
+
+function entryFromTranscriptRecord(record: TranscriptRecord): TranscriptEntry | null {
+  const timestamp = record.timestamp;
+  const id = `transcript:${record.run_id}:${record.step_name}:${record.sequence}`;
+  const text = payloadText(record.payload);
+
+  if (record.kind === "assistant_message") {
+    return {
+      kind: "agent_message",
+      id,
+      message: {
+        index: record.sequence,
+        role: "assistant",
+        content: text,
+        tool_calls: null,
+        tool_output: null,
+      },
+      timestamp,
+    };
+  }
+
+  if (record.kind === "error") {
+    return {
+      kind: "error",
+      id,
+      message: text,
+      timestamp,
+    };
+  }
+
+  if (
+    record.kind === "reasoning" ||
+    record.kind === "tool_call" ||
+    record.kind === "tool_result" ||
+    record.kind === "prompt" ||
+    record.kind === "permission_request" ||
+    record.kind === "permission_resolution" ||
+    record.kind === "raw"
+  ) {
+    return {
+      kind: "tool_activity",
+      id,
+      event: transcriptRecordEvent(record, text),
+      timestamp,
+    };
+  }
+
+  return {
+    kind: "workflow_event",
+    id,
+    event: transcriptRecordEvent(record, text),
+    timestamp,
+  };
 }
 
 function earliestInteractionTimestamp(interactions: InteractionDetail[]): string | null {
@@ -299,6 +382,17 @@ function reuseGroupedEntries(
 
 export function buildTranscriptEntries(source: TranscriptSource): TranscriptEntry[] {
   const sortable: SortableEntry[] = [];
+
+  for (const record of source.transcriptRecords ?? []) {
+    const entry = entryFromTranscriptRecord(record);
+    if (entry == null) continue;
+    sortable.push({
+      entry,
+      sortTimestamp: toMs(record.timestamp),
+      sortSequence: record.sequence,
+      sortPriority: TRANSCRIPT_SORT_PRIORITY.agentOrTool,
+    });
+  }
 
   for (const event of source.events) {
     const entryId = `event:${event.runId ?? "run"}:${event.sequence ?? event.timestamp}:${event.type}`;

--- a/crates/ensemble-ui/src-ui/src/hooks.ts
+++ b/crates/ensemble-ui/src-ui/src/hooks.ts
@@ -26,13 +26,13 @@ import {
   getConfig,
   getSetupDefaults,
 } from "./generated/api/config/config";
-import { getConversation } from "./generated/api/conversation/conversation";
+import { getStepConversation } from "./generated/api/conversation/conversation";
 import type {
-  GetConversationParams,
+  GetStepConversationParams,
   GetHistoryParams,
   RuntimeSnapshot,
   IssueDetailSnapshot,
-  ConversationResponse,
+  TranscriptResponse,
   HistoryResponse,
   ConfigStateResponse,
   GuidedConfigForm,
@@ -200,18 +200,18 @@ export function useInteractionDetailQuery(id: string) {
   });
 }
 
-export function useConversationQuery(identifier: string, cursor?: string) {
-  const params: GetConversationParams = {
-    cursor: cursor ? Number(cursor) : undefined,
-    limit: 50,
-  };
-
+export function useStepConversationQuery(
+  identifier: string,
+  runId: string,
+  stepName: string,
+  params: GetStepConversationParams = {},
+) {
   return useQuery({
-    queryKey: ["getConversation", identifier, cursor],
-    enabled: identifier.length > 0,
-    queryFn: async (): Promise<ConversationResponse> => {
-      const resp = await getConversation(identifier, params);
-      return resp.data as ConversationResponse;
+    queryKey: ["getStepConversation", identifier, runId, stepName, params],
+    enabled: identifier.length > 0 && runId.length > 0 && stepName.length > 0,
+    queryFn: async (): Promise<TranscriptResponse> => {
+      const resp = await getStepConversation(identifier, runId, stepName, params);
+      return resp.data as TranscriptResponse;
     },
   });
 }

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
@@ -68,10 +68,20 @@ const hooksMock = vi.hoisted(() => {
       },
     })),
     useTimelineQuery: vi.fn(() => ({ data: { events: [] }, isError: false })),
-    useConversationQuery: vi.fn(() => ({
+    useStepConversationQuery: vi.fn(() => ({
       data: {
-        messages: [
-          { index: 1, role: "assistant", content: "I am ready", tool_calls: null },
+        records: [
+          {
+            schema_version: 1,
+            run_id: "run-1",
+            issue_identifier: "todo-1",
+            step_name: "deploy",
+            attempt: 1,
+            sequence: 1,
+            timestamp: "2026-04-14T10:00:01Z",
+            kind: "assistant_message",
+            payload: { text: "I am ready" },
+          },
         ],
       },
       isLoading: false,
@@ -255,13 +265,18 @@ describe("IssueDetail", () => {
     const user = userEvent.setup();
     const connectWsMock = vi.mocked(connectWs);
 
-    hooksMock.useConversationQuery.mockImplementation(() => ({
+    hooksMock.useStepConversationQuery.mockImplementation(() => ({
       data: {
-        messages: Array.from({ length: 55 }, (_, index) => ({
-          index: index + 1,
-          role: "user",
-          content: `history message ${index + 1}`,
-          tool_calls: null,
+        records: Array.from({ length: 55 }, (_, index) => ({
+          schema_version: 1,
+          run_id: "run-1",
+          issue_identifier: "todo-1",
+          step_name: "deploy",
+          attempt: 1,
+          sequence: index + 1,
+          timestamp: `2026-04-14T10:${String(index).padStart(2, "0")}:00Z`,
+          kind: "assistant_message",
+          payload: { text: `history message ${index + 1}` },
         })),
       },
       isLoading: false,
@@ -336,13 +351,18 @@ describe("IssueDetail", () => {
       error: null,
     }));
 
-    hooksMock.useConversationQuery.mockImplementation(() => ({
+    hooksMock.useStepConversationQuery.mockImplementation(() => ({
       data: {
-        messages: Array.from({ length: 55 }, (_, index) => ({
-          index: index + 1,
-          role: "user",
-          content: `${currentPrefix} message ${index + 1}`,
-          tool_calls: null,
+        records: Array.from({ length: 55 }, (_, index) => ({
+          schema_version: 1,
+          run_id: currentRunId,
+          issue_identifier: "todo-1",
+          step_name: "deploy",
+          attempt: 1,
+          sequence: index + 1,
+          timestamp: `2026-04-14T10:${String(index).padStart(2, "0")}:00Z`,
+          kind: "assistant_message",
+          payload: { text: `${currentPrefix} message ${index + 1}` },
         })),
       },
       isLoading: false,
@@ -401,5 +421,195 @@ describe("IssueDetail", () => {
     expect(screen.getByRole("button", { name: "Load older activity" })).toBeInTheDocument();
     expect(screen.queryByText("session two message 5")).not.toBeInTheDocument();
     expect(screen.getByText("session two message 55")).toBeInTheDocument();
+  });
+
+  it("resets transcript history after rerendering with a different step in the same run", async () => {
+    const user = userEvent.setup();
+    let currentStepName = "build";
+
+    hooksMock.useIssueDetailQuery.mockImplementation(() => ({
+      data: {
+        issue_identifier: "todo-1",
+        status: "running",
+        running: {
+          step_name: currentStepName,
+          turn_count: 2,
+          tokens: { total_tokens: 100 },
+          run_id: "run-1",
+        },
+        attempts: { restart_count: 0 },
+        retry: null,
+        last_error: null,
+        issue: { title: "Deploy feature", labels: [] },
+        workspace: { path: "/tmp/workspace" },
+        workflow_steps: [
+          {
+            name: currentStepName,
+            agent: "builder",
+            dependencies: [],
+            state: "running",
+            can_navigate: true,
+          },
+        ],
+        pending_input: { ask_id: "ask-1" },
+        current_interaction: { interaction_request_id: "ask-1" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+
+    hooksMock.useStepConversationQuery.mockImplementation(() => ({
+      data: {
+        records: Array.from({ length: 55 }, (_, index) => ({
+          schema_version: 1,
+          run_id: "run-1",
+          issue_identifier: "todo-1",
+          step_name: currentStepName,
+          attempt: 1,
+          sequence: index + 1,
+          timestamp: `2026-04-14T10:${String(index).padStart(2, "0")}:00Z`,
+          kind: "assistant_message",
+          payload: { text: `${currentStepName} message ${index + 1}` },
+        })),
+      },
+      isLoading: false,
+      isError: false,
+    }));
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/issue/todo-1"]}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const view = render(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { wrapper },
+    );
+
+    expect(screen.queryByText("build message 1")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Load older activity" }));
+    expect(screen.getByText("build message 1")).toBeInTheDocument();
+
+    currentStepName = "review";
+
+    view.rerender(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+    );
+
+    expect(screen.getByRole("button", { name: "Load older activity" })).toBeInTheDocument();
+    expect(screen.queryByText("review message 1")).not.toBeInTheDocument();
+    expect(screen.getByText("review message 55")).toBeInTheDocument();
+  });
+
+  it("keeps querying the last running step after the run completes", () => {
+    let isRunning = true;
+
+    hooksMock.useIssueDetailQuery.mockImplementation(() => ({
+      data: {
+        issue_identifier: "todo-1",
+        status: isRunning ? "running" : "completed",
+        running: isRunning
+          ? {
+              step_name: "build",
+              turn_count: 2,
+              tokens: { total_tokens: 100 },
+              run_id: "run-1",
+            }
+          : null,
+        attempts: { restart_count: 0 },
+        retry: null,
+        last_error: null,
+        issue: { title: "Deploy feature", labels: [] },
+        workspace: { path: "/tmp/workspace" },
+        workflow_steps: [
+          {
+            name: "build",
+            agent: "builder",
+            dependencies: [],
+            state: isRunning ? "running" : "completed",
+            can_navigate: true,
+          },
+        ],
+        pending_input: { ask_id: "ask-1" },
+        current_interaction: { interaction_request_id: "ask-1" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    }) as ReturnType<typeof hooksMock.useIssueDetailQuery>);
+
+    hooksMock.useStepConversationQuery.mockImplementation(((
+      _identifier: string,
+      _runId: string,
+      stepName: string,
+    ) => ({
+      data: {
+        records:
+          stepName === "build"
+            ? [
+                {
+                  schema_version: 1,
+                  run_id: "run-1",
+                  issue_identifier: "todo-1",
+                  step_name: "build",
+                  attempt: 1,
+                  sequence: 1,
+                  timestamp: "2026-04-14T10:00:01Z",
+                  kind: "assistant_message",
+                  payload: { text: isRunning ? "running build record" : "completed build record" },
+                },
+              ]
+            : [],
+      },
+      isLoading: false,
+      isError: false,
+    })) as () => ReturnType<typeof hooksMock.useStepConversationQuery>);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/issue/todo-1"]}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const view = render(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { wrapper },
+    );
+
+    expect(screen.getByText("running build record")).toBeInTheDocument();
+
+    isRunning = false;
+
+    view.rerender(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+    );
+
+    expect(hooksMock.useStepConversationQuery).toHaveBeenLastCalledWith(
+      "todo-1",
+      "run-1",
+      "build",
+      { limit: 200 },
+    );
+    expect(screen.getByText("completed build record")).toBeInTheDocument();
   });
 });

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
@@ -3,11 +3,11 @@ import { Link, useParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import {
   useCancelInteractionMutation,
-  useConversationQuery,
   useInteractionDetailQuery,
   useIssueDetailQuery,
   useIssueInputMutation,
   useRetryMutation,
+  useStepConversationQuery,
   useStopMutation,
   useTimelineQuery,
 } from "@/hooks";
@@ -57,7 +57,6 @@ export default function IssueDetail() {
     data?.current_interaction?.interaction_request_id ??
     "";
   const { data: interaction } = useInteractionDetailQuery(interactionId);
-  const conversationQuery = useConversationQuery(identifier);
   const stopMutation = useStopMutation();
   const retryMutation = useRetryMutation();
   const inputMutation = useIssueInputMutation(identifier, interactionId);
@@ -68,9 +67,11 @@ export default function IssueDetail() {
   const [showStopConfirm, setShowStopConfirm] = useState(false);
   const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
   const [lastKnownRunId, setLastKnownRunId] = useState("");
+  const [lastKnownStepName, setLastKnownStepName] = useState("");
 
   const isLiveRun = data?.running != null;
   const currentRunId = (data?.running as { run_id?: string } | undefined)?.run_id;
+  const currentStepName = data?.running?.step_name ?? null;
 
   useEffect(() => {
     if (currentRunId) {
@@ -80,8 +81,20 @@ export default function IssueDetail() {
     }
   }, [currentRunId]);
 
+  useEffect(() => {
+    if (currentStepName) {
+      setLastKnownStepName((previousStepName) =>
+        previousStepName === currentStepName ? previousStepName : currentStepName,
+      );
+    }
+  }, [currentStepName]);
+
   const effectiveRunId = currentRunId ?? lastKnownRunId;
-  const transcriptSessionKey = `${identifier}:${effectiveRunId || "no-run"}`;
+  const activeStepName = currentStepName ?? lastKnownStepName;
+  const transcriptQuery = useStepConversationQuery(identifier, effectiveRunId, activeStepName ?? "", {
+    limit: 200,
+  });
+  const transcriptSessionKey = `${identifier}:${effectiveRunId || "no-run"}:${activeStepName ?? "no-step"}`;
   const activeEntrySessionKeyRef = useRef(transcriptSessionKey);
   const timelineQuery = useTimelineQuery(identifier, effectiveRunId);
   const persistedEvents = useMemo(
@@ -166,7 +179,8 @@ export default function IssueDetail() {
         : undefined;
 
     const nextEntries = reconcileGroupedTranscriptEntries(previousEntries, {
-      conversation: conversationQuery.data?.messages ?? [],
+      conversation: [],
+      transcriptRecords: transcriptQuery.data?.records ?? [],
       interactions: interaction ? [interaction] : [],
       events,
     });
@@ -175,7 +189,12 @@ export default function IssueDetail() {
     transcriptEntriesSessionKeyRef.current = transcriptSessionKey;
 
     return nextEntries;
-  }, [conversationQuery.data?.messages, interaction, events, transcriptSessionKey]);
+  }, [transcriptQuery.data?.records, interaction, events, transcriptSessionKey]);
+
+  const transcriptEntryIdForConversationIndex = (index: number) =>
+    activeStepName
+      ? `transcript:${effectiveRunId}:${activeStepName}:${index}`
+      : `message:${index}`;
 
   useEffect(() => {
     activeEntrySessionKeyRef.current = transcriptSessionKey;
@@ -252,7 +271,7 @@ export default function IssueDetail() {
         live={isLiveRun}
         onViewConversation={(index) => {
         activeEntrySessionKeyRef.current = transcriptSessionKey;
-        setActiveEntryId(`message:${index}`);
+        setActiveEntryId(transcriptEntryIdForConversationIndex(index));
       }}
       />
     </div>
@@ -262,7 +281,7 @@ export default function IssueDetail() {
       live={isLiveRun}
       onViewConversation={(index) => {
         activeEntrySessionKeyRef.current = transcriptSessionKey;
-        setActiveEntryId(`message:${index}`);
+        setActiveEntryId(transcriptEntryIdForConversationIndex(index));
       }}
     />
   );

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1434,7 +1434,23 @@ Line handling requirements:
   - ignore it or log it as diagnostics
   - do not attempt protocol JSON parsing on stderr
 
-### 10.4 Emitted Runtime Events (Upstream to Orchestrator)
+### 10.4 Per-Step Conversation Transcripts
+
+For each pipeline step, Ensemble persists a typed JSONL transcript at:
+
+```text
+{workspace}/.ensemble/runs/{run_id}/steps/{step_name}/transcript.jsonl
+```
+
+Transcript records are distinct from timeline events. Timeline events summarize run progress;
+transcript records preserve step-level agent activity such as assistant messages, exposed reasoning
+chunks, tool calls, tool results, permission activity, turn completion, prompts, and errors.
+
+Large tool results are truncated with head and tail retention. Adjacent assistant and reasoning
+deltas may be coalesced before persistence. Transcript persistence failures are logged and do not
+fail the agent step.
+
+### 10.5 Emitted Runtime Events (Upstream to Orchestrator)
 
 The active runtime emits structured events to the orchestrator callback. Each event should
 include:
@@ -1459,7 +1475,7 @@ Important emitted events may include:
 - `other_message` — unrecognized JSON-RPC message
 - `malformed` — unparseable line
 
-### 10.5 Permission, Tool Calls, and User Input Policy
+### 10.6 Permission, Tool Calls, and User Input Policy
 
 Permission and user-input behavior on direct ACP paths is governed by `agent.permission_request_policy`.
 
@@ -1564,7 +1580,7 @@ Human interaction requirement:
 - First valid command wins immediately (request-level lock). Later valid/invalid commands are ignored
   for state transitions and may be audited as ignored events.
 
-### 10.6 Timeouts and Error Mapping
+### 10.7 Timeouts and Error Mapping
 
 Timeouts:
 
@@ -1585,7 +1601,7 @@ Error mapping (recommended normalized categories):
 - `turn_failed`
 - `turn_cancelled`
 
-### 10.7 Agent Runner Contract
+### 10.8 Agent Runner Contract
 
 The `Agent Runner` wraps workspace + prompt + ACP session client.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -205,6 +205,18 @@ POST /api/v1/{identifier}/retry?step=review
 
 Without `step`, the retry endpoint keeps its whole-issue behavior: it releases the retry claim so the next poll can pick the issue up fresh.
 
+## Step transcripts
+
+Each run step writes a drill-down transcript to:
+
+```text
+.ensemble/runs/{run_id}/steps/{step_name}/transcript.jsonl
+```
+
+Use the timeline to understand step state transitions. Use the step transcript when you need the
+agent conversation details: assistant output, exposed reasoning, tool activity, permission events,
+and turn completion records.
+
 ## Example: build + review pipeline
 
 A common pattern: one agent implements, another reviews.

--- a/docs/superpowers/plans/2026-06-14-per-step-conversation-transcript.md
+++ b/docs/superpowers/plans/2026-06-14-per-step-conversation-transcript.md
@@ -1,0 +1,1968 @@
+# Per-Step Conversation Transcript Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist and serve one typed JSONL conversation transcript per pipeline step, replacing the old issue-level conversation route with run/step-scoped transcript data.
+
+**Architecture:** Add a focused `transcript` module for record models, writing, persistence, coalescing, truncation, and reading. Extend ACP parsing and runtime events so transcript-worthy protocol blocks reach the orchestrator before data is lost, then expose those files through run/step-scoped API routes and update the UI transcript model to consume the new record shape.
+
+**Tech Stack:** Rust 2021, Tokio, Serde/serde_json, Chrono, Axum, Utoipa, existing ACP runtime/parser code, React/TypeScript/Vitest frontend, Orval-generated API client.
+
+---
+
+## Scope Check
+
+This plan implements one cohesive feature from the approved spec:
+
+- backend transcript persistence
+- ACP runtime transcript extraction
+- run/step-scoped conversation API
+- frontend consumption of transcript records
+- documentation and product E2E coverage
+
+Although it crosses backend and frontend, the UI depends directly on the new API contract, so it should stay in one implementation plan.
+
+## File Structure
+
+- Create `crates/ensemble-core/src/transcript/mod.rs`  
+  Re-export transcript model, writer, persistence, and reader APIs.
+- Create `crates/ensemble-core/src/transcript/model.rs`  
+  Define `TranscriptRecord`, `TranscriptRecordKind`, payload structs, truncation metadata, and request/path-safe identifiers.
+- Create `crates/ensemble-core/src/transcript/writer.rs`  
+  Own filesystem paths and append-only JSONL writes.
+- Create `crates/ensemble-core/src/transcript/persistence.rs`  
+  Own async channel, sequencing, coalescing, truncation, and flush behavior.
+- Create `crates/ensemble-core/src/transcript/reader.rs`  
+  Read, parse, paginate, and lookup transcript records.
+- Modify `crates/ensemble-core/src/lib.rs`  
+  Add `pub mod transcript;`.
+- Modify `crates/ensemble-core/src/agent/protocol.rs`  
+  Extract transcript blocks from ACP `session/update` payloads without changing existing verdict/token parsing.
+- Modify `crates/ensemble-core/src/agent/events.rs`  
+  Add transcript event payloads to `AgentEvent`.
+- Modify `crates/ensemble-core/src/agent/acpx_cli.rs`  
+  Emit transcript blocks from the acpx JSON-RPC path.
+- Modify `crates/ensemble-core/src/agent/acp_client.rs`  
+  Emit transcript blocks from the direct ACP SDK path.
+- Modify `crates/ensemble-core/src/orchestrator/mod.rs`  
+  Add `TranscriptPersistence`, persist transcript blocks with run context, and flush on shutdown.
+- Rewrite `crates/ensemble-core/src/api/conversation.rs`  
+  Replace old issue-level conversation shape with run/step-scoped transcript endpoints.
+- Modify `crates/ensemble-core/src/api/router.rs`  
+  Mount new route paths and remove old route paths.
+- Modify `crates/ensemble-core/src/api/openapi.rs`  
+  Replace old conversation schemas with transcript response schemas.
+- Modify `crates/ensemble-core/tests/api_endpoints.rs` and `crates/ensemble-cli/tests/product_e2e.rs`  
+  Cover route behavior and end-to-end transcript persistence.
+- Modify `crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.ts` and tests  
+  Map generated transcript records into existing UI transcript entries.
+- Modify `crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx` and tests  
+  Fetch step-scoped transcript records instead of the old issue-level conversation messages.
+- Update `docs/SPEC.md` and `docs/pipelines.md`  
+  Document the new transcript persistence and debugging contract.
+
+---
+
+### Task 1: Transcript Model, Writer, And Reader
+
+**Files:**
+- Create: `crates/ensemble-core/src/transcript/mod.rs`
+- Create: `crates/ensemble-core/src/transcript/model.rs`
+- Create: `crates/ensemble-core/src/transcript/writer.rs`
+- Create: `crates/ensemble-core/src/transcript/reader.rs`
+- Modify: `crates/ensemble-core/src/lib.rs`
+
+- [ ] **Step 1: Write failing model, writer, and reader tests**
+
+Add tests in the new files as shown below.
+
+In `crates/ensemble-core/src/transcript/model.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_step_path_segment_accepts_pipeline_names() {
+        assert_eq!(sanitize_step_path_segment("build").unwrap(), "build");
+        assert_eq!(sanitize_step_path_segment("review-step").unwrap(), "review-step");
+        assert_eq!(sanitize_step_path_segment("review_step.2").unwrap(), "review_step.2");
+    }
+
+    #[test]
+    fn sanitize_step_path_segment_rejects_traversal() {
+        assert!(sanitize_step_path_segment("../build").is_none());
+        assert!(sanitize_step_path_segment("build/review").is_none());
+        assert!(sanitize_step_path_segment("").is_none());
+    }
+
+    #[test]
+    fn transcript_record_round_trips() {
+        let record = TranscriptRecord {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION,
+            run_id: "run-1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            step_name: "build".to_string(),
+            attempt: 1,
+            sequence: 7,
+            timestamp: chrono::Utc::now(),
+            kind: TranscriptRecordKind::AssistantMessage,
+            payload: serde_json::json!({"text": "hello"}),
+            truncated: None,
+        };
+
+        let encoded = serde_json::to_string(&record).unwrap();
+        let decoded: TranscriptRecord = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded.schema_version, TRANSCRIPT_SCHEMA_VERSION);
+        assert_eq!(decoded.kind, TranscriptRecordKind::AssistantMessage);
+        assert_eq!(decoded.payload["text"], "hello");
+    }
+}
+```
+
+In `crates/ensemble-core/src/transcript/writer.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::model::{TranscriptRecord, TranscriptRecordKind, TRANSCRIPT_SCHEMA_VERSION};
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn sample_record(sequence: u64) -> TranscriptRecord {
+        TranscriptRecord {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION,
+            run_id: "run-1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            step_name: "build".to_string(),
+            attempt: 1,
+            sequence,
+            timestamp: Utc::now(),
+            kind: TranscriptRecordKind::AssistantMessage,
+            payload: serde_json::json!({"text": "hello"}),
+            truncated: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn append_writes_step_transcript_jsonl() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+
+        writer.append(&sample_record(1)).await.unwrap();
+
+        let path = writer.transcript_path("run-1", "build").unwrap();
+        let contents = tokio::fs::read_to_string(path).await.unwrap();
+        let parsed: TranscriptRecord = serde_json::from_str(contents.lines().next().unwrap()).unwrap();
+        assert_eq!(parsed.sequence, 1);
+        assert_eq!(parsed.step_name, "build");
+    }
+
+    #[test]
+    fn transcript_path_rejects_unsafe_segments() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+
+        assert!(writer.transcript_path("../run", "build").is_err());
+        assert!(writer.transcript_path("run-1", "../build").is_err());
+    }
+}
+```
+
+In `crates/ensemble-core/src/transcript/reader.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::model::{TranscriptRecord, TranscriptRecordKind, TRANSCRIPT_SCHEMA_VERSION};
+    use crate::transcript::writer::TranscriptWriter;
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn sample_record(sequence: u64) -> TranscriptRecord {
+        TranscriptRecord {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION,
+            run_id: "run-1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            step_name: "build".to_string(),
+            attempt: 1,
+            sequence,
+            timestamp: Utc::now(),
+            kind: TranscriptRecordKind::AssistantMessage,
+            payload: serde_json::json!({"text": format!("message-{sequence}")}),
+            truncated: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_transcript_paginates_records() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer.append(&sample_record(1)).await.unwrap();
+        writer.append(&sample_record(2)).await.unwrap();
+        writer.append(&sample_record(3)).await.unwrap();
+
+        let response = read_transcript_page(temp_dir.path(), "run-1", "build", Some(1), Some(1))
+            .await
+            .unwrap();
+
+        assert_eq!(response.records.len(), 1);
+        assert_eq!(response.records[0].sequence, 2);
+        assert_eq!(response.total, 3);
+        assert_eq!(response.next_cursor, Some(2));
+    }
+
+    #[tokio::test]
+    async fn read_transcript_returns_empty_for_missing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let response = read_transcript_page(temp_dir.path(), "run-1", "build", None, None)
+            .await
+            .unwrap();
+
+        assert!(response.records.is_empty());
+        assert_eq!(response.total, 0);
+        assert_eq!(response.next_cursor, None);
+    }
+
+    #[tokio::test]
+    async fn read_transcript_record_finds_sequence() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer.append(&sample_record(9)).await.unwrap();
+
+        let record = read_transcript_record(temp_dir.path(), "run-1", "build", 9)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(record.sequence, 9);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p ensemble-core transcript::
+```
+
+Expected: compile failure because the `transcript` module and types do not exist.
+
+- [ ] **Step 3: Add model, writer, and reader implementation**
+
+Create `crates/ensemble-core/src/transcript/mod.rs`:
+
+```rust
+pub mod model;
+pub mod reader;
+pub mod writer;
+```
+
+Create `crates/ensemble-core/src/transcript/model.rs`:
+
+```rust
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptRecordKind {
+    Prompt,
+    AssistantMessage,
+    Reasoning,
+    ToolCall,
+    ToolResult,
+    PermissionRequest,
+    PermissionResolution,
+    TurnComplete,
+    Error,
+    Raw,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TranscriptTruncation {
+    pub original_bytes: usize,
+    pub retained_head_bytes: usize,
+    pub retained_tail_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TranscriptRecord {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub issue_identifier: String,
+    pub step_name: String,
+    pub attempt: u32,
+    pub sequence: u64,
+    pub timestamp: DateTime<Utc>,
+    pub kind: TranscriptRecordKind,
+    pub payload: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<TranscriptTruncation>,
+}
+
+pub fn sanitize_step_path_segment(value: &str) -> Option<String> {
+    if value.is_empty() || value == "." || value == ".." {
+        return None;
+    }
+
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        Some(value.to_string())
+    } else {
+        None
+    }
+}
+
+pub fn sanitize_run_path_segment(value: &str) -> Option<String> {
+    sanitize_step_path_segment(value)
+}
+```
+
+Create `crates/ensemble-core/src/transcript/writer.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+
+use super::model::{sanitize_run_path_segment, sanitize_step_path_segment, TranscriptRecord};
+
+#[derive(Debug, Clone)]
+pub struct TranscriptWriter {
+    workspace_root: PathBuf,
+}
+
+impl TranscriptWriter {
+    pub fn new(workspace_root: PathBuf) -> Self {
+        Self { workspace_root }
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+
+    pub fn transcript_path(&self, run_id: &str, step_name: &str) -> Result<PathBuf, std::io::Error> {
+        let run_id = sanitize_run_path_segment(run_id).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid run id")
+        })?;
+        let step_name = sanitize_step_path_segment(step_name).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid step name")
+        })?;
+
+        Ok(self
+            .workspace_root
+            .join(".ensemble")
+            .join("runs")
+            .join(run_id)
+            .join("steps")
+            .join(step_name)
+            .join("transcript.jsonl"))
+    }
+
+    pub async fn append(&self, record: &TranscriptRecord) -> Result<(), std::io::Error> {
+        let path = self.transcript_path(&record.run_id, &record.step_name)?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let mut line = serde_json::to_string(record)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        line.push('\n');
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        file.write_all(line.as_bytes()).await?;
+        file.flush().await?;
+        Ok(())
+    }
+}
+```
+
+Create `crates/ensemble-core/src/transcript/reader.rs`:
+
+```rust
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::model::TranscriptRecord;
+use super::writer::TranscriptWriter;
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct TranscriptResponse {
+    pub records: Vec<TranscriptRecord>,
+    pub total: usize,
+    pub next_cursor: Option<usize>,
+}
+
+async fn read_transcript_file(path: &Path) -> Result<Option<String>, std::io::Error> {
+    match tokio::fs::read_to_string(path).await {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn parse_transcript_records(contents: &str) -> Result<Vec<TranscriptRecord>, serde_json::Error> {
+    contents.lines().map(serde_json::from_str).collect()
+}
+
+pub async fn read_transcript_page(
+    workspace_root: &Path,
+    run_id: &str,
+    step_name: &str,
+    cursor: Option<usize>,
+    limit: Option<usize>,
+) -> Result<TranscriptResponse, Box<dyn std::error::Error + Send + Sync>> {
+    let writer = TranscriptWriter::new(workspace_root.to_path_buf());
+    let path = writer.transcript_path(run_id, step_name)?;
+    let Some(contents) = read_transcript_file(&path).await? else {
+        return Ok(TranscriptResponse {
+            records: vec![],
+            total: 0,
+            next_cursor: None,
+        });
+    };
+
+    let records = parse_transcript_records(&contents)?;
+    let total = records.len();
+    let cursor = cursor.unwrap_or(0);
+    let limit = limit.unwrap_or(50).min(200);
+    let page: Vec<TranscriptRecord> = records.into_iter().skip(cursor).take(limit).collect();
+    let next_cursor = if cursor + page.len() < total {
+        Some(cursor + page.len())
+    } else {
+        None
+    };
+
+    Ok(TranscriptResponse {
+        records: page,
+        total,
+        next_cursor,
+    })
+}
+
+pub async fn read_transcript_record(
+    workspace_root: &Path,
+    run_id: &str,
+    step_name: &str,
+    sequence: u64,
+) -> Result<Option<TranscriptRecord>, Box<dyn std::error::Error + Send + Sync>> {
+    let response = read_transcript_page(workspace_root, run_id, step_name, None, Some(usize::MAX))
+        .await?;
+    Ok(response.records.into_iter().find(|record| record.sequence == sequence))
+}
+```
+
+Modify `crates/ensemble-core/src/lib.rs`:
+
+```rust
+pub mod transcript;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p ensemble-core transcript::
+```
+
+Expected: transcript model, writer, and reader tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/lib.rs crates/ensemble-core/src/transcript/
+git commit -m "feat: add step transcript storage model"
+```
+
+---
+
+### Task 2: Transcript Persistence, Sequencing, Coalescing, And Truncation
+
+**Files:**
+- Modify: `crates/ensemble-core/src/transcript/mod.rs`
+- Create: `crates/ensemble-core/src/transcript/persistence.rs`
+- Modify: `crates/ensemble-core/src/transcript/model.rs`
+
+- [ ] **Step 1: Write failing persistence tests**
+
+Create `crates/ensemble-core/src/transcript/persistence.rs` with tests first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::model::TranscriptRecordKind;
+    use tempfile::TempDir;
+
+    fn request(kind: TranscriptRecordKind, text: &str) -> TranscriptPersistRequest {
+        TranscriptPersistRequest {
+            run_id: "run-1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            step_name: "build".to_string(),
+            attempt: 1,
+            timestamp: chrono::Utc::now(),
+            kind,
+            payload: serde_json::json!({"text": text}),
+            truncated: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn persistence_assigns_sequence_numbers() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+
+        persistence.send(request(TranscriptRecordKind::AssistantMessage, "one"));
+        persistence.send(request(TranscriptRecordKind::ToolCall, "tool"));
+        persistence.flush().await;
+
+        let contents = tokio::fs::read_to_string(
+            temp_dir.path().join(".ensemble/runs/run-1/steps/build/transcript.jsonl"),
+        )
+        .await
+        .unwrap();
+        let records: Vec<crate::transcript::model::TranscriptRecord> =
+            contents.lines().map(|line| serde_json::from_str(line).unwrap()).collect();
+
+        assert_eq!(records[0].sequence, 1);
+        assert_eq!(records[1].sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn persistence_coalesces_adjacent_assistant_messages() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+
+        persistence.send(request(TranscriptRecordKind::AssistantMessage, "hel"));
+        persistence.send(request(TranscriptRecordKind::AssistantMessage, "lo"));
+        persistence.flush().await;
+
+        let contents = tokio::fs::read_to_string(
+            temp_dir.path().join(".ensemble/runs/run-1/steps/build/transcript.jsonl"),
+        )
+        .await
+        .unwrap();
+        let records: Vec<crate::transcript::model::TranscriptRecord> =
+            contents.lines().map(|line| serde_json::from_str(line).unwrap()).collect();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].payload["text"], "hello");
+    }
+
+    #[test]
+    fn truncate_large_payload_keeps_head_and_tail() {
+        let input = "a".repeat(96 * 1024) + &"b".repeat(64 * 1024);
+        let (payload, truncation) = truncate_tool_result_payload(serde_json::json!({"text": input}));
+
+        let truncation = truncation.expect("large payload should be truncated");
+        assert!(payload["text"].as_str().unwrap().starts_with("aaaa"));
+        assert!(payload["text"].as_str().unwrap().ends_with("bbbb"));
+        assert!(truncation.original_bytes > truncation.retained_head_bytes);
+        assert_eq!(truncation.retained_tail_bytes, TOOL_RESULT_TAIL_BYTES);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p ensemble-core transcript::persistence
+```
+
+Expected: compile failure because persistence types and truncation helpers do not exist.
+
+- [ ] **Step 3: Implement persistence**
+
+Add to `crates/ensemble-core/src/transcript/mod.rs`:
+
+```rust
+pub mod persistence;
+```
+
+Add to `crates/ensemble-core/src/transcript/persistence.rs`:
+
+```rust
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::warn;
+
+use super::model::{
+    TranscriptRecord, TranscriptRecordKind, TranscriptTruncation, TRANSCRIPT_SCHEMA_VERSION,
+};
+use super::writer::TranscriptWriter;
+
+pub const COALESCE_MAX_BYTES: usize = 16 * 1024;
+pub const TOOL_RESULT_MAX_BYTES: usize = 128 * 1024;
+pub const TOOL_RESULT_HEAD_BYTES: usize = 96 * 1024;
+pub const TOOL_RESULT_TAIL_BYTES: usize = 32 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct TranscriptPersistRequest {
+    pub run_id: String,
+    pub issue_identifier: String,
+    pub step_name: String,
+    pub attempt: u32,
+    pub timestamp: DateTime<Utc>,
+    pub kind: TranscriptRecordKind,
+    pub payload: serde_json::Value,
+    pub truncated: Option<TranscriptTruncation>,
+}
+
+pub struct TranscriptPersistence {
+    sender: Option<mpsc::Sender<TranscriptPersistRequest>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl TranscriptPersistence {
+    pub fn new(workspace_root: PathBuf) -> Self {
+        let writer = TranscriptWriter::new(workspace_root);
+        let (sender, mut receiver) = mpsc::channel::<TranscriptPersistRequest>(10_000);
+
+        let handle = tokio::spawn(async move {
+            let mut state = PersistState::default();
+            while let Some(req) = receiver.recv().await {
+                state.write_request(&writer, req).await;
+            }
+            state.flush_all(&writer).await;
+        });
+
+        Self {
+            sender: Some(sender),
+            handle: Some(handle),
+        }
+    }
+
+    pub fn send(&self, request: TranscriptPersistRequest) {
+        if let Some(sender) = &self.sender {
+            match sender.try_send(request) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    warn!("transcript persist channel full; transcript record dropped");
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    warn!("transcript persist channel closed; transcript record dropped");
+                }
+            }
+        }
+    }
+
+    pub async fn flush(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            drop(sender);
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for TranscriptPersistence {
+    fn drop(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            drop(sender);
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[derive(Default)]
+struct PersistState {
+    sequences: HashMap<(String, String), u64>,
+    coalesced: HashMap<(String, String, TranscriptRecordKind), TranscriptPersistRequest>,
+}
+
+impl PersistState {
+    async fn write_request(&mut self, writer: &TranscriptWriter, mut req: TranscriptPersistRequest) {
+        if should_coalesce(req.kind) {
+            let key = (req.run_id.clone(), req.step_name.clone(), req.kind);
+            if let Some(existing) = self.coalesced.get_mut(&key) {
+                if merge_text_payload(&mut existing.payload, &req.payload) {
+                    return;
+                }
+            }
+            self.flush_key(writer, key.clone()).await;
+            self.coalesced.insert(key, req);
+            return;
+        }
+
+        self.flush_step(writer, &req.run_id, &req.step_name).await;
+        if req.kind == TranscriptRecordKind::ToolResult {
+            let (payload, truncation) = truncate_tool_result_payload(req.payload);
+            req.payload = payload;
+            req.truncated = req.truncated.or(truncation);
+        }
+        self.append(writer, req).await;
+    }
+
+    async fn flush_key(&mut self, writer: &TranscriptWriter, key: (String, String, TranscriptRecordKind)) {
+        if let Some(req) = self.coalesced.remove(&key) {
+            self.append(writer, req).await;
+        }
+    }
+
+    async fn flush_step(&mut self, writer: &TranscriptWriter, run_id: &str, step_name: &str) {
+        let keys: Vec<_> = self
+            .coalesced
+            .keys()
+            .filter(|(run, step, _)| run == run_id && step == step_name)
+            .cloned()
+            .collect();
+        for key in keys {
+            self.flush_key(writer, key).await;
+        }
+    }
+
+    async fn flush_all(&mut self, writer: &TranscriptWriter) {
+        let keys: Vec<_> = self.coalesced.keys().cloned().collect();
+        for key in keys {
+            self.flush_key(writer, key).await;
+        }
+    }
+
+    async fn append(&mut self, writer: &TranscriptWriter, req: TranscriptPersistRequest) {
+        let sequence_key = (req.run_id.clone(), req.step_name.clone());
+        let sequence = self.sequences.entry(sequence_key).or_insert(0);
+        *sequence += 1;
+
+        let record = TranscriptRecord {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION,
+            run_id: req.run_id,
+            issue_identifier: req.issue_identifier,
+            step_name: req.step_name,
+            attempt: req.attempt,
+            sequence: *sequence,
+            timestamp: req.timestamp,
+            kind: req.kind,
+            payload: req.payload,
+            truncated: req.truncated,
+        };
+
+        if let Err(error) = writer.append(&record).await {
+            warn!(
+                event = "transcript_persist_failed",
+                run_id = %record.run_id,
+                step_name = %record.step_name,
+                error = %error,
+                "failed to persist transcript record"
+            );
+        }
+    }
+}
+
+fn should_coalesce(kind: TranscriptRecordKind) -> bool {
+    matches!(kind, TranscriptRecordKind::AssistantMessage | TranscriptRecordKind::Reasoning)
+}
+
+fn merge_text_payload(existing: &mut serde_json::Value, next: &serde_json::Value) -> bool {
+    let Some(existing_text) = existing.get_mut("text").and_then(|value| value.as_str().map(str::to_string)) else {
+        return false;
+    };
+    let Some(next_text) = next.get("text").and_then(|value| value.as_str()) else {
+        return false;
+    };
+    if existing_text.len() + next_text.len() > COALESCE_MAX_BYTES {
+        return false;
+    }
+
+    existing["text"] = serde_json::Value::String(format!("{existing_text}{next_text}"));
+    true
+}
+
+pub fn truncate_tool_result_payload(
+    payload: serde_json::Value,
+) -> (serde_json::Value, Option<TranscriptTruncation>) {
+    let text = match payload.get("text").and_then(|value| value.as_str()) {
+        Some(text) => text,
+        None => return (payload, None),
+    };
+    if text.len() <= TOOL_RESULT_MAX_BYTES {
+        return (payload, None);
+    }
+
+    let head = &text[..TOOL_RESULT_HEAD_BYTES.min(text.len())];
+    let tail_start = text.len().saturating_sub(TOOL_RESULT_TAIL_BYTES);
+    let tail = &text[tail_start..];
+    let retained = format!("{head}\n\n[truncated]\n\n{tail}");
+    let truncation = TranscriptTruncation {
+        original_bytes: text.len(),
+        retained_head_bytes: head.len(),
+        retained_tail_bytes: tail.len(),
+    };
+
+    let mut wrapper = payload;
+    wrapper["text"] = serde_json::Value::String(retained);
+    (wrapper, Some(truncation))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p ensemble-core transcript::persistence
+```
+
+Expected: persistence tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/transcript/
+git commit -m "feat: persist step transcript records"
+```
+
+---
+
+### Task 3: ACP Parser Transcript Blocks
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/protocol.rs`
+- Modify: `crates/ensemble-core/src/agent/events.rs`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add to `crates/ensemble-core/src/agent/protocol.rs` tests:
+
+```rust
+#[test]
+fn parse_session_update_extracts_transcript_tool_call() {
+    let line = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "sessionId": "s1",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call-1",
+                "title": "Read file",
+                "kind": "read",
+                "status": "pending",
+                "content": {
+                    "type": "tool_call",
+                    "name": "read_file",
+                    "arguments": {"path": "Cargo.toml"}
+                }
+            }
+        }
+    });
+
+    let parsed = parse_session_update(&line).unwrap();
+    assert_eq!(parsed.transcript_blocks.len(), 1);
+    assert_eq!(parsed.transcript_blocks[0].kind, TranscriptBlockKind::ToolCall);
+    assert_eq!(parsed.transcript_blocks[0].payload["tool_call_id"], "call-1");
+    assert_eq!(parsed.transcript_blocks[0].payload["name"], "read_file");
+}
+
+#[test]
+fn parse_session_update_extracts_reasoning_block() {
+    let line = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "sessionId": "s1",
+            "update": {
+                "sessionUpdate": "reasoning_chunk",
+                "content": {"type": "reasoning", "text": "thinking"}
+            }
+        }
+    });
+
+    let parsed = parse_session_update(&line).unwrap();
+    assert_eq!(parsed.transcript_blocks.len(), 1);
+    assert_eq!(parsed.transcript_blocks[0].kind, TranscriptBlockKind::Reasoning);
+    assert_eq!(parsed.transcript_blocks[0].payload["text"], "thinking");
+}
+
+#[test]
+fn parse_session_update_keeps_assistant_text_as_transcript_block() {
+    let line = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "sessionId": "s1",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "hello"}
+            }
+        }
+    });
+
+    let parsed = parse_session_update(&line).unwrap();
+    assert_eq!(parsed.output_text.as_deref(), Some("hello"));
+    assert_eq!(parsed.transcript_blocks[0].kind, TranscriptBlockKind::AssistantMessage);
+    assert_eq!(parsed.transcript_blocks[0].payload["text"], "hello");
+}
+```
+
+Add to `crates/ensemble-core/src/agent/events.rs` tests:
+
+```rust
+#[test]
+fn transcript_block_event_has_stable_name() {
+    let event = AgentEvent::TranscriptBlock {
+        kind: crate::agent::protocol::TranscriptBlockKind::AssistantMessage,
+        payload: serde_json::json!({"text": "hello"}),
+    };
+
+    assert_eq!(event.event_name(), "transcript_block");
+    assert_eq!(event.message_for_state().as_deref(), Some("hello"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p ensemble-core agent::protocol agent::events
+```
+
+Expected: compile failure because `TranscriptBlockKind`, `TranscriptBlock`, and `AgentEvent::TranscriptBlock` do not exist.
+
+- [ ] **Step 3: Implement parser transcript block extraction**
+
+In `crates/ensemble-core/src/agent/protocol.rs`, add:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranscriptBlockKind {
+    AssistantMessage,
+    Reasoning,
+    ToolCall,
+    ToolResult,
+    PermissionRequest,
+    TurnComplete,
+    Raw,
+}
+
+#[derive(Debug, Clone)]
+pub struct TranscriptBlock {
+    pub kind: TranscriptBlockKind,
+    pub payload: serde_json::Value,
+}
+```
+
+Extend `ParsedSessionUpdate`:
+
+```rust
+pub struct ParsedSessionUpdate {
+    pub output_text: Option<String>,
+    pub usage: Option<TokenUsage>,
+    pub stop_reason: Option<StopReason>,
+    pub permission_request: Option<PermissionRequest>,
+    pub verdict: Option<serde_json::Value>,
+    pub transcript_blocks: Vec<TranscriptBlock>,
+}
+```
+
+In `parse_session_update`, compute and include blocks:
+
+```rust
+let transcript_blocks = extract_transcript_blocks(params, update, output_text.as_deref());
+
+let parsed = ParsedSessionUpdate {
+    output_text,
+    usage,
+    stop_reason,
+    permission_request,
+    verdict,
+    transcript_blocks,
+};
+
+if parsed.output_text.is_none()
+    && parsed.usage.is_none()
+    && parsed.stop_reason.is_none()
+    && parsed.permission_request.is_none()
+    && parsed.verdict.is_none()
+    && parsed.transcript_blocks.is_empty()
+{
+    return None;
+}
+```
+
+Add helpers:
+
+```rust
+fn extract_transcript_blocks(
+    params: &serde_json::Value,
+    update: Option<&serde_json::Value>,
+    output_text: Option<&str>,
+) -> Vec<TranscriptBlock> {
+    let source = update.unwrap_or(params);
+    let session_update = source
+        .get("sessionUpdate")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let content = source.get("content").or_else(|| params.get("content"));
+
+    if let Some(text) = output_text {
+        return vec![TranscriptBlock {
+            kind: TranscriptBlockKind::AssistantMessage,
+            payload: serde_json::json!({"text": text}),
+        }];
+    }
+
+    if session_update.contains("reasoning") {
+        if let Some(text) = content.and_then(content_text) {
+            return vec![TranscriptBlock {
+                kind: TranscriptBlockKind::Reasoning,
+                payload: serde_json::json!({"text": text}),
+            }];
+        }
+    }
+
+    if session_update == "tool_call_update" {
+        let tool_call_id = source
+            .get("toolCallId")
+            .or_else(|| source.get("tool_call_id"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let name = content
+            .and_then(|value| value.get("name"))
+            .cloned()
+            .or_else(|| source.get("name").cloned())
+            .unwrap_or(serde_json::Value::Null);
+        let arguments = content
+            .and_then(|value| value.get("arguments"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        return vec![TranscriptBlock {
+            kind: TranscriptBlockKind::ToolCall,
+            payload: serde_json::json!({
+                "tool_call_id": tool_call_id,
+                "name": name,
+                "arguments": arguments,
+                "status": source.get("status").cloned().unwrap_or(serde_json::Value::Null),
+                "title": source.get("title").cloned().unwrap_or(serde_json::Value::Null)
+            }),
+        }];
+    }
+
+    if session_update.contains("tool_result") || session_update.contains("tool_output") {
+        return vec![TranscriptBlock {
+            kind: TranscriptBlockKind::ToolResult,
+            payload: serde_json::json!({
+                "tool_call_id": source.get("toolCallId").or_else(|| source.get("tool_call_id")).cloned(),
+                "content": content.cloned().unwrap_or(serde_json::Value::Null)
+            }),
+        }];
+    }
+
+    vec![]
+}
+```
+
+In `crates/ensemble-core/src/agent/events.rs`, import `TranscriptBlockKind` and add:
+
+```rust
+TranscriptBlock {
+    kind: TranscriptBlockKind,
+    payload: serde_json::Value,
+},
+```
+
+Add `event_name` branch:
+
+```rust
+AgentEvent::TranscriptBlock { .. } => "transcript_block",
+```
+
+Add `message_for_state` branch:
+
+```rust
+AgentEvent::TranscriptBlock { payload, .. } => payload
+    .get("text")
+    .and_then(|value| value.as_str())
+    .map(truncate_for_state),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p ensemble-core agent::protocol agent::events
+```
+
+Expected: parser and event tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/protocol.rs crates/ensemble-core/src/agent/events.rs
+git commit -m "feat: parse ACP transcript blocks"
+```
+
+---
+
+### Task 4: Runtime Emission And Orchestrator Persistence
+
+**Files:**
+- Modify: `crates/ensemble-core/src/agent/acpx_cli.rs`
+- Modify: `crates/ensemble-core/src/agent/acp_client.rs`
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+
+- [ ] **Step 1: Write failing runtime/orchestrator tests**
+
+In `crates/ensemble-core/src/agent/acpx_cli.rs`, add a test near existing session update tests:
+
+```rust
+#[tokio::test]
+async fn prompt_emits_transcript_blocks_for_visible_updates() {
+    let script = make_acpx_script(
+        r#"
+if [ "$1" = "sessions" ] && [ "$2" = "ensure" ]; then
+  echo "session"
+  exit 0
+fi
+if [ "$1" = "prompt" ]; then
+  printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"turn_complete","stopReason":"end_turn"}}}'
+  exit 0
+fi
+"#,
+    );
+
+    let mut events = Vec::new();
+    run_prompt_command_for_test(script.path(), |event| {
+        events.push(event);
+        async {}
+    })
+    .await
+    .unwrap();
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AgentEvent::TranscriptBlock {
+            kind: crate::agent::protocol::TranscriptBlockKind::AssistantMessage,
+            ..
+        }
+    )));
+}
+```
+
+Use the existing test helpers in `acpx_cli.rs`; if helper names differ, adapt the test to the local helpers without changing the assertion.
+
+In `crates/ensemble-core/src/orchestrator/mod.rs`, add an orchestrator unit test near timeline persistence tests:
+
+```rust
+#[tokio::test]
+async fn handle_agent_update_persists_transcript_block() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let orchestrator = make_test_orchestrator_with_workspace_root(dir.path()).await;
+    seed_running_issue_with_run_id(&orchestrator, "issue-1", "repo#1", "run-1").await;
+
+    orchestrator
+        .handle_worker_event(WorkerEvent::AgentUpdate {
+            issue_id: "issue-1".to_string(),
+            step_name: "build".to_string(),
+            event: AgentEvent::TranscriptBlock {
+                kind: crate::agent::protocol::TranscriptBlockKind::AssistantMessage,
+                payload: serde_json::json!({"text": "hello"}),
+            },
+            timestamp: chrono::Utc::now(),
+        })
+        .await;
+
+    orchestrator.flush_transcript_persistence_for_tests().await;
+
+    let contents = tokio::fs::read_to_string(
+        dir.path().join(".ensemble/runs/run-1/steps/build/transcript.jsonl"),
+    )
+    .await
+    .unwrap();
+    assert!(contents.contains("\"assistant_message\""));
+    assert!(contents.contains("\"hello\""));
+}
+```
+
+If the local test harness does not expose those helper names, create private test helpers in the orchestrator test module that construct the existing test orchestrator and insert a running entry with `run_id: Some("run-1".to_string())`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p ensemble-core prompt_emits_transcript_blocks_for_visible_updates handle_agent_update_persists_transcript_block
+```
+
+Expected: compile failure because runtime emission and orchestrator persistence are not wired.
+
+- [ ] **Step 3: Emit transcript blocks from runtimes**
+
+In `crates/ensemble-core/src/agent/acpx_cli.rs`, after parsing an update and before consuming fields, emit blocks:
+
+```rust
+for block in update.transcript_blocks.clone() {
+    if visible {
+        on_event(AgentEvent::TranscriptBlock {
+            kind: block.kind,
+            payload: block.payload,
+        })
+        .await;
+    }
+}
+```
+
+In `crates/ensemble-core/src/agent/acp_client.rs`, in the `SessionMessage::SessionMessage(dispatch)` branch after `parse_sdk_dispatch`, emit blocks:
+
+```rust
+for block in parsed.transcript_blocks.clone() {
+    if visible {
+        emit_event(
+            event_tx,
+            issue_id,
+            step_name,
+            AgentEvent::TranscriptBlock {
+                kind: block.kind,
+                payload: block.payload,
+            },
+        )
+        .await;
+    }
+}
+```
+
+- [ ] **Step 4: Wire orchestrator transcript persistence**
+
+In `crates/ensemble-core/src/orchestrator/mod.rs`, import:
+
+```rust
+use crate::transcript::model::TranscriptRecordKind;
+use crate::transcript::persistence::{TranscriptPersistRequest, TranscriptPersistence};
+```
+
+Add a field to `Orchestrator`:
+
+```rust
+transcript_persistence: Option<TranscriptPersistence>,
+```
+
+Initialize beside timeline persistence:
+
+```rust
+transcript_persistence: Some(TranscriptPersistence::new(parts.workspace_root.clone())),
+```
+
+Flush on shutdown after timeline flush:
+
+```rust
+if let Some(ref mut persistence) = self.transcript_persistence {
+    persistence.flush().await;
+}
+```
+
+In `handle_agent_update`, before dropping state, convert transcript blocks:
+
+```rust
+let transcript_request = match &event {
+    AgentEvent::TranscriptBlock { kind, payload } => run_id.as_ref().map(|run_id| {
+        TranscriptPersistRequest {
+            run_id: run_id.clone(),
+            issue_identifier: issue_identifier.clone(),
+            step_name: step_name.to_string(),
+            attempt: attempt_num,
+            timestamp,
+            kind: transcript_kind_from_agent_kind(*kind),
+            payload: payload.clone(),
+            truncated: None,
+        }
+    }),
+    _ => None,
+};
+```
+
+After `drop(state);`, send the request:
+
+```rust
+if let Some(request) = transcript_request {
+    if let Some(ref persistence) = self.transcript_persistence {
+        persistence.send(request);
+    }
+}
+```
+
+Add mapper:
+
+```rust
+fn transcript_kind_from_agent_kind(
+    kind: crate::agent::protocol::TranscriptBlockKind,
+) -> TranscriptRecordKind {
+    match kind {
+        crate::agent::protocol::TranscriptBlockKind::AssistantMessage => {
+            TranscriptRecordKind::AssistantMessage
+        }
+        crate::agent::protocol::TranscriptBlockKind::Reasoning => TranscriptRecordKind::Reasoning,
+        crate::agent::protocol::TranscriptBlockKind::ToolCall => TranscriptRecordKind::ToolCall,
+        crate::agent::protocol::TranscriptBlockKind::ToolResult => TranscriptRecordKind::ToolResult,
+        crate::agent::protocol::TranscriptBlockKind::PermissionRequest => {
+            TranscriptRecordKind::PermissionRequest
+        }
+        crate::agent::protocol::TranscriptBlockKind::TurnComplete => TranscriptRecordKind::TurnComplete,
+        crate::agent::protocol::TranscriptBlockKind::Raw => TranscriptRecordKind::Raw,
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p ensemble-core prompt_emits_transcript_blocks_for_visible_updates handle_agent_update_persists_transcript_block
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/agent/acpx_cli.rs crates/ensemble-core/src/agent/acp_client.rs crates/ensemble-core/src/orchestrator/mod.rs
+git commit -m "feat: persist runtime transcript blocks"
+```
+
+---
+
+### Task 5: Run/Step-Scoped Conversation API
+
+**Files:**
+- Rewrite: `crates/ensemble-core/src/api/conversation.rs`
+- Modify: `crates/ensemble-core/src/api/router.rs`
+- Modify: `crates/ensemble-core/src/api/openapi.rs`
+- Modify: `crates/ensemble-core/tests/api_endpoints.rs`
+- Modify: `crates/ensemble-core/tests/openapi_spec.rs`
+
+- [ ] **Step 1: Write failing API tests**
+
+In `crates/ensemble-core/tests/api_endpoints.rs`, add:
+
+```rust
+#[tokio::test]
+async fn get_step_conversation_returns_transcript_records() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let app = test_app_with_workspace_root(temp.path()).await;
+    let workspace_key = ensemble_core::tracker::model::sanitize_workspace_key("repo#1").unwrap();
+    let transcript_dir = temp
+        .path()
+        .join(workspace_key)
+        .join(".ensemble/runs/run-1/steps/build");
+    tokio::fs::create_dir_all(&transcript_dir).await.unwrap();
+    tokio::fs::write(
+        transcript_dir.join("transcript.jsonl"),
+        r#"{"schema_version":1,"run_id":"run-1","issue_identifier":"repo#1","step_name":"build","attempt":1,"sequence":1,"timestamp":"2026-06-14T00:00:00Z","kind":"assistant_message","payload":{"text":"hello"}}"#,
+    )
+    .await
+    .unwrap();
+
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/v1/repo%231/runs/run-1/steps/build/conversation")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let body = response_json(response).await;
+    assert_eq!(body["records"][0]["kind"], "assistant_message");
+    assert_eq!(body["records"][0]["payload"]["text"], "hello");
+}
+
+#[tokio::test]
+async fn old_issue_conversation_route_is_removed() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let app = test_app_with_workspace_root(temp.path()).await;
+
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/v1/repo%231/conversation")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+}
+```
+
+Use the existing `api_endpoints.rs` app-state helper names. If `test_app_with_workspace_root` does not exist, add a small helper in that file that creates the existing test app state and assigns `workspace_root`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p ensemble-core --test api_endpoints get_step_conversation_returns_transcript_records old_issue_conversation_route_is_removed
+```
+
+Expected: first test returns 404 and second may still return 200 because routes are not rewritten.
+
+- [ ] **Step 3: Rewrite conversation API**
+
+Replace `ConversationMessage` and `ConversationResponse` with transcript response usage in `crates/ensemble-core/src/api/conversation.rs`:
+
+```rust
+use crate::api::handlers::{api_error, ApiError};
+use crate::api::router::AppState;
+use crate::tracker::model::sanitize_workspace_key;
+use crate::transcript::reader::{read_transcript_page, read_transcript_record, TranscriptResponse};
+use crate::transcript::model::TranscriptRecord;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Default, Deserialize, utoipa::IntoParams)]
+pub struct ConversationQuery {
+    pub cursor: Option<usize>,
+    pub limit: Option<usize>,
+}
+
+fn workspace_path(workspace_root: &str, identifier: &str) -> Result<PathBuf, ApiError> {
+    let workspace_key = sanitize_workspace_key(identifier).ok_or_else(|| {
+        ApiError::new(
+            "invalid_identifier",
+            "identifier cannot be sanitized to a workspace key",
+        )
+    })?;
+    Ok(PathBuf::from(workspace_root).join(workspace_key))
+}
+```
+
+Define list endpoint:
+
+```rust
+#[utoipa::path(
+    get,
+    path = "/api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation",
+    operation_id = "getStepConversation",
+    params(
+        ("identifier" = String, Path, description = "Issue identifier"),
+        ("run_id" = String, Path, description = "Run id"),
+        ("step_name" = String, Path, description = "Step name"),
+        ConversationQuery,
+    ),
+    responses(
+        (status = 200, description = "Step transcript records", body = TranscriptResponse),
+        (status = 400, description = "Invalid path", body = ApiError)
+    ),
+    tag = "conversation"
+)]
+pub async fn get_conversation(
+    State(state): State<AppState>,
+    Path((identifier, run_id, step_name)): Path<(String, String, String)>,
+    Query(query): Query<ConversationQuery>,
+) -> impl IntoResponse {
+    let workspace_path = match workspace_path(&state.workspace_root, &identifier) {
+        Ok(path) => path,
+        Err(error) => return (StatusCode::BAD_REQUEST, Json(error)).into_response(),
+    };
+
+    match read_transcript_page(&workspace_path, &run_id, &step_name, query.cursor, query.limit).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error) if error.downcast_ref::<std::io::Error>().is_some_and(|e| e.kind() == std::io::ErrorKind::InvalidInput) => {
+            (StatusCode::BAD_REQUEST, api_error("invalid_path", "run id or step name is invalid")).into_response()
+        }
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            api_error("conversation_read_error", format!("failed to read transcript: {error}")),
+        )
+            .into_response(),
+    }
+}
+```
+
+Define single-record endpoint:
+
+```rust
+#[utoipa::path(
+    get,
+    path = "/api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation/{sequence}",
+    operation_id = "getStepConversationRecord",
+    params(
+        ("identifier" = String, Path, description = "Issue identifier"),
+        ("run_id" = String, Path, description = "Run id"),
+        ("step_name" = String, Path, description = "Step name"),
+        ("sequence" = u64, Path, description = "Transcript sequence"),
+    ),
+    responses(
+        (status = 200, description = "Transcript record", body = TranscriptRecord),
+        (status = 404, description = "Record not found", body = ApiError)
+    ),
+    tag = "conversation"
+)]
+pub async fn get_conversation_message(
+    State(state): State<AppState>,
+    Path((identifier, run_id, step_name, sequence)): Path<(String, String, String, u64)>,
+) -> impl IntoResponse {
+    let workspace_path = match workspace_path(&state.workspace_root, &identifier) {
+        Ok(path) => path,
+        Err(error) => return (StatusCode::BAD_REQUEST, Json(error)).into_response(),
+    };
+
+    match read_transcript_record(&workspace_path, &run_id, &step_name, sequence).await {
+        Ok(Some(record)) => (StatusCode::OK, Json(record)).into_response(),
+        Ok(None) => api_error("message_not_found", format!("no transcript record at sequence {sequence}")).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            api_error("conversation_read_error", format!("failed to read transcript: {error}")),
+        )
+            .into_response(),
+    }
+}
+```
+
+- [ ] **Step 4: Update router and OpenAPI**
+
+In `crates/ensemble-core/src/api/router.rs`, replace old routes:
+
+```rust
+.route(
+    "/{identifier}/runs/{run_id}/steps/{step_name}/conversation",
+    get(conversation::get_conversation),
+)
+.route(
+    "/{identifier}/runs/{run_id}/steps/{step_name}/conversation/{sequence}",
+    get(conversation::get_conversation_message),
+)
+```
+
+Update endpoint comments in the router doc comment to describe the new routes.
+
+In `crates/ensemble-core/src/api/openapi.rs`, replace components:
+
+```rust
+crate::transcript::reader::TranscriptResponse,
+crate::transcript::model::TranscriptRecord,
+crate::transcript::model::TranscriptRecordKind,
+crate::transcript::model::TranscriptTruncation,
+```
+
+Remove:
+
+```rust
+crate::api::conversation::ConversationResponse,
+crate::api::conversation::ConversationMessage,
+```
+
+- [ ] **Step 5: Run API and OpenAPI tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core --test api_endpoints get_step_conversation_returns_transcript_records old_issue_conversation_route_is_removed
+cargo test -p ensemble-core --test openapi_spec
+```
+
+Expected: targeted API tests pass and OpenAPI spec generation passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ensemble-core/src/api/conversation.rs crates/ensemble-core/src/api/router.rs crates/ensemble-core/src/api/openapi.rs crates/ensemble-core/tests/api_endpoints.rs crates/ensemble-core/tests/openapi_spec.rs
+git commit -m "feat: expose step transcript conversation API"
+```
+
+---
+
+### Task 6: Frontend Transcript Consumption
+
+**Files:**
+- Modify: `crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.ts`
+- Modify: `crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.test.ts`
+- Modify: `crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx`
+- Modify: `crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx`
+- Regenerate if needed: `crates/ensemble-ui/src-ui/src/generated/`
+
+- [ ] **Step 1: Regenerate API client after backend OpenAPI changes**
+
+Run:
+
+```bash
+cd crates/ensemble-ui/src-ui
+pnpm run generate
+```
+
+Expected: generated models include `TranscriptRecord`, `TranscriptRecordKind`, `TranscriptResponse`, and no code depends on the old `ConversationMessage` response contract.
+
+- [ ] **Step 2: Write failing transcript model tests**
+
+In `crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.test.ts`, add:
+
+```ts
+it("maps transcript records into agent and tool activity entries", () => {
+  const entries = buildTranscriptEntries({
+    conversation: [],
+    transcriptRecords: [
+      {
+        schema_version: 1,
+        run_id: "run-1",
+        issue_identifier: "repo#1",
+        step_name: "build",
+        attempt: 1,
+        sequence: 1,
+        timestamp: "2026-06-14T00:00:00Z",
+        kind: "assistant_message",
+        payload: { text: "hello" },
+      },
+      {
+        schema_version: 1,
+        run_id: "run-1",
+        issue_identifier: "repo#1",
+        step_name: "build",
+        attempt: 1,
+        sequence: 2,
+        timestamp: "2026-06-14T00:00:01Z",
+        kind: "tool_call",
+        payload: { name: "read_file", arguments: { path: "Cargo.toml" } },
+      },
+    ],
+    interactions: [],
+    timelineEvents: [],
+    issue: null,
+    sourceStatus: {},
+  });
+
+  expect(entries).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ kind: "agent_message" }),
+      expect.objectContaining({ kind: "tool_activity" }),
+    ]),
+  );
+});
+```
+
+- [ ] **Step 3: Run frontend test to verify it fails**
+
+Run:
+
+```bash
+cd crates/ensemble-ui/src-ui
+pnpm test transcript-model.test.ts
+```
+
+Expected: TypeScript/test failure because `transcriptRecords` is not part of the transcript model source.
+
+- [ ] **Step 4: Update transcript model**
+
+In `transcript-model.ts`, update the source type:
+
+```ts
+import type { TranscriptRecord } from "@/generated/models";
+
+export interface TranscriptSource {
+  conversation: ConversationMessage[];
+  transcriptRecords?: TranscriptRecord[];
+  interactions: InteractionDetail[];
+  timelineEvents: TimelineEventRecord[];
+  issue: IssueDetailSnapshot | null;
+  sourceStatus?: TranscriptSourceStatus;
+}
+```
+
+Add a mapping helper:
+
+```ts
+function entryFromTranscriptRecord(record: TranscriptRecord): TranscriptEntry | null {
+  const timestamp = record.timestamp;
+  const id = `transcript:${record.run_id}:${record.step_name}:${record.sequence}`;
+  const text =
+    typeof record.payload === "object" && record.payload != null && "text" in record.payload
+      ? String((record.payload as { text?: unknown }).text ?? "")
+      : JSON.stringify(record.payload);
+
+  if (record.kind === "assistant_message") {
+    return {
+      kind: "agent_message",
+      id,
+      message: {
+        index: record.sequence,
+        role: "assistant",
+        content: text,
+        tool_calls: null,
+        tool_output: null,
+      },
+      timestamp,
+      stepName: record.step_name,
+    };
+  }
+
+  if (
+    record.kind === "reasoning" ||
+    record.kind === "tool_call" ||
+    record.kind === "tool_result" ||
+    record.kind === "raw"
+  ) {
+    return {
+      kind: "tool_activity",
+      id,
+      event: {
+        run_id: record.run_id,
+        issue_identifier: record.issue_identifier,
+        sequence: record.sequence,
+        timestamp: record.timestamp,
+        event_type: record.kind,
+        step_name: record.step_name,
+        attempt: record.attempt,
+        detail: text,
+        verdict: null,
+        tool_name:
+          typeof record.payload === "object" && record.payload != null && "name" in record.payload
+            ? String((record.payload as { name?: unknown }).name ?? "")
+            : null,
+      },
+      timestamp,
+      stepName: record.step_name,
+    };
+  }
+
+  return null;
+}
+```
+
+In `buildTranscriptEntries`, add before old `source.conversation` processing:
+
+```ts
+for (const record of source.transcriptRecords ?? []) {
+  const entry = entryFromTranscriptRecord(record);
+  if (entry == null) continue;
+  sortable.push({
+    entry,
+    sortTimestamp: toMs(record.timestamp),
+    sortSequence: record.sequence,
+    sortPriority: TRANSCRIPT_SORT_PRIORITY.agentOrTool,
+  });
+}
+```
+
+Keep the old `conversation` field temporarily as an empty-compatible source while the page migration lands in the same task.
+
+- [ ] **Step 5: Update IssueDetail data fetching**
+
+In `IssueDetail.tsx`, replace old conversation query usage with the new step-scoped query once generated hooks are available. Use the selected/current step and run id from issue detail:
+
+```ts
+const activeRunId = issue?.running?.run_id ?? issue?.attempt?.run_id ?? null;
+const activeStepName = selectedStepName ?? issue?.running?.current_step ?? null;
+
+const transcriptQuery = useGetStepConversation(
+  identifier ?? "",
+  activeRunId ?? "",
+  activeStepName ?? "",
+  { limit: 200 },
+  {
+    query: {
+      enabled: Boolean(identifier && activeRunId && activeStepName),
+    },
+  },
+);
+```
+
+Pass records into transcript source:
+
+```ts
+const transcriptEntries = buildTranscriptEntries({
+  conversation: [],
+  transcriptRecords: transcriptQuery.data?.records ?? [],
+  interactions: interactionData,
+  timelineEvents,
+  issue,
+  sourceStatus,
+});
+```
+
+Use the actual generated hook/function name from Orval if it differs from `useGetStepConversation`.
+
+- [ ] **Step 6: Run frontend tests**
+
+Run:
+
+```bash
+cd crates/ensemble-ui/src-ui
+pnpm test transcript-model.test.ts IssueDetail.test.tsx
+```
+
+Expected: targeted frontend tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-ui/src-ui/src/generated crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.ts crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.test.ts crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
+git commit -m "feat: render step transcript records in UI"
+```
+
+---
+
+### Task 7: Product E2E, Docs, And Full Verification
+
+**Files:**
+- Modify: `crates/ensemble-cli/tests/product_e2e.rs`
+- Modify: `docs/SPEC.md`
+- Modify: `docs/pipelines.md`
+
+- [ ] **Step 1: Add product E2E assertion**
+
+In `crates/ensemble-cli/tests/product_e2e.rs`, extend the mock ACP stream with a tool-call update and assert the transcript file exists. Add the ACP line near existing `session/update` fixture output:
+
+```rust
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-1","status":"completed","content":{"type":"tool_call","name":"read_file","arguments":{"path":"Cargo.toml"}}}}}'
+```
+
+After the run completes, add:
+
+```rust
+let transcript_path = workspace_root
+    .join(workspace_key)
+    .join(".ensemble")
+    .join("runs")
+    .join(run_id)
+    .join("steps")
+    .join("implement")
+    .join("transcript.jsonl");
+assert!(transcript_path.exists(), "step transcript should be written");
+let transcript = tokio::fs::read_to_string(&transcript_path).await.unwrap();
+assert!(transcript.contains("\"assistant_message\""));
+assert!(transcript.contains("\"tool_call\""));
+assert!(transcript.contains("\"read_file\""));
+```
+
+Use the existing local variable names for workspace root, workspace key, run id, and step name in that test.
+
+- [ ] **Step 2: Run product E2E to verify it fails or exposes missing wiring**
+
+Run:
+
+```bash
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
+```
+
+Expected: passes if prior tasks are complete; if it fails, fix only transcript-related path or fixture mismatches.
+
+- [ ] **Step 3: Update `docs/SPEC.md`**
+
+Add a subsection under ACP streaming or observability:
+
+````markdown
+### Per-step conversation transcripts
+
+For each pipeline step, Ensemble persists a typed JSONL transcript at:
+
+```text
+{workspace}/.ensemble/runs/{run_id}/steps/{step_name}/transcript.jsonl
+```
+
+Transcript records are distinct from timeline events. Timeline events summarize run progress;
+transcript records preserve step-level agent activity such as assistant messages, exposed reasoning
+chunks, tool calls, tool results, permission activity, turn completion, and errors.
+
+Large tool results are truncated with head and tail retention. Adjacent assistant and reasoning
+deltas may be coalesced before persistence. Transcript persistence failures are logged and do not
+fail the agent step.
+````
+
+- [ ] **Step 4: Update `docs/pipelines.md`**
+
+Add a debugging note:
+
+````markdown
+## Step transcripts
+
+Each run step writes a drill-down transcript to:
+
+```text
+.ensemble/runs/{run_id}/steps/{step_name}/transcript.jsonl
+```
+
+Use the timeline to understand step state transitions. Use the step transcript when you need the
+agent conversation details: assistant output, exposed reasoning, tool activity, permission events,
+and turn completion records.
+````
+
+- [ ] **Step 5: Run backend verification**
+
+Run:
+
+```bash
+cargo test --workspace --exclude ensemble-desktop
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
+cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 6: Run frontend verification**
+
+Run:
+
+```bash
+cd crates/ensemble-ui/src-ui
+pnpm test
+pnpm run build
+```
+
+Expected: frontend tests and build pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-cli/tests/product_e2e.rs docs/SPEC.md docs/pipelines.md
+git commit -m "test: cover per-step conversation transcripts"
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Per-step transcript files are implemented in Tasks 1, 2, and 4.
+- Assistant, reasoning, tool, permission, turn, error, and raw record kinds are modeled in Task 1 and extracted in Task 3.
+- Coalescing and truncation are implemented in Task 2.
+- The old route is intentionally replaced in Task 5.
+- Frontend consumption is handled in Task 6.
+- Product E2E and docs are handled in Task 7.
+
+Placeholder scan:
+
+- The plan contains no red-flag marker strings or empty steps.
+- Steps that require code include concrete snippets or exact local adaptation instructions tied to existing helper names.
+
+Type consistency:
+
+- Backend record types use `TranscriptRecord`, `TranscriptRecordKind`, `TranscriptTruncation`, and `TranscriptResponse` consistently.
+- Parser-level blocks use `TranscriptBlock` and `TranscriptBlockKind`, then map to persisted `TranscriptRecordKind` in the orchestrator.
+- API routes keep the existing Rust function names `get_conversation` and `get_conversation_message` while changing the path and response contract, which limits router/OpenAPI churn.

--- a/docs/superpowers/specs/2026-06-14-per-step-conversation-transcript-design.md
+++ b/docs/superpowers/specs/2026-06-14-per-step-conversation-transcript-design.md
@@ -1,0 +1,281 @@
+# Per-Step Conversation Transcript Design
+
+Date: 2026-06-14
+Status: Approved for implementation planning
+
+## Goal
+
+Add a per-step JSONL transcript that records what happened inside each agent step:
+assistant messages, reasoning chunks when exposed by the runtime, tool calls, tool results,
+permission activity, prompt metadata, and turn completion details.
+
+This transcript is separate from the pipeline timeline. The timeline remains a compact event stream
+for step state transitions and run progress. The transcript is the drill-down record operators use
+when they need to debug a specific step.
+
+## Context
+
+Issue 181 requests one JSONL transcript file per pipeline step. The existing timeline writer already
+persists run-level events under `.ensemble/runs/{run_id}/events.jsonl`, but timeline events are too
+coarse and intentionally truncate output.
+
+The current conversation API reads `{workspace}/.ensemble/conversation.jsonl`, but the project does
+not need to preserve that route or data shape. The correct long-term design is a run and step scoped
+transcript contract.
+
+The current ACP parsing path also loses important transcript data before the orchestrator sees it.
+`parse_session_update` preserves assistant text, usage, stop reason, permission request, and verdict,
+but not structured tool-call updates, tool results, or reasoning chunks. A persistence sink that only
+consumes today's `AgentEvent` values would therefore miss key content from the issue.
+
+## Requirements
+
+1. Persist one transcript file per run step.
+2. Preserve assistant text, reasoning chunks, tool calls, tool results, prompt metadata, permission
+   activity, turn completion, and errors when the runtime exposes them.
+3. Do not rely on pipeline timeline events to reconstruct the transcript.
+4. Coalesce adjacent text and reasoning deltas so transcripts do not contain thousands of tiny rows.
+5. Truncate large tool results using head and tail retention while recording truncation metadata.
+6. Replace the old issue-level conversation API with run and step scoped transcript endpoints.
+7. Keep transcript file I/O off the orchestrator hot path.
+8. Update documentation because this changes the API contract and runtime persistence behavior.
+
+## Storage Layout
+
+Store transcript rows at:
+
+```text
+{workspace}/.ensemble/runs/{run_id}/steps/{step_name}/transcript.jsonl
+```
+
+`step_name` must be sanitized before being used as a path segment. The implementation should either
+reuse an existing workspace-key style sanitizer or add a small sanitizer that accepts normal pipeline
+step names and rejects or encodes path separators.
+
+This path intentionally lives beside run timeline storage so a run's timeline and step transcripts
+can be inspected together.
+
+## Transcript Record Model
+
+Each JSONL line should deserialize as a typed `TranscriptRecord`.
+
+```text
+schema_version: u32
+run_id: String
+issue_identifier: String
+step_name: String
+attempt: u32
+sequence: u64
+timestamp: DateTime<Utc>
+kind: TranscriptRecordKind
+payload: serde_json::Value
+truncated: Option<TranscriptTruncation>
+```
+
+Initial record kinds:
+
+```text
+prompt
+assistant_message
+reasoning
+tool_call
+tool_result
+permission_request
+permission_resolution
+turn_complete
+error
+raw
+```
+
+`payload` is kind-specific and should preserve structured protocol data where practical. For example,
+tool calls should keep the tool call id, tool name, arguments, and status fields when present rather
+than reducing them to a display string.
+
+`raw` is a fallback for transcript-worthy data that cannot yet be normalized safely. It should not be
+used for every ACP message, because that would turn the transcript into a protocol dump.
+
+## ACP Runtime Flow
+
+Extend the ACP parser to return transcript blocks in addition to its current reduced fields.
+
+The existing normalized fields remain useful for verdict extraction, token accounting, and state
+updates. The new transcript blocks are for persistence and UI drill-down.
+
+The parser should recognize these logical categories from `session/update` payloads:
+
+- assistant text/message chunks
+- reasoning chunks when present
+- tool-call updates, including call id, tool name, arguments, and lifecycle status
+- tool-result or tool-output blocks
+- permission requests
+- stop reason and usage updates
+- final structured result/verdict payloads
+
+Both runtime paths must emit transcript data:
+
+- the `acpx` CLI/session path reading JSON-RPC lines from stdout
+- the direct ACP SDK path reading dispatch/session messages
+
+The runtime layer should not decide final storage paths. It should emit transcript blocks through the
+worker/orchestrator event channel with issue id, step name, and timestamp, matching the current worker
+event shape.
+
+## Orchestrator And Persistence
+
+Add a `TranscriptWriter` and `TranscriptPersistence` module parallel to timeline persistence.
+
+Responsibilities:
+
+- compute the per-run, per-step transcript path
+- append JSONL records
+- create parent directories as needed
+- assign monotonically increasing sequence numbers per `(run_id, step_name)`
+- buffer and coalesce adjacent assistant/reasoning deltas
+- truncate large tool output before writing
+- expose a flush path for orchestrator shutdown and tests
+
+The orchestrator should resolve run context in the same place it handles agent updates. When a
+transcript block arrives without a run id, it should still update in-memory state if appropriate but
+skip persistence and log a warning. Missing run context should not crash the worker loop.
+
+Coalescing should happen in transcript persistence or a small helper owned by that module, not in the
+parser. The parser should report protocol facts; persistence should decide how to batch noisy deltas.
+
+## Coalescing
+
+Coalesce adjacent records when all of these are true:
+
+- same `run_id`
+- same `step_name`
+- same `kind` of `assistant_message` or `reasoning`
+- same logical source stream, if the runtime exposes one
+- the accumulated content remains below the configured or constant byte threshold
+- the elapsed time since the previous fragment remains within the configured or constant window
+
+Reasonable first constants:
+
+```text
+coalesce_window_ms = 250
+coalesce_max_bytes = 16 KiB
+```
+
+Flush coalesced records when a different kind arrives, a size/time threshold is exceeded, the worker
+exits, or the orchestrator shuts down.
+
+## Truncation
+
+Large tool results should be truncated before persistence using head and tail retention.
+
+Recommended first constants:
+
+```text
+tool_result_max_bytes = 128 KiB
+tool_result_head_bytes = 96 KiB
+tool_result_tail_bytes = 32 KiB
+```
+
+Truncation metadata should include:
+
+```text
+original_bytes
+retained_head_bytes
+retained_tail_bytes
+```
+
+The retained payload must remain valid JSON. If a structured value is too large, store a structured
+wrapper that contains the retained text representation and truncation metadata instead of writing
+invalid partial JSON.
+
+## API Contract
+
+Replace the old issue-level conversation route with run and step scoped transcript routes.
+
+```text
+GET /api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation
+GET /api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation/{sequence}
+```
+
+The list endpoint should support cursor and limit pagination. The single-record endpoint should
+return one transcript row by sequence.
+
+Responses should return transcript records, not the old role/content `ConversationMessage` shape.
+Missing transcript files should return an empty list for the list endpoint and `404` for a specific
+sequence lookup.
+
+Path inputs must be validated:
+
+- `identifier` is sanitized to the workspace key, as the existing API does.
+- `run_id` must reject path traversal and separators.
+- `step_name` must use the same step-name path sanitizer as the writer.
+
+## UI Integration
+
+The run transcript UI should consume step-scoped transcript records as the primary conversation
+source. Timeline and interaction data remain supporting sources for run-level state, human Q&A, and
+navigation.
+
+The first UI integration can load transcript records for the currently selected or active step. A
+later enhancement can prefetch transcripts for all visible steps if performance and UX require it.
+
+The frontend transcript model should map backend record kinds to existing presentation entries:
+
+- `assistant_message` -> agent message entries
+- `reasoning`, `tool_call`, `tool_result`, and `raw` -> collapsed tool/activity groups by default
+- `permission_request` and `permission_resolution` -> warning or workflow activity entries
+- `turn_complete` -> compact step/turn event
+- `error` -> error entry
+
+## Error Handling
+
+Transcript persistence failures should not fail the agent step. They should be logged with enough
+context to diagnose the affected run and step.
+
+API parse failures should return an internal error because malformed JSONL indicates corrupted local
+state. Missing files are not errors for list reads.
+
+If the runtime exposes an unknown transcript block, preserve it as `raw` only when it is useful for
+operator debugging and small enough to retain safely. Otherwise, summarize it as a warning/error
+record.
+
+## Testing
+
+Backend tests should cover:
+
+- parser extraction of assistant messages, reasoning chunks, tool-call updates, tool results,
+  permission requests, usage, and stop reasons
+- `TranscriptWriter` path construction and append-only JSONL behavior
+- transcript persistence ordering and flush behavior
+- coalescing adjacent assistant/reasoning deltas
+- head/tail truncation of large tool results
+- API pagination, missing-file behavior, malformed JSONL behavior, and path validation
+- product E2E fixture proving a mock ACP stream writes a per-step transcript
+
+Frontend tests should cover:
+
+- transcript API client model changes
+- mapping backend transcript record kinds into normalized UI transcript entries
+- collapsed rendering for reasoning/tool records
+- loading transcript data for the selected or active step
+
+## Documentation
+
+Update the canonical docs that describe:
+
+- agent runtime persistence behavior in `docs/SPEC.md`
+- pipeline/transcript debugging behavior in `docs/pipelines.md`
+- API route behavior if an API reference section exists or is generated from OpenAPI
+
+Because the old issue-level conversation route is intentionally replaced, docs and generated client
+types should not keep describing it as the primary contract.
+
+## Open Implementation Notes
+
+The implementation plan should decide the exact Rust module names, but the likely split is:
+
+- `crates/ensemble-core/src/transcript/model.rs`
+- `crates/ensemble-core/src/transcript/writer.rs`
+- `crates/ensemble-core/src/transcript/persistence.rs`
+- `crates/ensemble-core/src/api/conversation.rs` rewritten around transcript records
+
+The old `conversation.rs` module name can remain for API route compatibility with generated frontend
+names, but the data contract should be transcript-based.


### PR DESCRIPTION
## Summary

Adds per-step conversation transcript persistence for pipeline runs. Each step now writes typed JSONL records under `.ensemble/runs/{run_id}/steps/{step_name}/transcript.jsonl`, covering assistant messages, reasoning, tool calls/results, permissions, prompts, turn completion, and errors.

The backend exposes run/step-scoped conversation endpoints, and the web UI consumes transcript records for the issue detail transcript view. The implementation also documents transcript behavior and adds product E2E coverage for assistant and tool-call transcript persistence.

Fixes #181

## Validation

- `cargo test --workspace --exclude ensemble-desktop`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm test`
- `pnpm run build`