### PR TITLE
Restore live journal before dispatch

### DIFF
--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -86,6 +86,13 @@ struct StepDispatchContext<'a> {
     step_outputs: StepOutputTemplateContext,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CandidateRestoreOutcome {
+    NotRestored,
+    ReadyForDispatch,
+    Parked,
+}
+
 struct InteractionRequestContext {
     step_name: String,
     agent_name: String,
@@ -604,15 +611,34 @@ impl Orchestrator {
 
             let restored_pipeline_ready = {
                 let state = self.state.read().await;
-                state.get_pipeline_run(&issue.id).is_some()
-                    && state.is_claimed(&issue.id)
-                    && !state.is_running(&issue.id)
-                    && !state.is_waiting_on_human(&issue.id)
-                    && !state.retry_attempts.contains_key(&issue.id)
+                Self::restored_pipeline_ready_for_dispatch(&state, &issue.id)
             };
 
-            if eligible.is_none() || restored_pipeline_ready {
+            if restored_pipeline_ready {
                 self.dispatch_issue(issue, None).await;
+                continue;
+            }
+
+            if eligible.is_some() {
+                continue;
+            }
+
+            match self.restore_pipeline_run_for_candidate(issue).await {
+                Ok(
+                    CandidateRestoreOutcome::NotRestored
+                    | CandidateRestoreOutcome::ReadyForDispatch,
+                ) => {
+                    self.dispatch_issue(issue, None).await;
+                }
+                Ok(CandidateRestoreOutcome::Parked) => {}
+                Err(error) => {
+                    warn!(
+                        issue_id = %issue.id,
+                        identifier = %issue.identifier,
+                        error = %error,
+                        "failed to restore live pipeline journal before dispatch"
+                    );
+                }
             }
         }
 
@@ -621,6 +647,81 @@ impl Orchestrator {
             duration_ms = elapsed_ms(tick_started_at),
             "orchestrator tick finished"
         );
+    }
+
+    async fn restore_pipeline_run_for_candidate(
+        &self,
+        issue: &Issue,
+    ) -> Result<CandidateRestoreOutcome, EnsembleError> {
+        {
+            let state = self.state.read().await;
+            if Self::restored_pipeline_ready_for_dispatch(&state, &issue.id) {
+                return Ok(CandidateRestoreOutcome::ReadyForDispatch);
+            }
+            if state.get_pipeline_run(&issue.id).is_some()
+                || state.is_running(&issue.id)
+                || state.is_claimed(&issue.id)
+            {
+                return Ok(CandidateRestoreOutcome::Parked);
+            }
+        }
+
+        let record = self
+            .pipeline_journal
+            .latest_live_record_for_issue(&issue.id)
+            .await
+            .map_err(|error| AgentError::IoError {
+                reason: format!(
+                    "failed to read pipeline transition journal for issue '{}': {error}",
+                    issue.id
+                ),
+            })?;
+
+        let Some(record) = record else {
+            return Ok(CandidateRestoreOutcome::NotRestored);
+        };
+
+        let config_snapshot = {
+            let config = self.config.read().await;
+            Arc::new(config.clone())
+        };
+        let issues_by_id = HashMap::from([(issue.id.clone(), issue.clone())]);
+        self.restore_pipeline_run_record(&record, config_snapshot, &issues_by_id)
+            .await?;
+
+        let state = self.state.read().await;
+        if Self::restored_pipeline_ready_for_dispatch(&state, &issue.id) {
+            Ok(CandidateRestoreOutcome::ReadyForDispatch)
+        } else if state.get_pipeline_run(&issue.id).is_some()
+            || state.is_claimed(&issue.id)
+            || state.is_waiting_on_human(&issue.id)
+            || state.retry_attempts.contains_key(&issue.id)
+        {
+            Ok(CandidateRestoreOutcome::Parked)
+        } else {
+            Ok(CandidateRestoreOutcome::NotRestored)
+        }
+    }
+
+    fn restored_pipeline_ready_for_dispatch(state: &OrchestratorState, issue_id: &str) -> bool {
+        let Some(run) = state.get_pipeline_run(issue_id) else {
+            return false;
+        };
+
+        state.is_claimed(issue_id)
+            && !state.is_running(issue_id)
+            && !state.is_waiting_on_human(issue_id)
+            && !state.retry_attempts.contains_key(issue_id)
+            && !Self::pipeline_has_waiting_step(run)
+    }
+
+    fn pipeline_has_waiting_step(run: &PipelineRun) -> bool {
+        run.step_states.values().any(|state| {
+            matches!(
+                state,
+                StepState::BlockedOnHuman { .. } | StepState::AwaitingApproval { .. }
+            )
+        })
     }
 
     /// Dispatch a single issue: build DAG, create PipelineRun, dispatch initial steps.
@@ -632,18 +733,25 @@ impl Orchestrator {
             if state.get_pipeline_run(&issue.id).is_some() {
                 drop(state);
 
-                let (config_snapshot, action) = {
+                let (config_snapshot, action, effective_cycle, effective_attempt) = {
                     let mut state = self.state.write().await;
-                    state.add_running(issue, attempt);
+                    let existing_cycle = state
+                        .get_pipeline_run(&issue.id)
+                        .map(|run| run.cycle)
+                        .unwrap_or(cycle);
+                    let effective_cycle = attempt.unwrap_or(existing_cycle);
+                    let effective_attempt =
+                        attempt.or_else(|| (effective_cycle > 1).then_some(effective_cycle));
+                    state.add_running(issue, effective_attempt);
                     let config = state.get_pipeline_config(&issue.id).cloned();
                     let action = state
                         .get_pipeline_run_mut(&issue.id)
                         .map(|run| {
-                            run.cycle = cycle;
+                            run.cycle = effective_cycle;
                             run.start()
                         })
                         .unwrap_or(PipelineAction::Waiting);
-                    (config, action)
+                    (config, action, effective_cycle, effective_attempt)
                 };
 
                 let Some(config_snapshot) = config_snapshot else {
@@ -659,7 +767,7 @@ impl Orchestrator {
                     event = ISSUE_DISPATCH_STARTED,
                     issue_id = %issue.id,
                     identifier = %issue.identifier,
-                    cycle = cycle,
+                    cycle = effective_cycle,
                     "resuming with existing pipeline"
                 );
 
@@ -802,7 +910,7 @@ impl Orchestrator {
                                         agent_name: &req.agent_name,
                                         step_kind: req.step_kind,
                                         tracker_state: req.tracker_state.as_deref(),
-                                        attempt,
+                                        attempt: effective_attempt,
                                         timeout_ms: Self::effective_step_timeout_ms(
                                             req.timeout_ms,
                                             &config_snapshot,
@@ -825,7 +933,7 @@ impl Orchestrator {
                     event = ISSUE_DISPATCH_COMPLETED,
                     issue_id = %issue.id,
                     identifier = %issue.identifier,
-                    cycle = cycle,
+                    cycle = effective_cycle,
                     "existing pipeline dispatch setup completed"
                 );
                 return;
@@ -5651,6 +5759,170 @@ agent:
     }
 
     #[tokio::test]
+    async fn handle_tick_restores_step_retry_journal_without_dispatching() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_retry_step_config();
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.retry_from_step("build");
+        let retry = RetryEntry {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            attempt: 2,
+            due_at_ms: current_time_ms().saturating_add(60_000),
+            error: Some("retry later".to_string()),
+            retry_from_step: Some("build".to_string()),
+            with_fixup: false,
+        };
+        let retry_record = orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepRetryScheduled,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("retry later".to_string()),
+                retry: Some(retry),
+                snapshot: Some(run.to_snapshot()),
+            })
+            .await
+            .unwrap();
+
+        orchestrator.handle_tick().await;
+
+        let lock = state.read().await;
+        assert!(lock.retry_attempts.contains_key(&issue.id));
+        assert!(!lock.is_running(&issue.id));
+        drop(lock);
+
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        assert!(!records.iter().any(|record| {
+            record.seq > retry_record.seq && record.kind == PipelineTransitionKind::StepRunning
+        }));
+    }
+
+    #[tokio::test]
+    async fn handle_tick_restores_blocked_live_journal_without_dispatching() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_retry_step_config();
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.step_states.insert(
+            "build".to_string(),
+            StepState::BlockedOnHuman {
+                interaction_request_id: "ask-1".to_string(),
+            },
+        );
+        let blocked_record = orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepBlockedOnHuman,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("need input".to_string()),
+                retry: None,
+                snapshot: Some(run.to_snapshot()),
+            })
+            .await
+            .unwrap();
+
+        orchestrator.handle_tick().await;
+
+        let lock = state.read().await;
+        assert!(lock.get_pipeline_run(&issue.id).is_some());
+        assert!(!lock.is_running(&issue.id));
+        drop(lock);
+
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        assert!(!records.iter().any(|record| {
+            record.seq > blocked_record.seq && record.kind == PipelineTransitionKind::StepRunning
+        }));
+    }
+
+    #[tokio::test]
     async fn restored_live_pipeline_run_dispatches_on_next_tick() {
         let temp = tempfile::tempdir().unwrap();
         let cfg = make_config();
@@ -5719,6 +5991,136 @@ agent:
                 .and_then(|run| run.step_states.get("build")),
             Some(StepState::Running { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn handle_tick_rehydrates_live_journal_before_fresh_dispatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress"]
+  terminal_states: ["Done", "Closed"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{ issue.identifier }}."
+steps:
+  - name: implement
+    agent: builder
+  - name: review
+    agent: builder
+    depends: ["implement"]
+max_cycles: 10
+on_success: Done
+on_failure: Todo
+concurrency:
+  max_concurrent_agents: 5
+polling:
+  interval_ms: 100
+workspace:
+  root: /tmp/ensemble-test
+agent:
+  max_turns: 3
+  command: "echo test"
+  session_mode: code
+"#;
+        let cfg = parse_config(yaml).unwrap();
+        let issue = test_issue("1", "In Progress");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 2, dag);
+        run.step_completed("implement", succeeded_step_output(), false);
+        run.mark_running("review", "stale-review-session".to_string());
+        orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepRunning,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-existing".to_string()),
+                cycle: 2,
+                step: Some("review".to_string()),
+                reason: None,
+                retry: None,
+                snapshot: Some(run.to_snapshot()),
+            })
+            .await
+            .unwrap();
+
+        orchestrator.handle_tick().await;
+
+        let lock = state.read().await;
+        assert!(lock.is_running(&issue.id));
+        assert_eq!(
+            lock.issue_run_ids.get(&issue.id).map(String::as_str),
+            Some("run-existing")
+        );
+        let restored_run = lock.get_pipeline_run(&issue.id).unwrap();
+        assert_eq!(restored_run.cycle, 2);
+        assert_eq!(
+            restored_run.step_states.get("implement"),
+            Some(&StepState::Passed)
+        );
+        assert!(matches!(
+            restored_run.step_states.get("review"),
+            Some(StepState::Running { session_id }) if session_id != "stale-review-session"
+        ));
+        assert_eq!(
+            lock.get_running(&issue.id)
+                .and_then(|entry| entry.retry_attempt),
+            Some(2)
+        );
+
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record.kind == PipelineTransitionKind::RunStarted)
+                .count(),
+            0
+        );
+        assert!(records
+            .iter()
+            .any(|record| record.kind == PipelineTransitionKind::StepRunning && record.seq == 2));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -636,8 +636,9 @@ impl Orchestrator {
                         issue_id = %issue.id,
                         identifier = %issue.identifier,
                         error = %error,
-                        "failed to restore live pipeline journal before dispatch"
+                        "failed to restore live pipeline journal before dispatch, falling back to fresh dispatch"
                     );
