### PR TITLE
Fix Rust 1.97 clippy failures

### DIFF
--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -338,14 +338,12 @@ pub fn extract_step_detail_state(
         .find(|(_, finalize)| finalize.issue_identifier == identifier)
     {
         issue_id.clone()
-    } else if let Some(entry) = state
-        .completed
-        .values()
-        .find(|e| e.identifier == identifier)
-    {
-        entry.issue_id.clone()
     } else {
-        return None;
+        let entry = state
+            .completed
+            .values()
+            .find(|e| e.identifier == identifier)?;
+        entry.issue_id.clone()
     };
 
     // Try to get step info from pipeline config/run first
@@ -539,10 +537,9 @@ pub async fn build_issue_snapshot(
         (entry.issue_id.clone(), entry.identifier.clone())
     } else if let Some((issue_id, finalize)) = finalize_entry {
         (issue_id.clone(), finalize.issue_identifier.clone())
-    } else if let Some(entry) = completed_entry {
-        (entry.issue_id.clone(), entry.identifier.clone())
     } else {
-        return None;
+        let entry = completed_entry?;
+        (entry.issue_id.clone(), entry.identifier.clone())
     };
 
     let workspace_key = crate::tracker::model::sanitize_workspace_key(identifier)?;


### PR DESCRIPTION
## Summary
- rewrite the final completed-entry fallbacks with `?`
- preserve lookup priority and existing `None` behavior
- restore the Rust 1.97 Clippy gate on main

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo test --workspace --exclude ensemble-desktop`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`