### PR TITLE
Improve dashboard tool call display

### DIFF
--- a/crates/ensemble-ui/src-ui/src/components/ConversationViewer.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ConversationViewer.tsx
@@ -3,19 +3,13 @@ import { useStepConversationQuery } from "@/hooks";
 import type { TranscriptRecord } from "@/generated/models";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { transcriptRecordDetail } from "@/components/transcript/transcript-model";
 
 interface ConversationViewerProps {
   identifier: string;
   runId: string;
   stepName: string;
   scrollToIndex?: number;
-}
-
-function recordText(record: TranscriptRecord): string {
-  if (typeof record.payload === "object" && record.payload != null && "text" in record.payload) {
-    return String((record.payload as { text?: unknown }).text ?? "");
-  }
-  return JSON.stringify(record.payload);
 }
 
 function MessageBubble({ record, highlight }: { record: TranscriptRecord; highlight?: boolean }) {
@@ -31,7 +25,7 @@ function MessageBubble({ record, highlight }: { record: TranscriptRecord; highli
         <span className="font-medium capitalize">{record.kind.replace(/_/g, " ")}</span>
         <span>#{record.sequence}</span>
       </div>
-      <p className="text-sm whitespace-pre-wrap">{recordText(record)}</p>
+      <p className="text-sm whitespace-pre-wrap break-words">{transcriptRecordDetail(record)}</p>
       {record.payload != null && record.kind !== "assistant_message" ? (
         <details className="mt-2">
           <summary className="text-xs text-muted-foreground cursor-pointer hover:underline">

--- a/crates/ensemble-ui/src-ui/src/components/transcript/RunTranscript.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/transcript/RunTranscript.test.tsx
@@ -153,4 +153,49 @@ describe("RunTranscript", () => {
     expect(screen.getByText("message 4")).toBeInTheDocument();
     expect(humanMessageRender.fn).toHaveBeenCalledTimes(4);
   });
+
+  it("renders tool activity entries with an icon", () => {
+    const entries: GroupedTranscriptEntry[] = [
+      {
+        kind: "tool_activity",
+        id: "tool-1",
+        timestamp: "2026-04-14T10:00:00Z",
+        event: {
+          type: "tool_call",
+          timestamp: "2026-04-14T10:00:00Z",
+          detail: "Tool call call_123 completed",
+        },
+      },
+      {
+        kind: "tool_activity_group",
+        id: "tool-group-1",
+        timestamp: "2026-04-14T10:00:01Z",
+        count: 2,
+        defaultExpanded: false,
+        entries: [
+          {
+            kind: "tool_activity",
+            id: "tool-2",
+            timestamp: "2026-04-14T10:00:01Z",
+            event: {
+              type: "tool_call",
+              timestamp: "2026-04-14T10:00:01Z",
+              detail: "Tool call call_456 completed",
+            },
+          },
+        ],
+      },
+    ];
+
+    render(
+      <RunTranscript
+        entries={entries}
+        activeEntryId={null}
+        onJumpToEntry={() => {}}
+        transcriptSessionKey="session-1"
+      />,
+    );
+
+    expect(screen.getAllByTestId("tool-activity-icon")).toHaveLength(2);
+  });
 });

--- a/crates/ensemble-ui/src-ui/src/components/transcript/entries/StepEventEntry.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/transcript/entries/StepEventEntry.tsx
@@ -1,3 +1,4 @@
+import { Wrench } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import type { TranscriptEntry } from "../transcript-model";
@@ -21,7 +22,12 @@ export function StepEventEntry({ entry, isActive }: StepEventEntryProps) {
 
   return (
     <Card className={cn("border-slate-300/60 bg-slate-50/40 p-4", isActive && "ring-2 ring-primary")}>
-      <div className="text-xs font-medium uppercase text-slate-700">{label}</div>
+      <div className="flex items-center gap-1.5 text-xs font-medium uppercase text-slate-700">
+        {entry.kind === "tool_activity" ? (
+          <Wrench data-testid="tool-activity-icon" aria-hidden="true" className="size-3.5" />
+        ) : null}
+        <span>{label}</span>
+      </div>
       <div className="mt-1 text-sm font-medium">{entry.event.type}</div>
       <p className="mt-1 text-sm text-muted-foreground whitespace-pre-wrap">{entry.event.detail}</p>
       <div className="mt-2 text-xs text-muted-foreground">

--- a/crates/ensemble-ui/src-ui/src/components/transcript/entries/ToolActivityGroupEntry.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/transcript/entries/ToolActivityGroupEntry.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Wrench } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import type { GroupedTranscriptEntry } from "../transcript-model";
@@ -16,7 +17,10 @@ export function ToolActivityGroupEntry({ entry, isActive }: ToolActivityGroupEnt
       className={cn("border-dashed border-slate-300 bg-slate-100/40 p-4", isActive && "ring-2 ring-primary")}
       data-active={isActive ? "true" : "false"}
     >
-      <div className="text-xs font-medium uppercase text-slate-700">Tool activity</div>
+      <div className="flex items-center gap-1.5 text-xs font-medium uppercase text-slate-700">
+        <Wrench data-testid="tool-activity-icon" aria-hidden="true" className="size-3.5" />
+        <span>Tool activity</span>
+      </div>
       <p className="mt-1 text-sm">{entry.count} low-level activities</p>
       <button
         type="button"

--- a/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.test.ts
+++ b/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.test.ts
@@ -124,6 +124,42 @@ describe("buildTranscriptEntries", () => {
     );
   });
 
+  it("formats sparse tool-call transcript payloads as readable activity", () => {
+    const entries = buildTranscriptEntries({
+      conversation: [],
+      transcriptRecords: [
+        {
+          schema_version: 1,
+          run_id: "run-1",
+          issue_identifier: "repo#1",
+          step_name: "build",
+          attempt: 1,
+          sequence: 1,
+          timestamp: "2026-06-14T00:00:00Z",
+          kind: "tool_call",
+          payload: {
+            arguments: null,
+            name: null,
+            status: "completed",
+            title: null,
+            tool_call_id: "call_MW2une4H5kusBk7wSwUglCyS",
+          },
+        },
+      ],
+      interactions: [],
+      events: [],
+    });
+
+    expect(entries).toEqual([
+      expect.objectContaining({
+        kind: "tool_activity",
+        event: expect.objectContaining({
+          detail: "Tool call call_MW2une4H5kusBk7wSwUglCyS completed",
+        }),
+      }),
+    ]);
+  });
+
   it("maps non-message transcript records into visible entries", () => {
     const entries = buildTranscriptEntries({
       conversation: [],

--- a/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.ts
+++ b/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.ts
@@ -140,12 +140,61 @@ function interactionSequence(index: number): number {
   return index;
 }
 
+function objectPayload(payload: unknown): Record<string, unknown> | null {
+  if (typeof payload === "object" && payload != null) {
+    return payload as Record<string, unknown>;
+  }
+  return null;
+}
+
+function stringPayloadValue(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function compactJson(value: unknown): string {
+  const json = JSON.stringify(value);
+  return json ?? String(value);
+}
+
 function payloadText(payload: unknown): string {
   if (typeof payload === "object" && payload != null && "text" in payload) {
     return String((payload as { text?: unknown }).text ?? "");
   }
   const json = JSON.stringify(payload);
   return json ?? "";
+}
+
+export function transcriptRecordDetail(record: TranscriptRecord): string {
+  if (record.kind !== "tool_call") {
+    return payloadText(record.payload);
+  }
+
+  const payload = objectPayload(record.payload);
+  if (!payload) {
+    return payloadText(record.payload);
+  }
+
+  const label =
+    stringPayloadValue(payload, "title") ??
+    stringPayloadValue(payload, "name") ??
+    "Tool call";
+  const toolCallId = stringPayloadValue(payload, "tool_call_id");
+  const status = stringPayloadValue(payload, "status");
+  const args = payload.arguments;
+
+  const parts = [label];
+  if (toolCallId && !label.includes(toolCallId)) {
+    parts.push(toolCallId);
+  }
+  if (status) {
+    parts.push(status);
+  }
+  if (args != null) {
+    parts.push(compactJson(args));
+  }
+
+  return parts.join(" ");
 }
 
 function transcriptRecordEvent(record: TranscriptRecord, detail: string): WsEventData {
@@ -163,7 +212,7 @@ function transcriptRecordEvent(record: TranscriptRecord, detail: string): WsEven
 function entryFromTranscriptRecord(record: TranscriptRecord): TranscriptEntry | null {
   const timestamp = record.timestamp;
   const id = `transcript:${record.run_id}:${record.step_name}:${record.sequence}`;
-  const text = payloadText(record.payload);
+  const text = transcriptRecordDetail(record);
 
   if (record.kind === "assistant_message") {
     return {


### PR DESCRIPTION
## Summary

- Format sparse tool-call transcript payloads into readable activity text instead of rendering null-heavy JSON as the primary display.
- Reuse the transcript formatter in the standalone conversation viewer and allow long tool-call identifiers to wrap cleanly.
- Add a small tool icon to single and grouped tool activity entries.

## Why

Tool-call transcript records could arrive with mostly null fields plus a `tool_call_id`, which made the dashboard show repeated raw JSON blocks and caused poor wrapping in the transcript UI.

## Validation

- `npm test`
- `npm exec tsc -- --noEmit`
- `npm exec vite -- build`