+                    self.dispatch_issue(issue, None).await;
                 }
             }
         }
@@ -5181,7 +5182,7 @@ mod tests {
     use crate::agent::events::{
         AgentEvent, InteractionRequestDraft, StepApprovalRequestDraft, WorkerEvent, WorkerResult,
     };
-    use crate::config::ensemble::{parse_config, ConcurrencyConfig};
+    use crate::config::ensemble::{parse_config, ConcurrencyConfig, StepConfig};
     use crate::error::AgentError;
     use crate::interaction::{
         InteractionKind, InteractionResponse, InteractionResumeStrategy, InteractionStatus,
@@ -6121,6 +6122,104 @@ agent:
         assert!(records
             .iter()
             .any(|record| record.kind == PipelineTransitionKind::StepRunning && record.seq == 2));
+    }
+
+    #[tokio::test]
+    async fn handle_tick_falls_back_to_fresh_dispatch_when_live_journal_restore_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_config();
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        let stale_dag = build_dag(&[StepConfig {
+            name: "removed".to_string(),
+            kind: StepKind::Agent,
+            agent: "builder".to_string(),
+            depends: Some(vec![]),
+            tracker_state: None,
+            timeout_ms: None,
+            approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
+        }])
+        .unwrap();
+        let stale_run = PipelineRun::new(issue.id.clone(), 1, stale_dag);
+        orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepRunning,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-stale".to_string()),
+                cycle: 1,
+                step: Some("removed".to_string()),
+                reason: None,
+                retry: None,
+                snapshot: Some(stale_run.to_snapshot()),
+            })
+            .await
+            .unwrap();
+
+        orchestrator.handle_tick().await;
+
+        let lock = state.read().await;
+        assert!(lock.is_running(&issue.id));
+        let restored_run = lock.get_pipeline_run(&issue.id).unwrap();
+        assert!(!restored_run.step_states.contains_key("removed"));
+        assert!(matches!(
+            restored_run.step_states.get("build"),
+            Some(StepState::Running { .. })
+        ));
+        drop(lock);
+
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record.kind == PipelineTransitionKind::RunStarted)
+                .count(),
+            1
+        );
+        assert!(records
+            .iter()
+            .any(|record| record.kind == PipelineTransitionKind::StepRunning
+                && record.step.as_deref() == Some("build")));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -4,7 +4,7 @@ pub mod retry;
 pub mod scheduler;
 pub mod state;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -379,10 +379,12 @@ impl Orchestrator {
         self.process_finalize_retries().await;
 
         // Pre-compute lowercase state lists once per tick
-        let (active_lower, terminal_lower) = {
+        let (active_lower, reconcile_active_lower, terminal_lower) = {
             let state = self.state.read().await;
+            let config = self.config.read().await;
             (
                 state.active_states_lower.clone(),
+                build_reconcile_active_states_lower(&config),
                 state.terminal_states_lower.clone(),
             )
         };
@@ -426,7 +428,7 @@ impl Orchestrator {
             let reconcile_result = reconcile_tracker_states(
                 &state,
                 self.tracker.as_ref(),
-                &active_lower,
+                &reconcile_active_lower,
                 &terminal_lower,
             )
             .await;
@@ -2017,26 +2019,27 @@ impl Orchestrator {
                 let completed_at = Utc::now();
                 let mut final_failure = false;
                 let mut history_record = None;
-                let mut completed_identifier = None;
                 let mut history_run_id = None;
 
-                if let Some(entry) = state.remove_running(issue_id) {
-                    completed_identifier = Some(entry.identifier.clone());
+                if let Some(entry) = state.running.get(issue_id).cloned() {
                     history_run_id = entry.run_id.clone();
-                    state.add_runtime_seconds(&entry);
-                    let retry_scheduled = schedule_failure_retry(
-                        &mut state,
-                        FailureRetryRequest {
-                            issue_id,
-                            identifier: &entry.identifier,
-                            attempt: next_attempt(entry.retry_attempt),
-                            max_backoff_ms: config.agent.max_retry_backoff_ms,
-                            max_cycles: config.max_cycles,
-                            error: &error,
-                            retry_from_step: None,
-                            with_fixup: false,
-                        },
-                    );
+                    let retry_scheduled = if retry::is_non_retryable_failure(&error) {
+                        None
+                    } else {
+                        schedule_failure_retry(
+                            &mut state,
+                            FailureRetryRequest {
+                                issue_id,
+                                identifier: &entry.identifier,
+                                attempt: next_attempt(entry.retry_attempt),
+                                max_backoff_ms: config.agent.max_retry_backoff_ms,
+                                max_cycles: config.max_cycles,
+                                error: &error,
+                                retry_from_step: None,
+                                with_fixup: false,
+                            },
+                        )
+                    };
                     final_failure = retry_scheduled.is_none();
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
@@ -2050,6 +2053,9 @@ impl Orchestrator {
                             )
                         });
                     }
+                    if final_failure {
+                        state.complete_issue(issue_id, Some("completed_failed".to_string()), None);
+                    }
                     if retry_scheduled.is_none() && self.tracker.supports_writes() {
                         if let Err(e) = self
                             .tracker
@@ -2059,17 +2065,11 @@ impl Orchestrator {
                             warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state");
                         }
                     }
-                }
-                state.remove_pipeline_run(issue_id);
-                if final_failure {
-                    if let Some(identifier) = completed_identifier {
-                        state.add_completed(
-                            issue_id.to_string(),
-                            identifier,
-                            "completed_failed".to_string(),
-                        );
+                    if let Some(entry) = state.remove_running(issue_id) {
+                        state.add_runtime_seconds(&entry);
                     }
                 }
+                state.remove_pipeline_run(issue_id);
 
                 drop(state);
                 if final_failure {
@@ -4829,6 +4829,45 @@ fn transcript_kind_from_agent_kind(
     }
 }
 
+fn build_reconcile_active_states_lower(config: &EnsembleConfig) -> Vec<String> {
+    let terminal: HashSet<String> = config
+        .tracker
+        .terminal_states
+        .iter()
+        .map(|state| state.to_lowercase())
+        .collect();
+    let mut states = HashSet::new();
+
+    for state in &config.tracker.active_states {
+        let state = state.to_lowercase();
+        if !terminal.contains(&state) {
+            states.insert(state);
+        }
+    }
+
+    for step in &config.steps {
+        if let Some(state) = step.tracker_state.as_deref() {
+            let state = state.to_lowercase();
+            if !terminal.contains(&state) {
+                states.insert(state);
+            }
+        }
+
+        if let Some(state) = step
+            .approval
+            .as_ref()
+            .and_then(|approval| approval.state.as_deref())
+        {
+            let state = state.to_lowercase();
+            if !terminal.contains(&state) {
+                states.insert(state);
+            }
+        }
+    }
+
+    states.into_iter().collect()
+}
+
 fn new_run_id() -> String {
     let millis = Utc::now().timestamp_millis();
     let seq = RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -6069,6 +6108,46 @@ agent:
         parse_config(yaml).unwrap()
     }
 
+    #[test]
+    fn reconciliation_active_states_include_workflow_managed_tracker_states() {
+        let yaml = r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress"]
+  terminal_states: ["Done", "Paused"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{ issue.identifier }}."
+steps:
+  - name: implement
+    agent: builder
+  - name: review
+    agent: builder
+    tracker_state: Review
+  - name: plan
+    agent: builder
+    tracker_state: Planning
+    approval:
+      mode: when_requested_by_agent
+      state: Plan Review
+on_success: Done
+on_failure: Paused
+"#;
+        let config = parse_config(yaml).unwrap();
+
+        let states = build_reconcile_active_states_lower(&config);
+
+        assert!(states.contains(&"todo".to_string()));
+        assert!(states.contains(&"in progress".to_string()));
+        assert!(states.contains(&"review".to_string()));
+        assert!(states.contains(&"planning".to_string()));
+        assert!(states.contains(&"plan review".to_string()));
+        assert!(!states.contains(&"done".to_string()));
+        assert!(!states.contains(&"paused".to_string()));
+    }
+
     fn make_parallel_resume_config() -> EnsembleConfig {
         let yaml = r#"
 tracker:
@@ -7022,6 +7101,77 @@ agent:
         assert!(
             tokio::fs::read_to_string(&history_path).await.is_err(),
             "retryable failure should not append history"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_does_not_retry_acpx_unsupported_model_failure() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut raw_config = make_config();
+        raw_config.workspace.root = Some(dir.path().display().to_string());
+        raw_config.max_cycles = 3;
+
+        let config = Arc::new(RwLock::new(raw_config));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+        let orchestrator = Orchestrator::new(
+            config.clone(),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), Some(1));
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        let unsupported_model_error = "acpx command failed: sessions ensure — exit status: 1; stderr: ; stdout: {\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32603,\"message\":\"Cannot apply --model \\\"opencode-go/kimi-k2.5\\\": the ACP agent did not advertise model support. Generic model selection requires ACP models plus session/set_model support, or an adapter-specific startup model flag.\",\"data\":{\"acpxCode\":\"RUNTIME\",\"origin\":\"cli\",\"sessionId\":\"unknown\"}}}".to_string();
+
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Failed {
+                    error: unsupported_model_error.clone(),
+                    kind: WorkerFailureKind::Runtime,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.retry_attempts.contains_key("1"));
+        assert!(state.completed.contains_key("1"));
+        drop(state);
+
+        let history_path = dir.path().join("ensemble_history.jsonl");
+        let contents = tokio::fs::read_to_string(&history_path).await.unwrap();
+        let record = contents
+            .lines()
+            .map(|line| serde_json::from_str::<crate::history::model::HistoryRecord>(line).unwrap())
+            .next()
+            .unwrap();
+        assert_eq!(
+            record.last_error.as_deref(),
+            Some(unsupported_model_error.as_str())
         );
     }
 

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -163,10 +163,7 @@ impl PipelineRunJournal {
                 continue;
             }
             if let Some(record) = self.read_last_valid_record(&path).await? {
-                if record.schema_version == SCHEMA_VERSION
-                    && !record.kind.is_terminal()
-                    && record.snapshot.is_some()
-                {
+                if is_live_restore_record(&record) {
                     records.push(record);
                 }
             }
@@ -174,6 +171,16 @@ impl PipelineRunJournal {
 
         records.sort_by(|left, right| left.issue_id.cmp(&right.issue_id));
         Ok(records)
+    }
+
+    pub async fn latest_live_record_for_issue(
+        &self,
+        issue_id: &str,
+    ) -> Result<Option<PipelineTransitionRecord>, std::io::Error> {
+        let record = self
+            .read_last_valid_record(&self.path_for_issue(issue_id))
+            .await?;
+        Ok(record.filter(is_live_restore_record))
     }
 
     async fn read_last_valid_record(
@@ -288,6 +295,12 @@ fn hex_value(byte: u8) -> Result<u8, std::io::Error> {
 
 fn invalid_data(reason: impl Into<String>) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, reason.into())
+}
+
+fn is_live_restore_record(record: &PipelineTransitionRecord) -> bool {
+    record.schema_version == SCHEMA_VERSION
+        && !record.kind.is_terminal()
+        && record.snapshot.is_some()
 }
 
 #[cfg(test)]
@@ -412,6 +425,83 @@ mod tests {
 
         let live = journal.latest_live_records().await.unwrap();
         assert!(live.is_empty());
+    }
+
+    #[tokio::test]
+    async fn latest_live_record_for_issue_returns_latest_non_terminal_snapshot() {
+        let dir = tempdir().unwrap();
+        let journal = PipelineRunJournal::new(dir.path());
+
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::RunStarted,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: None,
+                reason: None,
+                retry: None,
+                snapshot: Some(snapshot()),
+            })
+            .await
+            .unwrap();
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepRunning,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: None,
+                retry: None,
+                snapshot: Some(snapshot()),
+            })
+            .await
+            .unwrap();
+
+        let live = journal
+            .latest_live_record_for_issue("issue/1")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(live.seq, 2);
+        assert_eq!(live.kind, PipelineTransitionKind::StepRunning);
+        assert_eq!(live.run_id.as_deref(), Some("run-1"));
+    }
+
+    #[tokio::test]
+    async fn latest_live_record_for_issue_returns_none_for_terminal_record() {
+        let dir = tempdir().unwrap();
+        let journal = PipelineRunJournal::new(dir.path());
+
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::RunStarted,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: None,
+                reason: None,
+                retry: None,
+                snapshot: Some(snapshot()),
+            })
+            .await
+            .unwrap();
+        journal
+            .append_released("issue/1", "repo#1", Some("run-1".to_string()), "completed")
+            .await
+            .unwrap();
+
+        let live = journal
+            .latest_live_record_for_issue("issue/1")
+            .await
+            .unwrap();
+
+        assert!(live.is_none());
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -123,6 +123,13 @@ pub fn schedule_failure_retry(
     Some(due_at_ms)
 }
 
