### PR TITLE
Fix orchestrator retry and state recovery handling

### DIFF
--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -4,7 +4,7 @@ pub mod retry;
 pub mod scheduler;
 pub mod state;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -379,10 +379,12 @@ impl Orchestrator {
         self.process_finalize_retries().await;
 
         // Pre-compute lowercase state lists once per tick
-        let (active_lower, terminal_lower) = {
+        let (active_lower, reconcile_active_lower, terminal_lower) = {
             let state = self.state.read().await;
+            let config = self.config.read().await;
             (
                 state.active_states_lower.clone(),
+                build_reconcile_active_states_lower(&config),
                 state.terminal_states_lower.clone(),
             )
         };
@@ -426,7 +428,7 @@ impl Orchestrator {
             let reconcile_result = reconcile_tracker_states(
                 &state,
                 self.tracker.as_ref(),
-                &active_lower,
+                &reconcile_active_lower,
                 &terminal_lower,
             )
             .await;
@@ -2017,26 +2019,27 @@ impl Orchestrator {
                 let completed_at = Utc::now();
                 let mut final_failure = false;
                 let mut history_record = None;
-                let mut completed_identifier = None;
                 let mut history_run_id = None;
 
-                if let Some(entry) = state.remove_running(issue_id) {
-                    completed_identifier = Some(entry.identifier.clone());
+                if let Some(entry) = state.running.get(issue_id).cloned() {
                     history_run_id = entry.run_id.clone();
-                    state.add_runtime_seconds(&entry);
-                    let retry_scheduled = schedule_failure_retry(
-                        &mut state,
-                        FailureRetryRequest {
-                            issue_id,
-                            identifier: &entry.identifier,
-                            attempt: next_attempt(entry.retry_attempt),
-                            max_backoff_ms: config.agent.max_retry_backoff_ms,
-                            max_cycles: config.max_cycles,
-                            error: &error,
-                            retry_from_step: None,
-                            with_fixup: false,
-                        },
-                    );
+                    let retry_scheduled = if retry::is_non_retryable_failure(&error) {
+                        None
+                    } else {
+                        schedule_failure_retry(
+                            &mut state,
+                            FailureRetryRequest {
+                                issue_id,
+                                identifier: &entry.identifier,
+                                attempt: next_attempt(entry.retry_attempt),
+                                max_backoff_ms: config.agent.max_retry_backoff_ms,
+                                max_cycles: config.max_cycles,
+                                error: &error,
+                                retry_from_step: None,
+                                with_fixup: false,
+                            },
+                        )
+                    };
                     final_failure = retry_scheduled.is_none();
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
@@ -2050,6 +2053,9 @@ impl Orchestrator {
                             )
                         });
                     }
+                    if final_failure {
+                        state.complete_issue(issue_id, Some("completed_failed".to_string()), None);
+                    }
                     if retry_scheduled.is_none() && self.tracker.supports_writes() {
                         if let Err(e) = self
                             .tracker
@@ -2059,17 +2065,11 @@ impl Orchestrator {
                             warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
                         }
                     }
-                }
-                state.remove_pipeline_run(issue_id);
-                if final_failure {
-                    if let Some(identifier) = completed_identifier {
-                        state.add_completed(
-                            issue_id.to_string(),
-                            identifier,
-                            "completed_failed".to_string(),
-                        );
+                    if let Some(entry) = state.remove_running(issue_id) {
+                        state.add_runtime_seconds(&entry);
                     }
                 }
+                state.remove_pipeline_run(issue_id);
 
                 drop(state);
                 if final_failure {
@@ -4829,6 +4829,45 @@ fn transcript_kind_from_agent_kind(
     }
 }
 
+fn build_reconcile_active_states_lower(config: &EnsembleConfig) -> Vec<String> {
+    let terminal: HashSet<String> = config
+        .tracker
+        .terminal_states
+        .iter()
+        .map(|state| state.to_lowercase())
+        .collect();
+    let mut states = HashSet::new();
+
+    for state in &config.tracker.active_states {
+        let state = state.to_lowercase();
+        if !terminal.contains(&state) {
+            states.insert(state);
+        }
+    }
+
+    for step in &config.steps {
+        if let Some(state) = step.tracker_state.as_deref() {
+            let state = state.to_lowercase();
+            if !terminal.contains(&state) {
+                states.insert(state);
+            }
+        }
+
+        if let Some(state) = step
+            .approval
+            .as_ref()
+            .and_then(|approval| approval.state.as_deref())
+        {
+            let state = state.to_lowercase();
+            if !terminal.contains(&state) {
+                states.insert(state);
+            }
+        }
+    }
+
+    states.into_iter().collect()
+}
+
 fn new_run_id() -> String {
     let millis = Utc::now().timestamp_millis();
     let seq = RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -6069,6 +6108,46 @@ agent:
         parse_config(yaml).unwrap()
     }
 
+    #[test]
+    fn reconciliation_active_states_include_workflow_managed_tracker_states() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress"]
+  terminal_states: ["Done", "Paused"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{ issue.identifier }}."
+steps:
+  - name: implement
+    agent: builder
+  - name: review
+    agent: builder
+    tracker_state: Review
+  - name: plan
+    agent: builder
+    tracker_state: Planning
+    approval:
+      mode: when_requested_by_agent
+      state: Plan Review
+on_success: Done
+on_failure: Paused
+"#;
+        let config = parse_config(yaml).unwrap();
+
+        let states = build_reconcile_active_states_lower(&config);
+
+        assert!(states.contains(&"todo".to_string()));
+        assert!(states.contains(&"in progress".to_string()));
+        assert!(states.contains(&"review".to_string()));
+        assert!(states.contains(&"planning".to_string()));
+        assert!(states.contains(&"plan review".to_string()));
+        assert!(!states.contains(&"done".to_string()));
+        assert!(!states.contains(&"paused".to_string()));
+    }
+
     fn make_parallel_resume_config() -> EnsembleConfig {
         let yaml = r#"
 tracker:
@@ -7022,6 +7101,77 @@ agent:
         assert!(
             tokio::fs::read_to_string(&history_path).await.is_err(),
             "retryable failure should not append history"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_does_not_retry_acpx_unsupported_model_failure() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut raw_config = make_config();
+        raw_config.workspace.root = Some(dir.path().display().to_string());
+        raw_config.max_cycles = 3;
+
+        let config = Arc::new(RwLock::new(raw_config));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config.clone(),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), Some(1));
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        let unsupported_model_error = "acpx command failed: sessions ensure — exit status: 1; stderr: ; stdout: {\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32603,\"message\":\"Cannot apply --model \\\"opencode-go/kimi-k2.5\\\": the ACP agent did not advertise model support. Generic model selection requires ACP models plus session/set_model support, or an adapter-specific startup model flag.\",\"data\":{\"acpxCode\":\"RUNTIME\",\"origin\":\"cli\",\"sessionId\":\"unknown\"}}}".to_string();
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Failed {
+                    error: unsupported_model_error.clone(),
+                    kind: WorkerFailureKind::Runtime,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.retry_attempts.contains_key("1"));
+        assert!(state.completed.contains_key("1"));
+        drop(state);
+
+        let history_path = dir.path().join("ensemble_history.jsonl");
+        let contents = tokio::fs::read_to_string(&history_path).await.unwrap();
+        let record = contents
+            .lines()
+            .map(|line| serde_json::from_str::<crate::history::model::HistoryRecord>(line).unwrap())
+            .next()
+            .unwrap();
+        assert_eq!(
+            record.last_error.as_deref(),
+            Some(unsupported_model_error.as_str())
         );
     }
 

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -123,6 +123,13 @@ pub fn schedule_failure_retry(
     Some(due_at_ms)
 }
 
+/// Identify deterministic agent/runtime configuration failures that another
+/// retry cannot fix.
+pub fn is_non_retryable_failure(reason: &str) -> bool {
+    let reason = reason.to_ascii_lowercase();
+    reason.contains("cannot apply --model") && reason.contains("did not advertise model support")
+}
+
 /// Determine the next attempt number from a running entry.
 /// If the entry had a retry_attempt, increment it; otherwise start at 1.
 pub fn next_attempt(current: Option<u32>) -> u32 {
@@ -179,6 +186,18 @@ mod tests {
     fn retry_reason_is_non_empty() {
         let reason = normalize_reason("");
         assert_eq!(reason, "unknown");
+    }
+
+    #[test]
+    fn unsupported_acpx_model_capability_failure_is_not_retryable() {
+        assert!(is_non_retryable_failure(
+            "acpx command failed: sessions ensure — exit status: 1; stdout: {\"message\":\"Cannot apply --model \\\"opencode-go/kimi-k2.5\\\": the ACP agent did not advertise model support.\"}"
+        ));
+    }
+
+    #[test]
+    fn ordinary_agent_failure_is_retryable() {
+        assert!(!is_non_retryable_failure("temporary agent crash"));
     }
 
     #[test]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1124,6 +1124,12 @@ Tick sequence:
 If per-tick validation fails, dispatch is skipped for that tick, but reconciliation still happens
 first.
 
+Reconciliation uses a broader active-state set than candidate dispatch. In addition to
+`tracker.active_states`, any non-terminal `steps[].tracker_state` and approval `state` written by
+the workflow are considered active for already-running or waiting issues. This prevents the
+orchestrator from abandoning a run just because it moved the tracker item into a workflow-owned
+intermediate state such as `Review` or `Plan Review`.
+
 ### 8.2 Candidate Selection Rules
 
 An issue is dispatch-eligible only if all are true:
@@ -1174,6 +1180,8 @@ Backoff formula:
 - Normal continuation retries after a clean worker exit use a short fixed delay of `1000` ms.
 - Failure-driven retries use `delay = min(10000 * 2^(attempt - 1), agent.max_retry_backoff_ms)`.
 - Power is capped by the configured max retry backoff (default `300000` / 5m).
+- Deterministic configuration/runtime capability failures may be treated as terminal immediately
+  instead of retrying, because another attempt cannot change the configured agent capabilities.
 
 Retry handling behavior:
 
@@ -1622,7 +1630,8 @@ Behavior:
 2. Build prompt from workflow template.
 3. Start ACP session (`initialize` + `session/new`).
 4. Forward ACP `session/update` events to orchestrator.
-5. On any error, fail the worker attempt (the orchestrator will retry).
+5. On any error, fail the worker attempt. The orchestrator decides whether the failure is
+   retryable or terminal.
 
 Note:
 
@@ -1767,6 +1776,8 @@ Orchestrator-driven writes:
 
 - **Step entry**: When a pipeline step begins, the orchestrator writes the step's `tracker_state`
   to the tracker (for example "In Progress", "In Review").
+  Non-terminal step-entry and approval states are treated as active for reconciliation of existing
+  runs, but they do not automatically make new issues dispatch-eligible.
 - **Pipeline success**: When all steps pass, the orchestrator writes `on_success` (for example
   "Done").
 - **Pipeline failure/rejection**: When any step fails or returns a failed result, the orchestrator
@@ -2390,7 +2401,7 @@ function reconcile_running_issues(state):
   for issue in refreshed:
     if issue.state in terminal_states:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=true)
-    else if issue.state in active_states:
+    else if issue.state in reconciliation_active_states:
       state.running[issue.id].issue = issue
     else:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=false)

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,9 +5,11 @@ set -euo pipefail
 # Run from the repo root.
 #
 # Usage:
-#   ./scripts/dev.sh build              # full build with UI
-#   ./scripts/dev.sh run                # run with no args
-#   ./scripts/dev.sh run --help         # pass --help to ensemble
+#   ./scripts/dev.sh build                # full build with UI
+#   ./scripts/dev.sh build --web-ui       # also build ensemble-cli with the web-ui feature
+#   ./scripts/dev.sh run                  # run with no args
+#   ./scripts/dev.sh run --help           # pass --help to ensemble
+#   ./scripts/dev.sh run --web-ui web     # build with web-ui, then run `web` subcommand
 #
 # To skip UI build, set SKIP_UI_BUILD=1:
 #   SKIP_UI_BUILD=1 ./scripts/dev.sh build
@@ -17,6 +19,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UI_DIR="$REPO_ROOT/crates/ensemble-ui/src-ui"
 
+# Whether the ensemble-cli binary should be built with the web-ui feature.
+WEB_UI_ENABLED=0
+
 # Show usage for this script (not ensemble)
 show_usage() {
   cat << 'EOF'
@@ -25,6 +30,10 @@ Usage: ./scripts/dev.sh <command> [args]
 Commands:
   build                Build the workspace
   run                  Build and run the ensemble CLI
+
+Flags:
+  --web-ui             Build ensemble-cli with the `web-ui` Cargo feature
+                       (embeds the dashboard so `ensemble web` is available)
 
 Environment Variables:
   SKIP_UI_BUILD=1      Skip UI build (Rust-only)
@@ -36,18 +45,24 @@ Arguments after the command are passed to ensemble:
 
 Examples:
   ./scripts/dev.sh build                    # Full build
+  ./scripts/dev.sh build --web-ui           # Full build, embed web dashboard
   SKIP_UI_BUILD=1 ./scripts/dev.sh build    # Rust-only build
   ./scripts/dev.sh run                      # Run ensemble with no args
   ./scripts/dev.sh run --help               # Show ensemble help
+  ./scripts/dev.sh run --web-ui web         # Run `web` with the dashboard
   SKIP_UI_BUILD=1 ./scripts/dev.sh run web  # Skip UI, run web command
 EOF
 }
 
-# Common build logic
+# Build the workspace, then (if --web-ui) layer the web-ui feature onto
+# ensemble-cli as an incremental second build.
 run_build() {
   if [ -n "${SKIP_UI_BUILD:-}" ]; then
     echo "==> Skipping UI build (SKIP_UI_BUILD=1)"
     cargo build --workspace --exclude ensemble-desktop
+    if [[ "$WEB_UI_ENABLED" == "1" ]]; then
+      cargo build -p ensemble-cli --features web-ui
+    fi
     return 0
   fi
 
@@ -62,14 +77,22 @@ run_build() {
   # 3. Build the workspace (build.rs will run codegen:client + tsc + vite via build:embed)
   echo "==> Building workspace"
   cargo build --workspace --exclude ensemble-desktop
+  if [[ "$WEB_UI_ENABLED" == "1" ]]; then
+    cargo build -p ensemble-cli --features web-ui
+  fi
 }
 
 # Run command logic
 run_dev() {
+  local web_ui_args=()
+  if [[ "$WEB_UI_ENABLED" == "1" ]]; then
+    web_ui_args=(--features web-ui)
+  fi
+
   if [ -n "${SKIP_UI_BUILD:-}" ]; then
     echo "==> Skipping UI build (SKIP_UI_BUILD=1)"
-    echo "==> Running: cargo run --workspace --exclude ensemble-desktop -- $*"
-    cargo run --workspace --exclude ensemble-desktop -- "$@"
+    echo "==> Running: cargo run -p ensemble-cli $*"
+    cargo run -p ensemble-cli "${web_ui_args[@]+"${web_ui_args[@]}"}" -- "$@"
     return 0
   fi
 
@@ -83,8 +106,8 @@ run_dev() {
 
   # 3. Build and run the workspace
   echo "==> Building and running workspace"
-  echo "==> Running: cargo run -p ensemble-cli -- $*"
-  cargo run -p ensemble-cli -- "$@"
+  echo "==> Running: cargo run -p ensemble-cli $*"
+  cargo run -p ensemble-cli "${web_ui_args[@]+"${web_ui_args[@]}"}" -- "$@"
 }
 
 # Main
@@ -104,11 +127,34 @@ fi
 
 case "$command" in
   build)
+    for arg in "$@"; do
+      case "$arg" in
+        --web-ui)
+          WEB_UI_ENABLED=1
+          ;;
+        *)
+          echo "Unknown argument for build: $arg"
+          show_usage
+          exit 1
+          ;;
+      esac
+    done
     run_build
     echo "==> Done"
     ;;
   run)
-    run_dev "$@"
+    REMAINING=()
+    for arg in "$@"; do
+      case "$arg" in
+        --web-ui)
+          WEB_UI_ENABLED=1
+          ;;
+        *)
+          REMAINING+=("$arg")
+          ;;
+      esac
+    done
+    run_dev "${REMAINING[@]+"${REMAINING[@]}"}"
     ;;
   *)
     echo "Unknown command: $command"


### PR DESCRIPTION
## Summary
- classify deterministic acpx generic model capability failures as terminal so they do not retry forever
- keep workflow-managed tracker states active for reconciliation so running pipelines are not dropped when a step writes states like Review or Plan Review
- document the retry/reconciliation state behavior

## Testing
- cargo fmt --all -- --check
- cargo test -p ensemble-core