+/// Identify deterministic agent/runtime configuration failures that another
+/// retry cannot fix.
+pub fn is_non_retryable_failure(reason: &str) -> bool {
+    let reason = reason.to_ascii_lowercase();
+    reason.contains("cannot apply --model") && reason.contains("did not advertise model support")
+}
+
 /// Determine the next attempt number from a running entry.
 /// If the entry had a retry_attempt, increment it; otherwise start at 1.
 pub fn next_attempt(current: Option<u32>) -> u32 {
@@ -179,6 +186,18 @@ mod tests {
     fn retry_reason_is_non_empty() {
         let reason = normalize_reason("");
         assert_eq!(reason, "unknown");
+    }
+
+    #[test]
+    fn unsupported_acpx_model_capability_failure_is_not_retryable() {
+        assert!(is_non_retryable_failure(
+            "acpx command failed: sessions ensure — exit status: 1; stdout: {\"message\":\"Cannot apply --model \\\"opencode-go/kimi-k2.5\\\": the ACP agent did not advertise model support.\"}"
+        ));
+    }
+
+    #[test]
+    fn ordinary_agent_failure_is_retryable() {
+        assert!(!is_non_retryable_failure("temporary agent crash"));
     }
 
     #[test]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -291,8 +291,14 @@ Pipeline run recovery:
 - Each recoverable transition includes a full `PipelineRun` snapshot.
 - On orchestrator startup, Ensemble restores the latest non-released snapshot for each issue before
   the first poll tick.
+- During normal tick dispatch, before starting a candidate as a fresh pipeline, Ensemble checks that
+  issue's latest journal record. If it is live and contains a snapshot, Ensemble restores that run
+  instead of appending a new `run_started` record.
+- Dispatch-time restore never creates new candidates; it only applies to issues already returned by
+  the tracker as dispatch-eligible candidates.
+- Restored retry and waiting records stay parked until their normal resume or retry path.
 - Stale `Running` steps from a previous process are normalized to `Pending`; agent processes are not
-  recovered across orchestrator restarts.
+  recovered across orchestrator restarts or in-process journal rehydration.
 - A `released` transition prevents older snapshots for the issue from being restored after
   completion, stop, terminal reconciliation, or whole-issue retry.
 
@@ -2229,8 +2235,10 @@ After restart:
 - No retry timers are restored from prior process memory.
 - No running sessions are assumed recoverable.
 - Service recovers by:
+  - startup restoration of live pipeline journal snapshots
   - startup terminal workspace cleanup
   - fresh polling of active issues
+  - dispatch-time restoration of live journal snapshots for already eligible candidates
   - re-dispatching eligible work
 
 ### 14.4 Operator Intervention Points

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1124,6 +1124,12 @@ Tick sequence:
 If per-tick validation fails, dispatch is skipped for that tick, but reconciliation still happens
 first.
 
+Reconciliation uses a broader active-state set than candidate dispatch. In addition to
+`tracker.active_states`, any non-terminal `steps[].tracker_state` and approval `state` written by
+the workflow are considered active for already-running or waiting issues. This prevents the
+orchestrator from abandoning a run just because it moved the tracker item into a workflow-owned
+intermediate state such as `Review` or `Plan Review`.
+
 ### 8.2 Candidate Selection Rules
 
 An issue is dispatch-eligible only if all are true:
@@ -1174,6 +1180,8 @@ Backoff formula:
 - Normal continuation retries after a clean worker exit use a short fixed delay of `1000` ms.
 - Failure-driven retries use `delay = min(10000 * 2^(attempt - 1), agent.max_retry_backoff_ms)`.
 - Power is capped by the configured max retry backoff (default `300000` / 5m).
+- Deterministic configuration/runtime capability failures may be treated as terminal immediately
+  instead of retrying, because another attempt cannot change the configured agent capabilities.
 
 Retry handling behavior:
 
@@ -1622,7 +1630,8 @@ Behavior:
 2. Build prompt from workflow template.
 3. Start ACP session (`initialize` + `session/new`).
 4. Forward ACP `session/update` events to orchestrator.
-5. On any error, fail the worker attempt (the orchestrator will retry).
+5. On any error, fail the worker attempt. The orchestrator decides whether the failure is
+   retryable or terminal.
 
 Note:
 
@@ -1767,6 +1776,8 @@ Orchestrator-driven writes:
 
 - **Step entry**: When a pipeline step begins, the orchestrator writes the step's `tracker_state`
   to the tracker (for example "In Progress", "In Review").
+  Non-terminal step-entry and approval states are treated as active for reconciliation of existing
+  runs, but they do not automatically make new issues dispatch-eligible.
 - **Pipeline success**: When all steps pass, the orchestrator writes `on_success` (for example
   "Done").
 - **Pipeline failure/rejection**: When any step fails or returns a failed result, the orchestrator
@@ -2390,7 +2401,7 @@ function reconcile_running_issues(state):
   for issue in refreshed:
     if issue.state in terminal_states:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=true)
-    else if issue.state in active_states:
+    else if issue.state in reconciliation_active_states:
       state.running[issue.id].issue = issue
     else:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=false)

--- a/docs/superpowers/plans/2026-06-16-dispatch-journal-rehydrate.md
+++ b/docs/superpowers/plans/2026-06-16-dispatch-journal-rehydrate.md
@@ -1,0 +1,575 @@
+# Dispatch Journal Rehydrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Before starting a fresh pipeline for an eligible issue, restore any latest live journal snapshot for that issue and resume from that state.
+
+**Architecture:** Keep startup restore as the broad multi-issue path. Add a single-issue live journal lookup and call it from the normal tick dispatch path only after an issue is already candidate-eligible and only when no in-memory pipeline exists. Reuse `restore_pipeline_run_record()` so dispatch-time restore gets the same config validation, stale-running normalization, run-id preservation, retry restoration, and halted-pipeline handling as startup restore.
+
+**Tech Stack:** Rust 2021, Tokio async tests, existing `PipelineRunJournal`, `Orchestrator`, `PipelineRunSnapshot`, and in-file orchestrator test doubles.
+
+---
+
+## File Structure
+
+- Modify `crates/ensemble-core/src/orchestrator/pipeline_journal.rs`
+  - Add a single-issue live record lookup.
+  - Share live-record filtering with `latest_live_records()`.
+  - Add unit coverage for the targeted lookup.
+- Modify `crates/ensemble-core/src/orchestrator/mod.rs`
+  - Add `restore_pipeline_run_for_candidate()`.
+  - Call it from `handle_tick()` immediately before `dispatch_issue()` would create a fresh run.
+  - Add a regression test that does not call startup restore.
+- Modify `docs/SPEC.md`
+  - Update pipeline run recovery and partial state recovery wording to include dispatch-time restore.
+
+## Task 1: Add Targeted Live Journal Lookup
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/pipeline_journal.rs`
+
+- [ ] **Step 1: Add the failing journal unit test**
+
+Add this test in the existing `#[cfg(test)] mod tests` in `pipeline_journal.rs`, near the other live-record tests:
+
+```rust
+#[tokio::test]
+async fn latest_live_record_for_issue_returns_latest_non_terminal_snapshot() {
+    let dir = tempdir().unwrap();
+    let journal = PipelineRunJournal::new(dir.path());
+
+    journal
+        .append(PipelineTransitionInput {
+            kind: PipelineTransitionKind::RunStarted,
+            issue_id: "issue/1".to_string(),
+            identifier: "repo#1".to_string(),
+            run_id: Some("run-1".to_string()),
+            cycle: 1,
+            step: None,
+            reason: None,
+            retry: None,
+            snapshot: Some(snapshot()),
+        })
+        .await
+        .unwrap();
+    journal
+        .append(PipelineTransitionInput {
+            kind: PipelineTransitionKind::StepRunning,
+            issue_id: "issue/1".to_string(),
+            identifier: "repo#1".to_string(),
+            run_id: Some("run-1".to_string()),
+            cycle: 1,
+            step: Some("build".to_string()),
+            reason: None,
+            retry: None,
+            snapshot: Some(snapshot()),
+        })
+        .await
+        .unwrap();
+
+    let live = journal
+        .latest_live_record_for_issue("issue/1")
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(live.seq, 2);
+    assert_eq!(live.kind, PipelineTransitionKind::StepRunning);
+    assert_eq!(live.run_id.as_deref(), Some("run-1"));
+}
+
+#[tokio::test]
+async fn latest_live_record_for_issue_returns_none_for_terminal_record() {
+    let dir = tempdir().unwrap();
+    let journal = PipelineRunJournal::new(dir.path());
+
+    journal
+        .append(PipelineTransitionInput {
+            kind: PipelineTransitionKind::RunStarted,
+            issue_id: "issue/1".to_string(),
+            identifier: "repo#1".to_string(),
+            run_id: Some("run-1".to_string()),
+            cycle: 1,
+            step: None,
+            reason: None,
+            retry: None,
+            snapshot: Some(snapshot()),
+        })
+        .await
+        .unwrap();
+    journal
+        .append_released("issue/1", "repo#1", Some("run-1".to_string()), "completed")
+        .await
+        .unwrap();
+
+    let live = journal
+        .latest_live_record_for_issue("issue/1")
+        .await
+        .unwrap();
+
+    assert!(live.is_none());
+}
+```
+
+- [ ] **Step 2: Run the targeted journal tests and verify the failure**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core orchestrator::pipeline_journal::tests::latest_live_record_for_issue -- --nocapture
+```
+
+Expected: compilation fails because `PipelineRunJournal::latest_live_record_for_issue` does not exist.
+
+- [ ] **Step 3: Add the targeted lookup and shared live filter**
+
+In `impl PipelineRunJournal`, change `latest_live_records()` to use a helper and add the new method:
+
+```rust
+    pub async fn latest_live_records(
+        &self,
+    ) -> Result<Vec<PipelineTransitionRecord>, std::io::Error> {
+        let mut records = Vec::new();
+        let mut entries = match tokio::fs::read_dir(&self.root).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(records),
+            Err(error) => return Err(error),
+        };
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+                continue;
+            }
+            if let Some(record) = self.read_last_valid_record(&path).await? {
+                if is_live_restore_record(&record) {
+                    records.push(record);
+                }
+            }
+        }
+
+        records.sort_by(|left, right| left.issue_id.cmp(&right.issue_id));
+        Ok(records)
+    }
+
+    pub async fn latest_live_record_for_issue(
+        &self,
+        issue_id: &str,
+    ) -> Result<Option<PipelineTransitionRecord>, std::io::Error> {
+        let record = self.read_last_valid_record(&self.path_for_issue(issue_id)).await?;
+        Ok(record.filter(is_live_restore_record))
+    }
+```
+
+Add this helper near `invalid_data()`:
+
+```rust
+fn is_live_restore_record(record: &PipelineTransitionRecord) -> bool {
+    record.schema_version == SCHEMA_VERSION && !record.kind.is_terminal() && record.snapshot.is_some()
+}
+```
+
+If `cargo fmt` wraps the boolean expression, keep the formatted version.
+
+- [ ] **Step 4: Run the targeted journal tests and verify they pass**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core orchestrator::pipeline_journal::tests::latest_live_record_for_issue -- --nocapture
+```
+
+Expected: both new tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+git commit -m "Add targeted pipeline journal restore lookup"
+```
+
+## Task 2: Add Dispatch-Time Rehydrate Before Fresh Runs
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs`
+
+- [ ] **Step 1: Add the failing regression test**
+
+Add this test near `restored_live_pipeline_run_dispatches_on_next_tick()` in the existing orchestrator tests:
+
+```rust
+#[tokio::test]
+async fn handle_tick_rehydrates_live_journal_before_fresh_dispatch() {
+    let temp = tempfile::tempdir().unwrap();
+    let yaml = r#"
+tracker:
+  kind: todo_file
+  active_states: ["Todo", "In Progress"]
+  terminal_states: ["Done", "Closed"]
+agents:
+  builder:
+    executor: claude
+    model: opus
+    prompt: "Work on {{ issue.identifier }}."
+steps:
+  - name: implement
+    agent: builder
+  - name: review
+    agent: builder
+    depends: ["implement"]
+max_cycles: 10
+on_success: Done
+on_failure: Todo
+concurrency:
+  max_concurrent_agents: 5
+polling:
+  interval_ms: 100
+workspace:
+  root: /tmp/ensemble-test
+agent:
+  max_turns: 3
+  command: "echo test"
+  session_mode: code
+"#;
+    let cfg = parse_config(yaml).unwrap();
+    let issue = test_issue("1", "In Progress");
+    let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+        issues: Arc::new(RwLock::new(vec![issue.clone()])),
+    });
+    let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+        delay_ms: 0,
+        observed_commands: None,
+        observed_timeouts: None,
+        cancellation_probe: None,
+    });
+    let config = Arc::new(RwLock::new(cfg.clone()));
+    let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+    drop(shutdown_tx);
+    let state = Arc::new(RwLock::new(OrchestratorState::new(
+        cfg.polling.interval_ms,
+        &cfg.concurrency,
+    )));
+    let orchestrator = Orchestrator::new_with_state(
+        OrchestratorRuntimeParts {
+            state: Arc::clone(&state),
+            config,
+            tracker,
+            agent_runner: runner,
+            workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                .unwrap(),
+            refresh_requested: Arc::new(tokio::sync::Notify::new()),
+            cancellation_registry: new_cancellation_registry(),
+            event_bus: EventBus::new(),
+            transcript_event_bus: TranscriptEventBus::new(),
+            workspace_root: temp.path().join("workspaces"),
+        },
+        temp.path(),
+        shutdown_rx,
+    );
+
+    let dag = build_dag(&cfg.steps).unwrap();
+    let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+    run.step_completed("implement", succeeded_step_output(), false);
+    run.mark_running("review", "stale-review-session".to_string());
+    orchestrator
+        .pipeline_journal
+        .append(PipelineTransitionInput {
+            kind: PipelineTransitionKind::StepRunning,
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            run_id: Some("run-existing".to_string()),
+            cycle: 1,
+            step: Some("review".to_string()),
+            reason: None,
+            retry: None,
+            snapshot: Some(run.to_snapshot()),
+        })
+        .await
+        .unwrap();
+
+    orchestrator.handle_tick().await;
+
+    let lock = state.read().await;
+    assert!(lock.is_running(&issue.id));
+    assert_eq!(
+        lock.issue_run_ids.get(&issue.id).map(String::as_str),
+        Some("run-existing")
+    );
+    let restored_run = lock.get_pipeline_run(&issue.id).unwrap();
+    assert_eq!(
+        restored_run.step_states.get("implement"),
+        Some(&StepState::Passed)
+    );
+    assert!(matches!(
+        restored_run.step_states.get("review"),
+        Some(StepState::Running { session_id }) if session_id != "stale-review-session"
+    ));
+
+    let records = orchestrator
+        .pipeline_journal
+        .read_records_for_issue(&issue.id)
+        .await
+        .unwrap();
+    assert_eq!(
+        records
+            .iter()
+            .filter(|record| record.kind == PipelineTransitionKind::RunStarted)
+            .count(),
+        0
+    );
+    assert!(records
+        .iter()
+        .any(|record| record.kind == PipelineTransitionKind::StepRunning && record.seq == 2));
+}
+```
+
+- [ ] **Step 2: Run the regression test and verify it fails**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core orchestrator::tests::handle_tick_rehydrates_live_journal_before_fresh_dispatch -- --nocapture
+```
+
+Expected: the assertion for `run-existing`, preserved `implement`, or zero fresh `RunStarted` records fails because `handle_tick()` creates a new run.
+
+- [ ] **Step 3: Add the candidate restore helper**
+
+In `impl Orchestrator`, immediately before `dispatch_issue()`, add:
+
+```rust
+    async fn restore_pipeline_run_for_candidate(
+        &self,
+        issue: &Issue,
+    ) -> Result<bool, EnsembleError> {
+        {
+            let state = self.state.read().await;
+            if state.get_pipeline_run(&issue.id).is_some()
+                || state.is_running(&issue.id)
+                || state.is_claimed(&issue.id)
+            {
+                return Ok(false);
+            }
+        }
+
+        let record = self
+            .pipeline_journal
+            .latest_live_record_for_issue(&issue.id)
+            .await
+            .map_err(|error| AgentError::IoError {
+                reason: format!(
+                    "failed to read pipeline transition journal for issue '{}': {error}",
+                    issue.id
+                ),
+            })?;
+
+        let Some(record) = record else {
+            return Ok(false);
+        };
+
+        let config_snapshot = {
+            let config = self.config.read().await;
+            Arc::new(config.clone())
+        };
+        let issues_by_id = HashMap::from([(issue.id.clone(), issue.clone())]);
+        self.restore_pipeline_run_record(&record, config_snapshot, &issues_by_id)
+            .await?;
+
+        let state = self.state.read().await;
+        Ok(state.get_pipeline_run(&issue.id).is_some() && state.is_claimed(&issue.id))
+    }
+```
+
+This helper deliberately does not fetch or create candidates. It only acts on the already eligible candidate passed by `handle_tick()`.
+
+- [ ] **Step 4: Call the helper before fresh dispatch**
+
+In `handle_tick()`, replace this block:
+
+```rust
+            if eligible.is_none() || restored_pipeline_ready {
+                self.dispatch_issue(issue, None).await;
+            }
+```
+
+with:
+
+```rust
+            if eligible.is_none() || restored_pipeline_ready {
+                if eligible.is_none() && !restored_pipeline_ready {
+                    match self.restore_pipeline_run_for_candidate(issue).await {
+                        Ok(true) => {}
+                        Ok(false) => {}
+                        Err(error) => {
+                            warn!(
+                                issue_id = %issue.id,
+                                identifier = %issue.identifier,
+                                error = %error,
+                                "failed to restore live pipeline journal before dispatch"
+                            );
+                        }
+                    }
+                }
+
+                self.dispatch_issue(issue, None).await;
+            }
+```
+
+This keeps dispatch control centralized in `dispatch_issue()`. When restore succeeds, `dispatch_issue()` takes its existing "resuming with existing pipeline" branch. When there is no live journal record or restore validation fails, dispatch proceeds as it does today.
+
+- [ ] **Step 5: Run the regression test and verify it passes**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core orchestrator::tests::handle_tick_rehydrates_live_journal_before_fresh_dispatch -- --nocapture
+```
+
+Expected: test passes. The restored run keeps `implement` as `Passed`, resumes `review`, preserves `run-existing`, and does not append a fresh `RunStarted`.
+
+- [ ] **Step 6: Run adjacent orchestrator journal tests**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core orchestrator::tests::restored_live_pipeline_run_dispatches_on_next_tick orchestrator::tests::dispatch_issue_writes_run_started_and_step_running_transitions -- --nocapture
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ensemble-core/src/orchestrator/mod.rs
+git commit -m "Restore live journal snapshots before dispatch"
+```
+
+## Task 3: Update Recovery Documentation
+
+**Files:**
+- Modify: `docs/SPEC.md`
+
+- [ ] **Step 1: Update pipeline recovery wording**
+
+In `docs/SPEC.md`, in section `4.1.6 Pipeline Run`, replace the startup-only recovery bullets:
+
+```markdown
+- On orchestrator startup, Ensemble restores the latest non-released snapshot for each issue before
+  the first poll tick.
+- Stale `Running` steps from a previous process are normalized to `Pending`; agent processes are not
+  recovered across orchestrator restarts.
+```
+
+with:
+
+```markdown
+- On orchestrator startup, Ensemble restores the latest non-released snapshot for each issue before
+  the first poll tick.
+- During normal tick dispatch, before starting a candidate as a fresh pipeline, Ensemble checks that
+  issue's latest journal record. If it is live and contains a snapshot, Ensemble restores that run
+  instead of appending a new `run_started` record.
+- Dispatch-time restore never creates new candidates; it only applies to issues already returned by
+  the tracker as dispatch-eligible candidates.
+- Stale `Running` steps from a previous process are normalized to `Pending`; agent processes are not
+  recovered across orchestrator restarts or in-process journal rehydration.
+```
+
+- [ ] **Step 2: Update partial recovery wording**
+
+In `docs/SPEC.md`, in section `14.3 Partial State Recovery (Restart)`, replace:
+
+```markdown
+- No retry timers are restored from prior process memory.
+- No running sessions are assumed recoverable.
+- Service recovers by:
+  - startup terminal workspace cleanup
+  - fresh polling of active issues
+  - re-dispatching eligible work
+```
+
+with:
+
+```markdown
+- No retry timers are restored from prior process memory.
+- No running sessions are assumed recoverable.
+- Service recovers by:
+  - startup terminal workspace cleanup
+  - startup restoration of live pipeline journal snapshots
+  - fresh polling of active issues
+  - dispatch-time restoration of live journal snapshots for already eligible candidates
+  - re-dispatching eligible work
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/SPEC.md
+git commit -m "Document dispatch-time journal restore"
+```
+
+## Task 4: Final Verification
+
+**Files:**
+- Test: `crates/ensemble-core/src/orchestrator/pipeline_journal.rs`
+- Test: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Test: workspace formatting and clippy surface
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core orchestrator::pipeline_journal::tests::latest_live_record_for_issue -- --nocapture
+rtk cargo test -p ensemble-core orchestrator::tests::handle_tick_rehydrates_live_journal_before_fresh_dispatch -- --nocapture
+rtk cargo test -p ensemble-core orchestrator::tests::restored_live_pipeline_run_dispatches_on_next_tick orchestrator::tests::dispatch_issue_writes_run_started_and_step_running_transitions -- --nocapture
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run package tests**
+
+Run:
+
+```bash
+rtk cargo test -p ensemble-core
+```
+
+Expected: all `ensemble-core` tests pass.
+
+- [ ] **Step 3: Run formatting**
+
+Run:
+
+```bash
+rtk cargo fmt --all -- --check
+```
+
+Expected: no formatting diff.
+
+- [ ] **Step 4: Run clippy for the affected workspace subset**
+
+Run:
+
+```bash
+rtk cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+```
+
+Expected: clippy exits successfully with no warnings.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+rtk git diff -- crates/ensemble-core/src/orchestrator/pipeline_journal.rs crates/ensemble-core/src/orchestrator/mod.rs docs/SPEC.md
+```
+
+Expected: diff contains only the targeted journal lookup, dispatch-time restore, regression tests, and documentation updates.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: The plan covers candidate-only dispatch restore, latest live snapshot lookup, startup validation reuse, stale `Running` normalization through `restore_pipeline_run_record()`, run-id preservation, and regression coverage for no fresh `RunStarted`.
+- Placeholder scan: No task relies on unspecified code; all new functions and tests are shown with concrete code.
+- Type consistency: The plan uses existing `PipelineRunJournal`, `PipelineTransitionRecord`, `PipelineTransitionKind`, `PipelineRun`, `StepState`, `OrchestratorState`, `AgentError`, and `EnsembleError` names exactly as they exist in the current code.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,9 +5,11 @@ set -euo pipefail
 # Run from the repo root.
 #
 # Usage:
-#   ./scripts/dev.sh build              # full build with UI
-#   ./scripts/dev.sh run                # run with no args
-#   ./scripts/dev.sh run --help         # pass --help to ensemble
+#   ./scripts/dev.sh build                # full build with UI
+#   ./scripts/dev.sh build --web-ui       # also build ensemble-cli with the web-ui feature
+#   ./scripts/dev.sh run                  # run with no args
+#   ./scripts/dev.sh run --help           # pass --help to ensemble
+#   ./scripts/dev.sh run --web-ui web     # build with web-ui, then run `web` subcommand
 #
 # To skip UI build, set SKIP_UI_BUILD=1:
 #   SKIP_UI_BUILD=1 ./scripts/dev.sh build
@@ -17,6 +19,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UI_DIR="$REPO_ROOT/crates/ensemble-ui/src-ui"
 
+# Whether the ensemble-cli binary should be built with the web-ui feature.
+WEB_UI_ENABLED=0
+
 # Show usage for this script (not ensemble)
 show_usage() {
   cat << 'EOF'
@@ -25,6 +30,10 @@ Usage: ./scripts/dev.sh <command> [args]
 Commands:
   build                Build the workspace
   run                  Build and run the ensemble CLI
+
+Flags:
+  --web-ui             Build ensemble-cli with the `web-ui` Cargo feature
+                       (embeds the dashboard so `ensemble web` is available)
 
 Environment Variables:
   SKIP_UI_BUILD=1      Skip UI build (Rust-only)
@@ -36,18 +45,24 @@ Arguments after the command are passed to ensemble:
 
 Examples:
   ./scripts/dev.sh build                    # Full build
+  ./scripts/dev.sh build --web-ui           # Full build, embed web dashboard
   SKIP_UI_BUILD=1 ./scripts/dev.sh build    # Rust-only build
   ./scripts/dev.sh run                      # Run ensemble with no args
   ./scripts/dev.sh run --help               # Show ensemble help
+  ./scripts/dev.sh run --web-ui web         # Run `web` with the dashboard
   SKIP_UI_BUILD=1 ./scripts/dev.sh run web  # Skip UI, run web command
 EOF
 }
 
-# Common build logic
+# Build the workspace, then (if --web-ui) layer the web-ui feature onto
+# ensemble-cli as an incremental second build.
 run_build() {
   if [ -n "${SKIP_UI_BUILD:-}" ]; then
     echo "==> Skipping UI build (SKIP_UI_BUILD=1)"
     cargo build --workspace --exclude ensemble-desktop
+    if [[ "$WEB_UI_ENABLED" == "1" ]]; then
+      cargo build -p ensemble-cli --features web-ui
+    fi
     return 0
   fi
 
@@ -62,14 +77,22 @@ run_build() {
   # 3. Build the workspace (build.rs will run codegen:client + tsc + vite via build:embed)
   echo "==> Building workspace"
   cargo build --workspace --exclude ensemble-desktop
+  if [[ "$WEB_UI_ENABLED" == "1" ]]; then
+    cargo build -p ensemble-cli --features web-ui
+  fi
 }
 
 # Run command logic
 run_dev() {
+  local web_ui_args=()
+  if [[ "$WEB_UI_ENABLED" == "1" ]]; then
+    web_ui_args=(--features web-ui)
+  fi
+
   if [ -n "${SKIP_UI_BUILD:-}" ]; then
     echo "==> Skipping UI build (SKIP_UI_BUILD=1)"
-    echo "==> Running: cargo run --workspace --exclude ensemble-desktop -- $*"
-    cargo run --workspace --exclude ensemble-desktop -- "$@"
+    echo "==> Running: cargo run -p ensemble-cli $*"
+    cargo run -p ensemble-cli "${web_ui_args[@]+"${web_ui_args[@]}"}" -- "$@"
     return 0
   fi
 
@@ -83,8 +106,8 @@ run_dev() {
 
   # 3. Build and run the workspace
   echo "==> Building and running workspace"
-  echo "==> Running: cargo run -p ensemble-cli -- $*"
-  cargo run -p ensemble-cli -- "$@"
+  echo "==> Running: cargo run -p ensemble-cli $*"
+  cargo run -p ensemble-cli "${web_ui_args[@]+"${web_ui_args[@]}"}" -- "$@"
 }
 
 # Main
@@ -104,11 +127,34 @@ fi
 
 case "$command" in
   build)
+    for arg in "$@"; do
+      case "$arg" in
+        --web-ui)
+          WEB_UI_ENABLED=1
+          ;;
+        *)
+          echo "Unknown argument for build: $arg"
+          show_usage
+          exit 1
+          ;;
+      esac
+    done
     run_build
     echo "==> Done"
     ;;
   run)
-    run_dev "$@"
+    REMAINING=()
+    for arg in "$@"; do
+      case "$arg" in
+        --web-ui)
+          WEB_UI_ENABLED=1
+          ;;
+        *)
+          REMAINING+=("$arg")
+          ;;
+      esac
+    done
+    run_dev "${REMAINING[@]+"${REMAINING[@]}"}"
     ;;
   *)
     echo "Unknown command: $command"


### PR DESCRIPTION
## Summary

- add a targeted live pipeline journal lookup for a single issue
- restore live journal snapshots during normal tick dispatch before starting a fresh pipeline
- keep restored retry and human-waiting states parked, while preserving restored run IDs and cycles for resumable runs
- document dispatch-time journal recovery behavior in the spec

## Root Cause

Startup restore handled live pipeline journal snapshots, but normal tick dispatch could start a brand-new pipeline when in-memory state and the journal diverged. That could discard passed upstream steps and append a new `run_started` record for an issue that already had a live run snapshot.

Fixes #225 