### PR TITLE
Add Mission Control phase 1

### DIFF
--- a/crates/ensemble-core/src/api/interactions.rs
+++ b/crates/ensemble-core/src/api/interactions.rs
@@ -1,7 +1,9 @@
 use crate::api::handlers::ApiError;
 use crate::api::router::AppState;
 use crate::interaction::error::InteractionError;
-use crate::interaction::model::{InteractionRequest, InteractionResponse};
+use crate::interaction::model::{
+    InteractionKind, InteractionRequest, InteractionResponse, InteractionStatus,
+};
 use crate::interaction::store::InteractionStore;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, State};
@@ -18,11 +20,13 @@ pub struct InteractionDetail {
     pub issue_identifier: String,
     pub step_name: String,
     pub agent_name: String,
+    pub kind: InteractionKind,
     pub question: String,
     pub why_blocked: String,
     pub suggested_answer: Option<String>,
     pub extra_context: Option<String>,
-    pub status: String,
+    pub status: InteractionStatus,
+    pub awaiting_resume: bool,
     pub requested_at: DateTime<Utc>,
 }
 
@@ -34,11 +38,13 @@ impl From<&InteractionRequest> for InteractionDetail {
             issue_identifier: req.issue_identifier.clone(),
             step_name: req.step_name.clone(),
             agent_name: req.agent_name.clone(),
+            kind: req.kind.clone(),
             question: req.title.clone(),
             why_blocked: req.body.clone(),
             suggested_answer: req.options.first().cloned(),
             extra_context: req.step_tracker_state.clone(),
-            status: req.status.as_str().to_string(),
+            status: req.status.clone(),
+            awaiting_resume: req.awaiting_resume,
             requested_at: req.requested_at,
         }
     }

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -308,6 +308,41 @@ async fn test_get_issue_detail_running() {
 }
 
 #[tokio::test]
+async fn encoded_slash_issue_identifier_reaches_detail_and_control_handlers() {
+    let (app_state, _temp_dir) = build_populated_app_state();
+    {
+        let mut state = app_state.orchestrator_state.write().await;
+        let running = state.running.get_mut("NODE_123").unwrap();
+        running.identifier = "org/repo#42".to_string();
+        running.issue.identifier = "org/repo#42".to_string();
+    }
+    let base_url = start_test_server(app_state).await;
+    let client = reqwest::Client::new();
+
+    let detail = client
+        .get(format!("{}/api/v1/org%2Frepo%2342", base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(detail.status(), 200);
+    let detail_json: serde_json::Value = detail.json().await.unwrap();
+    assert_eq!(detail_json["issue_identifier"], "org/repo#42");
+
+    let control = client
+        .post(format!("{}/api/v1/org%2Frepo%2342/retry", base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(control.status(), 409);
+    let control_json: serde_json::Value = control.json().await.unwrap();
+    assert_eq!(control_json["error"]["code"], "not_retrying");
+    assert!(control_json["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("org/repo#42"));
+}
+
+#[tokio::test]
 async fn test_get_issue_detail_retrying() {
     let (app_state, _temp_dir) = build_populated_app_state();
     let base_url = start_test_server(app_state).await;
@@ -469,6 +504,23 @@ async fn get_step_conversation_returns_transcript_records() {
     let body: serde_json::Value = response.json().await.unwrap();
     assert_eq!(body["records"][0]["kind"], "assistant_message");
     assert_eq!(body["records"][0]["payload"]["text"], "hello");
+}
+
+#[tokio::test]
+async fn encoded_slash_and_space_step_name_reaches_conversation_path_validation() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let base_url = test_app_with_workspace_root(temp.path()).await;
+
+    let response = reqwest::get(format!(
+        "{base_url}/api/v1/org%2Frepo%2342/runs/run-1/steps/qa%2Freview%20pass/conversation"
+    ))
+    .await
+    .unwrap();
+    let status = response.status();
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"]["code"], "invalid_path");
 }
 
 #[tokio::test]
@@ -873,7 +925,9 @@ async fn get_interaction_by_id() {
     assert_eq!(json["issue_identifier"], "my-repo#77");
     assert_eq!(json["question"], "Need clarification");
     assert_eq!(json["why_blocked"], "Pick a deployment target");
+    assert_eq!(json["kind"], "question");
     assert_eq!(json["status"], "open");
+    assert_eq!(json["awaiting_resume"], true);
 }
 
 #[tokio::test]

--- a/crates/ensemble-ui/src-ui/src/components/ConfirmDialog.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ConfirmDialog.tsx
@@ -14,6 +14,7 @@ interface ConfirmDialogProps {
   title: string;
   message: string;
   confirmLabel: string;
+  confirmDisabled?: boolean;
   destructive?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
@@ -24,6 +25,7 @@ export default function ConfirmDialog({
   title,
   message,
   confirmLabel,
+  confirmDisabled = false,
   destructive = true,
   onConfirm,
   onCancel,
@@ -39,6 +41,7 @@ export default function ConfirmDialog({
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
             onClick={onConfirm}
+            disabled={confirmDisabled}
             variant={destructive ? "destructive" : "default"}
           >
             {confirmLabel}

--- a/crates/ensemble-ui/src-ui/src/components/FinalizeApprovalDialog.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/FinalizeApprovalDialog.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { RepoFinalizeSnapshot } from "@/generated/models";
+import FinalizeApprovalDialog from "./FinalizeApprovalDialog";
+
+const pendingRepo = {
+  approval_required: true,
+  last_error: null,
+  mode: "push_and_pr",
+  repo: "acme/backend",
+  status: "pending_approval",
+} satisfies RepoFinalizeSnapshot;
+
+describe("FinalizeApprovalDialog", () => {
+  it("confirms an unchanged pending target", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <FinalizeApprovalDialog
+        open
+        status="pending_approval"
+        repos={[pendingRepo]}
+        isPending={false}
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+    );
+
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Approve finalize" }),
+    );
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["status", "in_progress", [{ ...pendingRepo, status: "in_progress" }]],
+    ["target", "pending_approval", [{ ...pendingRepo, repo: "acme/frontend" }]],
+  ] as const)("invalidates confirmation when the pending %s changes", async (_change, status, repos) => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    const view = render(
+      <FinalizeApprovalDialog
+        open
+        status="pending_approval"
+        repos={[pendingRepo]}
+        isPending={false}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    await screen.findByRole("alertdialog");
+
+    view.rerender(
+      <FinalizeApprovalDialog
+        open
+        status={status}
+        repos={[...repos]}
+        isPending={false}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("blocks confirmation while the approval mutation is pending", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <FinalizeApprovalDialog
+        open
+        status="pending_approval"
+        repos={[pendingRepo]}
+        isPending
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+    );
+
+    const confirm = within(await screen.findByRole("alertdialog")).getByRole("button", {
+      name: "Approve finalize",
+    });
+    expect(confirm).toBeDisabled();
+    await userEvent.click(confirm);
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/components/FinalizeApprovalDialog.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/FinalizeApprovalDialog.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { RepoFinalizeSnapshot } from "@/generated/models";
+import ConfirmDialog from "./ConfirmDialog";
+
+interface FinalizeApprovalDialogProps {
+  open: boolean;
+  status: string;
+  repos: RepoFinalizeSnapshot[];
+  isPending: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function approvalSignature(status: string, repos: RepoFinalizeSnapshot[]) {
+  const pendingRepos = repos
+    .filter((repo) => repo.status === "pending_approval")
+    .map((repo) => ({
+      approval_required: repo.approval_required,
+      last_error: repo.last_error ?? null,
+      mode: repo.mode,
+      repo: repo.repo,
+      status: repo.status,
+    }))
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  return JSON.stringify({ status, pendingRepos });
+}
+
+export default function FinalizeApprovalDialog({
+  open,
+  status,
+  repos,
+  isPending,
+  onConfirm,
+  onCancel,
+}: FinalizeApprovalDialogProps) {
+  const pendingRepos = repos
+    .filter((repo) => repo.status === "pending_approval")
+    .sort((left, right) => left.repo.localeCompare(right.repo) || left.mode.localeCompare(right.mode));
+  const currentSignature = approvalSignature(status, repos);
+  const [capturedSignature, setCapturedSignature] = useState<string | null>(null);
+  const eligible = status === "pending_approval" && pendingRepos.length > 0;
+  const signatureMatches = capturedSignature === currentSignature;
+  const canConfirm = open && eligible && signatureMatches && !isPending;
+  const canConfirmRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) {
+      setCapturedSignature(null);
+      return;
+    }
+    setCapturedSignature((previous) => previous ?? currentSignature);
+  }, [currentSignature, open]);
+
+  useEffect(() => {
+    if (open && capturedSignature !== null && (!eligible || !signatureMatches)) {
+      onCancel();
+    }
+  }, [capturedSignature, eligible, onCancel, open, signatureMatches]);
+
+  useLayoutEffect(() => {
+    canConfirmRef.current = canConfirm;
+  }, [canConfirm]);
+
+  const targets = pendingRepos.map((repo) => `${repo.repo} (${repo.mode})`).join(", ");
+  const message = targets
+    ? `This may publish finalized workspace changes. Affected repositories: ${targets}.`
+    : "This may publish finalized workspace changes. No pending repository details are available.";
+
+  return (
+    <ConfirmDialog
+      open={open && eligible && signatureMatches}
+      title="Approve finalize"
+      message={message}
+      confirmLabel="Approve finalize"
+      confirmDisabled={!canConfirm}
+      destructive={false}
+      onConfirm={() => {
+        if (canConfirmRef.current) onConfirm();
+      }}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/components/InteractionPanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/InteractionPanel.test.tsx
@@ -11,11 +11,13 @@ function interaction(overrides: Partial<InteractionDetail> = {}): InteractionDet
     issue_identifier: "my-repo#42",
     step_name: "review",
     agent_name: "reviewer",
+    awaiting_resume: true,
     status: "open",
     question: "Need clarification",
     why_blocked: "The agent needs human input to continue",
     requested_at: "2026-04-04T10:00:00Z",
     ...overrides,
+    kind: overrides.kind ?? "question",
   };
 }
 

--- a/crates/ensemble-ui/src-ui/src/components/Layout.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/Layout.test.tsx
@@ -1,0 +1,176 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppNotification } from "@/notification-types";
+import Layout from "./Layout";
+
+let mockConfigData:
+  | {
+      state: string;
+      active_config: object | null;
+      issues: unknown[];
+    }
+  | undefined;
+let mockUnreadCount = 0;
+let mockNotifications: AppNotification[] = [];
+const notificationListeners = new Set<() => void>();
+
+vi.mock("@/hooks", () => ({
+  useConfigStateQuery: () => ({ data: mockConfigData }),
+}));
+
+vi.mock("@/notifications", () => ({
+  getNotifications: () => mockNotifications,
+  getUnreadCount: () => mockUnreadCount,
+  markAllRead: vi.fn(),
+  subscribe: (listener: () => void) => {
+    notificationListeners.add(listener);
+    return () => notificationListeners.delete(listener);
+  },
+}));
+
+vi.mock("@/theme", () => ({
+  getTheme: () => "light",
+  toggleTheme: () => "dark",
+}));
+
+function renderLayout(initialEntry = "/config") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route path="/" element={<section>Dashboard content</section>} />
+          <Route path="/history" element={<section>History content</section>} />
+          <Route path="/config" element={<section>Config content</section>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function desktopNavigation() {
+  return within(screen.getByRole("navigation", { name: "Desktop navigation" }));
+}
+
+function mobileNavigation() {
+  return within(screen.getByRole("navigation", { name: "Mobile navigation" }));
+}
+
+describe("Layout", () => {
+  beforeEach(() => {
+    mockConfigData = undefined;
+    mockUnreadCount = 0;
+    mockNotifications = [];
+    notificationListeners.clear();
+  });
+
+  it("renders operational routes as non-link disabled items when configuration is not runnable", () => {
+    renderLayout();
+
+    expect(desktopNavigation().queryByRole("link", { name: "Mission Control" })).not.toBeInTheDocument();
+    expect(mobileNavigation().queryByRole("link", { name: "History" })).not.toBeInTheDocument();
+
+    for (const navigation of [desktopNavigation(), mobileNavigation()]) {
+      const missionControlItem = navigation.getByLabelText("Mission Control");
+      const historyItem = navigation.getByLabelText("History");
+      expect(missionControlItem).toHaveAttribute("aria-disabled", "true");
+      expect(missionControlItem).not.toHaveAttribute("href");
+      expect(historyItem).toHaveAttribute("aria-disabled", "true");
+      expect(historyItem).not.toHaveAttribute("href");
+      expect(navigation.getByRole("link", { name: "Config" })).toHaveAttribute("href", "/config");
+    }
+  });
+
+  it("allows pointer and keyboard navigation when configuration is runnable", async () => {
+    const user = userEvent.setup();
+    mockConfigData = { state: "parsed", active_config: {}, issues: [] };
+    renderLayout();
+
+    const historyLink = desktopNavigation().getByRole("link", { name: "History" });
+    expect(historyLink).not.toHaveAttribute("aria-disabled");
+    historyLink.focus();
+    await user.keyboard("{Enter}");
+    expect(screen.getByText("History content")).toBeInTheDocument();
+
+    await user.click(mobileNavigation().getByRole("link", { name: "Mission Control" }));
+    expect(screen.getByText("Dashboard content")).toBeInTheDocument();
+  });
+
+  it("updates utility labels with notification and theme state", async () => {
+    const user = userEvent.setup();
+    mockNotifications = [
+      {
+        id: "notification-1",
+        severity: "info",
+        title: "Agent update",
+        detail: "Review completed",
+        timestamp: "2026-07-09T09:30:00Z",
+        issue_identifier: "repo#1",
+        read: false,
+      },
+    ];
+    renderLayout();
+
+    expect(screen.getAllByRole("button", { name: "Notifications" })).toHaveLength(2);
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
+
+    act(() => {
+      mockUnreadCount = 3;
+      notificationListeners.forEach((listener) => listener());
+    });
+
+    expect(screen.getAllByRole("button", { name: "Notifications (3 unread)" })).toHaveLength(2);
+    expect(screen.getByRole("status")).toHaveTextContent("3 unread notifications");
+
+    await user.click(mobileNavigation().getByRole("button", { name: "Notifications (3 unread)" }));
+    const popover = document.querySelector('[data-slot="popover-content"]');
+    expect(popover).toHaveClass(
+      "w-[min(24rem,calc(100vw-2rem))]",
+      "max-h-[var(--available-height)]",
+      "overflow-hidden",
+    );
+    const notificationList = screen.getByRole("list");
+    expect(notificationList.parentElement).toHaveClass("flex", "min-h-0", "flex-1", "flex-col");
+    expect(notificationList).toHaveClass("min-h-0", "flex-1", "overflow-y-auto");
+
+    act(() => {
+      mockUnreadCount = 0;
+      notificationListeners.forEach((listener) => listener());
+    });
+
+    expect(screen.getAllByRole("button", { name: "Notifications" })).toHaveLength(2);
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+    expect(screen.getByRole("status")).toHaveTextContent("No unread notifications");
+
+    await user.click(mobileNavigation().getByRole("button", { name: "Switch to dark theme" }));
+    expect(screen.getAllByRole("button", { name: "Switch to light theme" })).toHaveLength(2);
+  });
+
+  it("constrains the shell and keeps only main content scrollable", () => {
+    const { container } = renderLayout();
+
+    expect(container.firstElementChild).toHaveClass(
+      "flex",
+      "h-dvh",
+      "min-h-0",
+      "overflow-hidden",
+      "bg-background",
+      "text-foreground",
+    );
+    expect(screen.getByRole("complementary")).toHaveClass("hidden", "w-16", "md:flex");
+    expect(screen.getByRole("navigation", { name: "Mobile navigation" })).toHaveClass(
+      "overflow-hidden",
+      "px-2",
+      "sm:px-4",
+      "md:hidden",
+    );
+
+    const main = screen.getByRole("main");
+    expect(main.parentElement).toHaveClass("min-h-0", "min-w-0", "flex-1");
+    expect(main).toHaveClass("min-h-0", "flex-1", "overflow-auto");
+    expect(container.querySelectorAll("main")).toHaveLength(1);
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/components/Layout.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/Layout.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import { NavLink, Outlet } from "react-router-dom";
-import { Bell, Sun, Moon } from "lucide-react";
+import { Bell, Gauge, History, Moon, Settings, Sun } from "lucide-react";
 import { getTheme, toggleTheme } from "@/theme";
 import type { Theme } from "@/theme";
 import { Button } from "@/components/ui/button";
@@ -10,18 +11,85 @@ import { getUnreadCount, subscribe } from "@/notifications";
 import { cn } from "@/lib/utils";
 import { useConfigStateQuery } from "@/hooks";
 
+function navIconClass({ isActive }: { isActive: boolean }, disabled = false) {
+  return cn(
+    "mb-2 flex h-10 w-10 items-center justify-center rounded-lg text-xs font-semibold transition-colors",
+    isActive
+      ? "bg-primary text-primary-foreground"
+      : cn("text-muted-foreground", !disabled && "hover:bg-muted hover:text-foreground"),
+    disabled && "cursor-not-allowed opacity-50",
+  );
+}
+
+function navLinkClass({ isActive }: { isActive: boolean }, disabled = false) {
+  return cn(
+    "flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-sm font-medium transition-colors sm:w-auto sm:gap-2 sm:px-3",
+    isActive
+      ? "bg-primary text-primary-foreground"
+      : cn("text-muted-foreground", !disabled && "hover:bg-muted hover:text-foreground"),
+    disabled && "cursor-not-allowed opacity-50",
+  );
+}
+
+interface GatedNavItemProps {
+  children: ReactNode;
+  className: (props: { isActive: boolean }) => string;
+  disabled: boolean;
+  end?: boolean;
+  label: string;
+  to: string;
+}
+
+function GatedNavItem({
+  children,
+  className,
+  disabled,
+  end,
+  label,
+  to,
+}: GatedNavItemProps) {
+  if (disabled) {
+    return (
+      <span aria-disabled="true" aria-label={label} className={className({ isActive: false })}>
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <NavLink to={to} end={end} aria-label={label} className={className}>
+      {children}
+    </NavLink>
+  );
+}
+
 export default function Layout() {
   const [theme, setThemeState] = useState<Theme>(getTheme);
   const [unreadCount, setUnreadCount] = useState(getUnreadCount);
+  const previousUnreadCount = useRef(unreadCount);
+  const [notificationAnnouncement, setNotificationAnnouncement] = useState(
+    unreadCount > 0 ? `${unreadCount} unread notifications` : "",
+  );
   const { data: configData } = useConfigStateQuery();
 
   // Check if config is runnable (parsed state with no issues and valid config)
   const isConfigRunnable = configData
     ? configData.state === "parsed" && configData.active_config != null && configData.issues.length === 0
     : false;
+  const notificationLabel =
+    unreadCount > 0 ? `Notifications (${unreadCount} unread)` : "Notifications";
 
   useEffect(() => {
-    return subscribe(() => setUnreadCount(getUnreadCount()));
+    return subscribe(() => {
+      const nextUnreadCount = getUnreadCount();
+      setUnreadCount(nextUnreadCount);
+      if (nextUnreadCount > 0) {
+        setNotificationAnnouncement(`${nextUnreadCount} unread notifications`);
+      } else if (previousUnreadCount.current > 0) {
+        setNotificationAnnouncement("No unread notifications");
+      }
+      previousUnreadCount.current = nextUnreadCount;
+    });
   }, []);
 
   function handleToggleTheme() {
@@ -29,76 +97,122 @@ export default function Layout() {
     setThemeState(next);
   }
 
-  function navLinkClass({ isActive }: { isActive: boolean }, disabled = false) {
-    return cn(
-      "px-3 py-2 rounded-md text-sm font-medium transition-colors",
-      isActive
-        ? "bg-gray-900 text-white dark:bg-gray-700"
-        : "text-gray-300 hover:bg-gray-700 hover:text-white",
-      disabled && "opacity-50 cursor-not-allowed pointer-events-none",
+  function renderUtilityActions(className?: string) {
+    return (
+      <div className={cn("flex shrink-0 items-center gap-1", className)}>
+        <Popover>
+          <PopoverTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon"
+                className="relative text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label={notificationLabel}
+              />
+            }
+          >
+            <Bell className="h-5 w-5" />
+            {unreadCount > 0 && (
+              <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-xs font-bold text-white">
+                {unreadCount > 9 ? "9+" : unreadCount}
+              </span>
+            )}
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            className="max-h-[var(--available-height)] w-[min(24rem,calc(100vw-2rem))] overflow-hidden p-0"
+          >
+            <NotificationPanel />
+          </PopoverContent>
+        </Popover>
+
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleToggleTheme}
+          className="text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
+        >
+          {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+        </Button>
+      </div>
     );
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <nav className="bg-gray-800 shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-14">
-            <div className="flex items-center gap-4">
-              <span className="text-white font-bold text-lg">Ensemble</span>
-              <div className="flex items-center gap-1">
-                <NavLink
-                  to="/"
-                  end
-                  className={(props) => navLinkClass(props, !isConfigRunnable)}
-                >
-                  Dashboard
-                </NavLink>
-                <NavLink
-                  to="/history"
-                  className={(props) => navLinkClass(props, !isConfigRunnable)}
-                >
-                  History
-                </NavLink>
-                <NavLink
-                  to="/config"
-                  className={navLinkClass}
-                >
-                  Config
-                </NavLink>
-              </div>
-            </div>
+    <div className="flex h-dvh min-h-0 overflow-hidden bg-background text-foreground">
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {notificationAnnouncement}
+      </span>
+      <aside className="hidden min-h-0 w-16 shrink-0 flex-col items-center border-r bg-card px-2 py-3 md:flex">
+        <nav aria-label="Desktop navigation" className="flex flex-col items-center">
+          <GatedNavItem
+            to="/"
+            end
+            disabled={!isConfigRunnable}
+            className={(props) => navIconClass(props, !isConfigRunnable)}
+            label="Mission Control"
+          >
+            MC
+          </GatedNavItem>
+          <GatedNavItem
+            to="/history"
+            disabled={!isConfigRunnable}
+            className={(props) => navIconClass(props, !isConfigRunnable)}
+            label="History"
+          >
+            H
+          </GatedNavItem>
+          <NavLink to="/config" className={navIconClass} aria-label="Config">
+            C
+          </NavLink>
+        </nav>
+        <div className="flex-1" />
+        {renderUtilityActions("flex-col")}
+      </aside>
 
-            <div className="flex items-center gap-1">
-              <Popover>
-                <PopoverTrigger
-                  render={
-                    <Button variant="ghost" size="icon" className="relative text-gray-300 hover:text-white hover:bg-gray-700" />
-                  }
-                >
-                  <Bell className="h-5 w-5" />
-                  {unreadCount > 0 && (
-                    <span className="absolute -top-1 -right-1 flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full">
-                      {unreadCount > 9 ? "9+" : unreadCount}
-                    </span>
-                  )}
-                </PopoverTrigger>
-                <PopoverContent align="end" className="w-96 p-0">
-                  <NotificationPanel />
-                </PopoverContent>
-              </Popover>
-
-              <Button variant="ghost" size="icon" onClick={handleToggleTheme} className="text-gray-300 hover:text-white hover:bg-gray-700">
-                {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
-              </Button>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <nav
+          aria-label="Mobile navigation"
+          className="flex h-14 shrink-0 items-center justify-between overflow-hidden border-b bg-card px-2 sm:px-4 md:hidden"
+        >
+          <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+            <span className="hidden shrink-0 text-lg font-bold text-foreground sm:inline">
+              Ensemble
+            </span>
+            <div className="flex min-w-0 items-center gap-1">
+              <GatedNavItem
+                to="/"
+                end
+                disabled={!isConfigRunnable}
+                className={(props) => navLinkClass(props, !isConfigRunnable)}
+                label="Mission Control"
+              >
+                <Gauge className="h-4 w-4" />
+                <span className="hidden sm:inline">Mission Control</span>
+              </GatedNavItem>
+              <GatedNavItem
+                to="/history"
+                disabled={!isConfigRunnable}
+                className={(props) => navLinkClass(props, !isConfigRunnable)}
+                label="History"
+              >
+                <History className="h-4 w-4" />
+                <span className="hidden sm:inline">History</span>
+              </GatedNavItem>
+              <NavLink to="/config" className={navLinkClass} aria-label="Config">
+                <Settings className="h-4 w-4" />
+                <span className="hidden sm:inline">Config</span>
+              </NavLink>
             </div>
           </div>
-        </div>
-      </nav>
+          {renderUtilityActions()}
+        </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        <Outlet />
-      </main>
+        <main className="min-h-0 flex-1 overflow-auto p-4 lg:p-6">
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 }

--- a/crates/ensemble-ui/src-ui/src/components/NotificationPanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/NotificationPanel.tsx
@@ -25,8 +25,8 @@ export default function NotificationPanel() {
   }
 
   return (
-    <div>
-      <div className="flex items-center justify-between p-3 border-b">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between border-b p-3">
         <h3 className="text-sm font-semibold">Notifications</h3>
         <Button variant="link" size="sm" className="h-auto p-0 text-xs" onClick={markAllRead}>
           Mark all read
@@ -34,9 +34,11 @@ export default function NotificationPanel() {
       </div>
 
       {notifications.length === 0 ? (
-        <div className="p-4 text-sm text-center text-muted-foreground">No notifications</div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-4 text-center text-sm text-muted-foreground">
+          No notifications
+        </div>
       ) : (
-        <ul className="max-h-80 overflow-y-auto divide-y">
+        <ul className="min-h-0 max-h-80 flex-1 divide-y overflow-y-auto">
           {notifications.map((n) => (
             <li
               key={n.id}

--- a/crates/ensemble-ui/src-ui/src/components/issue-detail/IssueComposer.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/issue-detail/IssueComposer.test.tsx
@@ -13,6 +13,9 @@ describe("IssueComposer", () => {
       <IssueComposer
         pendingQuestion={{
           interactionId: "ask-1",
+          kind: "question",
+          status: "open",
+          awaitingResume: true,
           question: "Which API key?",
           whyBlocked: "Deploy is blocked",
           suggestedAnswer: "Use staging",
@@ -30,6 +33,107 @@ describe("IssueComposer", () => {
     await user.type(screen.getByLabelText("Reply"), "Use staging key");
     await user.click(screen.getByRole("button", { name: "Submit Reply" }));
 
-    expect(onSubmitReply).toHaveBeenCalledWith("Use staging key");
+    expect(onSubmitReply).toHaveBeenCalledWith({ kind: "question", text: "Use staging key" });
+  });
+
+  it.each([
+    ["Approve", true],
+    ["Reject", false],
+  ] as const)("submits an explicit approval decision from %s", async (buttonName, approved) => {
+    const user = userEvent.setup();
+    const onSubmitReply = vi.fn();
+
+    renderWithProviders(
+      <IssueComposer
+        pendingQuestion={{
+          interactionId: "ask-approval",
+          kind: "approval",
+          status: "open",
+          awaitingResume: true,
+          question: "Publish the release?",
+          whyBlocked: "Approval is required",
+          suggestedAnswer: null,
+          stepName: "release",
+        }}
+        onSubmitReply={onSubmitReply}
+        onSubmitFollowUp={vi.fn()}
+        isSubmitting={false}
+      />,
+      { route: "/" },
+    );
+
+    await user.type(screen.getByLabelText("Reason (optional)"), "Operator decision");
+    await user.click(screen.getByRole("button", { name: buttonName }));
+
+    expect(onSubmitReply).toHaveBeenCalledWith({
+      kind: "approval",
+      approved,
+      reason: "Operator decision",
+    });
+  });
+
+  it.each([
+    ["Complete", true],
+    ["Incomplete", false],
+  ] as const)("submits an explicit handoff decision from %s", async (buttonName, completed) => {
+    const user = userEvent.setup();
+    const onSubmitReply = vi.fn();
+
+    renderWithProviders(
+      <IssueComposer
+        pendingQuestion={{
+          interactionId: "ask-handoff",
+          kind: "handoff",
+          status: "open",
+          awaitingResume: true,
+          question: "Was the manual deployment completed?",
+          whyBlocked: "Waiting for the operator",
+          suggestedAnswer: null,
+          stepName: "deploy",
+        }}
+        onSubmitReply={onSubmitReply}
+        onSubmitFollowUp={vi.fn()}
+        isSubmitting={false}
+      />,
+      { route: "/" },
+    );
+
+    await user.type(screen.getByLabelText("Notes (optional)"), "Deployment outcome");
+    await user.click(screen.getByRole("button", { name: buttonName }));
+
+    expect(onSubmitReply).toHaveBeenCalledWith({
+      kind: "handoff",
+      completed,
+      notes: "Deployment outcome",
+    });
+  });
+
+  it("offers resume-only recovery for a resolved interaction awaiting resume", async () => {
+    const user = userEvent.setup();
+    const onResumeInteraction = vi.fn();
+
+    renderWithProviders(
+      <IssueComposer
+        pendingQuestion={{
+          interactionId: "ask-resolved",
+          kind: "approval",
+          status: "resolved",
+          awaitingResume: true,
+          question: "Publish the release?",
+          whyBlocked: "Approval is required",
+          suggestedAnswer: null,
+          stepName: "release",
+        }}
+        onSubmitReply={vi.fn()}
+        onSubmitFollowUp={vi.fn()}
+        onResumeInteraction={onResumeInteraction}
+        isSubmitting={false}
+      />,
+      { route: "/" },
+    );
+
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Resume issue" }));
+    expect(onResumeInteraction).toHaveBeenCalledOnce();
   });
 });

--- a/crates/ensemble-ui/src-ui/src/components/issue-detail/IssueComposer.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/issue-detail/IssueComposer.tsx
@@ -3,48 +3,153 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { IssueQuestionBanner, type PendingQuestion } from "./IssueQuestionBanner";
 
+export type IssueInteractionReply =
+  | { kind: "question"; text: string }
+  | { kind: "approval"; approved: boolean; reason: string }
+  | { kind: "handoff"; completed: boolean; notes: string };
+
 interface IssueComposerProps {
   pendingQuestion: PendingQuestion | null;
-  onSubmitReply: (value: string) => void;
-  onSubmitFollowUp: (value: string) => void;
+  onSubmitReply: (reply: IssueInteractionReply) => Promise<boolean> | boolean;
+  onSubmitFollowUp: (value: string) => Promise<boolean> | boolean;
+  onResumeInteraction?: () => Promise<boolean> | boolean;
   isSubmitting: boolean;
+  error?: string | null;
 }
 
 export function IssueComposer({
   pendingQuestion,
   onSubmitReply,
   onSubmitFollowUp,
+  onResumeInteraction,
   isSubmitting,
+  error = null,
 }: IssueComposerProps) {
   const [value, setValue] = useState("");
   const isQuestionMode = pendingQuestion !== null;
 
-  const handleSubmit = () => {
-    if (isQuestionMode) {
-      onSubmitReply(value);
-    } else {
-      onSubmitFollowUp(value);
+  const submit = async (reply: IssueInteractionReply) => {
+    const submitted = await onSubmitReply(reply);
+    if (submitted) {
+      setValue("");
     }
-    setValue("");
   };
+
+  const handleSubmit = async () => {
+    const submitted = await onSubmitFollowUp(value);
+    if (submitted) setValue("");
+  };
+
+  const interactionControls = (() => {
+    if (!pendingQuestion) return null;
+
+    if (pendingQuestion.status === "resolved" && pendingQuestion.awaitingResume) {
+      return (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            The response was recorded, but the issue still needs to resume.
+          </p>
+          <Button onClick={() => onResumeInteraction?.()} disabled={isSubmitting}>
+            Resume issue
+          </Button>
+        </div>
+      );
+    }
+
+    switch (pendingQuestion.kind) {
+      case "question":
+        return (
+          <>
+            <label htmlFor="issue-composer" className="text-sm font-medium">
+              Reply
+            </label>
+            <Textarea
+              id="issue-composer"
+              value={value}
+              onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setValue(event.target.value)}
+              placeholder="Answer the agent question"
+            />
+            <Button
+              onClick={() => submit({ kind: "question", text: value })}
+              disabled={isSubmitting || value.trim().length === 0}
+            >
+              Submit Reply
+            </Button>
+          </>
+        );
+      case "approval":
+        return (
+          <>
+            <label htmlFor="issue-composer" className="text-sm font-medium">
+              Reason (optional)
+            </label>
+            <Textarea
+              id="issue-composer"
+              value={value}
+              onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setValue(event.target.value)}
+              placeholder="Add context for this decision"
+            />
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" onClick={() => submit({ kind: "approval", approved: false, reason: value })} disabled={isSubmitting}>
+                Reject
+              </Button>
+              <Button onClick={() => submit({ kind: "approval", approved: true, reason: value })} disabled={isSubmitting}>
+                Approve
+              </Button>
+            </div>
+          </>
+        );
+      case "handoff":
+        return (
+          <>
+            <label htmlFor="issue-composer" className="text-sm font-medium">
+              Notes (optional)
+            </label>
+            <Textarea
+              id="issue-composer"
+              value={value}
+              onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setValue(event.target.value)}
+              placeholder="Describe the handoff outcome"
+            />
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" onClick={() => submit({ kind: "handoff", completed: false, notes: value })} disabled={isSubmitting}>
+                Incomplete
+              </Button>
+              <Button onClick={() => submit({ kind: "handoff", completed: true, notes: value })} disabled={isSubmitting}>
+                Complete
+              </Button>
+            </div>
+          </>
+        );
+      default: {
+        const exhaustive: never = pendingQuestion.kind;
+        return exhaustive;
+      }
+    }
+  })();
 
   return (
     <div className="border-t bg-background p-4 space-y-3">
       {pendingQuestion ? <IssueQuestionBanner pendingQuestion={pendingQuestion} /> : null}
-      <label htmlFor="issue-composer" className="text-sm font-medium">
-        {isQuestionMode ? "Reply" : "Follow-up"}
-      </label>
-      <Textarea
-        id="issue-composer"
-        value={value}
-        onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setValue(event.target.value)}
-        placeholder={isQuestionMode ? "Answer the agent question" : "Add operator guidance"}
-      />
-      <div className="flex gap-2">
-        <Button onClick={handleSubmit} disabled={isSubmitting || value.trim().length === 0}>
-          {isQuestionMode ? "Submit Reply" : "Send Follow-up"}
-        </Button>
-      </div>
+      {isQuestionMode ? (
+        interactionControls
+      ) : (
+        <>
+          <label htmlFor="issue-composer" className="text-sm font-medium">
+            Follow-up
+          </label>
+          <Textarea
+            id="issue-composer"
+            value={value}
+            onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setValue(event.target.value)}
+            placeholder="Add operator guidance"
+          />
+          <Button onClick={handleSubmit} disabled={isSubmitting || value.trim().length === 0}>
+            Send Follow-up
+          </Button>
+        </>
+      )}
+      {error ? <p role="alert" className="text-sm text-destructive">{error}</p> : null}
     </div>
   );
 }

--- a/crates/ensemble-ui/src-ui/src/components/issue-detail/IssueQuestionBanner.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/issue-detail/IssueQuestionBanner.tsx
@@ -1,7 +1,11 @@
 import { Card } from "@/components/ui/card";
+import type { InteractionKind, InteractionStatus } from "@/generated/models";
 
 export interface PendingQuestion {
   interactionId: string;
+  kind: InteractionKind;
+  status: InteractionStatus;
+  awaitingResume: boolean;
   question: string;
   whyBlocked: string | null;
   suggestedAnswer: string | null;
@@ -16,7 +20,7 @@ export function IssueQuestionBanner({ pendingQuestion }: IssueQuestionBannerProp
   return (
     <Card className="border-blue-300 bg-blue-50/60 p-3 dark:border-blue-900 dark:bg-blue-950/20">
       <div className="text-xs font-medium uppercase text-blue-700 dark:text-blue-200">
-        Waiting for human input
+        {pendingQuestion.status === "resolved" ? "Response recorded" : "Waiting for human input"}
       </div>
       <div className="mt-1 font-semibold">{pendingQuestion.question}</div>
       {pendingQuestion.whyBlocked ? (

--- a/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.test.ts
+++ b/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.test.ts
@@ -20,10 +20,12 @@ describe("buildTranscriptEntries", () => {
       interactions: [
         {
           agent_name: "builder",
+          awaiting_resume: true,
           id: "ask-1",
           issue_id: "issue-1",
           issue_identifier: "todo-1",
-          status: "pending",
+          status: "open",
+          kind: "question",
           question: "What API key should I use?",
           why_blocked: "Deployment requires credentials",
           suggested_answer: "Use staging key",
@@ -276,10 +278,12 @@ describe("buildTranscriptEntries", () => {
       interactions: [
         {
           agent_name: "builder",
+          awaiting_resume: true,
           id: "ask-2",
           issue_id: "issue-1",
           issue_identifier: "todo-1",
-          status: "pending",
+          status: "open",
+          kind: "question",
           question: "Second question",
           why_blocked: "Need approval",
           suggested_answer: null,
@@ -289,10 +293,12 @@ describe("buildTranscriptEntries", () => {
         },
         {
           agent_name: "builder",
+          awaiting_resume: true,
           id: "ask-1",
           issue_id: "issue-1",
           issue_identifier: "todo-1",
-          status: "pending",
+          status: "open",
+          kind: "question",
           question: "First question",
           why_blocked: "Need credentials",
           suggested_answer: null,
@@ -496,6 +502,39 @@ describe("buildTranscriptEntries", () => {
           sequence: 2,
         },
       ],
+    });
+
+    expect(second[0]).not.toBe(first[0]);
+  });
+
+  it.each([
+    ["kind", { kind: "approval" as const }],
+    ["awaiting resume", { awaiting_resume: false }],
+  ])("replaces an interaction entry when %s changes", (_field, change) => {
+    const interaction = {
+      agent_name: "builder",
+      awaiting_resume: true,
+      id: "ask-1",
+      issue_id: "issue-1",
+      issue_identifier: "repo#1",
+      status: "open" as const,
+      kind: "question" as const,
+      question: "Continue?",
+      why_blocked: "Needs input",
+      suggested_answer: null,
+      extra_context: null,
+      step_name: "build",
+      requested_at: "2026-07-09T10:00:00Z",
+    };
+    const first = reconcileGroupedTranscriptEntries(undefined, {
+      conversation: [],
+      interactions: [interaction],
+      events: [],
+    });
+    const second = reconcileGroupedTranscriptEntries(first, {
+      conversation: [],
+      interactions: [{ ...interaction, ...change }],
+      events: [],
     });
 
     expect(second[0]).not.toBe(first[0]);

--- a/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.ts
+++ b/crates/ensemble-ui/src-ui/src/components/transcript/transcript-model.ts
@@ -295,10 +295,12 @@ function sameInteractionDetail(
 ): boolean {
   return (
     a.agent_name === b.agent_name &&
+    a.awaiting_resume === b.awaiting_resume &&
     a.extra_context === b.extra_context &&
     a.id === b.id &&
     a.issue_id === b.issue_id &&
     a.issue_identifier === b.issue_identifier &&
+    a.kind === b.kind &&
     a.question === b.question &&
     a.requested_at === b.requested_at &&
     a.status === b.status &&

--- a/crates/ensemble-ui/src-ui/src/hooks.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/hooks.test.tsx
@@ -1,0 +1,505 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { InteractionDetail, IssueDetailSnapshot } from "./generated/models";
+import {
+  useCancelInteractionMutation,
+  useFinalizeApproveMutation,
+  useFinalizeRetryMutation,
+  useInteractionDetailQuery,
+  useIssueDetailQuery,
+  useRespondToInteractionMutation,
+  useResumeIssueMutation,
+  useRetryMutation,
+  useStepConversationQuery,
+  useStepDetailQuery,
+  useStopMutation,
+  useTimelineQuery,
+} from "./hooks";
+
+function jsonResponse(data: unknown) {
+  return Promise.resolve(
+    new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+function queryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function wrapper(client = queryClient()) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function interaction(status: InteractionDetail["status"]): InteractionDetail {
+  return {
+    agent_name: "builder",
+    awaiting_resume: status === "resolved",
+    id: "ask-1",
+    issue_id: "issue-1",
+    issue_identifier: "repo#1",
+    kind: "question",
+    question: "Continue?",
+    requested_at: "2026-07-09T10:00:00Z",
+    status,
+    step_name: "build",
+    why_blocked: "Needs input",
+  };
+}
+
+function issueDetail(finalizeStatus: string, approvalRequired = false): IssueDetailSnapshot {
+  return {
+    artifacts: null,
+    attempts: { restart_count: 0, current_retry_attempt: null },
+    current_interaction: null,
+    finalize: {
+      status: finalizeStatus,
+      repos: [
+        {
+          approval_required: approvalRequired,
+          last_error: finalizeStatus === "failed" ? "push failed" : null,
+          mode: "push",
+          repo: "repo",
+          status: finalizeStatus,
+        },
+      ],
+    },
+    issue: { title: "Finalize issue", description: null, labels: [] },
+    issue_id: "issue-1",
+    issue_identifier: "repo#1",
+    last_error: null,
+    pending_input: null,
+    retry: null,
+    running: null,
+    status: "completed_succeeded",
+    workflow_steps: [],
+    workspace: { path: "/tmp/workspace" },
+  };
+}
+
+function ResumeControl() {
+  const detail = useInteractionDetailQuery("ask-1");
+  const mutation = useResumeIssueMutation();
+
+  return detail.data?.status === "resolved" && detail.data.awaiting_resume ? (
+    <button
+      type="button"
+      disabled={mutation.isPending}
+      onClick={() =>
+        mutation.mutate({ identifier: "repo#1", interactionId: detail.data?.id })
+      }
+    >
+      Resume issue
+    </button>
+  ) : (
+    <span>Resume unavailable</span>
+  );
+}
+
+function FinalizeApproveControl() {
+  const detail = useIssueDetailQuery("repo#1");
+  const mutation = useFinalizeApproveMutation();
+
+  return detail.data?.finalize.status === "pending_approval" ? (
+    <button
+      type="button"
+      disabled={mutation.isPending}
+      onClick={() => mutation.mutate({ identifier: "repo#1" })}
+    >
+      Approve finalize
+    </button>
+  ) : (
+    <span>Finalize refreshed</span>
+  );
+}
+
+function FinalizeRetryControl() {
+  const detail = useIssueDetailQuery("repo#1");
+  const mutation = useFinalizeRetryMutation();
+
+  return detail.data?.finalize.status === "failed" ? (
+    <button
+      type="button"
+      disabled={mutation.isPending}
+      onClick={() => mutation.mutate({ identifier: "repo#1" })}
+    >
+      Retry finalize
+    </button>
+  ) : (
+    <span>Finalize refreshed</span>
+  );
+}
+
+function FinalizeControl() {
+  const detail = useIssueDetailQuery("repo#1");
+  const approveMutation = useFinalizeApproveMutation();
+  const retryMutation = useFinalizeRetryMutation();
+
+  if (detail.data?.finalize.status === "pending_approval") {
+    return (
+      <button type="button" onClick={() => approveMutation.mutate({ identifier: "repo#1" })}>
+        Approve finalize
+      </button>
+    );
+  }
+
+  if (detail.data?.finalize.status === "failed") {
+    return (
+      <button type="button" onClick={() => retryMutation.mutate({ identifier: "repo#1" })}>
+        Retry finalize
+      </button>
+    );
+  }
+
+  return <span>Finalize refreshed</span>;
+}
+
+describe("issue-scoped API hooks", () => {
+  it.each([
+    ["repo#42", "/api/v1/repo%2342"],
+    ["org/repo#42", "/api/v1/org%2Frepo%2342"],
+  ])("URL-encodes issue detail identifier %s", async (identifier, expectedUrl) => {
+    const fetchMock = vi.fn(() => jsonResponse({ issue_identifier: identifier }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useIssueDetailQuery(identifier), { wrapper: wrapper() });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(expectedUrl, expect.objectContaining({ method: "GET" }));
+  });
+
+  it.each([
+    ["stop", () => useStopMutation(), "/api/v1/org%2Frepo%2342/stop"],
+    ["retry", () => useRetryMutation(), "/api/v1/org%2Frepo%2342/retry"],
+    ["resume", () => useResumeIssueMutation("org/repo#42"), "/api/v1/issues/org%2Frepo%2342/resume"],
+    [
+      "finalize approve",
+      () => useFinalizeApproveMutation("org/repo#42"),
+      "/api/v1/org%2Frepo%2342/finalize/approve",
+    ],
+    [
+      "finalize retry",
+      () => useFinalizeRetryMutation("org/repo#42"),
+      "/api/v1/org%2Frepo%2342/finalize/retry",
+    ],
+  ])("URL-encodes issue identifier for %s", async (_name, useHook, expectedUrl) => {
+    const fetchMock = vi.fn(() => jsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(useHook, { wrapper: wrapper() });
+
+    result.current.mutate({ identifier: "org/repo#42" });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(expectedUrl, expect.objectContaining({ method: "POST" }));
+  });
+
+  it("URL-encodes issue identifier for timeline", async () => {
+    const fetchMock = vi.fn(() => jsonResponse({ events: [], total: 0 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useTimelineQuery("org/repo#42", "run-1"), { wrapper: wrapper() });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/org%2Frepo%2342/timeline?run_id=run-1&limit=200",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("URL-encodes issue identifier and step name for step detail", async () => {
+    const fetchMock = vi.fn(() => jsonResponse({ step_name: "review pass" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useStepDetailQuery("org/repo#42", "review pass"), { wrapper: wrapper() });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/org%2Frepo%2342/step/review%20pass",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("URL-encodes issue identifier and step name for step conversation transcript", async () => {
+    const fetchMock = vi.fn(() => jsonResponse({ records: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useStepConversationQuery("org/repo#42", "run-1", "qa/review", { limit: 50 }), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/org%2Frepo%2342/runs/run-1/steps/qa%2Freview/conversation?limit=50",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it.each([
+    ["respond", "resolved"],
+    ["cancel", "cancelled"],
+  ] as const)(
+    "refreshes the cached interaction detail after %s so remount cannot restore an open action",
+    async (action, terminalStatus) => {
+      let status: InteractionDetail["status"] = "open";
+      const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "POST") {
+          status = terminalStatus;
+          return jsonResponse({ ...interaction(status), body: "Continue?" });
+        }
+        if (url === "/api/v1/interactions/ask-1") {
+          return jsonResponse(interaction(status));
+        }
+        return jsonResponse({});
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const client = queryClient();
+      const hookWrapper = wrapper(client);
+      const detail = renderHook(() => useInteractionDetailQuery("ask-1"), {
+        wrapper: hookWrapper,
+      });
+      await waitFor(() => expect(detail.result.current.data?.status).toBe("open"));
+      let unmountMutation = () => {};
+      if (action === "respond") {
+        const mutation = renderHook(() => useRespondToInteractionMutation("repo#1"), {
+          wrapper: hookWrapper,
+        });
+        unmountMutation = mutation.unmount;
+        await act(async () => {
+          await mutation.result.current.mutateAsync({
+            id: "ask-1",
+            kind: "question",
+            response_schema_version: 1,
+            selected_option: null,
+            text: "continue",
+          });
+        });
+      } else {
+        const mutation = renderHook(() => useCancelInteractionMutation("repo#1"), {
+          wrapper: hookWrapper,
+        });
+        unmountMutation = mutation.unmount;
+        await act(async () => {
+          await mutation.result.current.mutateAsync({ id: "ask-1" });
+        });
+      }
+
+      expect(
+        client.getQueryData<InteractionDetail>(["getInteractionById", "ask-1"])?.status,
+      ).toBe(terminalStatus);
+      detail.unmount();
+      unmountMutation();
+
+      const remounted = renderHook(() => useInteractionDetailQuery("ask-1"), {
+        wrapper: hookWrapper,
+      });
+      expect(remounted.result.current.data?.status).toBe(terminalStatus);
+    },
+  );
+
+  it("keeps queued resume server-authoritative until polling reports completion", async () => {
+    let interactionReads = 0;
+    const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/v1/issues/repo%231/resume" && init?.method === "POST") {
+        return jsonResponse({ resumed: true });
+      }
+      if (url === "/api/v1/interactions/ask-1") {
+        interactionReads += 1;
+        return jsonResponse({
+          ...interaction("resolved"),
+          awaiting_resume: interactionReads < 3,
+        });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const client = queryClient();
+    const hookWrapper = wrapper(client);
+    const user = userEvent.setup();
+    const view = render(<ResumeControl />, { wrapper: hookWrapper });
+
+    await user.click(await screen.findByRole("button", { name: "Resume issue" }));
+    await waitFor(() =>
+      expect(
+        client.getQueryData<InteractionDetail>(["getInteractionById", "ask-1"])
+          ?.awaiting_resume,
+      ).toBe(true),
+    );
+    expect(screen.getByRole("button", { name: "Resume issue" })).toBeInTheDocument();
+    expect(interactionReads).toBe(2);
+
+    await waitFor(
+      () =>
+        expect(
+          client.getQueryData<InteractionDetail>(["getInteractionById", "ask-1"])
+            ?.awaiting_resume,
+        ).toBe(false),
+      { timeout: 3000 },
+    );
+    expect(interactionReads).toBe(3);
+    expect(screen.getByText("Resume unavailable")).toBeInTheDocument();
+
+    view.unmount();
+    render(<ResumeControl />, { wrapper: hookWrapper });
+    expect(screen.queryByRole("button", { name: "Resume issue" })).not.toBeInTheDocument();
+    expect(screen.getByText("Resume unavailable")).toBeInTheDocument();
+    await act(async () => Promise.resolve());
+    expect(
+      fetchMock.mock.calls.filter(
+        ([input, init]) =>
+          String(input) === "/api/v1/interactions/ask-1" && init?.method === "GET",
+      ),
+    ).toHaveLength(3);
+    expect(
+      fetchMock.mock.calls.filter(
+        ([input, init]) =>
+          String(input) === "/api/v1/issues/repo%231/resume" && init?.method === "POST",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    ["approve", "pending_approval", FinalizeApproveControl, "Approve finalize"],
+    ["retry", "failed", FinalizeRetryControl, "Retry finalize"],
+  ] as const)(
+    "suppresses the %s finalize control across remount while detail refresh is deferred",
+    async (_action, initialStatus, Control, buttonName) => {
+      let postCompleted = false;
+      let resolveRefetch: (response: Response) => void = () => {};
+      const refetchResponse = new Promise<Response>((resolve) => {
+        resolveRefetch = resolve;
+      });
+      const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "POST") {
+          postCompleted = true;
+          return jsonResponse({ ok: true });
+        }
+        if (url === "/api/v1/repo%231" && postCompleted) return refetchResponse;
+        return jsonResponse(issueDetail(initialStatus));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const client = queryClient();
+      const user = userEvent.setup();
+      const hookWrapper = wrapper(client);
+      const view = render(<Control />, { wrapper: hookWrapper });
+
+      const control = await screen.findByRole("button", { name: buttonName });
+      await user.click(control);
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+        "/api/v1/repo%231",
+        expect.objectContaining({ method: "GET" }),
+      ));
+
+      expect(client.getQueryData<IssueDetailSnapshot>(["getIssueDetail", "repo#1"])).toMatchObject({
+        finalize: {
+          status: "in_progress",
+          repos: [{ status: "in_progress", last_error: null }],
+        },
+      });
+      view.unmount();
+      render(<Control />, { wrapper: hookWrapper });
+      expect(screen.queryByRole("button", { name: buttonName })).not.toBeInTheDocument();
+      expect(screen.getByText("Finalize refreshed")).toBeInTheDocument();
+
+      await act(async () => {
+        resolveRefetch(
+          await jsonResponse(issueDetail("in_progress")),
+        );
+      });
+      expect(await screen.findByText("Finalize refreshed")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: buttonName })).not.toBeInTheDocument();
+    },
+  );
+
+  it("preserves approval after retry when detail refresh fails and the control remounts", async () => {
+    let postCompleted = false;
+    const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (init?.method === "POST") {
+        postCompleted = true;
+        return jsonResponse({ ok: true });
+      }
+      if (url === "/api/v1/repo%231" && postCompleted) {
+        return Promise.reject(new Error("detail refresh failed"));
+      }
+      return jsonResponse(issueDetail("failed", true));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const client = queryClient();
+    const hookWrapper = wrapper(client);
+    const view = render(<FinalizeControl />, { wrapper: hookWrapper });
+
+    await userEvent.click(await screen.findByRole("button", { name: "Retry finalize" }));
+    await waitFor(() =>
+      expect(client.getQueryData<IssueDetailSnapshot>(["getIssueDetail", "repo#1"]))
+        .toMatchObject({
+          finalize: {
+            status: "pending_approval",
+            repos: [{ status: "pending_approval", last_error: null }],
+          },
+        }),
+    );
+
+    view.unmount();
+    render(<FinalizeControl />, { wrapper: hookWrapper });
+    expect(screen.getByRole("button", { name: "Approve finalize" })).toBeInTheDocument();
+    expect(screen.queryByText("Finalize refreshed")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["approve", "pending_approval", FinalizeApproveControl, "Approve finalize"],
+    ["retry", "failed", FinalizeRetryControl, "Retry finalize"],
+  ] as const)(
+    "keeps the %s finalize control suppressed after detail refresh fails and the control remounts",
+    async (_action, initialStatus, Control, buttonName) => {
+      let postCompleted = false;
+      const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "POST") {
+          postCompleted = true;
+          return jsonResponse({ ok: true });
+        }
+        if (url === "/api/v1/repo%231" && postCompleted) {
+          return Promise.reject(new Error("detail refresh failed"));
+        }
+        return jsonResponse(issueDetail(initialStatus));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const client = queryClient();
+      const hookWrapper = wrapper(client);
+      const user = userEvent.setup();
+      const view = render(<Control />, { wrapper: hookWrapper });
+
+      await user.click(await screen.findByRole("button", { name: buttonName }));
+      await waitFor(() =>
+        expect(
+          client.getQueryData<IssueDetailSnapshot>(["getIssueDetail", "repo#1"]),
+        ).toMatchObject({
+          finalize: {
+            status: "in_progress",
+            repos: [{ status: "in_progress", last_error: null }],
+          },
+        }),
+      );
+
+      view.unmount();
+      render(<Control />, { wrapper: hookWrapper });
+      expect(screen.queryByRole("button", { name: buttonName })).not.toBeInTheDocument();
+      expect(screen.getByText("Finalize refreshed")).toBeInTheDocument();
+    },
+  );
+});

--- a/crates/ensemble-ui/src-ui/src/hooks.ts
+++ b/crates/ensemble-ui/src-ui/src/hooks.ts
@@ -1,15 +1,9 @@
 import { useState, useEffect } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { getState } from "./generated/api/state/state";
-import { getIssueDetail } from "./generated/api/issues/issues";
 import { getHistory } from "./generated/api/history/history";
 import { listDirectory } from "./generated/api/filesystem/filesystem";
-import {
-  postRefresh,
-  postResumeIssue,
-  postStop,
-  postRetry,
-} from "./generated/api/controls/controls";
+import { postRefresh } from "./generated/api/controls/controls";
 import {
   listOpenInteractions,
   getInteractionById,
@@ -26,7 +20,6 @@ import {
   getConfig,
   getSetupDefaults,
 } from "./generated/api/config/config";
-import { getStepConversation } from "./generated/api/conversation/conversation";
 import type {
   GetStepConversationParams,
   GetHistoryParams,
@@ -47,6 +40,8 @@ import type {
   InteractionResponseBody,
   ListDirectoryParams,
   ListResponse,
+  FinalizeStatus,
+  RepoFinalizeSnapshot,
 } from "./generated/models";
 import { customFetch } from "./fetch-client";
 
@@ -57,12 +52,62 @@ const STATE_QUERY_KEY = ["/api/v1/state"] as const;
 const CONFIG_QUERY_KEY = ["getConfig"] as const;
 const LIST_OPEN_INTERACTIONS_KEY = ["listOpenInteractions"] as const;
 
+function pathSegment(value: string) {
+  return encodeURIComponent(value);
+}
+
+function issuePath(identifier: string) {
+  return `/api/v1/${pathSegment(identifier)}`;
+}
+
+function issuesPath(identifier: string) {
+  return `/api/v1/issues/${pathSegment(identifier)}`;
+}
+
 function issueDetailQueryKey(identifier: string) {
   return ["getIssueDetail", identifier] as const;
 }
 
 function interactionByIdQueryKey(id: string) {
   return ["getInteractionById", id] as const;
+}
+
+function aggregateFinalizeStatus(repos: RepoFinalizeSnapshot[]): FinalizeStatus {
+  if (repos.every((repo) => repo.status === "succeeded")) return "succeeded";
+  if (repos.some((repo) => repo.status === "in_progress")) return "in_progress";
+  return "pending_approval";
+}
+
+function markFinalizeTransition(
+  queryClient: QueryClient,
+  identifier: string,
+  previousStatus: "pending_approval" | "failed",
+) {
+  queryClient.setQueryData<IssueDetailSnapshot>(issueDetailQueryKey(identifier), (current) => {
+    if (!current) return current;
+
+    const repos = current.finalize.repos.map((repo) =>
+      repo.status === previousStatus
+        ? {
+            ...repo,
+            status:
+              previousStatus === "failed" && repo.approval_required
+                ? ("pending_approval" as const)
+                : ("in_progress" as const),
+            last_error: null,
+          }
+        : repo,
+    );
+
+    return {
+      ...current,
+      finalize: {
+        ...current.finalize,
+        status: aggregateFinalizeStatus(repos),
+        repos,
+      },
+    };
+  });
 }
 
 export function useStateQuery() {
@@ -111,7 +156,9 @@ export function useIssueDetailQuery(identifier: string) {
     refetchInterval: 2000,
     enabled: identifier.length > 0,
     queryFn: async (): Promise<IssueDetailSnapshot> => {
-      const resp = await getIssueDetail(identifier);
+      const resp = await customFetch<{ data: IssueDetailSnapshot }>(issuePath(identifier), {
+        method: "GET",
+      });
       return resp.data as IssueDetailSnapshot;
     },
   });
@@ -146,7 +193,8 @@ export function useTimelineQuery(identifier: string, runId?: string, limit = 200
         limit: String(limit),
       });
       const response = await customFetch<{ data: TimelineResponse }>(
-        `/api/v1/${encodeURIComponent(identifier)}/timeline?${params.toString()}`,
+        `${issuePath(identifier)}/timeline?${params.toString()}`,
+        { method: "GET" },
       );
       return response.data;
     },
@@ -179,7 +227,8 @@ export function useStepDetailQuery(identifier: string, stepName: string) {
     enabled: identifier.length > 0 && stepName.length > 0,
     queryFn: async (): Promise<StepDetailSnapshot> => {
       const response = await customFetch<{ data: StepDetailSnapshot }>(
-        `/api/v1/${encodeURIComponent(identifier)}/step/${encodeURIComponent(stepName)}`,
+        `${issuePath(identifier)}/step/${pathSegment(stepName)}`,
+        { method: "GET" },
       );
       return response.data;
     },
@@ -201,6 +250,14 @@ export function useInteractionDetailQuery(id: string) {
   return useQuery({
     queryKey: interactionByIdQueryKey(id),
     enabled: id.length > 0,
+    refetchInterval: (query) => {
+      const detail = query.state.data;
+      return detail?.status === "resolved" && detail.awaiting_resume ? 2000 : false;
+    },
+    staleTime: (query) => {
+      const detail = query.state.data;
+      return detail?.status === "resolved" && !detail.awaiting_resume ? Infinity : 0;
+    },
     queryFn: async (): Promise<InteractionDetail> => {
       const resp = await getInteractionById(id);
       return resp.data as InteractionDetail;
@@ -218,7 +275,15 @@ export function useStepConversationQuery(
     queryKey: ["getStepConversation", identifier, runId, stepName, params],
     enabled: identifier.length > 0 && runId.length > 0 && stepName.length > 0,
     queryFn: async (): Promise<TranscriptResponse> => {
-      const resp = await getStepConversation(identifier, runId, stepName, params);
+      const normalizedParams = new URLSearchParams();
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined) {
+          normalizedParams.append(key, value === null ? "null" : String(value));
+        }
+      });
+      const query = normalizedParams.toString();
+      const url = `${issuePath(identifier)}/runs/${pathSegment(runId)}/steps/${pathSegment(stepName)}/conversation${query ? `?${query}` : ""}`;
+      const resp = await customFetch<{ data: TranscriptResponse }>(url, { method: "GET" });
       return resp.data as TranscriptResponse;
     },
   });
@@ -297,7 +362,8 @@ export function useRefreshMutation() {
 export function useStopMutation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (params: { identifier: string }) => postStop(params.identifier),
+    mutationFn: (params: { identifier: string }) =>
+      customFetch(`${issuePath(params.identifier)}/stop`, { method: "POST" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY });
     },
@@ -307,7 +373,8 @@ export function useStopMutation() {
 export function useRetryMutation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (params: { identifier: string }) => postRetry(params.identifier),
+    mutationFn: (params: { identifier: string }) =>
+      customFetch(`${issuePath(params.identifier)}/retry`, { method: "POST" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY });
     },
@@ -317,15 +384,34 @@ export function useRetryMutation() {
 export function useRespondToInteractionMutation(identifier?: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (params: { id: string } & InteractionResponseBody) => respondToInteraction(params.id, params),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY });
-      queryClient.invalidateQueries({ queryKey: LIST_OPEN_INTERACTIONS_KEY });
-      if (identifier) {
-        queryClient.invalidateQueries({
-          queryKey: issueDetailQueryKey(identifier),
-        });
+    mutationFn: ({ id, ...body }: { id: string } & InteractionResponseBody) =>
+      respondToInteraction(id, body),
+    onSuccess: async (response, variables) => {
+      const interactionData = response.data;
+      if ("status" in interactionData) {
+        queryClient.setQueryData<InteractionDetail>(
+          interactionByIdQueryKey(variables.id),
+          (current) =>
+            current
+              ? {
+                  ...current,
+                  status: interactionData.status,
+                  awaiting_resume: interactionData.awaiting_resume ?? current.awaiting_resume,
+                }
+              : current,
+        );
       }
+      const invalidations = [
+        queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: LIST_OPEN_INTERACTIONS_KEY }),
+        queryClient.invalidateQueries({ queryKey: interactionByIdQueryKey(variables.id) }),
+      ];
+      if (identifier) {
+        invalidations.push(
+          queryClient.invalidateQueries({ queryKey: issueDetailQueryKey(identifier) }),
+        );
+      }
+      await Promise.all(invalidations);
     },
   });
 }
@@ -334,62 +420,85 @@ export function useCancelInteractionMutation(identifier?: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (params: { id: string }) => cancelInteraction(params.id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY });
-      queryClient.invalidateQueries({ queryKey: LIST_OPEN_INTERACTIONS_KEY });
-      if (identifier) {
-        queryClient.invalidateQueries({
-          queryKey: issueDetailQueryKey(identifier),
-        });
+    onSuccess: async (response, variables) => {
+      const interactionData = response.data;
+      if ("status" in interactionData) {
+        queryClient.setQueryData<InteractionDetail>(
+          interactionByIdQueryKey(variables.id),
+          (current) =>
+            current
+              ? {
+                  ...current,
+                  status: interactionData.status,
+                  awaiting_resume: interactionData.awaiting_resume ?? current.awaiting_resume,
+                }
+              : current,
+        );
       }
+      const invalidations = [
+        queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: LIST_OPEN_INTERACTIONS_KEY }),
+        queryClient.invalidateQueries({ queryKey: interactionByIdQueryKey(variables.id) }),
+      ];
+      if (identifier) {
+        invalidations.push(
+          queryClient.invalidateQueries({ queryKey: issueDetailQueryKey(identifier) }),
+        );
+      }
+      await Promise.all(invalidations);
     },
   });
 }
 
-export function useResumeIssueMutation(identifier?: string) {
+export function useResumeIssueMutation(_identifier?: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (params: { identifier: string }) => postResumeIssue(params.identifier),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY });
-      queryClient.invalidateQueries({ queryKey: LIST_OPEN_INTERACTIONS_KEY });
-      if (identifier) {
-        queryClient.invalidateQueries({
-          queryKey: issueDetailQueryKey(identifier),
-        });
+    mutationFn: (params: { identifier: string; interactionId?: string }) =>
+      customFetch(`${issuesPath(params.identifier)}/resume`, { method: "POST" }),
+    onSuccess: async (_response, variables) => {
+      const invalidations = [
+        queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: LIST_OPEN_INTERACTIONS_KEY }),
+        queryClient.invalidateQueries({ queryKey: issueDetailQueryKey(variables.identifier) }),
+      ];
+      if (variables.interactionId) {
+        invalidations.push(
+          queryClient.invalidateQueries({
+            queryKey: interactionByIdQueryKey(variables.interactionId),
+          }),
+        );
       }
+      await Promise.all(invalidations);
     },
   });
 }
 
-export function useIssueInputMutation(identifier?: string, interactionId?: string) {
+export function useFinalizeApproveMutation(_identifier?: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (response: string) => {
-      if (!identifier) {
-        throw new Error("issue identifier is required");
-      }
-      return customFetch(`/api/v1/issues/${encodeURIComponent(identifier)}/input`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ response }),
-      });
+    mutationFn: (params: { identifier: string }) =>
+      customFetch(`${issuePath(params.identifier)}/finalize/approve`, { method: "POST" }),
+    onSuccess: async (_response, variables) => {
+      markFinalizeTransition(queryClient, variables.identifier, "pending_approval");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: issueDetailQueryKey(variables.identifier) }),
+      ]);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY });
-      queryClient.invalidateQueries({ queryKey: LIST_OPEN_INTERACTIONS_KEY });
-      if (identifier) {
-        queryClient.invalidateQueries({
-          queryKey: issueDetailQueryKey(identifier),
-        });
-      }
-      if (interactionId) {
-        queryClient.invalidateQueries({
-          queryKey: interactionByIdQueryKey(interactionId),
-        });
-      }
+  });
+}
+
+export function useFinalizeRetryMutation(_identifier?: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { identifier: string }) =>
+      customFetch(`${issuePath(params.identifier)}/finalize/retry`, { method: "POST" }),
+    onSuccess: async (_response, variables) => {
+      markFinalizeTransition(queryClient, variables.identifier, "failed");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: STATE_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: issueDetailQueryKey(variables.identifier) }),
+      ]);
     },
   });
 }

--- a/crates/ensemble-ui/src-ui/src/pages/Dashboard.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/Dashboard.test.tsx
@@ -1,95 +1,64 @@
-import { describe, expect, it } from "vitest";
-import { screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { render } from "@testing-library/react";
-import Dashboard from "./Dashboard";
-import type { RuntimeSnapshot, WaitingInteractionRow } from "@/generated/models";
+import { describe, expect, it } from "vitest";
 
-function mockSnapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
+import type { RuntimeSnapshot } from "@/generated/models";
+import Dashboard from "./Dashboard";
+
+function mockSnapshot(): RuntimeSnapshot {
   return {
     agent_totals: { input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0 },
-    counts: { running: 0, retrying: 0, waiting_on_human: 0, completed: 0 },
-    generated_at: "2026-04-14T12:00:00Z",
+    counts: { running: 1, retrying: 0, waiting_on_human: 1, completed: 0 },
+    generated_at: "2026-07-09T09:30:00Z",
+    last_tick_at: "2026-07-09T09:29:58Z",
     poll_interval_ms: 3000,
-    running: [],
+    running: [
+      {
+        issue_id: "issue-running",
+        issue_identifier: "repo#1",
+        last_event: "tool_call",
+        last_event_at: "2026-07-09T09:29:50Z",
+        last_message: "Running tests",
+        session_id: "session-1",
+        started_at: "2026-07-09T09:00:00Z",
+        state: "running",
+        step_name: "build",
+        tokens: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+        turn_count: 3,
+      },
+    ],
     retrying: [],
-    waiting_on_human: [],
+    waiting_on_human: [
+      {
+        interaction_request_id: "ask-1",
+        issue_id: "issue-waiting",
+        issue_identifier: "repo#2",
+        requested_at: "2026-07-09T09:10:00Z",
+        step_name: "review",
+      },
+    ],
     completed: [],
-    ...overrides,
   } as RuntimeSnapshot;
 }
 
-function waitingInteraction(
-  overrides: Partial<WaitingInteractionRow> = {},
-): WaitingInteractionRow {
-  return {
-    interaction_request_id: "interaction-1",
-    issue_id: "NODE_123",
-    issue_identifier: "my-repo#42",
-    question: "Need clarification",
-    requested_at: "2026-04-14T10:00:00Z",
-    step_name: "review",
-    ...overrides,
-  } as WaitingInteractionRow;
-}
-
-function renderDashboardWithData(data: RuntimeSnapshot) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-    },
-  });
-  queryClient.setQueryData(["/api/v1/state"], { data });
-
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={["/"]}>
-        <Dashboard />
-      </MemoryRouter>
-    </QueryClientProvider>,
-  );
-}
-
 describe("Dashboard", () => {
-  it("renders a Needs attention section ahead of normal execution buckets", () => {
-    const waiting: WaitingInteractionRow[] = [
-      waitingInteraction({ issue_identifier: "org/repo#101" }),
-    ];
-    const snapshot = mockSnapshot({
-      waiting_on_human: waiting,
-      running: [],
-      retrying: [],
-      completed: [],
-    });
+  it("renders Mission Control with attention and operations surfaces", () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(["/api/v1/state"], { data: mockSnapshot() });
 
-    renderDashboardWithData(snapshot);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/"]}>
+          <Dashboard />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
 
-    const needsAttention = screen.getByText("Needs attention");
-    expect(needsAttention).toBeInTheDocument();
-  });
-
-  it("shows waiting tickets with issue identifier and blocking step in the queue", () => {
-    const waiting: WaitingInteractionRow[] = [
-      waitingInteraction({
-        issue_identifier: "my-repo#42",
-        step_name: "review",
-        interaction_request_id: "interaction-1",
-      }),
-    ];
-    const snapshot = mockSnapshot({
-      waiting_on_human: waiting,
-      running: [],
-      retrying: [],
-      completed: [],
-    });
-
-    renderDashboardWithData(snapshot);
-
-    expect(screen.getByText("Needs attention")).toBeInTheDocument();
-    const links = screen.getAllByText("my-repo#42");
-    expect(links).toHaveLength(1);
-    expect(links[0]).toHaveAttribute("href", "/issue/my-repo%2342");
-    expect(screen.getByText("review")).toBeInTheDocument();
+    expect(screen.getByText("Mission Control")).toBeInTheDocument();
+    expect(screen.getByText("Needs Attention")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Running" })).toBeInTheDocument();
+    expect(screen.getByText("repo#1")).toBeInTheDocument();
+    expect(screen.getAllByText("repo#2")).toHaveLength(2);
   });
 });

--- a/crates/ensemble-ui/src-ui/src/pages/Dashboard.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/Dashboard.tsx
@@ -1,54 +1,5 @@
-import { useStateQuery, useRefreshMutation } from "@/hooks";
-import { Button } from "@/components/ui/button";
-import KanbanBoard from "@/components/KanbanBoard";
-import InteractionQueue from "@/components/InteractionQueue";
+import MissionControl from "./mission-control";
 
 export default function Dashboard() {
-  const { data, isLoading, isError, error } = useStateQuery();
-  const refreshMutation = useRefreshMutation();
-
-  if (isLoading) {
-    return <div className="text-center py-12 text-muted-foreground">Loading...</div>;
-  }
-
-  if (isError) {
-    return (
-      <div className="text-center py-12">
-        <p className="text-destructive">
-          Failed to load state: {error instanceof Error ? error.message : "Unknown error"}
-        </p>
-      </div>
-    );
-  }
-
-  if (!data) return null;
-
-  const waitingInteractions = data.waiting_on_human ?? [];
-  const kanbanData = {
-    ...data,
-    waiting_on_human: waitingInteractions.length > 0 ? [] : data.waiting_on_human,
-  };
-
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Control Room</h1>
-        <Button
-          onClick={() => refreshMutation.mutate()}
-          disabled={refreshMutation.isPending}
-        >
-          {refreshMutation.isPending ? "Refreshing..." : "Refresh"}
-        </Button>
-      </div>
-
-      {waitingInteractions.length > 0 && (
-        <section>
-          <h2 className="text-lg font-semibold mb-3">Needs attention</h2>
-          <InteractionQueue interactions={waitingInteractions} />
-        </section>
-      )}
-
-      <KanbanBoard data={kanbanData} />
-    </div>
-  );
+  return <MissionControl />;
 }

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
@@ -1,27 +1,39 @@
-import { describe, expect, it, vi } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, renderHook, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { renderWithProviders } from "@/test/render";
 import { connectWs } from "@/ws";
+import { addNotification, requestPermissionIfNeeded } from "@/notifications";
 import { RunTranscript } from "@/components/transcript/RunTranscript";
 import type { GroupedTranscriptEntry } from "@/components/transcript/transcript-model";
+import type { InteractionKind, IssueDetailSnapshot } from "@/generated/models";
+import { FetchError } from "@/fetch-client";
 import IssueDetail from "./IssueDetail";
-import type { ReactNode } from "react";
+import { useIssueRuntime } from "./mission-control/useIssueRuntime";
+import { StrictMode, type ReactNode } from "react";
 
 const hooksMock = vi.hoisted(() => {
   const stopMutate = vi.fn();
   const retryMutate = vi.fn();
-  const inputMutate = vi.fn();
+  const respondMutateAsync = vi.fn();
+  const resumeMutateAsync = vi.fn();
+  const interactionRefetch = vi.fn();
+  const finalizeApproveMutate = vi.fn();
+  const finalizeRetryMutate = vi.fn();
   const cancelMutate = vi.fn();
 
   return {
     stopMutate,
     retryMutate,
-    inputMutate,
+    respondMutateAsync,
+    resumeMutateAsync,
+    interactionRefetch,
+    finalizeApproveMutate,
+    finalizeRetryMutate,
     cancelMutate,
-    useIssueDetailQuery: vi.fn(() => ({
+    useIssueDetailQuery: vi.fn((_identifier: string): any => ({
       data: {
         issue_identifier: "todo-1",
         status: "running",
@@ -50,15 +62,17 @@ const hooksMock = vi.hoisted(() => {
       },
       isLoading: false,
       isError: false,
-      error: null,
+      error: null as Error | null,
     })),
-    useInteractionDetailQuery: vi.fn(() => ({
+    useInteractionDetailQuery: vi.fn((_interactionId: string): any => ({
       data: {
         agent_name: "builder",
+        awaiting_resume: true,
         id: "ask-1",
         issue_id: "issue-1",
         issue_identifier: "todo-1",
-        status: "pending",
+        status: "open",
+        kind: "question",
         question: "Which environment?",
         why_blocked: "Need target",
         suggested_answer: "staging",
@@ -66,31 +80,74 @@ const hooksMock = vi.hoisted(() => {
         step_name: "deploy",
         requested_at: "2026-04-14T10:00:00Z",
       },
+      refetch: interactionRefetch,
     })),
-    useTimelineQuery: vi.fn(() => ({ data: { events: [] }, isError: false })),
-    useStepConversationQuery: vi.fn(() => ({
-      data: {
-        records: [
-          {
-            schema_version: 1,
-            run_id: "run-1",
-            issue_identifier: "todo-1",
-            step_name: "deploy",
-            attempt: 1,
-            sequence: 1,
-            timestamp: "2026-04-14T10:00:01Z",
-            kind: "assistant_message",
-            payload: { text: "I am ready" },
-          },
-        ],
-      } as any,
-      isLoading: false,
+    useTimelineQuery: vi.fn(
+      (_identifier: string, _runId?: string): any => ({ data: { events: [] }, isError: false }),
+    ),
+    useStepConversationQuery: vi.fn(
+      (_identifier: string, _runId: string, _stepName: string, _params?: unknown): any => ({
+        data: {
+          records: [
+            {
+              schema_version: 1,
+              run_id: "run-1",
+              issue_identifier: "todo-1",
+              step_name: "deploy",
+              attempt: 1,
+              sequence: 1,
+              timestamp: "2026-04-14T10:00:01Z",
+              kind: "assistant_message",
+              payload: { text: "I am ready" },
+            },
+          ],
+        } as any,
+        isLoading: false,
+        isError: false,
+      }),
+    ),
+    useStopMutation: vi.fn(() => ({
+      mutate: stopMutate,
+      isPending: false,
       isError: false,
+      error: null as Error | null,
     })),
-    useStopMutation: vi.fn(() => ({ mutate: stopMutate, isPending: false })),
-    useRetryMutation: vi.fn(() => ({ mutate: retryMutate, isPending: false })),
-    useIssueInputMutation: vi.fn(() => ({ mutate: inputMutate, isPending: false })),
-    useCancelInteractionMutation: vi.fn(() => ({ mutate: cancelMutate, isPending: false })),
+    useRetryMutation: vi.fn(() => ({
+      mutate: retryMutate,
+      isPending: false,
+      isError: false,
+      error: null as Error | null,
+    })),
+    useRespondToInteractionMutation: vi.fn(() => ({
+      mutateAsync: respondMutateAsync,
+      isPending: false,
+      isError: false,
+      error: null as Error | null,
+    })),
+    useResumeIssueMutation: vi.fn(() => ({
+      mutateAsync: resumeMutateAsync,
+      isPending: false,
+      isError: false,
+      error: null,
+    })),
+    useFinalizeApproveMutation: vi.fn(() => ({
+      mutate: finalizeApproveMutate,
+      isPending: false,
+      isError: false,
+      error: null as Error | null,
+    })),
+    useFinalizeRetryMutation: vi.fn(() => ({
+      mutate: finalizeRetryMutate,
+      isPending: false,
+      isError: false,
+      error: null as Error | null,
+    })),
+    useCancelInteractionMutation: vi.fn(() => ({
+      mutate: cancelMutate,
+      isPending: false,
+      isError: false,
+      error: null as Error | null,
+    })),
   };
 });
 
@@ -100,6 +157,21 @@ vi.mock("@/notifications", () => ({
   addNotification: vi.fn(),
   requestPermissionIfNeeded: vi.fn(),
 }));
+
+function SwitchableIssueDetail() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button type="button" onClick={() => navigate("/issue/issue-b")}>
+        Switch issue
+      </button>
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>
+    </>
+  );
+}
 
 describe("RunTranscript", () => {
   it("renders an empty state when there are no entries", () => {
@@ -129,10 +201,11 @@ describe("RunTranscript", () => {
         timestamp: "2026-04-14T10:00:00Z",
         interaction: {
           agent_name: "builder",
+          awaiting_resume: true,
           id: "ask-1",
           issue_id: "issue-1",
           issue_identifier: "todo-1",
-          status: "pending",
+          status: "open",
           question: "Which environment should I deploy to?",
           why_blocked: "Needs a deployment target",
           suggested_answer: "Use staging",
@@ -246,7 +319,1105 @@ describe("RunTranscript", () => {
 
 });
 
+describe("useIssueRuntime lifecycle", () => {
+  const issueDetail = (
+    identifier: string,
+    runId: string | null,
+    stepName: string | null = "deploy",
+  ) => ({
+    issue_identifier: identifier,
+    status: runId ? "running" : "completed",
+    running: runId
+      ? {
+          step_name: stepName,
+          turn_count: 2,
+          tokens: { total_tokens: 100 },
+          run_id: runId,
+        }
+      : null,
+    attempts: { restart_count: 0 },
+    retry: null,
+    last_error: null,
+    issue: { title: `${identifier} title`, labels: [] },
+    workspace: { path: "/tmp/workspace" },
+    workflow_steps: [],
+    pending_input: null,
+    current_interaction: null,
+  });
+
+  beforeEach(() => {
+    vi.mocked(connectWs).mockReset().mockImplementation(() => () => {});
+    vi.mocked(requestPermissionIfNeeded).mockClear();
+    vi.mocked(addNotification).mockClear();
+    hooksMock.respondMutateAsync.mockReset().mockResolvedValue({});
+    hooksMock.resumeMutateAsync.mockReset().mockResolvedValue({});
+    hooksMock.interactionRefetch.mockReset().mockResolvedValue({ data: undefined });
+    hooksMock.useInteractionDetailQuery.mockReset().mockReturnValue({ data: undefined });
+    hooksMock.useStepConversationQuery.mockReset().mockReturnValue({
+      data: { records: [] },
+      isLoading: false,
+      isError: false,
+    });
+    hooksMock.useTimelineQuery.mockReset().mockReturnValue({
+      data: { events: [] },
+      isError: false,
+    });
+  });
+
+  it("does not reuse the previous issue run, step, or live events after an identifier switch", () => {
+    const connections: Parameters<typeof connectWs>[0][] = [];
+    vi.mocked(connectWs).mockImplementation((options) => {
+      connections.push(options);
+      return () => {};
+    });
+    hooksMock.useIssueDetailQuery.mockImplementation((identifier: string) => ({
+      data: issueDetail(identifier, identifier === "issue-a" ? "run-a" : null),
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ identifier }) => useIssueRuntime(identifier),
+      { initialProps: { identifier: "issue-a" } },
+    );
+
+    act(() => {
+      connections[0]?.onMessage({
+        type: "event",
+        data: {
+          event_type: "output",
+          timestamp: "2026-07-09T10:00:00Z",
+          detail: "issue A live event",
+          run_id: "run-a",
+          sequence: 1,
+        },
+      });
+    });
+    expect(result.current.events.map((event) => event.detail)).toEqual(["issue A live event"]);
+
+    rerender({ identifier: "issue-b" });
+
+    expect(result.current.effectiveRunId).toBe("");
+    expect(result.current.activeStepName).toBe("");
+    expect(result.current.events).toEqual([]);
+    expect(hooksMock.useStepConversationQuery).toHaveBeenLastCalledWith(
+      "issue-b",
+      "",
+      "",
+      { limit: 200 },
+    );
+  });
+
+  it("starts a new live event buffer when the run changes", () => {
+    let runId = "run-1";
+    const connections: Parameters<typeof connectWs>[0][] = [];
+    vi.mocked(connectWs).mockImplementation((options) => {
+      connections.push(options);
+      return () => {};
+    });
+    hooksMock.useIssueDetailQuery.mockImplementation(() => ({
+      data: issueDetail("issue-a", runId, runId === "run-1" ? "build" : null),
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+
+    const { result, rerender } = renderHook(() => useIssueRuntime("issue-a"));
+    act(() => {
+      connections[0]?.onMessage({
+        type: "event",
+        data: {
+          event_type: "output",
+          timestamp: "2026-07-09T10:00:00Z",
+          detail: "first run event",
+          run_id: "run-1",
+          sequence: 1,
+        },
+      });
+    });
+
+    runId = "run-2";
+    rerender();
+
+    expect(result.current.effectiveRunId).toBe("run-2");
+    expect(result.current.activeStepName).toBe("");
+    expect(result.current.events).toEqual([]);
+
+    act(() => {
+      connections[connections.length - 1]?.onMessage({
+        type: "event",
+        data: {
+          event_type: "output",
+          timestamp: "2026-07-09T10:01:00Z",
+          detail: "second run event",
+          run_id: "run-2",
+          sequence: 1,
+        },
+      });
+    });
+    expect(result.current.events.map((event) => event.detail)).toEqual(["second run event"]);
+  });
+
+  it("reuses transcript entries within a session but not across issue sessions", () => {
+    let appendRecord = false;
+    hooksMock.useIssueDetailQuery.mockImplementation((identifier: string) => ({
+      data: issueDetail(identifier, "run-1", "build"),
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+    hooksMock.useStepConversationQuery.mockImplementation((identifier: string) => ({
+      data: {
+        records: [
+          {
+            schema_version: 1,
+            run_id: "run-1",
+            issue_identifier: identifier,
+            step_name: "build",
+            attempt: 1,
+            sequence: 1,
+            timestamp: "2026-07-09T10:00:00Z",
+            kind: "assistant_message",
+            payload: { text: "unchanged" },
+          },
+          ...(appendRecord
+            ? [
+                {
+                  schema_version: 1,
+                  run_id: "run-1",
+                  issue_identifier: identifier,
+                  step_name: "build",
+                  attempt: 1,
+                  sequence: 2,
+                  timestamp: "2026-07-09T10:00:01Z",
+                  kind: "assistant_message",
+                  payload: { text: "appended" },
+                },
+              ]
+            : []),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ identifier }) => useIssueRuntime(identifier),
+      { initialProps: { identifier: "issue-a" } },
+    );
+    const firstSessionEntry = result.current.transcriptEntries[0];
+
+    appendRecord = true;
+    rerender({ identifier: "issue-a" });
+    expect(result.current.transcriptEntries[0]).toBe(firstSessionEntry);
+
+    const committedEntry = result.current.transcriptEntries[0];
+    rerender({ identifier: "issue-b" });
+    expect(result.current.transcriptEntries[0]).not.toBe(committedEntry);
+  });
+
+  it("retires the previous run websocket before accepting events without a run id", () => {
+    let runId = "run-1";
+    const connections: Parameters<typeof connectWs>[0][] = [];
+    vi.mocked(connectWs).mockImplementation((options) => {
+      connections.push(options);
+      return () => {};
+    });
+    hooksMock.useIssueDetailQuery.mockImplementation(() => ({
+      data: issueDetail("issue-a", runId),
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+
+    const { result, rerender } = renderHook(() => useIssueRuntime("issue-a"));
+    const retiredConnection = connections[0]!;
+
+    runId = "run-2";
+    rerender();
+    expect(connections).toHaveLength(2);
+
+    act(() => {
+      retiredConnection.onMessage({
+        type: "event",
+        data: {
+          event_type: "error",
+          timestamp: "2026-07-09T10:00:00Z",
+          detail: "queued first-run event",
+          sequence: 1,
+        },
+      });
+    });
+
+    expect(result.current.events).toEqual([]);
+    expect(addNotification).not.toHaveBeenCalled();
+  });
+
+  it("ignores messages and status changes from a retired websocket", () => {
+    const connections: Parameters<typeof connectWs>[0][] = [];
+    vi.mocked(connectWs).mockImplementation((options) => {
+      connections.push(options);
+      return () => {};
+    });
+    hooksMock.useIssueDetailQuery.mockImplementation((identifier: string) => ({
+      data: issueDetail(identifier, `run-${identifier}`),
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ identifier }) => useIssueRuntime(identifier),
+      { initialProps: { identifier: "issue-a" } },
+    );
+    const retiredConnection = connections[0]!;
+
+    rerender({ identifier: "issue-b" });
+    act(() => {
+      retiredConnection.onStatusChange?.("connected");
+      retiredConnection.onMessage({
+        type: "event",
+        data: {
+          event_type: "output",
+          timestamp: "2026-07-09T10:00:00Z",
+          detail: "retired event",
+          run_id: "run-issue-a",
+          sequence: 1,
+        },
+      });
+    });
+
+    expect(result.current.wsStatus).toBe("disconnected");
+    expect(result.current.events).toEqual([]);
+  });
+
+  it("keeps only the committed websocket active under StrictMode lifecycle replay", () => {
+    let runId = "run-1";
+    const connections: Parameters<typeof connectWs>[0][] = [];
+    vi.mocked(connectWs).mockImplementation((options) => {
+      connections.push(options);
+      return () => {};
+    });
+    hooksMock.useIssueDetailQuery.mockImplementation(() => ({
+      data: issueDetail("issue-a", runId),
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <StrictMode>{children}</StrictMode>
+    );
+
+    const { result, rerender } = renderHook(() => useIssueRuntime("issue-a"), { wrapper });
+    const retiredConnection = connections[0]!;
+
+    runId = "run-2";
+    rerender();
+    expect(connections).toHaveLength(2);
+
+    act(() => {
+      retiredConnection.onMessage({
+        type: "event",
+        data: {
+          event_type: "error",
+          timestamp: "2026-07-09T10:00:00Z",
+          detail: "retired strict event",
+          sequence: 1,
+        },
+      });
+      connections[1]!.onMessage({
+        type: "event",
+        data: {
+          event_type: "error",
+          timestamp: "2026-07-09T10:00:01Z",
+          detail: "committed strict event",
+          sequence: 2,
+        },
+      });
+    });
+
+    expect(result.current.events.map((event) => event.detail)).toEqual([
+      "committed strict event",
+    ]);
+    expect(addNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not request notification permission or connect without an identifier", () => {
+    renderHook(() => useIssueRuntime(""));
+
+    expect(requestPermissionIfNeeded).not.toHaveBeenCalled();
+    expect(connectWs).not.toHaveBeenCalled();
+  });
+
+  it("exposes transcript persistence failures to runtime consumers", () => {
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: issueDetail("issue-a", "run-a", "build"),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useStepConversationQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    const { result } = renderHook(() => useIssueRuntime("issue-a"));
+
+    expect(result.current.transcriptIsError).toBe(true);
+  });
+
+  it("exposes interaction detail loading and failure state to runtime consumers", () => {
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        ...issueDetail("issue-a", "run-a", "build"),
+        pending_input: { ask_id: "ask-1" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+
+    const loadingView = renderHook(() => useIssueRuntime("issue-a"));
+    expect(loadingView.result.current.interactionIsLoading).toBe(true);
+    expect(loadingView.result.current.interactionIsError).toBe(false);
+    loadingView.unmount();
+
+    const interactionError = new Error("interaction lookup failed");
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: interactionError,
+    });
+    const errorView = renderHook(() => useIssueRuntime("issue-a"));
+
+    expect(errorView.result.current.interactionIsLoading).toBe(false);
+    expect(errorView.result.current.interactionIsError).toBe(true);
+    expect(errorView.result.current.interactionError).toBe(interactionError);
+  });
+
+  it("does not query or expose interaction UI for a synthetic halted id", () => {
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        ...issueDetail("issue-a", null, "review"),
+        status: "halted",
+        pending_input: { ask_id: "halted:issue-a:review" },
+        current_interaction: {
+          interaction_request_id: "halted:issue-a:review",
+          requested_at: "2026-07-09T10:00:00Z",
+          step_name: "review",
+        },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useInteractionDetailQuery.mockImplementation((interactionId: string) => ({
+      data: undefined,
+      isLoading: interactionId.length > 0,
+      isError: interactionId.length > 0,
+      error: interactionId.length > 0 ? new Error("interaction lookup should be disabled") : null,
+    }));
+
+    const { result } = renderHook(() => useIssueRuntime("issue-a"));
+
+    expect(hooksMock.useInteractionDetailQuery).toHaveBeenCalledWith("");
+    expect(result.current.interaction).toBeUndefined();
+    expect(result.current.pendingQuestion).toBeNull();
+    expect(result.current.interactionIsLoading).toBe(false);
+    expect(result.current.interactionIsError).toBe(false);
+  });
+
+  it("does not expose an in-flight reply error after the identifier changes", async () => {
+    let rejectReply: (error: Error) => void = () => {};
+    hooksMock.respondMutateAsync.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectReply = reject;
+        }),
+    );
+    hooksMock.useIssueDetailQuery.mockImplementation((identifier: string) => ({
+      data: {
+        ...issueDetail(identifier, `run-${identifier}`),
+        pending_input: { ask_id: `ask-${identifier}` },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+    hooksMock.useInteractionDetailQuery.mockImplementation((interactionId: string) => ({
+      data: {
+        agent_name: "builder",
+        awaiting_resume: true,
+        id: interactionId,
+        issue_id: interactionId,
+        issue_identifier: interactionId.replace("ask-", ""),
+        status: "open",
+        kind: "question",
+        question: "Continue?",
+        why_blocked: "Needs input",
+        suggested_answer: null,
+        extra_context: null,
+        step_name: "deploy",
+        requested_at: "2026-07-09T10:00:00Z",
+      },
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ identifier }) => useIssueRuntime(identifier),
+      { initialProps: { identifier: "issue-a" } },
+    );
+    let submission: Promise<boolean> | undefined;
+    act(() => {
+      submission = result.current.submitInteractionReply({ kind: "question", text: "continue" });
+    });
+
+    rerender({ identifier: "issue-b" });
+    await act(async () => {
+      rejectReply(new Error("issue A reply failed"));
+      await submission;
+    });
+
+    expect(result.current.identifier).toBe("issue-b");
+    expect(result.current.composerError).toBeNull();
+  });
+
+  it("answers a new issue normally after the previous issue was awaiting a resume retry", async () => {
+    hooksMock.resumeMutateAsync
+      .mockRejectedValueOnce(new Error("issue A resume failed"))
+      .mockResolvedValueOnce({});
+    hooksMock.useIssueDetailQuery.mockImplementation((identifier: string) => ({
+      data: {
+        ...issueDetail(identifier, `run-${identifier}`),
+        pending_input: { ask_id: `ask-${identifier}` },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+    hooksMock.useInteractionDetailQuery.mockImplementation((interactionId: string) => ({
+      data: {
+        agent_name: "builder",
+        awaiting_resume: true,
+        id: interactionId,
+        issue_id: interactionId,
+        issue_identifier: interactionId.replace("ask-", ""),
+        status: "open",
+        kind: "question",
+        question: "Continue?",
+        why_blocked: "Needs input",
+        suggested_answer: null,
+        extra_context: null,
+        step_name: "deploy",
+        requested_at: "2026-07-09T10:00:00Z",
+      },
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ identifier }) => useIssueRuntime(identifier),
+      { initialProps: { identifier: "issue-a" } },
+    );
+
+    await act(async () => {
+      expect(
+        await result.current.submitInteractionReply({ kind: "question", text: "answer A" }),
+      ).toBe(false);
+    });
+    expect(hooksMock.respondMutateAsync).toHaveBeenCalledTimes(1);
+    expect(hooksMock.resumeMutateAsync).toHaveBeenCalledTimes(1);
+
+    rerender({ identifier: "issue-b" });
+    await act(async () => {
+      expect(
+        await result.current.submitInteractionReply({ kind: "question", text: "answer B" }),
+      ).toBe(true);
+    });
+
+    expect(hooksMock.respondMutateAsync).toHaveBeenCalledTimes(2);
+    expect(hooksMock.respondMutateAsync).toHaveBeenLastCalledWith({
+      id: "ask-issue-b",
+      kind: "question",
+      response_schema_version: 1,
+      selected_option: null,
+      text: "answer B",
+    });
+    expect(hooksMock.resumeMutateAsync).toHaveBeenCalledTimes(2);
+    expect(hooksMock.resumeMutateAsync).toHaveBeenLastCalledWith({
+      identifier: "issue-b",
+      interactionId: "ask-issue-b",
+    });
+  });
+
+  it("resumes a persisted resolved interaction without responding again after remount", async () => {
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        ...issueDetail("issue-a", "run-a"),
+        pending_input: { ask_id: "ask-resolved" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: {
+        agent_name: "builder",
+        awaiting_resume: true,
+        id: "ask-resolved",
+        issue_id: "issue-a",
+        issue_identifier: "issue-a",
+        status: "resolved",
+        kind: "approval",
+        question: "Continue?",
+        why_blocked: "Needs approval",
+        suggested_answer: null,
+        extra_context: null,
+        step_name: "deploy",
+        requested_at: "2026-07-09T10:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useIssueRuntime("issue-a"));
+    await act(async () => {
+      expect(await result.current.resumeInteraction()).toBe(true);
+    });
+
+    expect(hooksMock.resumeMutateAsync).toHaveBeenCalledWith({
+      identifier: "issue-a",
+      interactionId: "ask-resolved",
+    });
+    expect(hooksMock.respondMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("queues resume only once until server authority reports completion", async () => {
+    let currentInteraction = {
+      agent_name: "builder",
+      awaiting_resume: true,
+      id: "ask-resolved",
+      issue_id: "issue-a",
+      issue_identifier: "issue-a",
+      status: "resolved" as const,
+      kind: "question" as const,
+      question: "Continue?",
+      why_blocked: "Needs input",
+      suggested_answer: null,
+      extra_context: null,
+      step_name: "deploy",
+      requested_at: "2026-07-09T10:00:00Z",
+    };
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        ...issueDetail("issue-a", "run-a"),
+        pending_input: { ask_id: "ask-resolved" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useInteractionDetailQuery.mockImplementation(() => ({
+      data: currentInteraction,
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+
+    const { result, rerender } = renderHook(() => useIssueRuntime("issue-a"));
+    await act(async () => {
+      expect(await result.current.resumeInteraction()).toBe(true);
+      expect(await result.current.resumeInteraction()).toBe(true);
+    });
+
+    expect(hooksMock.resumeMutateAsync).toHaveBeenCalledOnce();
+    expect(result.current.resumeQueued).toBe(true);
+    expect(result.current.pendingQuestion).not.toBeNull();
+
+    currentInteraction = { ...currentInteraction, awaiting_resume: false };
+    rerender();
+
+    expect(result.current.resumeQueued).toBe(false);
+    expect(result.current.pendingQuestion).toBeNull();
+  });
+
+  it("does not restore queued recovery after server authority completes during the request", async () => {
+    let currentInteraction = {
+      agent_name: "builder",
+      awaiting_resume: true,
+      id: "ask-resolved",
+      issue_id: "issue-a",
+      issue_identifier: "issue-a",
+      status: "resolved" as const,
+      kind: "question" as const,
+      question: "Continue?",
+      why_blocked: "Needs input",
+      suggested_answer: null,
+      extra_context: null,
+      step_name: "deploy",
+      requested_at: "2026-07-09T10:00:00Z",
+    };
+    let resolveResume: () => void = () => {};
+    hooksMock.resumeMutateAsync.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveResume = resolve;
+        }),
+    );
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        ...issueDetail("issue-a", "run-a"),
+        pending_input: { ask_id: "ask-resolved" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useInteractionDetailQuery.mockImplementation(() => ({
+      data: currentInteraction,
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+
+    const { result, rerender } = renderHook(() => useIssueRuntime("issue-a"));
+    let submission: Promise<boolean> | undefined;
+    act(() => {
+      submission = result.current.resumeInteraction();
+    });
+    expect(hooksMock.resumeMutateAsync).toHaveBeenCalledOnce();
+
+    currentInteraction = { ...currentInteraction, awaiting_resume: false };
+    rerender();
+    expect(result.current.resumeQueued).toBe(false);
+
+    await act(async () => {
+      resolveResume();
+      await submission;
+    });
+
+    expect(result.current.resumeQueued).toBe(false);
+    expect(result.current.pendingQuestion).toBeNull();
+  });
+
+  it("allows resume retry after a queued request fails", async () => {
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        ...issueDetail("issue-a", "run-a"),
+        pending_input: { ask_id: "ask-resolved" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: {
+        agent_name: "builder",
+        awaiting_resume: true,
+        id: "ask-resolved",
+        issue_id: "issue-a",
+        issue_identifier: "issue-a",
+        status: "resolved",
+        kind: "question",
+        question: "Continue?",
+        why_blocked: "Needs input",
+        suggested_answer: null,
+        extra_context: null,
+        step_name: "deploy",
+        requested_at: "2026-07-09T10:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.resumeMutateAsync
+      .mockRejectedValueOnce(new Error("resume unavailable"))
+      .mockResolvedValueOnce({});
+
+    const { result } = renderHook(() => useIssueRuntime("issue-a"));
+    await act(async () => {
+      expect(await result.current.resumeInteraction()).toBe(false);
+      expect(await result.current.resumeInteraction()).toBe(true);
+    });
+
+    expect(hooksMock.resumeMutateAsync).toHaveBeenCalledTimes(2);
+    expect(result.current.resumeQueued).toBe(true);
+  });
+
+  it("recovers a committed response after the response request rejects", async () => {
+    const openInteraction = {
+      agent_name: "builder",
+      awaiting_resume: true,
+      id: "ask-1",
+      issue_id: "issue-a",
+      issue_identifier: "issue-a",
+      status: "open",
+      kind: "question",
+      question: "Continue?",
+      why_blocked: "Needs input",
+      suggested_answer: null,
+      extra_context: null,
+      step_name: "deploy",
+      requested_at: "2026-07-09T10:00:00Z",
+    } as const;
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        ...issueDetail("issue-a", "run-a"),
+        pending_input: { ask_id: "ask-1" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.respondMutateAsync.mockRejectedValueOnce(new Error("response lost"));
+    hooksMock.interactionRefetch.mockResolvedValueOnce({
+      data: { ...openInteraction, status: "resolved", awaiting_resume: true },
+    });
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: openInteraction,
+      refetch: hooksMock.interactionRefetch,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useIssueRuntime("issue-a"));
+    await act(async () => {
+      expect(
+        await result.current.submitInteractionReply({ kind: "question", text: "continue" }),
+      ).toBe(true);
+    });
+
+    expect(hooksMock.respondMutateAsync).toHaveBeenCalledOnce();
+    expect(hooksMock.interactionRefetch).toHaveBeenCalledOnce();
+    expect(hooksMock.resumeMutateAsync).toHaveBeenCalledWith({
+      identifier: "issue-a",
+      interactionId: "ask-1",
+    });
+    expect(result.current.composerError).toBeNull();
+  });
+
+  it("does not recover a definitive interaction response conflict", async () => {
+    const openInteraction = {
+      agent_name: "builder",
+      awaiting_resume: true,
+      id: "ask-1",
+      issue_id: "issue-a",
+      issue_identifier: "issue-a",
+      status: "open",
+      kind: "question",
+      question: "Continue?",
+      why_blocked: "Needs input",
+      suggested_answer: null,
+      extra_context: null,
+      step_name: "deploy",
+      requested_at: "2026-07-09T10:00:00Z",
+    } as const;
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        ...issueDetail("issue-a", "run-a"),
+        pending_input: { ask_id: "ask-1" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.respondMutateAsync.mockRejectedValueOnce(
+      new FetchError(409, {
+        error: { code: "already_resolved", message: "interaction is already resolved" },
+      }),
+    );
+    hooksMock.interactionRefetch.mockResolvedValueOnce({
+      data: { ...openInteraction, status: "resolved", awaiting_resume: true },
+    });
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: openInteraction,
+      refetch: hooksMock.interactionRefetch,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useIssueRuntime("issue-a"));
+    await act(async () => {
+      expect(
+        await result.current.submitInteractionReply({ kind: "question", text: "continue" }),
+      ).toBe(false);
+    });
+
+    expect(hooksMock.interactionRefetch).not.toHaveBeenCalled();
+    expect(hooksMock.resumeMutateAsync).not.toHaveBeenCalled();
+    expect(result.current.composerError).toBe("interaction is already resolved");
+  });
+
+  it.each([
+    ["completed_failed", "failed"],
+    ["completed_succeeded", "passed"],
+  ])(
+    "prefers the last persisted transcript artifact when mounting a %s issue directly",
+    async (status, terminalStepState) => {
+      const terminalDetail = {
+        issue_identifier: "todo-1",
+        issue_id: "NODE_1",
+        status,
+        running: null,
+        attempts: { restart_count: 0, current_retry_attempt: null },
+        retry: null,
+        pending_input: null,
+        current_interaction: null,
+        last_error: status === "completed_failed" ? "review failed" : null,
+        issue: { title: "Deploy feature", description: null, labels: [] },
+        workspace: { path: "/tmp/workspace" },
+        finalize: { status: "not_required", repos: [] },
+        artifacts: {
+          run_id: "run-terminal",
+          workspace_path: "/tmp/workspace",
+          repos: [],
+          transcripts: [
+            { step_name: "setup", run_id: "run-terminal", record_count: 2 },
+            { step_name: "build", run_id: "run-terminal", record_count: 1 },
+          ],
+        },
+        workflow_steps: [
+          {
+            name: "build",
+            agent: "builder",
+            kind: "agent",
+            dependencies: [],
+            state: "passed",
+            can_navigate: true,
+          },
+          {
+            name: "review",
+            agent: "reviewer",
+            kind: "agent",
+            dependencies: ["build"],
+            state: terminalStepState,
+            can_navigate: true,
+          },
+          {
+            name: "publish",
+            agent: "publisher",
+            kind: "agent",
+            dependencies: ["review"],
+            state: "pending",
+            can_navigate: false,
+          },
+        ],
+      } satisfies IssueDetailSnapshot;
+      hooksMock.useIssueDetailQuery.mockReturnValue({
+        data: terminalDetail,
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+      hooksMock.useInteractionDetailQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+      hooksMock.useTimelineQuery.mockImplementation((_identifier: string, runId?: string) => ({
+        data: {
+          events:
+            runId === "run-terminal"
+              ? [
+                  {
+                    run_id: "run-terminal",
+                    issue_identifier: "todo-1",
+                    sequence: 1,
+                    timestamp: "2026-07-09T10:00:00Z",
+                    event_type: "output",
+                    step_name: "review",
+                    attempt: 1,
+                    detail: "Persisted terminal log",
+                  },
+                ]
+              : [],
+          total: runId === "run-terminal" ? 1 : 0,
+        },
+        isError: false,
+      }));
+      hooksMock.useStepConversationQuery.mockImplementation(
+        (_identifier: string, runId: string, stepName: string) => ({
+          data: {
+            records:
+              runId === "run-terminal" && stepName === "build"
+                ? [
+                    {
+                      schema_version: 1,
+                      run_id: "run-terminal",
+                      issue_identifier: "todo-1",
+                      step_name: "build",
+                      attempt: 1,
+                      sequence: 1,
+                      timestamp: "2026-07-09T10:00:01Z",
+                      kind: "assistant_message",
+                      payload: { text: "Persisted terminal transcript" },
+                    },
+                  ]
+                : [],
+          },
+          isLoading: false,
+          isError: false,
+        }),
+      );
+
+      const { result } = renderHook(() => useIssueRuntime("todo-1"));
+
+      expect(result.current.effectiveRunId).toBe("run-terminal");
+      expect(result.current.activeStepName).toBe("build");
+      expect(result.current.transcriptEntries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "agent_message",
+            message: expect.objectContaining({ content: "Persisted terminal transcript" }),
+          }),
+        ]),
+      );
+      expect(result.current.events).toEqual([
+        expect.objectContaining({ detail: "Persisted terminal log", stepName: "review" }),
+      ]);
+      expect(hooksMock.useTimelineQuery).toHaveBeenLastCalledWith("todo-1", "run-terminal");
+      expect(hooksMock.useStepConversationQuery).toHaveBeenLastCalledWith(
+        "todo-1",
+        "run-terminal",
+        "build",
+        { limit: 200 },
+      );
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/issue/:identifier" element={<IssueDetail />} />
+        </Routes>,
+        { route: "/issue/todo-1" },
+      );
+      expect(screen.getByText("Persisted terminal transcript")).toBeInTheDocument();
+      await userEvent.click(screen.getByRole("tab", { name: "Raw events" }));
+      expect(screen.getAllByText("Persisted terminal log").length).toBeGreaterThan(0);
+    },
+  );
+});
+
 describe("IssueDetail", () => {
+  beforeEach(() => {
+    hooksMock.stopMutate.mockClear();
+    hooksMock.retryMutate.mockClear();
+    hooksMock.respondMutateAsync.mockReset().mockResolvedValue({});
+    hooksMock.resumeMutateAsync.mockReset().mockResolvedValue({});
+    hooksMock.interactionRefetch.mockReset().mockResolvedValue({ data: undefined });
+    hooksMock.finalizeApproveMutate.mockClear();
+    hooksMock.finalizeRetryMutate.mockClear();
+    hooksMock.cancelMutate.mockClear();
+    hooksMock.useStopMutation.mockReturnValue({
+      mutate: hooksMock.stopMutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useRetryMutation.mockReturnValue({
+      mutate: hooksMock.retryMutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useCancelInteractionMutation.mockReturnValue({
+      mutate: hooksMock.cancelMutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+    vi.mocked(connectWs).mockReset().mockImplementation(() => () => {});
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        issue_identifier: "todo-1",
+        status: "running",
+        running: {
+          step_name: "deploy",
+          turn_count: 2,
+          tokens: { total_tokens: 100 },
+          run_id: "run-1",
+        },
+        attempts: { restart_count: 0 },
+        retry: null,
+        last_error: null,
+        issue: { title: "Deploy feature", labels: [] },
+        workspace: { path: "/tmp/workspace" },
+        workflow_steps: [
+          {
+            name: "deploy",
+            agent: "builder",
+            dependencies: [],
+            state: "running",
+            can_navigate: true,
+          },
+        ],
+        pending_input: { ask_id: "ask-1" },
+        current_interaction: { interaction_request_id: "ask-1" },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useTimelineQuery.mockReturnValue({ data: { events: [] }, isError: false });
+    hooksMock.useStepConversationQuery.mockReturnValue({
+      data: {
+        records: [
+          {
+            schema_version: 1,
+            run_id: "run-1",
+            issue_identifier: "todo-1",
+            step_name: "deploy",
+            attempt: 1,
+            sequence: 1,
+            timestamp: "2026-04-14T10:00:01Z",
+            kind: "assistant_message",
+            payload: { text: "I am ready" },
+          },
+        ],
+      } as any,
+      isLoading: false,
+      isError: false,
+    });
+    hooksMock.useFinalizeApproveMutation.mockReturnValue({
+      mutate: hooksMock.finalizeApproveMutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useFinalizeRetryMutation.mockReturnValue({
+      mutate: hooksMock.finalizeRetryMutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: {
+        agent_name: "builder",
+        awaiting_resume: true,
+        id: "ask-1",
+        issue_id: "issue-1",
+        issue_identifier: "todo-1",
+        status: "open",
+        kind: "question",
+        question: "Which environment?",
+        why_blocked: "Need target",
+        suggested_answer: "staging",
+        extra_context: null,
+        step_name: "deploy",
+        requested_at: "2026-04-14T10:00:00Z",
+      },
+      refetch: hooksMock.interactionRefetch,
+    });
+  });
+
   it("renders the merged transcript shell and composer", () => {
     renderWithProviders(
       <Routes>
@@ -259,6 +1430,403 @@ describe("IssueDetail", () => {
     expect(screen.getByText("I am ready")).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Workflow" })).toBeInTheDocument();
+  });
+
+  it("shows interaction loading instead of an unsupported follow-up composer", () => {
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    expect(screen.getByText("Loading interaction...")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send Follow-up" })).not.toBeInTheDocument();
+  });
+
+  it("shows interaction errors instead of an unsupported follow-up composer", () => {
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("interaction endpoint unavailable"),
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    expect(screen.getByText("Failed to load interaction")).toBeInTheDocument();
+    expect(screen.getByText("interaction endpoint unavailable")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send Follow-up" })).not.toBeInTheDocument();
+  });
+
+  it("renders a passive Respond state when no interaction is actionable", () => {
+    const current = hooksMock.useIssueDetailQuery("todo-1");
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      ...current,
+      data: {
+        ...current.data,
+        pending_input: null,
+        current_interaction: null,
+      },
+    });
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    expect(screen.getByText(/No response is currently available/)).toBeInTheDocument();
+    expect(screen.getByText(/Transcript or Steps/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send Follow-up" })).not.toBeInTheDocument();
+  });
+
+  it("renders synthetic halted detail as passive inspection without an interaction error", () => {
+    const current = hooksMock.useIssueDetailQuery("todo-1");
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      ...current,
+      data: {
+        ...current.data,
+        status: "halted",
+        running: null,
+        pending_input: { ask_id: "halted:issue-1:deploy" },
+        current_interaction: {
+          interaction_request_id: "halted:issue-1:deploy",
+          requested_at: "2026-07-09T10:00:00Z",
+          step_name: "deploy",
+        },
+      },
+    });
+    hooksMock.useInteractionDetailQuery.mockImplementation((interactionId: string) => ({
+      data: undefined,
+      isLoading: false,
+      isError: interactionId.length > 0,
+      error: interactionId.length > 0 ? new Error("interaction not found") : null,
+    }));
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    expect(hooksMock.useInteractionDetailQuery).toHaveBeenCalledWith("");
+    expect(screen.getByText(/No response is currently available/)).toBeInTheDocument();
+    expect(screen.queryByText("Failed to load interaction")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Reply")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["open", true],
+    ["resolved", false],
+    ["cancelled", false],
+  ])("shows cancellation for %s interactions: %s", (status, shouldShowCancel) => {
+    hooksMock.useInteractionDetailQuery.mockReturnValue({
+      data: {
+        agent_name: "builder",
+        awaiting_resume: true,
+        id: "ask-1",
+        issue_id: "issue-1",
+        issue_identifier: "todo-1",
+        status,
+        kind: "question",
+        question: "Which environment?",
+        why_blocked: "Need target",
+        suggested_answer: "staging",
+        extra_context: null,
+        step_name: "deploy",
+        requested_at: "2026-04-14T10:00:00Z",
+      },
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    if (shouldShowCancel) {
+      expect(screen.getByRole("button", { name: "Cancel Request" })).toBeInTheDocument();
+    } else {
+      expect(screen.queryByRole("button", { name: "Cancel Request" })).not.toBeInTheDocument();
+    }
+  });
+
+  it("shows transcript persistence failure instead of an empty transcript", () => {
+    hooksMock.useStepConversationQuery.mockReturnValue({
+      data: { records: [] },
+      isLoading: false,
+      isError: true,
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    expect(screen.getByText(/Could not load saved transcript history/)).toBeInTheDocument();
+    expect(screen.queryByText("No transcript activity yet.")).not.toBeInTheDocument();
+  });
+
+  it("resets action UI when the route identifier changes", async () => {
+    const user = userEvent.setup();
+    hooksMock.useIssueDetailQuery.mockImplementation((identifier: string) => ({
+      data: {
+        issue_identifier: identifier,
+        status: "running",
+        running: {
+          step_name: "deploy",
+          turn_count: 2,
+          tokens: { total_tokens: 100 },
+          run_id: `run-${identifier}`,
+        },
+        attempts: { restart_count: 0 },
+        retry: null,
+        last_error: null,
+        issue: { title: `${identifier} title`, labels: [] },
+        workspace: { path: "/tmp/workspace" },
+        workflow_steps: [],
+        pending_input: { ask_id: `ask-${identifier}` },
+        current_interaction: { interaction_request_id: `ask-${identifier}` },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+    hooksMock.useInteractionDetailQuery.mockImplementation((interactionId: string) => ({
+      data: {
+        agent_name: "builder",
+        awaiting_resume: true,
+        id: interactionId,
+        issue_id: interactionId,
+        issue_identifier: interactionId.replace("ask-", ""),
+        status: "open",
+        kind: "question",
+        question: `Question for ${interactionId}`,
+        why_blocked: "Needs input",
+        suggested_answer: null,
+        extra_context: null,
+        step_name: "deploy",
+        requested_at: "2026-07-09T10:00:00Z",
+      },
+    }));
+
+    renderWithProviders(<SwitchableIssueDetail />, { route: "/issue/issue-a" });
+
+    await user.type(screen.getByLabelText("Reply"), "issue A draft");
+    await user.click(screen.getByRole("button", { name: "Stop Agent" }));
+    expect(screen.getByText(/stop the agent for issue-a/i)).toBeInTheDocument();
+
+    act(() => {
+      screen.getByRole("button", { name: "Switch issue", hidden: true }).click();
+    });
+
+    expect(screen.getByLabelText("Reply")).toHaveValue("");
+    expect(screen.queryByText(/stop the agent for issue-b/i)).not.toBeInTheDocument();
+  });
+
+  it("answers a blocked interaction and resumes the issue without using stale input", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    await user.type(screen.getByLabelText("Reply"), "Deploy to production");
+    await user.click(screen.getByRole("button", { name: "Submit Reply" }));
+
+    expect(hooksMock.respondMutateAsync).toHaveBeenCalledWith({
+      id: "ask-1",
+      kind: "question",
+      response_schema_version: 1,
+      selected_option: null,
+      text: "Deploy to production",
+    });
+    expect(hooksMock.resumeMutateAsync).toHaveBeenCalledWith({
+      identifier: "todo-1",
+      interactionId: "ask-1",
+    });
+  });
+
+  const interactionResponseCases: Array<
+    [InteractionKind, string, string, string, Record<string, unknown>]
+  > = [
+    [
+      "approval",
+      "Reason (optional)",
+      "Ship it",
+      "Approve",
+      { id: "ask-1", kind: "approval", response_schema_version: 1, approved: true, reason: "Ship it" },
+    ],
+    [
+      "approval",
+      "Reason (optional)",
+      "Unsafe to ship",
+      "Reject",
+      {
+        id: "ask-1",
+        kind: "approval",
+        response_schema_version: 1,
+        approved: false,
+        reason: "Unsafe to ship",
+      },
+    ],
+    [
+      "handoff",
+      "Notes (optional)",
+      "Operator completed setup",
+      "Complete",
+      {
+        id: "ask-1",
+        kind: "handoff",
+        response_schema_version: 1,
+        completed: true,
+        notes: "Operator completed setup",
+      },
+    ],
+    [
+      "handoff",
+      "Notes (optional)",
+      "Deployment failed",
+      "Incomplete",
+      {
+        id: "ask-1",
+        kind: "handoff",
+        response_schema_version: 1,
+        completed: false,
+        notes: "Deployment failed",
+      },
+    ],
+  ];
+
+  it.each(interactionResponseCases)(
+    "maps %s interactions to the matching response body",
+    async (kind, inputLabel, reply, buttonName, expectedBody) => {
+      const user = userEvent.setup();
+      hooksMock.useInteractionDetailQuery.mockReturnValue({
+        data: {
+          agent_name: "builder",
+          awaiting_resume: true,
+          id: "ask-1",
+          issue_id: "issue-1",
+          issue_identifier: "todo-1",
+          status: "open",
+          kind,
+          question: "Approve this action?",
+          why_blocked: "Need operator confirmation",
+          suggested_answer: "Approve this action",
+          extra_context: null,
+          step_name: "deploy",
+          requested_at: "2026-04-14T10:00:00Z",
+        },
+      });
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/issue/:identifier" element={<IssueDetail />} />
+        </Routes>,
+        { route: "/issue/todo-1" },
+      );
+
+      await user.type(screen.getByLabelText(inputLabel), reply);
+      await user.click(screen.getByRole("button", { name: buttonName }));
+
+      expect(hooksMock.respondMutateAsync).toHaveBeenCalledWith(expectedBody);
+      expect(hooksMock.resumeMutateAsync).toHaveBeenCalledWith({
+        identifier: "todo-1",
+        interactionId: "ask-1",
+      });
+    },
+  );
+
+  it("keeps the composer context visible and shows an inline error when reply fails", async () => {
+    const user = userEvent.setup();
+    hooksMock.respondMutateAsync.mockRejectedValueOnce(new Error("reply failed"));
+    hooksMock.interactionRefetch.mockResolvedValueOnce({
+      data: hooksMock.useInteractionDetailQuery("ask-1").data,
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    await user.type(screen.getByLabelText("Reply"), "Deploy to production");
+    await user.click(screen.getByRole("button", { name: "Submit Reply" }));
+
+    expect(screen.getAllByText("Which environment?")).toHaveLength(2);
+    expect(screen.getByLabelText("Reply")).toHaveValue("Deploy to production");
+    expect(await screen.findByText("reply failed")).toBeInTheDocument();
+    expect(hooksMock.interactionRefetch).toHaveBeenCalledOnce();
+    expect(hooksMock.resumeMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("keeps the composer context visible and shows an inline error when resume fails", async () => {
+    const user = userEvent.setup();
+    hooksMock.resumeMutateAsync.mockRejectedValueOnce(new Error("resume failed"));
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    await user.type(screen.getByLabelText("Reply"), "Deploy to production");
+    await user.click(screen.getByRole("button", { name: "Submit Reply" }));
+
+    expect(screen.getAllByText("Which environment?")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Resume issue" })).toBeInTheDocument();
+    expect(await screen.findByText("resume failed")).toBeInTheDocument();
+  });
+
+  it("retries only resume after response succeeds but resume fails", async () => {
+    const user = userEvent.setup();
+    hooksMock.resumeMutateAsync.mockRejectedValueOnce(new Error("resume failed"));
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    await user.type(screen.getByLabelText("Reply"), "Deploy to production");
+    await user.click(screen.getByRole("button", { name: "Submit Reply" }));
+    expect(await screen.findByText("resume failed")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Resume issue" }));
+
+    await waitFor(() => expect(hooksMock.resumeMutateAsync).toHaveBeenCalledTimes(2));
+    expect(hooksMock.respondMutateAsync).toHaveBeenCalledTimes(1);
   });
 
   it("appends live transcript records from the websocket", async () => {
@@ -791,5 +2359,313 @@ describe("IssueDetail", () => {
       "href",
       "https://github.com/acme/repo/pull/1",
     );
+  });
+
+  it("summarizes pending finalize targets and requires confirmation", async () => {
+    const user = userEvent.setup();
+
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        issue_identifier: "todo-1",
+        issue_id: "NODE_1",
+        status: "completed_succeeded",
+        running: null,
+        attempts: { restart_count: 0, current_retry_attempt: null },
+        retry: null,
+        pending_input: null,
+        current_interaction: null,
+        last_error: null,
+        issue: { title: "Deploy feature", labels: [] },
+        workspace: { path: "/tmp/workspace" },
+        finalize: {
+          status: "pending_approval",
+          repos: [
+            {
+              approval_required: true,
+              last_error: null,
+              mode: "push_and_pr",
+              repo: "/tmp/workspace/backend",
+              status: "pending_approval",
+            },
+          ],
+        },
+        workflow_steps: [],
+      } as any,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    expect(screen.getByText("Finalize approval required")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Approve finalize" }));
+    const dialog = screen.getByRole("alertdialog");
+    expect(within(dialog).getByText(/\/tmp\/workspace\/backend/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/push_and_pr/)).toBeInTheDocument();
+    expect(hooksMock.finalizeApproveMutate).not.toHaveBeenCalled();
+
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    expect(hooksMock.finalizeApproveMutate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Approve finalize" }));
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "Approve finalize",
+      }),
+    );
+
+    expect(hooksMock.finalizeApproveMutate).toHaveBeenCalledWith({ identifier: "todo-1" });
+    expect(hooksMock.finalizeRetryMutate).not.toHaveBeenCalled();
+  });
+
+  it("invalidates finalize confirmation when status changes", async () => {
+    const current = hooksMock.useIssueDetailQuery("todo-1");
+    const pendingRepo = {
+      approval_required: true,
+      last_error: null,
+      mode: "push_and_pr",
+      repo: "/tmp/workspace/backend",
+      status: "pending_approval",
+    };
+    let finalize = { status: "pending_approval", repos: [pendingRepo] };
+    hooksMock.useIssueDetailQuery.mockImplementation(() => ({
+      ...current,
+      data: { ...current.data, finalize },
+    }));
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/issue/todo-1"]}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+    const view = render(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { wrapper },
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Approve finalize" }));
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+    finalize = {
+      status: "in_progress",
+      repos: [{ ...pendingRepo, status: "in_progress" }],
+    };
+    view.rerender(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+    );
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+    expect(hooksMock.finalizeApproveMutate).not.toHaveBeenCalled();
+  });
+
+  it("renders failed finalize controls and calls retry", async () => {
+    const user = userEvent.setup();
+
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        issue_identifier: "todo-1",
+        issue_id: "NODE_1",
+        status: "failed",
+        running: null,
+        attempts: { restart_count: 0, current_retry_attempt: null },
+        retry: null,
+        pending_input: null,
+        current_interaction: null,
+        last_error: null,
+        issue: { title: "Deploy feature", labels: [] },
+        workspace: { path: "/tmp/workspace" },
+        finalize: { status: "failed", repos: [] },
+        workflow_steps: [],
+      } as any,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    expect(screen.getByText("Finalize failed")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry finalize" }));
+
+    expect(hooksMock.finalizeRetryMutate).toHaveBeenCalledWith({ identifier: "todo-1" });
+    expect(hooksMock.finalizeApproveMutate).not.toHaveBeenCalled();
+  });
+
+  it.each(["skipped_headless", "in_progress"])(
+    "renders %s finalize status without invalid actions",
+    (finalizeStatus) => {
+      hooksMock.useIssueDetailQuery.mockReturnValue({
+        data: {
+          issue_identifier: "todo-1",
+          issue_id: "NODE_1",
+          status: "running",
+          running: null,
+          attempts: { restart_count: 0, current_retry_attempt: null },
+          retry: null,
+          pending_input: null,
+          current_interaction: null,
+          last_error: null,
+          issue: { title: "Deploy feature", labels: [] },
+          workspace: { path: "/tmp/workspace" },
+          finalize: { status: finalizeStatus, repos: [] },
+          workflow_steps: [],
+        } as any,
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/issue/:identifier" element={<IssueDetail />} />
+        </Routes>,
+        { route: "/issue/todo-1" },
+      );
+
+      expect(screen.getByText("Finalize status")).toBeInTheDocument();
+      expect(screen.getByText(finalizeStatus)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Approve finalize" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Retry finalize" })).not.toBeInTheDocument();
+    },
+  );
+
+  it("shows finalize action errors inline", () => {
+    hooksMock.useFinalizeApproveMutation.mockReturnValue({
+      mutate: hooksMock.finalizeApproveMutate,
+      isPending: false,
+      isError: true,
+      error: new Error("approval failed"),
+    });
+    hooksMock.useIssueDetailQuery.mockReturnValue({
+      data: {
+        issue_identifier: "todo-1",
+        issue_id: "NODE_1",
+        status: "completed_succeeded",
+        running: null,
+        attempts: { restart_count: 0, current_retry_attempt: null },
+        retry: null,
+        pending_input: null,
+        current_interaction: null,
+        last_error: null,
+        issue: { title: "Deploy feature", labels: [] },
+        workspace: { path: "/tmp/workspace" },
+        finalize: { status: "pending_approval", repos: [] },
+        workflow_steps: [],
+      } as any,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("approval failed");
+  });
+
+  it.each([
+    ["stop", "stop failed"],
+    ["retry", "retry failed"],
+    ["cancel", "cancel failed"],
+  ] as const)("shows %s action failures in an inline alert", (action, message) => {
+    const failedMutation = {
+      mutate: vi.fn(),
+      isPending: false,
+      isError: true,
+      error: new Error(message),
+    };
+    if (action === "stop") hooksMock.useStopMutation.mockReturnValue(failedMutation);
+    if (action === "retry") hooksMock.useRetryMutation.mockReturnValue(failedMutation);
+    if (action === "cancel") hooksMock.useCancelInteractionMutation.mockReturnValue(failedMutation);
+    if (action === "retry") {
+      const current = hooksMock.useIssueDetailQuery("todo-1");
+      hooksMock.useIssueDetailQuery.mockReturnValue({
+        ...current,
+        data: {
+          ...current.data,
+          retry: {
+            issue_id: "issue-1",
+            issue_identifier: "todo-1",
+            attempt: 2,
+            due_at_ms: 1000,
+            error: "failed",
+          },
+        },
+      });
+    }
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/issue/:identifier" element={<IssueDetail />} />
+      </Routes>,
+      { route: "/issue/todo-1" },
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(message);
+  });
+
+  it("does not show an action failure after navigating to another identifier", async () => {
+    hooksMock.useStopMutation.mockReturnValue({
+      mutate: hooksMock.stopMutate,
+      isPending: false,
+      isError: true,
+      error: new Error("issue A stop failed"),
+    });
+    hooksMock.useIssueDetailQuery.mockImplementation((identifier: string) => ({
+      data: {
+        issue_identifier: identifier,
+        status: "running",
+        running: {
+          step_name: "deploy",
+          turn_count: 2,
+          tokens: { total_tokens: 100 },
+          run_id: `run-${identifier}`,
+        },
+        attempts: { restart_count: 0 },
+        retry: null,
+        last_error: null,
+        issue: { title: `${identifier} title`, labels: [] },
+        workspace: { path: "/tmp/workspace" },
+        workflow_steps: [],
+        pending_input: null,
+        current_interaction: null,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    }));
+
+    renderWithProviders(<SwitchableIssueDetail />, { route: "/issue/issue-a" });
+    expect(screen.getByRole("alert")).toHaveTextContent("issue A stop failed");
+
+    hooksMock.useStopMutation.mockReturnValue({
+      mutate: hooksMock.stopMutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Switch issue", hidden: true }));
+    expect(screen.queryByText("issue A stop failed")).not.toBeInTheDocument();
   });
 });

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
@@ -1,31 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-import {
-  useCancelInteractionMutation,
-  useInteractionDetailQuery,
-  useIssueDetailQuery,
-  useIssueInputMutation,
-  useRetryMutation,
-  useStepConversationQuery,
-  useStopMutation,
-  useTimelineQuery,
-} from "@/hooks";
-import { connectWs } from "@/ws";
-import type { WsStatus } from "@/ws";
-import type { WsEventData, WsPipelineEvent } from "@/ws-types";
-import {
-  isCompletionEvent,
-  normalizePipelineEvent,
-  timelineRecordToEventData,
-  transcriptRecordKey,
-} from "@/ws-events";
-import { addNotification, requestPermissionIfNeeded } from "@/notifications";
-import type { TranscriptRecord } from "@/generated/models";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import StatusBadge from "@/components/StatusBadge";
 import ConfirmDialog from "@/components/ConfirmDialog";
+import FinalizeApprovalDialog from "@/components/FinalizeApprovalDialog";
 import EventTimeline from "@/components/EventTimeline";
 import IssueInfoSection from "@/components/IssueInfoSection";
 import WorkflowStepsSidebar from "@/components/WorkflowStepsSidebar";
@@ -33,22 +13,7 @@ import ArtifactsPanel from "@/components/ArtifactsPanel";
 import { IssueComposer } from "@/components/issue-detail/IssueComposer";
 import { IssueContextPanel } from "@/components/issue-detail/IssueContextPanel";
 import { RunTranscript } from "@/components/transcript/RunTranscript";
-import {
-  reconcileGroupedTranscriptEntries,
-  type GroupedTranscriptEntry,
-} from "@/components/transcript/transcript-model";
-
-function triggerNotification(event: WsPipelineEvent, identifier: string) {
-  const detail = event.detail ?? event.event_type;
-
-  if (event.event_type === "error") {
-    addNotification("failure", "Agent error", detail, identifier);
-  } else if (event.event_type === "retry_scheduled") {
-    addNotification("warning", "Retry scheduled", detail, identifier);
-  } else if (event.event_type === "verdict" && event.verdict) {
-    addNotification("info", `Verdict: ${event.verdict}`, detail, identifier);
-  }
-}
+import { useIssueRuntime } from "./mission-control/useIssueRuntime";
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -56,192 +21,52 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Request failed";
+}
+
 export default function IssueDetail() {
   const { identifier = "" } = useParams<{ identifier: string }>();
-  const { data, isLoading, isError, error } = useIssueDetailQuery(identifier);
-  const interactionId =
-    data?.pending_input?.ask_id ??
-    data?.current_interaction?.interaction_request_id ??
-    "";
-  const { data: interaction } = useInteractionDetailQuery(interactionId);
-  const stopMutation = useStopMutation();
-  const retryMutation = useRetryMutation();
-  const inputMutation = useIssueInputMutation(identifier, interactionId);
-  const cancelMutation = useCancelInteractionMutation(identifier);
 
-  const [liveEvents, setLiveEvents] = useState<WsEventData[]>([]);
-  const [liveTranscriptRecords, setLiveTranscriptRecords] = useState<TranscriptRecord[]>([]);
-  const [wsStatus, setWsStatus] = useState<WsStatus>("disconnected");
+  return <IssueDetailContent key={identifier} identifier={identifier} />;
+}
+
+function IssueDetailContent({ identifier }: { identifier: string }) {
   const [showStopConfirm, setShowStopConfirm] = useState(false);
-  const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
-  const [lastKnownRunId, setLastKnownRunId] = useState("");
-  const [lastKnownStepName, setLastKnownStepName] = useState("");
-
-  const isLiveRun = data?.running != null;
-  const currentRunId = (data?.running as { run_id?: string } | undefined)?.run_id;
-  const currentStepName = data?.running?.step_name ?? null;
-
-  useEffect(() => {
-    if (currentRunId) {
-      setLastKnownRunId((previousRunId) =>
-        previousRunId === currentRunId ? previousRunId : currentRunId,
-      );
-    }
-  }, [currentRunId]);
-
-  useEffect(() => {
-    if (currentStepName) {
-      setLastKnownStepName((previousStepName) =>
-        previousStepName === currentStepName ? previousStepName : currentStepName,
-      );
-    }
-  }, [currentStepName]);
-
-  const effectiveRunId = currentRunId ?? lastKnownRunId;
-  const activeStepName = currentStepName ?? lastKnownStepName;
-  const transcriptQuery = useStepConversationQuery(identifier, effectiveRunId, activeStepName ?? "", {
-    limit: 200,
-  });
-  const refetchTranscript = transcriptQuery.refetch;
-  const transcriptSessionKey = `${identifier}:${effectiveRunId || "no-run"}:${activeStepName ?? "no-step"}`;
-  const activeEntrySessionKeyRef = useRef(transcriptSessionKey);
-  const timelineQuery = useTimelineQuery(identifier, effectiveRunId);
-  const refetchTimeline = timelineQuery.refetch;
-  const persistedEvents = useMemo(
-    () => (timelineQuery.data?.events ?? []).map(timelineRecordToEventData),
-    [timelineQuery.data?.events],
-  );
-
-  const events = useMemo(() => {
-    const merged = [...persistedEvents, ...liveEvents];
-    const seen = new Set<string>();
-    const deduped: WsEventData[] = [];
-
-    for (const event of merged) {
-      const key =
-        event.runId && event.sequence != null
-          ? `${event.runId}:${event.sequence}`
-          : [
-              event.type,
-              event.timestamp,
-              event.detail,
-              event.stepName ?? "",
-              event.attempt ?? "",
-              event.conversationIndex ?? "",
-            ].join(":");
-
-      if (seen.has(key)) continue;
-      seen.add(key);
-      deduped.push(event);
-    }
-
-    return deduped.sort((a, b) => {
-      if (a.runId && b.runId && a.runId === b.runId && a.sequence != null && b.sequence != null) {
-        return a.sequence - b.sequence;
-      }
-
-      const tsDelta = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
-      if (tsDelta !== 0) {
-        return tsDelta;
-      }
-
-      return (a.sequence ?? 0) - (b.sequence ?? 0);
-    });
-  }, [liveEvents, persistedEvents]);
-
-  useEffect(() => {
-    requestPermissionIfNeeded();
-    return connectWs({
-      identifier,
-      enabled: isLiveRun,
-      onMessage: (msg) => {
-        if (msg.type === "snapshot") {
-          setLiveEvents([]);
-          setLiveTranscriptRecords([]);
-          void refetchTranscript?.();
-          void refetchTimeline?.();
-        } else if (msg.type === "event") {
-          const event = normalizePipelineEvent(msg.data);
-          setLiveEvents((prev) => [...prev, event]);
-          triggerNotification(msg.data, identifier);
-
-          if (isCompletionEvent(msg.data)) {
-            const severity = msg.data.outcome === "succeeded" ? "success" : "failure";
-            addNotification(
-              severity,
-              `Run ${msg.data.outcome}`,
-              `${identifier} ${msg.data.outcome}`,
-              identifier,
-            );
-          }
-        } else if (msg.type === "transcript_record") {
-          setLiveTranscriptRecords((prev) => {
-            const next = new Map(prev.map((record) => [transcriptRecordKey(record), record] as const));
-            next.set(transcriptRecordKey(msg.data), msg.data);
-            return Array.from(next.values()).sort((a, b) => a.sequence - b.sequence);
-          });
-        }
-      },
-      onStatusChange: setWsStatus,
-    });
-  }, [identifier, isLiveRun, refetchTimeline, refetchTranscript]);
-
-  const transcriptRecords = useMemo(() => {
-    const byKey = new Map<string, TranscriptRecord>();
-    for (const record of transcriptQuery.data?.records ?? []) {
-      byKey.set(transcriptRecordKey(record), record);
-    }
-    for (const record of liveTranscriptRecords) {
-      if (record.run_id !== effectiveRunId || record.step_name !== activeStepName) continue;
-      byKey.set(transcriptRecordKey(record), record);
-    }
-    return Array.from(byKey.values()).sort((a, b) => a.sequence - b.sequence);
-  }, [activeStepName, effectiveRunId, liveTranscriptRecords, transcriptQuery.data?.records]);
-
-  const activeTranscriptEntryId =
-    activeEntrySessionKeyRef.current === transcriptSessionKey ? activeEntryId : null;
-
-  const transcriptEntriesRef = useRef<GroupedTranscriptEntry[] | undefined>(undefined);
-  const transcriptEntriesSessionKeyRef = useRef<string | undefined>(undefined);
-  const transcriptEntries = useMemo(() => {
-    const previousEntries =
-      transcriptEntriesSessionKeyRef.current === transcriptSessionKey
-        ? transcriptEntriesRef.current
-        : undefined;
-
-    const nextEntries = reconcileGroupedTranscriptEntries(previousEntries, {
-      conversation: [],
-      transcriptRecords,
-      interactions: interaction ? [interaction] : [],
-      events,
-    });
-
-    transcriptEntriesRef.current = nextEntries;
-    transcriptEntriesSessionKeyRef.current = transcriptSessionKey;
-
-    return nextEntries;
-  }, [transcriptRecords, interaction, events, transcriptSessionKey]);
-
-  const transcriptEntryIdForConversationIndex = (index: number) =>
-    activeStepName
-      ? `transcript:${effectiveRunId}:${activeStepName}:${index}`
-      : `message:${index}`;
-
-  useEffect(() => {
-    activeEntrySessionKeyRef.current = transcriptSessionKey;
-    setActiveEntryId(null);
-    setLiveTranscriptRecords([]);
-  }, [transcriptSessionKey]);
-
-  const pendingQuestion = interaction
-    ? {
-        interactionId: interaction.id,
-        question: interaction.question,
-        whyBlocked: interaction.why_blocked,
-        suggestedAnswer: interaction.suggested_answer ?? null,
-        stepName: interaction.step_name,
-      }
-    : null;
+  const [showFinalizeConfirm, setShowFinalizeConfirm] = useState(false);
+  const runtime = useIssueRuntime(identifier);
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    interaction,
+    interactionIsLoading,
+    interactionIsError,
+    interactionError,
+    pendingQuestion,
+    isLiveRun,
+    wsStatus,
+    events,
+    transcriptEntries,
+    activeTranscriptEntryId,
+    transcriptSessionKey,
+    transcriptIsError,
+    timelineIsError,
+    retryMutation,
+    stopMutation,
+    respondMutation,
+    resumeMutation,
+    cancelMutation,
+    finalizeApproveMutation,
+    finalizeRetryMutation,
+    composerError,
+    resumeQueued,
+    submitInteractionReply,
+    resumeInteraction,
+    setActiveEntryIdForConversationIndex,
+    setActiveEntryId,
+  } = runtime;
 
   if (isLoading) {
     return <div className="py-12 text-center text-muted-foreground">Loading...</div>;
@@ -294,7 +119,54 @@ export default function IssueDetail() {
     </div>
   );
 
-  const rawEventsPanel = timelineQuery.isError ? (
+  const finalizeStatus = data.finalize?.status;
+  const actionError = [
+    stopMutation,
+    retryMutation,
+    cancelMutation,
+    finalizeApproveMutation,
+    finalizeRetryMutation,
+  ].find((mutation) => mutation.isError)?.error;
+  const finalizePanel = finalizeStatus ? (
+    <div className="rounded-lg border bg-card p-4 text-sm">
+      {finalizeStatus === "pending_approval" ? (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="font-medium">Finalize approval required</div>
+            <p className="text-muted-foreground">Approve publishing finalized workspace changes.</p>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => setShowFinalizeConfirm(true)}
+            disabled={finalizeApproveMutation.isPending}
+          >
+            Approve finalize
+          </Button>
+        </div>
+      ) : finalizeStatus === "failed" ? (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="font-medium">Finalize failed</div>
+            <p className="text-muted-foreground">Retry finalizing workspace changes.</p>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => finalizeRetryMutation.mutate({ identifier })}
+            disabled={finalizeRetryMutation.isPending}
+          >
+            Retry finalize
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="font-medium">Finalize status</div>
+          <div className="text-muted-foreground">{finalizeStatus}</div>
+        </div>
+      )}
+    </div>
+  ) : null;
+
+  const rawEventsPanel = timelineIsError ? (
     <div className="space-y-3">
       <p className="text-sm text-amber-700">
         Couldn&apos;t load saved timeline history; showing live events only.
@@ -302,21 +174,41 @@ export default function IssueDetail() {
       <EventTimeline
         events={events}
         live={isLiveRun}
-        onViewConversation={(index) => {
-        activeEntrySessionKeyRef.current = transcriptSessionKey;
-        setActiveEntryId(transcriptEntryIdForConversationIndex(index));
-      }}
+        onViewConversation={setActiveEntryIdForConversationIndex}
       />
     </div>
   ) : (
     <EventTimeline
       events={events}
       live={isLiveRun}
-      onViewConversation={(index) => {
-        activeEntrySessionKeyRef.current = transcriptSessionKey;
-        setActiveEntryId(transcriptEntryIdForConversationIndex(index));
-      }}
+      onViewConversation={setActiveEntryIdForConversationIndex}
     />
+  );
+  const interactionSubmitting =
+    respondMutation.isPending || resumeMutation.isPending || resumeQueued;
+  const respondPanel = interactionIsLoading ? (
+    <div className="m-4 rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+      Loading interaction...
+    </div>
+  ) : interactionIsError ? (
+    <div className="m-4 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm">
+      <div className="font-medium text-destructive">Failed to load interaction</div>
+      <p className="mt-1 text-muted-foreground">{errorMessage(interactionError)}</p>
+    </div>
+  ) : pendingQuestion ? (
+    <IssueComposer
+      key={`${identifier}:${pendingQuestion.interactionId}`}
+      pendingQuestion={pendingQuestion}
+      onSubmitReply={submitInteractionReply}
+      onSubmitFollowUp={() => false}
+      onResumeInteraction={resumeInteraction}
+      isSubmitting={interactionSubmitting}
+      error={composerError}
+    />
+  ) : (
+    <div className="m-4 rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+      No response is currently available. Use Transcript or Steps to inspect the issue.
+    </div>
   );
 
   return (
@@ -367,6 +259,12 @@ export default function IssueDetail() {
         </div>
       </div>
 
+      {actionError ? (
+        <p role="alert" className="text-sm text-destructive">
+          {errorMessage(actionError)}
+        </p>
+      ) : null}
+
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
         <Card>
           <CardContent className="p-4">
@@ -396,27 +294,34 @@ export default function IssueDetail() {
         </Card>
       </div>
 
+      {finalizePanel}
+
       <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
         <div className="flex min-h-0 flex-col overflow-hidden rounded-lg border bg-card">
           <div className="min-h-0 flex-1 overflow-auto p-4">
-            <RunTranscript
-              entries={transcriptEntries}
-              activeEntryId={activeTranscriptEntryId}
-              onJumpToEntry={(entryId) => {
-                activeEntrySessionKeyRef.current = transcriptSessionKey;
-                setActiveEntryId(entryId);
-              }}
-              transcriptSessionKey={transcriptSessionKey}
-            />
+            {transcriptIsError && transcriptEntries.length === 0 ? (
+              <div className="rounded-lg border border-amber-300/70 bg-amber-50/60 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/20 dark:text-amber-100">
+                Could not load saved transcript history.
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {transcriptIsError ? (
+                  <p className="text-sm text-amber-700 dark:text-amber-400">
+                    Could not load saved transcript history; showing live activity only.
+                  </p>
+                ) : null}
+                <RunTranscript
+                  entries={transcriptEntries}
+                  activeEntryId={activeTranscriptEntryId}
+                  onJumpToEntry={setActiveEntryId}
+                  transcriptSessionKey={transcriptSessionKey}
+                />
+              </div>
+            )}
           </div>
           <div className="border-t bg-background">
-            <IssueComposer
-              pendingQuestion={pendingQuestion}
-              onSubmitReply={(value) => inputMutation.mutate(value)}
-              onSubmitFollowUp={(value) => inputMutation.mutate(value)}
-              isSubmitting={inputMutation.isPending}
-            />
-            {interaction && interaction.status !== "resolved" ? (
+            {respondPanel}
+            {!interactionIsLoading && !interactionIsError && interaction?.status === "open" ? (
               <div className="px-4 pb-4">
                 <Button
                   variant="outline"
@@ -463,6 +368,17 @@ export default function IssueDetail() {
           setShowStopConfirm(false);
         }}
         onCancel={() => setShowStopConfirm(false)}
+      />
+      <FinalizeApprovalDialog
+        open={showFinalizeConfirm}
+        status={data.finalize?.status ?? "not_required"}
+        repos={data.finalize?.repos ?? []}
+        isPending={finalizeApproveMutation.isPending}
+        onConfirm={() => {
+          finalizeApproveMutation.mutate({ identifier });
+          setShowFinalizeConfirm(false);
+        }}
+        onCancel={() => setShowFinalizeConfirm(false)}
       />
     </div>
   );

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/AttentionQueue.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/AttentionQueue.tsx
@@ -1,0 +1,85 @@
+import { cn } from "@/lib/utils";
+
+import type { MissionAttentionItem } from "./model";
+
+interface AttentionQueueProps {
+  items: MissionAttentionItem[];
+  selectedIssueIdentifier: string | null;
+  onSelectIssue: (identifier: string) => void;
+}
+
+function formatAge(value: string | null): string {
+  if (!value) return "scheduled";
+
+  const minutes = Math.max(0, Math.floor((Date.now() - new Date(value).getTime()) / 60_000));
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function kindLabel(item: MissionAttentionItem): string {
+  if (item.stepName) return item.stepName;
+  if (item.kind === "human_input") return "human input";
+  return item.kind === "failure" ? "failure" : "retry";
+}
+
+export function AttentionQueue({ items, selectedIssueIdentifier, onSelectIssue }: AttentionQueueProps) {
+  return (
+    <section className="rounded-xl border bg-card p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold tracking-wide text-muted-foreground uppercase">
+            Needs Attention
+          </h2>
+          <p className="text-sm text-muted-foreground">Human questions and recovery paths.</p>
+        </div>
+        <span className="rounded-full bg-muted px-2 py-1 text-xs font-medium">{items.length}</span>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+          Nothing needs intervention right now.
+        </div>
+      ) : (
+        <div className="grid gap-2 lg:grid-cols-2 xl:grid-cols-3">
+          {items.map((item) => {
+            const selected = selectedIssueIdentifier === item.issueIdentifier;
+
+            return (
+              <button
+                key={item.id}
+                type="button"
+                aria-current={selected ? "true" : undefined}
+                aria-label={`${item.primaryAction} to ${item.issueIdentifier}`}
+                onClick={() => onSelectIssue(item.issueIdentifier)}
+                className={cn(
+                  "rounded-lg border p-3 text-left transition hover:border-primary/50 hover:bg-muted/40",
+                  selected && "border-primary bg-primary/5 ring-1 ring-primary/30",
+                )}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-semibold">{item.issueIdentifier}</div>
+                    <div className="mt-1 text-sm text-foreground">{item.title}</div>
+                    <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">{item.detail}</div>
+                  </div>
+                  <span className="shrink-0 rounded-full bg-primary px-2 py-1 text-xs font-medium text-primary-foreground">
+                    {item.primaryAction}
+                  </span>
+                </div>
+                <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                  <span className="truncate">{kindLabel(item)}</span>
+                  <span className="shrink-0">{formatAge(item.requestedAt)}</span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
@@ -1,0 +1,882 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { useState } from "react";
+import type {
+  InteractionDetail,
+  InteractionStatus,
+  IssueDetailSnapshot,
+} from "@/generated/models";
+import { IssueCommandPanel, type IssueCommandPanelTab } from "./IssueCommandPanel";
+import { useIssueRuntime, type IssueRuntimeState } from "./useIssueRuntime";
+
+vi.mock("./useIssueRuntime", () => ({
+  useIssueRuntime: vi.fn(),
+}));
+
+const actions = {
+  stop: vi.fn(),
+  retry: vi.fn(),
+  cancel: vi.fn(),
+  finalizeApprove: vi.fn(),
+  finalizeRetry: vi.fn(),
+  submitReply: vi.fn(),
+  setActiveEntry: vi.fn(),
+  setActiveEntryForConversation: vi.fn(),
+};
+
+function mockMutation<T>(mutate: ReturnType<typeof vi.fn>, overrides: Record<string, unknown> = {}) {
+  return {
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides,
+  } as T;
+}
+
+const issue = {
+  issue_identifier: "repo#1",
+  issue_id: "issue-1",
+  status: "running",
+  running: {
+    run_id: "run-1",
+    session_id: "session-1",
+    started_at: "2026-07-09T10:00:00Z",
+    state: "running",
+    step_name: "build",
+    turn_count: 3,
+    tokens: { total_tokens: 1_250, input_tokens: 1_000, output_tokens: 250 },
+  },
+  retry: null,
+  attempts: { restart_count: 1, current_retry_attempt: null },
+  workspace: { path: "/tmp/workspace" },
+  workflow_steps: [
+    {
+      name: "build",
+      agent: "builder",
+      kind: "agent",
+      dependencies: [],
+      state: "running",
+      can_navigate: true,
+    },
+  ],
+  artifacts: null,
+  finalize: { status: "not_required", repos: [] },
+  issue: { title: "Test issue", description: "Ship the command panel", labels: ["ui"] },
+  last_error: null,
+  pending_input: null,
+  current_interaction: null,
+} satisfies IssueDetailSnapshot;
+
+const openInteraction = {
+  agent_name: "builder",
+  awaiting_resume: true,
+  id: "ask-1",
+  issue_id: "issue-1",
+  issue_identifier: "repo#1",
+  kind: "question",
+  question: "Which environment?",
+  requested_at: "2026-07-09T10:05:00Z",
+  status: "open" satisfies InteractionStatus,
+  step_name: "build",
+  suggested_answer: "staging",
+  why_blocked: "A deployment target is required.",
+} satisfies InteractionDetail;
+
+function runtimeFixture(overrides: Partial<IssueRuntimeState> = {}): IssueRuntimeState {
+  return {
+    identifier: "repo#1",
+    data: issue,
+    isLoading: false,
+    isError: false,
+    error: null,
+    interaction: undefined,
+    interactionIsLoading: false,
+    interactionIsError: false,
+    interactionError: null,
+    pendingQuestion: null,
+    isLiveRun: true,
+    wsStatus: "connected",
+    effectiveRunId: "run-1",
+    activeStepName: "build",
+    events: [],
+    transcriptEntries: [],
+    activeTranscriptEntryId: null,
+    transcriptSessionKey: "repo#1:run-1:build",
+    transcriptIsError: false,
+    timelineIsError: false,
+    retryMutation: mockMutation<IssueRuntimeState["retryMutation"]>(actions.retry),
+    stopMutation: mockMutation<IssueRuntimeState["stopMutation"]>(actions.stop),
+    respondMutation: mockMutation<IssueRuntimeState["respondMutation"]>(vi.fn()),
+    resumeMutation: mockMutation<IssueRuntimeState["resumeMutation"]>(vi.fn()),
+    cancelMutation: mockMutation<IssueRuntimeState["cancelMutation"]>(actions.cancel),
+    finalizeApproveMutation: mockMutation<IssueRuntimeState["finalizeApproveMutation"]>(
+      actions.finalizeApprove,
+    ),
+    finalizeRetryMutation: mockMutation<IssueRuntimeState["finalizeRetryMutation"]>(
+      actions.finalizeRetry,
+    ),
+    composerError: null,
+    resumeQueued: false,
+    submitInteractionReply: actions.submitReply,
+    resumeInteraction: vi.fn(),
+    submitFollowUpInput: vi.fn(),
+    setActiveEntryIdForConversationIndex: actions.setActiveEntryForConversation,
+    setActiveEntryId: actions.setActiveEntry,
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  activeTab: IssueCommandPanelTab = "overview",
+  props: Partial<React.ComponentProps<typeof IssueCommandPanel>> = {},
+) {
+  return render(
+    <MemoryRouter>
+      <IssueCommandPanel
+        identifier="repo#1"
+        activeTab={activeTab}
+        onActiveTabChange={() => {}}
+        onClose={() => {}}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("IssueCommandPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    actions.submitReply.mockResolvedValue(true);
+    vi.mocked(useIssueRuntime).mockReturnValue(runtimeFixture());
+  });
+
+  it("asks the operator to select an issue without rendering selected issue controls", () => {
+    renderPanel("overview", { identifier: null });
+
+    expect(useIssueRuntime).toHaveBeenCalledWith("");
+    expect(screen.getByText("Select an issue")).toBeInTheDocument();
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Close issue panel" })).not.toBeInTheDocument();
+  });
+
+  it("renders the selected issue overview and accessible tabs", () => {
+    renderPanel();
+
+    expect(screen.getByRole("heading", { name: "repo#1" })).toBeInTheDocument();
+    expect(screen.getByText("Test issue")).toBeInTheDocument();
+    expect(screen.getByText("WS: connected")).toBeInTheDocument();
+    expect(screen.getByText("Current step")).toBeInTheDocument();
+    expect(screen.getByText("build")).toBeInTheDocument();
+    expect(screen.getByText("Current agent")).toBeInTheDocument();
+    expect(screen.getByText("builder")).toBeInTheDocument();
+    expect(screen.getByText("1.3k")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getAllByRole("tab")).toHaveLength(6);
+  });
+
+  it("renders tabs in contract order and activates them with roving keyboard focus", async () => {
+    const user = userEvent.setup();
+
+    function ControlledPanel() {
+      const [activeTab, setActiveTab] = useState<IssueCommandPanelTab>("overview");
+      return (
+        <IssueCommandPanel
+          identifier="repo#1"
+          activeTab={activeTab}
+          onActiveTabChange={setActiveTab}
+          onClose={() => {}}
+        />
+      );
+    }
+
+    render(
+      <MemoryRouter>
+        <ControlledPanel />
+      </MemoryRouter>,
+    );
+
+    const labels = screen.getAllByRole("tab").map((tab) => tab.textContent);
+    expect(labels).toEqual(["Overview", "Respond", "Steps", "Transcript", "Logs", "Artifacts"]);
+    const controlledPanelIds = screen
+      .getAllByRole("tab")
+      .map((tab) => tab.getAttribute("aria-controls"));
+    expect(new Set(controlledPanelIds).size).toBe(1);
+    expect(document.getElementById(controlledPanelIds[0]!)).not.toBeNull();
+
+    const overview = screen.getByRole("tab", { name: "Overview" });
+    overview.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("tab", { name: "Respond" })).toHaveFocus();
+    expect(screen.getByRole("tab", { name: "Respond" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await user.keyboard("{End}");
+    expect(screen.getByRole("tab", { name: "Artifacts" })).toHaveFocus();
+    expect(screen.getByRole("tab", { name: "Artifacts" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await user.keyboard("{Home}");
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveFocus();
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("tab", { name: "Artifacts" })).toHaveFocus();
+  });
+
+  it("notifies the parent when a tab is selected", async () => {
+    const onActiveTabChange = vi.fn();
+    renderPanel("overview", { onActiveTabChange });
+
+    await userEvent.click(screen.getByRole("tab", { name: "Transcript" }));
+
+    expect(onActiveTabChange).toHaveBeenCalledWith("transcript");
+  });
+
+  it("keeps the loading panel closable", async () => {
+    const onClose = vi.fn();
+    vi.mocked(useIssueRuntime).mockReturnValue(runtimeFixture({ isLoading: true, data: undefined }));
+    renderPanel("overview", { onClose });
+
+    expect(screen.getByText("Loading issue...")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Close issue panel" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a readable backend error panel closable", async () => {
+    const onClose = vi.fn();
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({ isLoading: false, isError: true, data: undefined, error: new Error("API offline") }),
+    );
+    renderPanel("overview", { onClose });
+
+    expect(screen.getByText("Failed to load issue")).toBeInTheDocument();
+    expect(screen.getByText("API offline")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Close issue panel" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes the panel", async () => {
+    const onClose = vi.fn();
+    renderPanel("overview", { onClose });
+
+    await userEvent.click(screen.getByRole("button", { name: "Close issue panel" }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("confirms before stopping an active run", async () => {
+    renderPanel();
+
+    await userEvent.click(screen.getByRole("button", { name: "Stop" }));
+    const dialog = screen.getByRole("alertdialog");
+    expect(within(dialog).getByText(/stop the agent for repo#1/i)).toBeInTheDocument();
+    expect(actions.stop).not.toHaveBeenCalled();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Stop" }));
+    expect(actions.stop).toHaveBeenCalledWith({ identifier: "repo#1" });
+  });
+
+  it("closes a pending stop confirmation when the selected issue changes", async () => {
+    const view = renderPanel();
+    await userEvent.click(screen.getByRole("button", { name: "Stop" }));
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        identifier: "repo#2",
+        data: { ...issue, issue_identifier: "repo#2", issue_id: "issue-2" },
+      }),
+    );
+    view.rerender(
+      <MemoryRouter>
+        <IssueCommandPanel
+          identifier="repo#2"
+          activeTab="overview"
+          onActiveTabChange={() => {}}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("remounts runtime mutation state when the selected identifier changes", () => {
+    vi.mocked(useIssueRuntime).mockImplementation((identifier) => {
+      const [retryMutation] = useState(() =>
+        mockMutation<IssueRuntimeState["retryMutation"]>(actions.retry, {
+          error: identifier === "repo#1" ? new Error("repo one retry failed") : null,
+          isError: identifier === "repo#1",
+          isIdle: identifier !== "repo#1",
+          status: identifier === "repo#1" ? "error" : "idle",
+        }),
+      );
+      return runtimeFixture({
+        identifier,
+        data: { ...issue, issue_identifier: identifier, issue_id: identifier },
+        retryMutation,
+      });
+    });
+
+    const view = renderPanel();
+    expect(screen.getByText("repo one retry failed")).toBeInTheDocument();
+
+    view.rerender(
+      <MemoryRouter>
+        <IssueCommandPanel
+          identifier="repo#2"
+          activeTab="overview"
+          onActiveTabChange={() => {}}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("repo one retry failed")).not.toBeInTheDocument();
+  });
+
+  it("keeps the empty selection key distinct from a no-selection identifier", () => {
+    let runtimeMountCount = 0;
+    vi.mocked(useIssueRuntime).mockImplementation((identifier) => {
+      const [runtimeMount] = useState(() => ++runtimeMountCount);
+      return runtimeFixture({
+        identifier,
+        data: {
+          ...issue,
+          issue_identifier: identifier,
+          issue_id: identifier,
+          issue: { ...issue.issue, title: `Runtime mount ${runtimeMount}` },
+        },
+      });
+    });
+
+    const view = renderPanel("overview", { identifier: null });
+    expect(screen.getByText("Select an issue")).toBeInTheDocument();
+
+    view.rerender(
+      <MemoryRouter>
+        <IssueCommandPanel
+          identifier="no-selection"
+          activeTab="overview"
+          onActiveTabChange={() => {}}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Runtime mount 2")).toBeInTheDocument();
+
+    view.rerender(
+      <MemoryRouter>
+        <IssueCommandPanel
+          identifier={null}
+          activeTab="overview"
+          onActiveTabChange={() => {}}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Select an issue")).toBeInTheDocument();
+
+    view.rerender(
+      <MemoryRouter>
+        <IssueCommandPanel
+          identifier="no-selection"
+          activeTab="overview"
+          onActiveTabChange={() => {}}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Runtime mount 4")).toBeInTheDocument();
+  });
+
+  it("retries retryable issues and displays action errors inline", async () => {
+    const retryError = new Error("retry endpoint unavailable");
+    const dueAt = Date.now() + 60_000;
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        data: {
+          ...issue,
+          running: null,
+          retry: {
+            attempt: 2,
+            due_at_ms: dueAt,
+            error: "step failed",
+            issue_id: "issue-1",
+            issue_identifier: "repo#1",
+          },
+        },
+        isLiveRun: false,
+        retryMutation: mockMutation<IssueRuntimeState["retryMutation"]>(actions.retry, {
+          isError: true,
+          isIdle: false,
+          error: retryError,
+          status: "error",
+        }),
+      }),
+    );
+    renderPanel();
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(actions.retry).toHaveBeenCalledWith({ identifier: "repo#1" });
+    expect(screen.getByText("Scheduled retry")).toBeInTheDocument();
+    expect(screen.getByText("Attempt 2")).toBeInTheDocument();
+    expect(screen.getByText(new Date(dueAt).toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText("step failed")).toBeInTheDocument();
+    expect(screen.getByText("retry endpoint unavailable")).toBeInTheDocument();
+  });
+
+  it("shows latest activity and compact navigation controls in Overview", async () => {
+    const onActiveTabChange = vi.fn();
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        events: [
+          {
+            type: "output",
+            timestamp: "2026-07-09T10:06:00Z",
+            detail: "Compiled release binary",
+            runId: "run-1",
+            sequence: 1,
+            stepName: "build",
+          },
+        ],
+      }),
+    );
+    renderPanel("overview", { onActiveTabChange });
+
+    expect(screen.getByText("Latest activity")).toBeInTheDocument();
+    expect(screen.getByText("Compiled release binary")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View steps" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View transcript" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "View logs" }));
+    expect(onActiveTabChange).toHaveBeenCalledWith("logs");
+  });
+
+  it("activates and focuses Transcript from the Overview control", async () => {
+    function ControlledPanel() {
+      const [activeTab, setActiveTab] = useState<IssueCommandPanelTab>("overview");
+      return (
+        <IssueCommandPanel
+          identifier="repo#1"
+          activeTab={activeTab}
+          onActiveTabChange={setActiveTab}
+          onClose={() => {}}
+        />
+      );
+    }
+
+    render(
+      <MemoryRouter>
+        <ControlledPanel />
+      </MemoryRouter>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "View transcript" }));
+
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Transcript" })).toHaveFocus());
+    expect(screen.getByRole("tab", { name: "Transcript" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("summarizes pending finalize targets and requires confirmation", async () => {
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        data: {
+          ...issue,
+          finalize: {
+            status: "pending_approval",
+            repos: [
+              {
+                approval_required: true,
+                last_error: null,
+                mode: "push_and_pr",
+                repo: "acme/backend",
+                status: "pending_approval",
+              },
+            ],
+          },
+        },
+      }),
+    );
+    renderPanel();
+
+    await userEvent.click(screen.getByRole("button", { name: "Approve finalize" }));
+    const dialog = screen.getByRole("alertdialog");
+    expect(within(dialog).getByText(/acme\/backend/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/push_and_pr/)).toBeInTheDocument();
+    expect(actions.finalizeApprove).not.toHaveBeenCalled();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    expect(actions.finalizeApprove).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Approve finalize" }));
+    await userEvent.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "Approve finalize",
+      }),
+    );
+
+    expect(actions.finalizeApprove).toHaveBeenCalledWith({ identifier: "repo#1" });
+  });
+
+  it("invalidates finalize confirmation when pending targets change", async () => {
+    const finalizeRepo = {
+      approval_required: true,
+      last_error: null,
+      mode: "push_and_pr",
+      repo: "acme/backend",
+      status: "pending_approval",
+    };
+    const view = renderPanel();
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        data: {
+          ...issue,
+          finalize: { status: "pending_approval", repos: [finalizeRepo] },
+        },
+      }),
+    );
+    view.rerender(
+      <MemoryRouter>
+        <IssueCommandPanel
+          identifier="repo#1"
+          activeTab="overview"
+          onActiveTabChange={() => {}}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Approve finalize" }));
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        data: {
+          ...issue,
+          finalize: {
+            status: "pending_approval",
+            repos: [{ ...finalizeRepo, repo: "acme/frontend" }],
+          },
+        },
+      }),
+    );
+    view.rerender(
+      <MemoryRouter>
+        <IssueCommandPanel
+          identifier="repo#1"
+          activeTab="overview"
+          onActiveTabChange={() => {}}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+    expect(actions.finalizeApprove).not.toHaveBeenCalled();
+  });
+
+  it("retries failed finalize work", async () => {
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({ data: { ...issue, finalize: { status: "failed", repos: [] } } }),
+    );
+    renderPanel();
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry finalize" }));
+
+    expect(actions.finalizeRetry).toHaveBeenCalledWith({ identifier: "repo#1" });
+  });
+
+  it.each(["in_progress", "skipped_headless"])(
+    "shows %s finalize work passively",
+    (finalizeStatus) => {
+      vi.mocked(useIssueRuntime).mockReturnValue(
+        runtimeFixture({ data: { ...issue, finalize: { status: finalizeStatus, repos: [] } } }),
+      );
+      renderPanel();
+
+      expect(screen.getByText(finalizeStatus)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /finalize/i })).not.toBeInTheDocument();
+    },
+  );
+
+  it("submits and can cancel an open interaction from Respond", async () => {
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        interaction: openInteraction,
+        pendingQuestion: {
+          interactionId: "ask-1",
+          kind: "question",
+          status: "open",
+          awaitingResume: true,
+          question: "Which environment?",
+          whyBlocked: "A deployment target is required.",
+          suggestedAnswer: "staging",
+          stepName: "build",
+        },
+        composerError: "Previous response failed",
+      }),
+    );
+    renderPanel("respond");
+
+    expect(screen.getByText("Previous response failed")).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText("Reply"), "production");
+    await userEvent.click(screen.getByRole("button", { name: "Submit Reply" }));
+    await userEvent.click(screen.getByRole("button", { name: "Cancel Request" }));
+
+    expect(actions.submitReply).toHaveBeenCalledWith({ kind: "question", text: "production" });
+    expect(actions.cancel).toHaveBeenCalledWith({ id: "ask-1" });
+  });
+
+  it.each([
+    ["approval", "Reason (optional)", "Approve", { kind: "approval", approved: true, reason: "approved" }],
+    ["approval", "Reason (optional)", "Reject", { kind: "approval", approved: false, reason: "approved" }],
+    ["handoff", "Notes (optional)", "Complete", { kind: "handoff", completed: true, notes: "approved" }],
+    ["handoff", "Notes (optional)", "Incomplete", { kind: "handoff", completed: false, notes: "approved" }],
+  ] as const)("submits an explicit %s decision from %s", async (kind, inputLabel, buttonName, expected) => {
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        interaction: { ...openInteraction, kind },
+        pendingQuestion: {
+          interactionId: "ask-1",
+          kind,
+          status: "open",
+          awaitingResume: true,
+          question: "Operator decision?",
+          whyBlocked: "A decision is required.",
+          suggestedAnswer: null,
+          stepName: "build",
+        },
+      }),
+    );
+    renderPanel("respond");
+
+    await userEvent.type(screen.getByLabelText(inputLabel), "approved");
+    await userEvent.click(screen.getByRole("button", { name: buttonName }));
+
+    expect(actions.submitReply).toHaveBeenCalledWith(expected);
+  });
+
+  it("offers resume-only recovery for a resolved interaction", async () => {
+    const resumeInteraction = vi.fn().mockResolvedValue(true);
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        interaction: { ...openInteraction, status: "resolved", awaiting_resume: true },
+        pendingQuestion: {
+          interactionId: "ask-1",
+          kind: "question",
+          status: "resolved",
+          awaitingResume: true,
+          question: "Which environment?",
+          whyBlocked: "A deployment target is required.",
+          suggestedAnswer: null,
+          stepName: "build",
+        },
+        resumeInteraction,
+      }),
+    );
+    renderPanel("respond");
+
+    expect(screen.queryByRole("button", { name: "Submit Reply" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Resume issue" }));
+
+    expect(resumeInteraction).toHaveBeenCalledOnce();
+    expect(actions.submitReply).not.toHaveBeenCalled();
+  });
+
+  it("disables pending response submission and renders a passive Respond state", () => {
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        interaction: openInteraction,
+        pendingQuestion: {
+          interactionId: "ask-1",
+          kind: "question",
+          status: "open",
+          awaitingResume: true,
+          question: "Which environment?",
+          whyBlocked: "A deployment target is required.",
+          suggestedAnswer: null,
+          stepName: "build",
+        },
+        respondMutation: mockMutation<IssueRuntimeState["respondMutation"]>(vi.fn(), {
+          isIdle: false,
+          isPending: true,
+          status: "pending",
+        }),
+      }),
+    );
+    const view = renderPanel("respond");
+    expect(screen.getByRole("button", { name: "Submit Reply" })).toBeDisabled();
+
+    vi.mocked(useIssueRuntime).mockReturnValue(runtimeFixture());
+    view.rerender(
+      <MemoryRouter>
+        <IssueCommandPanel
+          identifier="repo#1"
+          activeTab="respond"
+          onActiveTabChange={() => {}}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/No response is currently available/)).toBeInTheDocument();
+  });
+
+  it("distinguishes interaction loading and failure from a passive Respond state", () => {
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({ interactionIsLoading: true }),
+    );
+    const view = renderPanel("respond");
+
+    expect(screen.getByText("Loading interaction...")).toBeInTheDocument();
+    expect(screen.queryByText(/No response is currently available/)).not.toBeInTheDocument();
+
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        interactionIsLoading: false,
+        interactionIsError: true,
+        interactionError: new Error("interaction endpoint unavailable"),
+      }),
+    );
+    view.rerender(
+      <MemoryRouter>
+        <IssueCommandPanel
+          identifier="repo#1"
+          activeTab="respond"
+          onActiveTabChange={() => {}}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Failed to load interaction")).toBeInTheDocument();
+    expect(screen.getByText("interaction endpoint unavailable")).toBeInTheDocument();
+    expect(screen.queryByText(/No response is currently available/)).not.toBeInTheDocument();
+  });
+
+  it.each(["resolved", "cancelled"] satisfies InteractionStatus[])(
+    "does not offer cancellation for a %s interaction",
+    (status) => {
+      vi.mocked(useIssueRuntime).mockReturnValue(
+        runtimeFixture({ interaction: { ...openInteraction, status } }),
+      );
+      renderPanel("respond");
+
+      expect(screen.queryByRole("button", { name: "Cancel Request" })).not.toBeInTheDocument();
+    },
+  );
+
+  it("renders steps and a true empty transcript state", () => {
+    const stepsView = renderPanel("steps");
+    expect(screen.getByRole("link", { name: "build" })).toHaveAttribute(
+      "href",
+      "/issue/repo%231/step/build",
+    );
+
+    stepsView.unmount();
+    renderPanel("transcript");
+    expect(screen.getByText("No transcript activity yet.")).toBeInTheDocument();
+  });
+
+  it("distinguishes transcript persistence failure from an empty transcript", () => {
+    vi.mocked(useIssueRuntime).mockReturnValue(runtimeFixture({ transcriptIsError: true }));
+    renderPanel("transcript");
+
+    expect(screen.getByText(/Could not load saved transcript history/)).toBeInTheDocument();
+    expect(screen.queryByText("No transcript activity yet.")).not.toBeInTheDocument();
+  });
+
+  it("focuses Transcript after conversation-driven navigation", async () => {
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        timelineIsError: true,
+        events: [
+          {
+            type: "turn_completed",
+            timestamp: "2026-07-09T10:06:00Z",
+            detail: "Turn complete",
+            runId: "run-1",
+            sequence: 1,
+            conversationIndex: 4,
+          },
+        ],
+      }),
+    );
+    function ControlledPanel() {
+      const [activeTab, setActiveTab] = useState<IssueCommandPanelTab>("logs");
+      return (
+        <IssueCommandPanel
+          identifier="repo#1"
+          activeTab={activeTab}
+          onActiveTabChange={setActiveTab}
+          onClose={() => {}}
+        />
+      );
+    }
+    render(
+      <MemoryRouter>
+        <ControlledPanel />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/Could not load saved timeline history/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "View in conversation" }));
+    expect(actions.setActiveEntryForConversation).toHaveBeenCalledWith(4);
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Transcript" })).toHaveFocus());
+    expect(screen.getByRole("tab", { name: "Transcript" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("renders an explicit empty artifact state with issue information", () => {
+    renderPanel("artifacts");
+
+    expect(screen.getByText("No run artifacts recorded.")).toBeInTheDocument();
+    expect(screen.queryByText("Workspace")).not.toBeInTheDocument();
+    expect(screen.getByText("Ship the command panel")).toBeInTheDocument();
+  });
+
+  it("reuses the artifact panel when run artifacts exist", () => {
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        data: {
+          ...issue,
+          artifacts: {
+            repos: [],
+            run_id: "run-1",
+            transcripts: [],
+            workspace_path: "/tmp/artifact-workspace",
+          },
+        },
+      }),
+    );
+    renderPanel("artifacts");
+
+    expect(screen.getByText("Workspace")).toBeInTheDocument();
+    expect(screen.getByText("/tmp/artifact-workspace")).toBeInTheDocument();
+    expect(screen.queryByText("No run artifacts recorded.")).not.toBeInTheDocument();
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.tsx
@@ -1,0 +1,538 @@
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from "react";
+import { X } from "lucide-react";
+import ArtifactsPanel from "@/components/ArtifactsPanel";
+import ConfirmDialog from "@/components/ConfirmDialog";
+import FinalizeApprovalDialog from "@/components/FinalizeApprovalDialog";
+import EventTimeline from "@/components/EventTimeline";
+import IssueInfoSection from "@/components/IssueInfoSection";
+import StatusBadge from "@/components/StatusBadge";
+import WorkflowStepsSidebar from "@/components/WorkflowStepsSidebar";
+import { IssueComposer } from "@/components/issue-detail/IssueComposer";
+import { RunTranscript } from "@/components/transcript/RunTranscript";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useIssueRuntime } from "./useIssueRuntime";
+
+export type IssueCommandPanelTab =
+  | "overview"
+  | "respond"
+  | "steps"
+  | "transcript"
+  | "logs"
+  | "artifacts";
+
+interface IssueCommandPanelProps {
+  identifier: string | null;
+  activeTab: IssueCommandPanelTab;
+  onActiveTabChange: (tab: IssueCommandPanelTab) => void;
+  onClose: () => void;
+}
+
+const TABS: Array<{ id: IssueCommandPanelTab; label: string }> = [
+  { id: "overview", label: "Overview" },
+  { id: "respond", label: "Respond" },
+  { id: "steps", label: "Steps" },
+  { id: "transcript", label: "Transcript" },
+  { id: "logs", label: "Logs" },
+  { id: "artifacts", label: "Artifacts" },
+];
+
+function formatTokens(value: number | undefined): string {
+  if (value == null) return "--";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return String(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Request failed";
+}
+
+function PanelCloseButton({ onClose }: { onClose: () => void }) {
+  return (
+    <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close issue panel">
+      <X className="h-4 w-4" />
+    </Button>
+  );
+}
+
+export function IssueCommandPanel({
+  identifier,
+  activeTab,
+  onActiveTabChange,
+  onClose,
+}: IssueCommandPanelProps) {
+  return (
+    <IssueCommandPanelContent
+      key={identifier === null ? "empty" : `issue:${identifier}`}
+      identifier={identifier}
+      activeTab={activeTab}
+      onActiveTabChange={onActiveTabChange}
+      onClose={onClose}
+    />
+  );
+}
+
+function IssueCommandPanelContent({
+  identifier,
+  activeTab,
+  onActiveTabChange,
+  onClose,
+}: IssueCommandPanelProps) {
+  const runtime = useIssueRuntime(identifier ?? "");
+  const [stopConfirmationIdentifier, setStopConfirmationIdentifier] = useState<string | null>(
+    null,
+  );
+  const [showFinalizeConfirm, setShowFinalizeConfirm] = useState(false);
+  const tabSetId = useId();
+  const tabPanelId = `${tabSetId}-panel`;
+  const tabId = (tab: IssueCommandPanelTab) => `${tabSetId}-${tab}`;
+  const requestedFocusTab = useRef<IssueCommandPanelTab | null>(null);
+
+  useEffect(() => {
+    if (requestedFocusTab.current !== activeTab) return;
+    document.getElementById(`${tabSetId}-${activeTab}`)?.focus();
+    requestedFocusTab.current = null;
+  }, [activeTab, tabSetId]);
+
+  const activateTab = (tab: IssueCommandPanelTab, moveFocus = false) => {
+    if (moveFocus) requestedFocusTab.current = tab;
+    onActiveTabChange(tab);
+  };
+
+  if (!identifier) {
+    return (
+      <aside className="flex h-full min-h-[28rem] w-full flex-col rounded-xl border bg-card p-6 lg:w-[28rem]">
+        <h2 className="text-lg font-semibold">Select an issue</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Choose an issue from the board, list, or attention queue to inspect and intervene.
+        </p>
+      </aside>
+    );
+  }
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    interaction,
+    interactionIsLoading,
+    interactionIsError,
+    interactionError,
+    pendingQuestion,
+    isLiveRun,
+    wsStatus,
+    events,
+    transcriptEntries,
+    activeTranscriptEntryId,
+    transcriptSessionKey,
+    transcriptIsError,
+    timelineIsError,
+    retryMutation,
+    stopMutation,
+    respondMutation,
+    resumeMutation,
+    cancelMutation,
+    finalizeApproveMutation,
+    finalizeRetryMutation,
+    composerError,
+    resumeQueued,
+    submitInteractionReply,
+    resumeInteraction,
+    setActiveEntryIdForConversationIndex,
+    setActiveEntryId,
+  } = runtime;
+
+  if (isLoading) {
+    return (
+      <aside className="min-h-[28rem] w-full rounded-xl border bg-card p-6 lg:w-[30rem] xl:w-[34rem]">
+        <div className="flex items-start justify-between gap-3">
+          <span className="text-sm text-muted-foreground">Loading issue...</span>
+          <PanelCloseButton onClose={onClose} />
+        </div>
+      </aside>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <aside className="min-h-[28rem] w-full rounded-xl border bg-card p-6 lg:w-[30rem] xl:w-[34rem]">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="font-semibold text-destructive">Failed to load issue</div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {isError ? errorMessage(error) : "Issue details were not returned."}
+            </p>
+          </div>
+          <PanelCloseButton onClose={onClose} />
+        </div>
+      </aside>
+    );
+  }
+
+  const finalizeStatus = data.finalize.status;
+  const actionError = [
+    stopMutation,
+    retryMutation,
+    cancelMutation,
+    finalizeApproveMutation,
+    finalizeRetryMutation,
+  ].find((mutation) => mutation.isError)?.error;
+  const interactionSubmitting =
+    respondMutation.isPending || resumeMutation.isPending || resumeQueued;
+  const activeTabId = tabId(activeTab);
+  const currentAgent = data.running?.step_name
+    ? data.workflow_steps.find((step) => step.name === data.running?.step_name)?.agent
+    : undefined;
+  const latestEvent = events[events.length - 1];
+  const latestActivity = latestEvent?.detail ?? data.running?.last_event ?? data.running?.last_message;
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex: number | null = null;
+    switch (event.key) {
+      case "ArrowRight":
+        nextIndex = (index + 1) % TABS.length;
+        break;
+      case "ArrowLeft":
+        nextIndex = (index - 1 + TABS.length) % TABS.length;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = TABS.length - 1;
+        break;
+    }
+
+    if (nextIndex == null) return;
+    event.preventDefault();
+    const nextTab = TABS[nextIndex]!;
+    activateTab(nextTab.id, true);
+  };
+
+  const tabContent = (() => {
+    switch (activeTab) {
+      case "overview":
+        return (
+          <div className="space-y-4">
+            {pendingQuestion ? (
+              <button
+                type="button"
+                onClick={() => activateTab("respond", true)}
+                className="w-full rounded-lg border border-primary/40 bg-primary/5 p-3 text-left transition-colors hover:bg-primary/10"
+              >
+                <div className="text-sm font-semibold text-primary">Agent needs input</div>
+                <p className="mt-1 text-sm">{pendingQuestion.question}</p>
+              </button>
+            ) : null}
+
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div className="rounded-lg border bg-muted/20 p-3">
+                <div className="text-muted-foreground">Status</div>
+                <div className="mt-1 font-semibold">{data.status}</div>
+              </div>
+              <div className="rounded-lg border bg-muted/20 p-3">
+                <div className="text-muted-foreground">Current step</div>
+                <div className="mt-1 font-semibold">{data.running?.step_name ?? "--"}</div>
+              </div>
+              {currentAgent ? (
+                <div className="rounded-lg border bg-muted/20 p-3">
+                  <div className="text-muted-foreground">Current agent</div>
+                  <div className="mt-1 font-semibold">{currentAgent}</div>
+                </div>
+              ) : null}
+              <div className="rounded-lg border bg-muted/20 p-3">
+                <div className="text-muted-foreground">Attempts</div>
+                <div className="mt-1 font-semibold">{data.attempts.restart_count}</div>
+              </div>
+              <div className="rounded-lg border bg-muted/20 p-3">
+                <div className="text-muted-foreground">Turns</div>
+                <div className="mt-1 font-semibold">{data.running?.turn_count ?? 0}</div>
+              </div>
+              <div className="col-span-2 rounded-lg border bg-muted/20 p-3">
+                <div className="text-muted-foreground">Tokens</div>
+                <div className="mt-1 font-semibold">
+                  {formatTokens(data.running?.tokens.total_tokens)}
+                </div>
+              </div>
+            </div>
+
+            {data.retry ? (
+              <div className="rounded-lg border border-amber-300/70 bg-amber-50/60 p-3 text-sm dark:border-amber-900 dark:bg-amber-950/20">
+                <div className="font-medium">Scheduled retry</div>
+                <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-muted-foreground">
+                  <span>Attempt {data.retry.attempt}</span>
+                  <span>{new Date(data.retry.due_at_ms).toLocaleString()}</span>
+                </div>
+                {data.retry.error ? <p className="mt-2 whitespace-pre-wrap">{data.retry.error}</p> : null}
+              </div>
+            ) : null}
+
+            {latestActivity ? (
+              <div className="rounded-lg border bg-muted/20 p-3 text-sm">
+                <div className="font-medium">Latest activity</div>
+                <p className="mt-1 whitespace-pre-wrap text-muted-foreground">{latestActivity}</p>
+              </div>
+            ) : null}
+
+            {finalizeStatus !== "not_required" ? (
+              <div className="rounded-lg border bg-muted/20 p-3 text-sm">
+                <div className="font-medium">Finalize</div>
+                <div className="mt-1 text-muted-foreground">{finalizeStatus}</div>
+              </div>
+            ) : null}
+
+            {data.last_error ? (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm">
+                <div className="font-medium text-destructive">Last error</div>
+                <p className="mt-1 whitespace-pre-wrap">{data.last_error}</p>
+              </div>
+            ) : null}
+
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" size="sm" onClick={() => activateTab("steps", true)}>
+                View steps
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => activateTab("transcript", true)}
+              >
+                View transcript
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => activateTab("logs", true)}>
+                View logs
+              </Button>
+            </div>
+          </div>
+        );
+      case "respond":
+        return (
+          <div className="space-y-3">
+            {interactionIsLoading ? (
+              <div className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+                Loading interaction...
+              </div>
+            ) : interactionIsError ? (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm">
+                <div className="font-medium text-destructive">Failed to load interaction</div>
+                <p className="mt-1 text-muted-foreground">{errorMessage(interactionError)}</p>
+              </div>
+            ) : pendingQuestion ? (
+              <IssueComposer
+                key={`${identifier}:${pendingQuestion.interactionId}`}
+                pendingQuestion={pendingQuestion}
+                onSubmitReply={submitInteractionReply}
+                onSubmitFollowUp={() => false}
+                onResumeInteraction={resumeInteraction}
+                isSubmitting={interactionSubmitting}
+                error={composerError}
+              />
+            ) : (
+              <div className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+                No response is currently available. Use Transcript or Steps to inspect the issue.
+              </div>
+            )}
+            {!interactionIsLoading && !interactionIsError && interaction?.status === "open" ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => cancelMutation.mutate({ id: interaction.id })}
+                disabled={cancelMutation.isPending}
+              >
+                Cancel Request
+              </Button>
+            ) : null}
+          </div>
+        );
+      case "steps":
+        return data.workflow_steps.length > 0 ? (
+          <WorkflowStepsSidebar
+            steps={data.workflow_steps}
+            issueIdentifier={identifier}
+            currentStep={data.running?.step_name ?? undefined}
+          />
+        ) : (
+          <div className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+            No workflow steps available.
+          </div>
+        );
+      case "transcript":
+        return transcriptIsError && transcriptEntries.length === 0 ? (
+          <div className="rounded-lg border border-amber-300/70 bg-amber-50/60 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/20 dark:text-amber-100">
+            Could not load saved transcript history.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {transcriptIsError ? (
+              <p className="text-sm text-amber-700 dark:text-amber-400">
+                Could not load saved transcript history; showing live activity only.
+              </p>
+            ) : null}
+            <RunTranscript
+              entries={transcriptEntries}
+              activeEntryId={activeTranscriptEntryId}
+              onJumpToEntry={setActiveEntryId}
+              transcriptSessionKey={transcriptSessionKey}
+            />
+          </div>
+        );
+      case "logs":
+        return (
+          <div className="space-y-3">
+            {timelineIsError ? (
+              <p className="text-sm text-amber-700 dark:text-amber-400">
+                Could not load saved timeline history; showing live events only.
+              </p>
+            ) : null}
+            <EventTimeline
+              events={events}
+              live={isLiveRun}
+              onViewConversation={(index) => {
+                setActiveEntryIdForConversationIndex(index);
+                activateTab("transcript", true);
+              }}
+            />
+          </div>
+        );
+      case "artifacts":
+        return (
+          <div className="space-y-3">
+            {data.artifacts ? (
+              <ArtifactsPanel
+                identifier={identifier}
+                workspacePath={data.workspace.path}
+                artifacts={data.artifacts}
+              />
+            ) : (
+              <div className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+                No run artifacts recorded.
+              </div>
+            )}
+            <IssueInfoSection issue={data.issue} />
+          </div>
+        );
+    }
+  })();
+
+  return (
+    <aside className="flex h-full min-h-[34rem] w-full flex-col overflow-hidden rounded-xl border bg-card shadow-sm lg:w-[30rem] xl:w-[34rem]">
+      <div className="border-b p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="truncate text-lg font-semibold">{data.issue_identifier}</h2>
+              <StatusBadge status={data.status} />
+            </div>
+            <p className="mt-1 truncate text-sm text-muted-foreground">{data.issue.title}</p>
+          </div>
+          <PanelCloseButton onClose={onClose} />
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {isLiveRun ? (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setStopConfirmationIdentifier(identifier)}
+            >
+              Stop
+            </Button>
+          ) : null}
+          {data.retry ? (
+            <Button
+              size="sm"
+              onClick={() => retryMutation.mutate({ identifier })}
+              disabled={retryMutation.isPending}
+            >
+              Retry
+            </Button>
+          ) : null}
+          {finalizeStatus === "pending_approval" ? (
+            <Button
+              size="sm"
+              onClick={() => setShowFinalizeConfirm(true)}
+              disabled={finalizeApproveMutation.isPending}
+            >
+              Approve finalize
+            </Button>
+          ) : null}
+          {finalizeStatus === "failed" ? (
+            <Button
+              size="sm"
+              onClick={() => finalizeRetryMutation.mutate({ identifier })}
+              disabled={finalizeRetryMutation.isPending}
+            >
+              Retry finalize
+            </Button>
+          ) : null}
+          <span className="rounded-full border px-2 py-1 text-xs text-muted-foreground">
+            WS: {isLiveRun ? wsStatus : "inactive"}
+          </span>
+        </div>
+
+        {actionError ? (
+          <p role="alert" className="mt-3 text-sm text-destructive">
+            {errorMessage(actionError)}
+          </p>
+        ) : null}
+      </div>
+
+      <div role="tablist" aria-label="Issue command views" className="flex shrink-0 gap-1 overflow-x-auto border-b px-3 py-2">
+        {TABS.map((tab, index) => (
+          <button
+            key={tab.id}
+            id={tabId(tab.id)}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={tabPanelId}
+            tabIndex={activeTab === tab.id ? 0 : -1}
+            onClick={() => onActiveTabChange(tab.id)}
+            onKeyDown={(event) => handleTabKeyDown(event, index)}
+            className={cn(
+              "rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground",
+              activeTab === tab.id && "bg-muted text-foreground",
+              tab.id === "respond" && pendingQuestion && "text-primary",
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        id={tabPanelId}
+        role="tabpanel"
+        aria-labelledby={activeTabId}
+        className="min-h-0 flex-1 overflow-auto p-4"
+      >
+        {tabContent}
+      </div>
+
+      <ConfirmDialog
+        open={stopConfirmationIdentifier === identifier}
+        title="Stop Agent"
+        message={`Are you sure you want to stop the agent for ${identifier}? This action cannot be undone.`}
+        confirmLabel="Stop"
+        onConfirm={() => {
+          stopMutation.mutate({ identifier });
+          setStopConfirmationIdentifier(null);
+        }}
+        onCancel={() => setStopConfirmationIdentifier(null)}
+      />
+      <FinalizeApprovalDialog
+        open={showFinalizeConfirm}
+        status={data.finalize.status}
+        repos={data.finalize.repos}
+        isPending={finalizeApproveMutation.isPending}
+        onConfirm={() => {
+          finalizeApproveMutation.mutate({ identifier });
+          setShowFinalizeConfirm(false);
+        }}
+        onCancel={() => setShowFinalizeConfirm(false)}
+      />
+    </aside>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
@@ -835,7 +835,7 @@ describe("Mission Control page", () => {
     });
 
     expect(await screen.findByText("Select an issue")).toBeInTheDocument();
-    expect(operations).toHaveFocus();
+    await waitFor(() => expect(operations).toHaveFocus());
   });
 
   it("does not move focus or scroll the panel after desktop selection", async () => {

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
@@ -1,0 +1,1031 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { useState } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { postRefresh } from "@/generated/api/controls/controls";
+import { getState } from "@/generated/api/state/state";
+import type { IssueDetailSnapshot, RuntimeSnapshot } from "@/generated/models";
+import { AttentionQueue } from "./AttentionQueue";
+import MissionControl from "./MissionControl";
+import { MissionControlToolbar } from "./MissionControlToolbar";
+import { OperationsBoard } from "./OperationsBoard";
+import { OperationsList } from "./OperationsList";
+import type { MissionAttentionItem, MissionGroup, MissionIssueSummary, MissionSystemStats } from "./model";
+import { useIssueRuntime, type IssueRuntimeState } from "./useIssueRuntime";
+
+vi.mock("@/generated/api/controls/controls", () => ({ postRefresh: vi.fn() }));
+vi.mock("@/generated/api/state/state", () => ({ getState: vi.fn() }));
+vi.mock("./useIssueRuntime", () => ({ useIssueRuntime: vi.fn() }));
+
+const VIEW_MODE_KEY = "ensemble.mission-control.view-mode";
+const ACTIVE_TAB_KEY = "ensemble.mission-control.active-tab";
+const ATTENTION_ONLY_KEY = "ensemble.mission-control.attention-only";
+const originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
+const originalScrollIntoView = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "scrollIntoView",
+);
+
+const storedPreferences = new Map<string, string>();
+const testStorage: Storage = {
+  get length() {
+    return storedPreferences.size;
+  },
+  clear: () => storedPreferences.clear(),
+  getItem: (key) => storedPreferences.get(key) ?? null,
+  key: (index) => [...storedPreferences.keys()][index] ?? null,
+  removeItem: (key) => storedPreferences.delete(key),
+  setItem: (key, value) => storedPreferences.set(key, value),
+};
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockReturnValue({
+      matches,
+      media: "(min-width: 1280px)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+}
+
+function restoreProperty(
+  object: object,
+  key: PropertyKey,
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(object, key, descriptor);
+  } else {
+    Reflect.deleteProperty(object, key);
+  }
+}
+
+const stats: MissionSystemStats = {
+  running: 2,
+  retrying: 1,
+  waitingOnHuman: 1,
+  completed: 3,
+  failed: 1,
+  generatedAt: "2026-07-09T09:30:00Z",
+  lastTickAt: "2026-07-09T09:29:58Z",
+  pollIntervalMs: 3000,
+  rateLimitRemaining: 8,
+  rateLimitLimit: 100,
+  rateLimitResetAt: "2026-07-09T10:00:00Z",
+};
+
+const attentionItems: MissionAttentionItem[] = [
+  {
+    id: "ask-1",
+    issueId: "issue-1",
+    issueIdentifier: "repo#1",
+    kind: "human_input",
+    title: "Agent needs input",
+    detail: "Waiting in review",
+    stepName: "review",
+    requestedAt: "2026-07-09T09:10:00Z",
+    primaryAction: "Reply",
+  },
+];
+
+function issue(overrides: Partial<MissionIssueSummary> = {}): MissionIssueSummary {
+  return {
+    id: "issue-1",
+    identifier: "repo#1",
+    status: "running",
+    statusLabel: "Running",
+    stepName: "build",
+    activity: "Running tests",
+    updatedAt: "2026-07-09T09:29:50Z",
+    startedAt: "2026-07-09T09:00:00Z",
+    completedAt: null,
+    retryAttempt: null,
+    tokenTotal: 150,
+    turnCount: 3,
+    attention: false,
+    source: {} as MissionIssueSummary["source"],
+    ...overrides,
+  };
+}
+
+function runtimeSnapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
+  return {
+    agent_totals: { input_tokens: 100, output_tokens: 50, total_tokens: 150, seconds_running: 60 },
+    counts: { running: 1, retrying: 1, waiting_on_human: 1, completed: 1 },
+    generated_at: "2026-07-09T09:30:00Z",
+    last_tick_at: "2026-07-09T09:29:58Z",
+    poll_interval_ms: 3000,
+    running: [
+      {
+        issue_id: "issue-running",
+        issue_identifier: "repo#1",
+        last_event: "tool_call",
+        last_event_at: "2026-07-09T09:29:50Z",
+        last_message: "Running tests",
+        session_id: "session-1",
+        started_at: "2026-07-09T09:00:00Z",
+        state: "running",
+        step_name: "build",
+        tokens: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+        turn_count: 3,
+      },
+    ],
+    retrying: [
+      {
+        issue_id: "issue-retry",
+        issue_identifier: "repo#2",
+        attempt: 2,
+        due_at_ms: 1000,
+        error: "clippy failed",
+      },
+    ],
+    waiting_on_human: [
+      {
+        interaction_request_id: "ask-1",
+        issue_id: "issue-waiting",
+        issue_identifier: "repo#3",
+        requested_at: "2026-07-09T09:10:00Z",
+        step_name: "review",
+      },
+    ],
+    completed: [
+      {
+        issue_id: "issue-completed",
+        issue_identifier: "repo#4",
+        completed_at: "2026-07-09T09:20:00Z",
+        status: "completed_succeeded",
+      },
+    ],
+    ...overrides,
+  } as RuntimeSnapshot;
+}
+
+function mockMutation<T>(): T {
+  return {
+    error: null,
+    isError: false,
+    isPending: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+  } as T;
+}
+
+function runtimeFixture(identifier: string): IssueRuntimeState {
+  const data = {
+    issue_identifier: identifier,
+    issue_id: `id:${identifier}`,
+    status: "running",
+    running: null,
+    retry: null,
+    attempts: { restart_count: 0, current_retry_attempt: null },
+    workspace: { path: "/tmp/workspace" },
+    workflow_steps: [],
+    artifacts: null,
+    finalize: { status: "not_required", repos: [] },
+    issue: { title: `Selected ${identifier}`, description: null, labels: [] },
+    last_error: null,
+    pending_input: null,
+    current_interaction: null,
+  } satisfies IssueDetailSnapshot;
+
+  return {
+    identifier,
+    data,
+    isLoading: false,
+    isError: false,
+    error: null,
+    interaction: undefined,
+    interactionIsLoading: false,
+    interactionIsError: false,
+    interactionError: null,
+    pendingQuestion: null,
+    isLiveRun: false,
+    wsStatus: "disconnected",
+    effectiveRunId: "",
+    activeStepName: null,
+    events: [],
+    transcriptEntries: [],
+    activeTranscriptEntryId: null,
+    transcriptSessionKey: `${identifier}:idle`,
+    transcriptIsError: false,
+    timelineIsError: false,
+    retryMutation: mockMutation<IssueRuntimeState["retryMutation"]>(),
+    stopMutation: mockMutation<IssueRuntimeState["stopMutation"]>(),
+    respondMutation: mockMutation<IssueRuntimeState["respondMutation"]>(),
+    resumeMutation: mockMutation<IssueRuntimeState["resumeMutation"]>(),
+    cancelMutation: mockMutation<IssueRuntimeState["cancelMutation"]>(),
+    finalizeApproveMutation: mockMutation<IssueRuntimeState["finalizeApproveMutation"]>(),
+    finalizeRetryMutation: mockMutation<IssueRuntimeState["finalizeRetryMutation"]>(),
+    composerError: null,
+    resumeQueued: false,
+    submitInteractionReply: vi.fn(),
+    resumeInteraction: vi.fn(),
+    submitFollowUpInput: vi.fn(),
+    setActiveEntryIdForConversationIndex: vi.fn(),
+    setActiveEntryId: vi.fn(),
+  };
+}
+
+function renderMissionControl(snapshot?: RuntimeSnapshot) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  if (snapshot) queryClient.setQueryData(["/api/v1/state"], { data: snapshot });
+
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MissionControl />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+function missionGroups(overrides: Partial<Record<MissionGroup["id"], MissionIssueSummary[]>> = {}): MissionGroup[] {
+  return [
+    { id: "running", title: "Running", issues: overrides.running ?? [issue()] },
+    { id: "retrying", title: "Retrying", issues: overrides.retrying ?? [] },
+    { id: "waiting_on_human", title: "Waiting on Human", issues: overrides.waiting_on_human ?? [] },
+    { id: "completed_recently", title: "Completed Recently", issues: overrides.completed_recently ?? [] },
+    { id: "failed_or_blocked", title: "Failed or Blocked", issues: overrides.failed_or_blocked ?? [] },
+  ];
+}
+
+function renderToolbar(overrides: Partial<ComponentProps<typeof MissionControlToolbar>> = {}) {
+  return render(
+    <MissionControlToolbar
+      stats={stats}
+      query=""
+      status="all"
+      attentionOnly={false}
+      viewMode="board"
+      isRefreshing={false}
+      onQueryChange={() => {}}
+      onStatusChange={() => {}}
+      onAttentionOnlyChange={() => {}}
+      onViewModeChange={() => {}}
+      onRefresh={() => {}}
+      {...overrides}
+    />,
+  );
+}
+
+function ToolbarControlHarness({
+  onQueryChange,
+  onStatusChange,
+  onAttentionOnlyChange,
+  onViewModeChange,
+  onRefresh,
+}: Pick<
+  ComponentProps<typeof MissionControlToolbar>,
+  | "onQueryChange"
+  | "onStatusChange"
+  | "onAttentionOnlyChange"
+  | "onViewModeChange"
+  | "onRefresh"
+>) {
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState<ComponentProps<typeof MissionControlToolbar>["status"]>("all");
+  const [attentionOnly, setAttentionOnly] = useState(false);
+  const [viewMode, setViewMode] = useState<ComponentProps<typeof MissionControlToolbar>["viewMode"]>(
+    "board",
+  );
+
+  return (
+    <MissionControlToolbar
+      stats={stats}
+      query={query}
+      status={status}
+      attentionOnly={attentionOnly}
+      viewMode={viewMode}
+      isRefreshing={false}
+      onQueryChange={(value) => {
+        onQueryChange(value);
+        setQuery(value);
+      }}
+      onStatusChange={(value) => {
+        onStatusChange(value);
+        setStatus(value);
+      }}
+      onAttentionOnlyChange={(value) => {
+        onAttentionOnlyChange(value);
+        setAttentionOnly(value);
+      }}
+      onViewModeChange={(value) => {
+        onViewModeChange(value);
+        setViewMode(value);
+      }}
+      onRefresh={onRefresh}
+    />
+  );
+}
+
+describe("Mission Control shell components", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders compact system stats and view controls", () => {
+    renderToolbar();
+
+    expect(screen.getByText("Mission Control")).toBeInTheDocument();
+    expect(screen.getByText("2 running")).toBeInTheDocument();
+    expect(screen.getByText("1 retrying")).toBeInTheDocument();
+    expect(screen.getByText("1 waiting")).toBeInTheDocument();
+    expect(screen.getByText("3 completed")).toBeInTheDocument();
+    expect(screen.getByText("1 failed")).toBeInTheDocument();
+    expect(screen.getByText(/Rate low: 8\/100/)).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Search issues" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Status" })).toHaveValue("all");
+    expect(screen.getByRole("button", { name: "Attention only" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Board" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "List" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+  });
+
+  it("renders the last tick timestamp", () => {
+    renderToolbar();
+
+    const expectedTick = new Date(stats.lastTickAt ?? "").toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+
+    expect(screen.getByText(`Last tick ${expectedTick}`)).toBeInTheDocument();
+  });
+
+  it("marks system health stale when time advances without a rerender", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T09:30:05Z"));
+    renderToolbar();
+
+    expect(screen.getByRole("status", { name: /System live and fresh/i })).toHaveTextContent(
+      "Live / Fresh",
+    );
+
+    act(() => vi.advanceTimersByTime(4_000));
+
+    expect(screen.getByRole("status", { name: /System stale/i })).toHaveTextContent("Stale");
+  });
+
+  it("cleans up the system freshness clock on unmount", () => {
+    vi.useFakeTimers();
+    const view = renderToolbar();
+
+    expect(vi.getTimerCount()).toBe(1);
+    view.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("distinguishes normal rate capacity from a low-capacity warning with reset time", () => {
+    const normal = renderToolbar({
+      stats: { ...stats, rateLimitRemaining: 50 },
+    });
+    expect(screen.getByText("Rate 50/100")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    normal.rerender(
+      <MissionControlToolbar
+        stats={stats}
+        query=""
+        status="all"
+        attentionOnly={false}
+        viewMode="board"
+        isRefreshing={false}
+        onQueryChange={() => {}}
+        onStatusChange={() => {}}
+        onAttentionOnlyChange={() => {}}
+        onViewModeChange={() => {}}
+        onRefresh={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Rate low: 8/100");
+    expect(screen.getByRole("alert")).toHaveTextContent("resets");
+  });
+
+  it("omits rate text when rate limit values are unavailable", () => {
+    renderToolbar({
+      stats: {
+        ...stats,
+        rateLimitLimit: null,
+        rateLimitRemaining: null,
+        rateLimitResetAt: null,
+      },
+    });
+
+    expect(screen.queryByText(/Rate /)).not.toBeInTheDocument();
+  });
+
+  it("reports toolbar control changes", async () => {
+    const user = userEvent.setup();
+    const onQueryChange = vi.fn();
+    const onStatusChange = vi.fn();
+    const onAttentionOnlyChange = vi.fn();
+    const onViewModeChange = vi.fn();
+    const onRefresh = vi.fn();
+    render(
+      <ToolbarControlHarness
+        onQueryChange={onQueryChange}
+        onStatusChange={onStatusChange}
+        onAttentionOnlyChange={onAttentionOnlyChange}
+        onViewModeChange={onViewModeChange}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: "Search issues" }), "repo#1");
+    await user.selectOptions(screen.getByRole("combobox", { name: "Status" }), "retrying");
+    await user.click(screen.getByRole("button", { name: "Attention only" }));
+    await user.click(screen.getByRole("button", { name: "List" }));
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(onQueryChange).toHaveBeenLastCalledWith("repo#1");
+    expect(onStatusChange).toHaveBeenCalledWith("retrying");
+    expect(onAttentionOnlyChange).toHaveBeenCalledWith(true);
+    expect(onViewModeChange).toHaveBeenCalledWith("list");
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects an attention item", async () => {
+    const onSelectIssue = vi.fn();
+    render(
+      <AttentionQueue
+        items={attentionItems}
+        selectedIssueIdentifier={null}
+        onSelectIssue={onSelectIssue}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Reply to repo#1/i }));
+
+    expect(onSelectIssue).toHaveBeenCalledWith("repo#1");
+  });
+
+  it("renders attention item details and selected state", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T09:42:00Z"));
+
+    render(
+      <AttentionQueue
+        items={[
+          ...attentionItems,
+          {
+            id: "retry:issue-2",
+            issueId: "issue-2",
+            issueIdentifier: "repo#2",
+            kind: "retry",
+            title: "Retry scheduled",
+            detail: "clippy failed",
+            stepName: null,
+            requestedAt: null,
+            primaryAction: "Inspect",
+          },
+          {
+            id: "failure:issue-3",
+            issueId: "issue-3",
+            issueIdentifier: "repo#failed",
+            kind: "failure",
+            title: "Run failed",
+            detail: "completed_failed",
+            stepName: null,
+            requestedAt: "2026-07-09T09:30:00Z",
+            primaryAction: "Inspect",
+          },
+        ]}
+        selectedIssueIdentifier="repo#1"
+        onSelectIssue={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("repo#1")).toBeInTheDocument();
+    expect(screen.getByText("Agent needs input")).toBeInTheDocument();
+    expect(screen.getByText("Waiting in review")).toBeInTheDocument();
+    expect(screen.getByText("review")).toBeInTheDocument();
+    expect(screen.getByText("Reply")).toBeInTheDocument();
+    expect(screen.getByText("32m ago")).toBeInTheDocument();
+    expect(screen.getByText("repo#2")).toBeInTheDocument();
+    expect(screen.getAllByText("Inspect")).toHaveLength(2);
+    expect(screen.getByText("scheduled")).toBeInTheDocument();
+    expect(screen.getByText("repo#failed")).toBeInTheDocument();
+    expect(screen.getByText("Run failed")).toBeInTheDocument();
+    expect(screen.getByText("failure")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Reply to repo#1/i })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("renders an empty attention state", () => {
+    render(<AttentionQueue items={[]} selectedIssueIdentifier={null} onSelectIssue={() => {}} />);
+
+    expect(screen.getByText("Needs Attention")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("Nothing needs intervention right now.")).toBeInTheDocument();
+  });
+});
+
+describe("Mission Control operation surfaces", () => {
+  it("selects an issue from the board", async () => {
+    const onSelectIssue = vi.fn();
+
+    render(
+      <OperationsBoard
+        groups={missionGroups()}
+        selectedIssueIdentifier={null}
+        onSelectIssue={onSelectIssue}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Open\s*repo#1.*Running tests.*3 turns/i }));
+
+    expect(onSelectIssue).toHaveBeenCalledWith("repo#1");
+  });
+
+  it("selects an issue from the list and renders activity", async () => {
+    const onSelectIssue = vi.fn();
+
+    render(<OperationsList issues={[issue()]} selectedIssueIdentifier={null} onSelectIssue={onSelectIssue} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /Open\s*repo#1.*Running tests.*3 turns/i }));
+
+    expect(onSelectIssue).toHaveBeenCalledWith("repo#1");
+    expect(screen.getByText("Running tests")).toBeInTheDocument();
+  });
+
+  it("renders empty board and list states", () => {
+    render(
+      <>
+        <OperationsBoard groups={missionGroups({ running: [] })} selectedIssueIdentifier={null} onSelectIssue={() => {}} />
+        <OperationsList issues={[]} selectedIssueIdentifier={null} onSelectIssue={() => {}} />
+      </>,
+    );
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.getAllByText("No issues")).toHaveLength(5);
+    expect(screen.getByText("No issues match the current filters.")).toBeInTheDocument();
+  });
+
+  it("renders failed terminal work as attention in board and list views", () => {
+    const failedIssue = issue({
+      id: "issue-failed",
+      identifier: "repo#failed",
+      status: "failed_or_blocked",
+      statusLabel: "completed_failed",
+      activity: "completed_failed",
+      attention: true,
+      completedAt: "2026-07-09T09:25:00Z",
+    });
+
+    const board = render(
+      <OperationsBoard
+        groups={missionGroups({ running: [], failed_or_blocked: [failedIssue] })}
+        selectedIssueIdentifier={null}
+        onSelectIssue={() => {}}
+      />,
+    );
+    expect(screen.getByText("Failed or Blocked")).toBeInTheDocument();
+    expect(screen.getByText("Attention")).toBeInTheDocument();
+
+    board.unmount();
+    render(
+      <OperationsList
+        issues={[failedIssue]}
+        selectedIssueIdentifier={null}
+        onSelectIssue={() => {}}
+      />,
+    );
+    expect(screen.getByText("repo#failed")).toBeInTheDocument();
+    expect(screen.getByText("Needs attention")).toBeInTheDocument();
+  });
+
+  it("renders updated time and available operational signals in board and list views", () => {
+    const metadataIssue = issue({
+      attention: true,
+      retryAttempt: 3,
+      tokenTotal: 1_250,
+      turnCount: null,
+      updatedAt: "2026-07-09T09:29:50Z",
+    });
+
+    const board = render(
+      <OperationsBoard
+        groups={missionGroups({ running: [metadataIssue] })}
+        selectedIssueIdentifier={null}
+        onSelectIssue={() => {}}
+      />,
+    );
+    expect(screen.getByText("Updated Jul 9, 09:29 UTC")).toBeInTheDocument();
+    expect(screen.getByText("retry 3")).toBeInTheDocument();
+    expect(screen.getByText("1,250 tokens")).toBeInTheDocument();
+
+    board.unmount();
+    render(
+      <OperationsList
+        issues={[metadataIssue]}
+        selectedIssueIdentifier={null}
+        onSelectIssue={() => {}}
+      />,
+    );
+    expect(screen.getByText("Updated Jul 9, 09:29 UTC")).toBeInTheDocument();
+    expect(screen.getByText("Needs attention")).toBeInTheDocument();
+    expect(screen.getByText("retry 3")).toBeInTheDocument();
+    expect(screen.getByText("1,250 tokens")).toBeInTheDocument();
+  });
+});
+
+describe("Mission Control page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: testStorage,
+    });
+    mockMatchMedia(true);
+    window.localStorage.clear();
+    vi.mocked(getState).mockReturnValue(new Promise(() => {}));
+    vi.mocked(postRefresh).mockResolvedValue({} as Awaited<ReturnType<typeof postRefresh>>);
+    vi.mocked(useIssueRuntime).mockImplementation((identifier) => runtimeFixture(identifier || "unselected"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreProperty(window, "matchMedia", originalMatchMedia);
+    restoreProperty(HTMLElement.prototype, "scrollIntoView", originalScrollIntoView);
+  });
+
+  it("switches from board to list while keeping the filtered collection", async () => {
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    await user.type(screen.getByRole("textbox", { name: "Search issues" }), "repo#4");
+    await user.click(screen.getByRole("button", { name: "List" }));
+
+    const operations = screen.getByRole("region", { name: "Operations" });
+    expect(within(operations).getByText("Activity")).toBeInTheDocument();
+    expect(within(operations).getByText("repo#4")).toBeInTheDocument();
+    expect(within(operations).queryByText("repo#1")).not.toBeInTheDocument();
+  });
+
+  it("exposes operations as a named section without adding a nested main landmark", () => {
+    renderMissionControl(runtimeSnapshot());
+
+    expect(screen.getByRole("region", { name: "Operations" })).toBeInTheDocument();
+    expect(screen.queryByRole("main")).not.toBeInTheDocument();
+  });
+
+  it("filters operations by status and attention without filtering the attention queue", async () => {
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+    const operations = screen.getByRole("region", { name: "Operations" });
+
+    await user.selectOptions(screen.getByRole("combobox", { name: "Status" }), "retrying");
+    expect(within(operations).getByText("repo#2")).toBeInTheDocument();
+    expect(within(operations).queryByText("repo#1")).not.toBeInTheDocument();
+
+    await user.selectOptions(screen.getByRole("combobox", { name: "Status" }), "all");
+    await user.click(screen.getByRole("button", { name: "Attention only" }));
+    expect(within(operations).getByText("repo#2")).toBeInTheDocument();
+    expect(within(operations).getByText("repo#3")).toBeInTheDocument();
+    expect(within(operations).queryByText("repo#1")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reply to repo#3" })).toBeInTheDocument();
+  });
+
+  it("shows one filtered-empty state in board mode", async () => {
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    await user.type(screen.getByRole("textbox", { name: "Search issues" }), "no-such-issue");
+
+    const operations = screen.getByRole("region", { name: "Operations" });
+    expect(within(operations).getByText("No issues match the current filters.")).toBeInTheDocument();
+    expect(within(operations).queryByText("No issues")).not.toBeInTheDocument();
+  });
+
+  it("opens issues from board and list and closes the inline panel without resetting controls", async () => {
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+    const operations = screen.getByRole("region", { name: "Operations" });
+
+    await user.click(within(operations).getByRole("button", { name: /Open\s*repo#1/i }));
+    expect(screen.getByRole("heading", { name: "repo#1" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close issue panel" }));
+    expect(screen.getByText("Select an issue")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Board" })).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("button", { name: "List" }));
+    await user.click(within(operations).getByRole("button", { name: /Open\s*repo#4/i }));
+    expect(screen.getByRole("heading", { name: "repo#4" })).toBeInTheDocument();
+  });
+
+  it("restores focus to the originating issue control when the panel closes", async () => {
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+    const trigger = within(screen.getByRole("region", { name: "Operations" })).getByRole(
+      "button",
+      { name: /Open\s*repo#1/i },
+    );
+
+    await user.click(trigger);
+    await user.click(screen.getByRole("button", { name: "Close issue panel" }));
+
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it("opens human attention on Respond and preserves the current tab for retry attention", async () => {
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    await user.click(screen.getByRole("button", { name: "Reply to repo#3" }));
+    expect(screen.getByRole("heading", { name: "repo#3" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Respond" })).toHaveAttribute("aria-selected", "true");
+
+    await user.click(screen.getByRole("button", { name: "Inspect to repo#2" }));
+    expect(screen.getByRole("heading", { name: "repo#2" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Respond" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("does not force Respond when opening an ordinary or retrying issue", async () => {
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+    const operations = screen.getByRole("region", { name: "Operations" });
+
+    await user.click(within(operations).getByRole("button", { name: /Open\s*repo#1/i }));
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
+
+    await user.click(screen.getByRole("button", { name: "Close issue panel" }));
+    await user.click(screen.getByRole("button", { name: "Inspect to repo#2" }));
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("switches from Respond to Overview when opening halted attention for inspection", async () => {
+    const user = userEvent.setup();
+    renderMissionControl(
+      runtimeSnapshot({
+        counts: { running: 0, retrying: 0, waiting_on_human: 2, completed: 0 },
+        running: [],
+        retrying: [],
+        waiting_on_human: [
+          {
+            interaction_request_id: "ask-human",
+            issue_id: "issue-human",
+            issue_identifier: "repo#human",
+            requested_at: "2026-07-09T09:10:00Z",
+            step_name: "build",
+          },
+          {
+            interaction_request_id: "halted:issue-halted:review",
+            issue_id: "issue-halted",
+            issue_identifier: "repo#halted",
+            requested_at: "2026-07-09T09:15:00Z",
+            step_name: "review",
+          },
+        ],
+        completed: [],
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reply to repo#human" }));
+    expect(screen.getByRole("tab", { name: "Respond" })).toHaveAttribute("aria-selected", "true");
+
+    expect(screen.queryByRole("button", { name: "Reply to repo#halted" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Inspect to repo#halted" }));
+
+    expect(screen.getByRole("heading", { name: "repo#halted" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("closes the panel and focuses Operations when a refreshed snapshot removes the selected issue", async () => {
+    const user = userEvent.setup();
+    const { queryClient } = renderMissionControl(runtimeSnapshot());
+    const operations = screen.getByRole("region", { name: "Operations" });
+
+    await user.click(
+      within(screen.getByRole("region", { name: "Operations" })).getByRole("button", {
+        name: /Open\s*repo#1/i,
+      }),
+    );
+    expect(screen.getByRole("heading", { name: "repo#1" })).toBeInTheDocument();
+
+    act(() => {
+      queryClient.setQueryData(["/api/v1/state"], {
+        data: runtimeSnapshot({
+          counts: { running: 0, retrying: 1, waiting_on_human: 1, completed: 1 },
+          running: [],
+        }),
+      });
+    });
+
+    expect(await screen.findByText("Select an issue")).toBeInTheDocument();
+    expect(operations).toHaveFocus();
+  });
+
+  it("does not move focus or scroll the panel after desktop selection", async () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+    const trigger = within(screen.getByRole("region", { name: "Operations" })).getByRole(
+      "button",
+      { name: /Open\s*repo#1/i },
+    );
+
+    await user.click(trigger);
+
+    expect(screen.getByRole("region", { name: "Issue command panel" })).not.toHaveFocus();
+    expect(trigger).toHaveFocus();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("moves focus and scrolls to the issue panel after mobile selection", async () => {
+    mockMatchMedia(false);
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    await user.click(
+      within(screen.getByRole("region", { name: "Operations" })).getByRole("button", {
+        name: /Open\s*repo#1/i,
+      }),
+    );
+
+    const panel = screen.getByRole("region", { name: "Issue command panel" });
+    await waitFor(() => expect(panel).toHaveFocus());
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+  });
+
+  it("handles missing matchMedia support during selection", async () => {
+    Reflect.deleteProperty(window, "matchMedia");
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    await user.click(
+      within(screen.getByRole("region", { name: "Operations" })).getByRole("button", {
+        name: /Open\s*repo#1/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("region", { name: "Issue command panel" })).toHaveFocus(),
+    );
+  });
+
+  it("falls back from corrupt preferences and persists control changes", async () => {
+    window.localStorage.setItem(VIEW_MODE_KEY, "tiles");
+    window.localStorage.setItem(ACTIVE_TAB_KEY, "debug");
+    window.localStorage.setItem(ATTENTION_ONLY_KEY, "sometimes");
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    expect(screen.getByRole("button", { name: "Board" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Attention only" })).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(screen.getByRole("button", { name: "List" }));
+    await user.click(screen.getByRole("button", { name: "Attention only" }));
+    await user.click(
+      within(screen.getByRole("region", { name: "Operations" })).getByRole("button", {
+        name: /Open\s*repo#2/i,
+      }),
+    );
+    await user.click(screen.getByRole("tab", { name: "Logs" }));
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(VIEW_MODE_KEY)).toBe("list");
+      expect(window.localStorage.getItem(ACTIVE_TAB_KEY)).toBe("logs");
+      expect(window.localStorage.getItem(ATTENTION_ONLY_KEY)).toBe("true");
+    });
+  });
+
+  it("restores valid preferences", async () => {
+    window.localStorage.setItem(VIEW_MODE_KEY, "list");
+    window.localStorage.setItem(ACTIVE_TAB_KEY, "transcript");
+    window.localStorage.setItem(ATTENTION_ONLY_KEY, "true");
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    expect(screen.getByRole("button", { name: "List" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Attention only" })).toHaveAttribute("aria-pressed", "true");
+    await user.click(
+      within(screen.getByRole("region", { name: "Operations" })).getByRole("button", {
+        name: /Open\s*repo#2/i,
+      }),
+    );
+    expect(screen.getByRole("tab", { name: "Transcript" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("renders when localStorage access is unavailable", () => {
+    vi.spyOn(testStorage, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    vi.spyOn(testStorage, "setItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    renderMissionControl(runtimeSnapshot());
+
+    expect(screen.getByText("Mission Control")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Board" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows a loading state while the runtime snapshot is pending", () => {
+    renderMissionControl();
+
+    expect(screen.getByText("Loading Mission Control...")).toBeInTheDocument();
+    expect(screen.queryByText("Needs Attention")).not.toBeInTheDocument();
+  });
+
+  it("shows an error and retries through the refresh control", async () => {
+    vi.mocked(getState).mockRejectedValueOnce(new Error("runtime offline"));
+    const user = userEvent.setup();
+    renderMissionControl();
+
+    expect(await screen.findByText("Failed to load Mission Control")).toBeInTheDocument();
+    expect(screen.getByText("runtime offline")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(postRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps cached operations visible when a background refresh fails", async () => {
+    vi.mocked(getState).mockRejectedValueOnce(new Error("poll failed"));
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("poll failed");
+    expect(screen.getByText("Mission Control")).toBeInTheDocument();
+    expect(screen.getByText("repo#1")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry refresh" }));
+    expect(postRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a true empty operational state", () => {
+    renderMissionControl(
+      runtimeSnapshot({
+        counts: { running: 0, retrying: 0, waiting_on_human: 0, completed: 0 },
+        running: [],
+        retrying: [],
+        waiting_on_human: [],
+        completed: [],
+      }),
+    );
+
+    expect(screen.getByText("Nothing needs intervention right now.")).toBeInTheDocument();
+    expect(screen.getByText("No operational issues are currently tracked.")).toBeInTheDocument();
+  });
+
+  it("wires refresh and exposes its pending state", async () => {
+    let resolveRefresh: (value: Awaited<ReturnType<typeof postRefresh>>) => void = () => {};
+    vi.mocked(postRefresh).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(postRefresh).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Refreshing..." })).toBeDisabled();
+
+    resolveRefresh({} as Awaited<ReturnType<typeof postRefresh>>);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled());
+  });
+
+  it("keeps cached operations visible and exposes manual refresh failures", async () => {
+    vi.mocked(postRefresh).mockRejectedValue(new Error("manual refresh failed"));
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("manual refresh failed");
+    expect(screen.getByText("repo#1")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry manual refresh" }));
+    expect(postRefresh).toHaveBeenCalledTimes(2);
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
@@ -1,0 +1,280 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { useRefreshMutation, useStateQuery } from "@/hooks";
+import { AttentionQueue } from "./AttentionQueue";
+import { IssueCommandPanel, type IssueCommandPanelTab } from "./IssueCommandPanel";
+import { MissionControlToolbar, type MissionControlViewMode } from "./MissionControlToolbar";
+import { OperationsBoard } from "./OperationsBoard";
+import { OperationsList } from "./OperationsList";
+import {
+  deriveMissionControlState,
+  filterMissionControlIssues,
+  regroupMissionControlIssues,
+  type MissionControlFilters,
+  type MissionIssueStatus,
+} from "./model";
+
+const VIEW_MODE_KEY = "ensemble.mission-control.view-mode";
+const ACTIVE_TAB_KEY = "ensemble.mission-control.active-tab";
+const ATTENTION_ONLY_KEY = "ensemble.mission-control.attention-only";
+
+const PANEL_TABS: IssueCommandPanelTab[] = [
+  "overview",
+  "respond",
+  "steps",
+  "transcript",
+  "logs",
+  "artifacts",
+];
+
+function readPreference(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writePreference(key: string, value: string) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Preferences are optional when storage is blocked or unavailable.
+  }
+}
+
+function readViewMode(): MissionControlViewMode {
+  return readPreference(VIEW_MODE_KEY) === "list" ? "list" : "board";
+}
+
+function readActiveTab(): IssueCommandPanelTab {
+  const value = readPreference(ACTIVE_TAB_KEY);
+  return PANEL_TABS.includes(value as IssueCommandPanelTab)
+    ? (value as IssueCommandPanelTab)
+    : "overview";
+}
+
+function readAttentionOnly(): boolean {
+  return readPreference(ATTENTION_ONLY_KEY) === "true";
+}
+
+export default function MissionControl() {
+  const { data, isLoading, isError, error } = useStateQuery();
+  const refreshMutation = useRefreshMutation();
+  const operationsRegionRef = useRef<HTMLElement>(null);
+  const panelRegionRef = useRef<HTMLElement>(null);
+  const selectionTriggerRef = useRef<HTMLElement | null>(null);
+  const restoreSelectionFocusRef = useRef(false);
+  const [selectedIssueIdentifier, setSelectedIssueIdentifier] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<MissionControlViewMode>(readViewMode);
+  const [activeTab, setActiveTab] = useState<IssueCommandPanelTab>(readActiveTab);
+  const [filters, setFilters] = useState<MissionControlFilters>(() => ({
+    query: "",
+    status: "all",
+    attentionOnly: readAttentionOnly(),
+  }));
+
+  useEffect(() => writePreference(VIEW_MODE_KEY, viewMode), [viewMode]);
+  useEffect(() => writePreference(ACTIVE_TAB_KEY, activeTab), [activeTab]);
+  useEffect(
+    () => writePreference(ATTENTION_ONLY_KEY, String(filters.attentionOnly)),
+    [filters.attentionOnly],
+  );
+
+  const missionState = useMemo(() => (data ? deriveMissionControlState(data) : null), [data]);
+  const filteredIssues = useMemo(
+    () => (missionState ? filterMissionControlIssues(missionState.issues, filters) : []),
+    [filters, missionState],
+  );
+  const filteredGroups = useMemo(
+    () => regroupMissionControlIssues(filteredIssues),
+    [filteredIssues],
+  );
+
+  useEffect(() => {
+    if (
+      missionState &&
+      selectedIssueIdentifier &&
+      !missionState.issues.some((issue) => issue.identifier === selectedIssueIdentifier)
+    ) {
+      restoreSelectionFocusRef.current = true;
+      setSelectedIssueIdentifier(null);
+    }
+  }, [missionState, selectedIssueIdentifier]);
+
+  useEffect(() => {
+    if (selectedIssueIdentifier || !restoreSelectionFocusRef.current) return;
+
+    restoreSelectionFocusRef.current = false;
+    const trigger = selectionTriggerRef.current;
+    selectionTriggerRef.current = null;
+    const focusTarget = trigger?.isConnected ? trigger : operationsRegionRef.current;
+    focusTarget?.focus();
+  }, [selectedIssueIdentifier]);
+
+  useEffect(() => {
+    if (!selectedIssueIdentifier) return;
+
+    const isDesktop =
+      typeof window.matchMedia === "function" && window.matchMedia("(min-width: 1280px)").matches;
+    if (isDesktop) return;
+
+    panelRegionRef.current?.focus({ preventScroll: true });
+    panelRegionRef.current?.scrollIntoView?.({ behavior: "smooth", block: "start" });
+  }, [selectedIssueIdentifier]);
+
+  function selectIssue(identifier: string) {
+    selectionTriggerRef.current =
+      document.activeElement instanceof HTMLButtonElement ? document.activeElement : null;
+    setSelectedIssueIdentifier(identifier);
+    const attentionItem = missionState?.attentionItems.find(
+      (item) => item.issueIdentifier === identifier,
+    );
+    if (attentionItem?.kind === "human_input") {
+      setActiveTab("respond");
+    } else if (
+      attentionItem?.kind === "failure" &&
+      (attentionItem.primaryAction === "Inspect" || attentionItem.primaryAction === "Open")
+    ) {
+      setActiveTab("overview");
+    }
+  }
+
+  function closePanel() {
+    restoreSelectionFocusRef.current = true;
+    setSelectedIssueIdentifier(null);
+  }
+
+  if (!missionState) {
+    if (isLoading) {
+      return <div className="py-12 text-center text-muted-foreground">Loading Mission Control...</div>;
+    }
+
+    return (
+      <div className="rounded-xl border bg-card p-8 text-center">
+        <div className="font-semibold text-destructive">Failed to load Mission Control</div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {error instanceof Error ? error.message : "Unknown error"}
+        </p>
+        <Button
+          className="mt-4"
+          onClick={() => refreshMutation.mutate()}
+          disabled={refreshMutation.isPending}
+        >
+          {refreshMutation.isPending ? "Retrying..." : "Retry"}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-col gap-4">
+      <MissionControlToolbar
+        stats={missionState.stats}
+        query={filters.query}
+        status={filters.status}
+        attentionOnly={filters.attentionOnly}
+        viewMode={viewMode}
+        isRefreshing={refreshMutation.isPending}
+        onQueryChange={(query) => setFilters((current) => ({ ...current, query }))}
+        onStatusChange={(status: MissionIssueStatus | "all") =>
+          setFilters((current) => ({ ...current, status }))
+        }
+        onAttentionOnlyChange={(attentionOnly) =>
+          setFilters((current) => ({ ...current, attentionOnly }))
+        }
+        onViewModeChange={setViewMode}
+        onRefresh={() => refreshMutation.mutate()}
+      />
+
+      {isError ? (
+        <div
+          role="alert"
+          className="flex flex-col gap-3 rounded-xl border border-amber-300/70 bg-amber-50/60 p-4 text-sm text-amber-950 sm:flex-row sm:items-center sm:justify-between dark:border-amber-900 dark:bg-amber-950/20 dark:text-amber-100"
+        >
+          <span>
+            Showing the last known state. Refresh failed: {error instanceof Error ? error.message : "Unknown error"}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refreshMutation.mutate()}
+            disabled={refreshMutation.isPending}
+          >
+            {refreshMutation.isPending ? "Retrying refresh..." : "Retry refresh"}
+          </Button>
+        </div>
+      ) : null}
+
+      {refreshMutation.isError ? (
+        <div
+          role="alert"
+          className="flex flex-col gap-3 rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm sm:flex-row sm:items-center sm:justify-between"
+        >
+          <span>
+            Manual refresh failed: {refreshMutation.error instanceof Error ? refreshMutation.error.message : "Request failed"}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refreshMutation.mutate()}
+            disabled={refreshMutation.isPending}
+          >
+            {refreshMutation.isPending ? "Retrying manual refresh..." : "Retry manual refresh"}
+          </Button>
+        </div>
+      ) : null}
+
+      <AttentionQueue
+        items={missionState.attentionItems}
+        selectedIssueIdentifier={selectedIssueIdentifier}
+        onSelectIssue={selectIssue}
+      />
+
+      <div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1fr)_34rem]">
+        <section
+          ref={operationsRegionRef}
+          aria-label="Operations"
+          tabIndex={-1}
+          className="min-w-0 outline-none"
+        >
+          {missionState.issues.length === 0 ? (
+            <div className="rounded-xl border border-dashed bg-card p-8 text-center text-sm text-muted-foreground">
+              No operational issues are currently tracked.
+            </div>
+          ) : filteredIssues.length === 0 ? (
+            <div className="rounded-xl border border-dashed bg-card p-8 text-center text-sm text-muted-foreground">
+              No issues match the current filters.
+            </div>
+          ) : viewMode === "board" ? (
+            <OperationsBoard
+              groups={filteredGroups}
+              selectedIssueIdentifier={selectedIssueIdentifier}
+              onSelectIssue={selectIssue}
+            />
+          ) : (
+            <OperationsList
+              issues={filteredIssues}
+              selectedIssueIdentifier={selectedIssueIdentifier}
+              onSelectIssue={selectIssue}
+            />
+          )}
+        </section>
+        <section
+          ref={panelRegionRef}
+          aria-label="Issue command panel"
+          tabIndex={-1}
+          className="min-w-0 scroll-mt-4 outline-none [&>aside]:!w-full"
+        >
+          <IssueCommandPanel
+            identifier={selectedIssueIdentifier}
+            activeTab={activeTab}
+            onActiveTabChange={setActiveTab}
+            onClose={closePanel}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControlToolbar.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControlToolbar.tsx
@@ -1,0 +1,169 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { useEffect, useState } from "react";
+
+import {
+  getSystemFreshness,
+  isRateLimitLow,
+  type MissionControlFilters,
+  type MissionIssueStatus,
+  type MissionSystemStats,
+} from "./model";
+
+export type MissionControlViewMode = "board" | "list";
+
+interface MissionControlToolbarProps extends MissionControlFilters {
+  stats: MissionSystemStats;
+  viewMode: MissionControlViewMode;
+  isRefreshing: boolean;
+  onQueryChange: (value: string) => void;
+  onStatusChange: (value: MissionIssueStatus | "all") => void;
+  onAttentionOnlyChange: (value: boolean) => void;
+  onViewModeChange: (value: MissionControlViewMode) => void;
+  onRefresh: () => void;
+}
+
+const STATUS_OPTIONS: Array<{ value: MissionIssueStatus | "all"; label: string }> = [
+  { value: "all", label: "All statuses" },
+  { value: "running", label: "Running" },
+  { value: "retrying", label: "Retrying" },
+  { value: "waiting_on_human", label: "Waiting" },
+  { value: "failed_or_blocked", label: "Failed or Blocked" },
+  { value: "completed_recently", label: "Completed" },
+];
+
+const FRESHNESS_CLOCK_INTERVAL_MS = 1_000;
+
+function formatTick(value: string | null): string {
+  if (!value) return "No tick yet";
+
+  return new Date(value).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+export function MissionControlToolbar({
+  stats,
+  query,
+  status,
+  attentionOnly,
+  viewMode,
+  isRefreshing,
+  onQueryChange,
+  onStatusChange,
+  onAttentionOnlyChange,
+  onViewModeChange,
+  onRefresh,
+}: MissionControlToolbarProps) {
+  const [clockMs, setClockMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    const intervalId = window.setInterval(
+      () => setClockMs(Date.now()),
+      FRESHNESS_CLOCK_INTERVAL_MS,
+    );
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const freshness = getSystemFreshness(stats, clockMs);
+  const lowRateCapacity = isRateLimitLow(stats.rateLimitRemaining, stats.rateLimitLimit);
+
+  return (
+    <header className="rounded-xl border bg-card/95 p-4 shadow-sm">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-semibold tracking-tight">Mission Control</h1>
+            <span
+              role="status"
+              aria-label={freshness === "fresh" ? "System live and fresh" : "System stale"}
+              className={cn(
+                "rounded-full border px-2 py-0.5 text-xs font-medium",
+                freshness === "fresh"
+                  ? "border-emerald-300/70 bg-emerald-50 text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300"
+                  : "border-amber-300/70 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200",
+              )}
+            >
+              {freshness === "fresh" ? "Live / Fresh" : "Stale"}
+            </span>
+            <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
+              Last tick {formatTick(stats.lastTickAt)}
+            </span>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <span>{stats.running} running</span>
+            <span>{stats.retrying} retrying</span>
+            <span>{stats.waitingOnHuman} waiting</span>
+            <span>{stats.completed} completed</span>
+            <span>{stats.failed} failed</span>
+            {stats.rateLimitLimit != null && stats.rateLimitRemaining != null ? (
+              lowRateCapacity ? (
+                <span
+                  role="alert"
+                  className="font-medium text-amber-700 dark:text-amber-300"
+                >
+                  Rate low: {stats.rateLimitRemaining}/{stats.rateLimitLimit}
+                  {stats.rateLimitResetAt ? `, resets ${formatTick(stats.rateLimitResetAt)}` : ""}
+                </span>
+              ) : (
+                <span>Rate {stats.rateLimitRemaining}/{stats.rateLimitLimit}</span>
+              )
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center">
+          <Input
+            aria-label="Search issues"
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Search issues, steps, activity"
+            className="min-w-64"
+          />
+          <select
+            aria-label="Status"
+            value={status}
+            onChange={(event) => onStatusChange(event.target.value as MissionIssueStatus | "all")}
+            className="h-8 rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <Button
+            variant={attentionOnly ? "default" : "outline"}
+            size="sm"
+            aria-pressed={attentionOnly}
+            onClick={() => onAttentionOnlyChange(!attentionOnly)}
+          >
+            Attention only
+          </Button>
+          <div className="grid grid-cols-2 rounded-lg border bg-muted p-1">
+            {(["board", "list"] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                aria-pressed={viewMode === mode}
+                onClick={() => onViewModeChange(mode)}
+                className={cn(
+                  "rounded-md px-3 py-1 text-sm font-medium text-muted-foreground capitalize transition-colors",
+                  viewMode === mode && "bg-background text-foreground shadow-sm",
+                )}
+              >
+                {mode === "board" ? "Board" : "List"}
+              </button>
+            ))}
+          </div>
+          <Button size="sm" onClick={onRefresh} disabled={isRefreshing}>
+            {isRefreshing ? "Refreshing..." : "Refresh"}
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/OperationsBoard.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/OperationsBoard.tsx
@@ -1,0 +1,115 @@
+import { cn } from "@/lib/utils";
+
+import { formatTokenCount, formatUpdatedAt } from "./format";
+import type { MissionGroup, MissionIssueSummary } from "./model";
+
+interface OperationsBoardProps {
+  groups: MissionGroup[];
+  selectedIssueIdentifier: string | null;
+  onSelectIssue: (identifier: string) => void;
+}
+
+function signalText(issue: MissionIssueSummary): string {
+  if (issue.retryAttempt != null) return `retry ${issue.retryAttempt}`;
+  if (issue.turnCount != null) return `${issue.turnCount} turns`;
+  if (issue.completedAt) return "complete";
+  return "active";
+}
+
+function tokenText(issue: MissionIssueSummary): string | null {
+  if (issue.tokenTotal == null) return null;
+  return formatTokenCount(issue.tokenTotal);
+}
+
+function IssueTile({
+  issue,
+  selected,
+  onSelect,
+}: {
+  issue: MissionIssueSummary;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const updatedText = formatUpdatedAt(issue.updatedAt);
+
+  return (
+    <button
+      type="button"
+      aria-current={selected ? "true" : undefined}
+      onClick={onSelect}
+      className={cn(
+        "w-full rounded-lg border bg-background p-3 text-left shadow-sm transition hover:border-primary/50 hover:bg-muted/30",
+        issue.attention && "border-amber-400/70 bg-amber-50/50 dark:bg-amber-950/15",
+        selected && "border-primary bg-primary/5 ring-1 ring-primary/40",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+              Open
+            </span>
+            <span className="truncate text-sm font-semibold">{issue.identifier}</span>
+          </div>
+          <div className="mt-1 truncate text-xs font-medium text-muted-foreground">
+            {issue.stepName ?? issue.statusLabel}
+          </div>
+        </div>
+        {issue.attention ? (
+          <span className="shrink-0 rounded-full bg-amber-500 px-2 py-0.5 text-[10px] font-bold tracking-wide text-white uppercase">
+            Attention
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-2 line-clamp-2 text-xs text-muted-foreground">
+        {issue.activity ?? "No recent activity"}
+      </div>
+
+      {updatedText ? (
+        <time dateTime={issue.updatedAt ?? undefined} className="mt-1 block text-[11px] text-muted-foreground">
+          {updatedText}
+        </time>
+      ) : null}
+
+      <div className="mt-3 flex flex-wrap gap-1.5 text-[11px] text-muted-foreground">
+        <span className="rounded-full bg-muted px-2 py-0.5">{issue.statusLabel}</span>
+        <span className="rounded-full bg-muted px-2 py-0.5">{signalText(issue)}</span>
+        {tokenText(issue) ? <span className="rounded-full bg-muted px-2 py-0.5">{tokenText(issue)}</span> : null}
+      </div>
+    </button>
+  );
+}
+
+export function OperationsBoard({ groups, selectedIssueIdentifier, onSelectIssue }: OperationsBoardProps) {
+  return (
+    <div className="flex min-h-[28rem] gap-3 overflow-x-auto pb-2">
+      {groups.map((group) => (
+        <section key={group.id} className="flex w-72 shrink-0 flex-col rounded-xl border bg-card shadow-sm">
+          <div className="flex items-center justify-between gap-3 border-b px-4 py-3">
+            <h2 className="truncate text-sm font-semibold">{group.title}</h2>
+            <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+              {group.issues.length}
+            </span>
+          </div>
+          <div className="flex-1 space-y-2 p-3">
+            {group.issues.length === 0 ? (
+              <div className="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">
+                No issues
+              </div>
+            ) : (
+              group.issues.map((issue) => (
+                <IssueTile
+                  key={`${group.id}:${issue.id}`}
+                  issue={issue}
+                  selected={selectedIssueIdentifier === issue.identifier}
+                  onSelect={() => onSelectIssue(issue.identifier)}
+                />
+              ))
+            )}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/OperationsList.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/OperationsList.tsx
@@ -1,0 +1,92 @@
+import { cn } from "@/lib/utils";
+
+import { formatTokenCount, formatUpdatedAt } from "./format";
+import type { MissionIssueSummary } from "./model";
+
+interface OperationsListProps {
+  issues: MissionIssueSummary[];
+  selectedIssueIdentifier: string | null;
+  onSelectIssue: (identifier: string) => void;
+}
+
+function signalTexts(issue: MissionIssueSummary): string[] {
+  const signals: string[] = [];
+  if (issue.attention) signals.push("Needs attention");
+  if (issue.retryAttempt != null) signals.push(`retry ${issue.retryAttempt}`);
+  if (issue.turnCount != null) signals.push(`${issue.turnCount} turns`);
+  if (issue.completedAt) signals.push("complete");
+  if (issue.tokenTotal != null) signals.push(formatTokenCount(issue.tokenTotal));
+  return signals.length > 0 ? signals : ["--"];
+}
+
+export function OperationsList({ issues, selectedIssueIdentifier, onSelectIssue }: OperationsListProps) {
+  if (issues.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed bg-card p-8 text-center text-sm text-muted-foreground">
+        No issues match the current filters.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
+      <div className="overflow-x-auto">
+        <div className="min-w-[44rem]">
+          <div className="grid grid-cols-[minmax(10rem,1.1fr)_8rem_minmax(10rem,1fr)_8rem] gap-3 border-b bg-muted/40 px-4 py-2 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+            <span>Issue</span>
+            <span>Status</span>
+            <span>Activity</span>
+            <span className="text-right">Signals</span>
+          </div>
+          <div className="divide-y">
+            {issues.map((issue) => {
+              const selected = selectedIssueIdentifier === issue.identifier;
+              const updatedText = formatUpdatedAt(issue.updatedAt);
+
+              return (
+                <button
+                  key={`${issue.status}:${issue.id}`}
+                  type="button"
+                  aria-current={selected ? "true" : undefined}
+                  onClick={() => onSelectIssue(issue.identifier)}
+                  className={cn(
+                    "grid w-full grid-cols-[minmax(10rem,1.1fr)_8rem_minmax(10rem,1fr)_8rem] items-center gap-3 px-4 py-3 text-left text-sm transition hover:bg-muted/30",
+                    selected && "bg-primary/5 ring-1 ring-primary/30 ring-inset",
+                  )}
+                >
+                  <span className="min-w-0">
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+                        Open
+                      </span>
+                      <span className="truncate font-semibold">{issue.identifier}</span>
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {issue.stepName ?? "No active step"}
+                    </span>
+                  </span>
+                  <span className="truncate text-xs text-muted-foreground">{issue.statusLabel}</span>
+                  <span className="min-w-0 text-xs text-muted-foreground">
+                    <span className="block truncate">{issue.activity ?? "No recent activity"}</span>
+                    {updatedText ? (
+                      <time dateTime={issue.updatedAt ?? undefined} className="mt-0.5 block truncate text-[11px]">
+                        {updatedText}
+                      </time>
+                    ) : null}
+                  </span>
+                  <span className="flex flex-wrap justify-end gap-x-2 gap-y-0.5 text-right text-xs text-muted-foreground">
+                    {signalTexts(issue).map((signal) => (
+                      <span key={signal} className="whitespace-nowrap">
+                        {signal}
+                      </span>
+                    ))}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/format.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/format.ts
@@ -1,0 +1,23 @@
+const UPDATED_AT_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+  timeZone: "UTC",
+});
+
+const COUNT_FORMATTER = new Intl.NumberFormat("en-US");
+
+export function formatUpdatedAt(value: string | null): string | null {
+  if (!value) return null;
+
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return null;
+
+  return `Updated ${UPDATED_AT_FORMATTER.format(date)} UTC`;
+}
+
+export function formatTokenCount(value: number): string {
+  return `${COUNT_FORMATTER.format(value)} tokens`;
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/index.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MissionControl";

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/interactionIds.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/interactionIds.ts
@@ -1,0 +1,3 @@
+export function isSyntheticHaltedInteractionId(id: string | null | undefined): boolean {
+  return id?.startsWith("halted:") ?? false;
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/model.test.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/model.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest";
+import type { RuntimeSnapshot } from "@/generated/models";
+import {
+  deriveMissionControlState,
+  filterMissionControlIssues,
+  getSystemFreshness,
+  isRateLimitLow,
+  regroupMissionControlIssues,
+  type MissionControlFilters,
+} from "./model";
+
+function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
+  return {
+    agent_totals: {
+      input_tokens: 1000,
+      output_tokens: 2500,
+      total_tokens: 3500,
+      seconds_running: 95,
+    },
+    counts: { running: 1, retrying: 1, waiting_on_human: 1, completed: 1 },
+    generated_at: "2026-07-09T09:30:00Z",
+    last_tick_at: "2026-07-09T09:29:58Z",
+    poll_interval_ms: 3000,
+    rate_limits: { limit: 100, remaining: 8, reset_at: "2026-07-09T10:00:00Z" },
+    running: [
+      {
+        issue_id: "issue-running",
+        issue_identifier: "repo#1",
+        last_event: "tool_call",
+        last_event_at: "2026-07-09T09:29:50Z",
+        last_message: "Running tests",
+        session_id: "session-1",
+        started_at: "2026-07-09T09:00:00Z",
+        state: "running",
+        step_name: "build",
+        tokens: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+        turn_count: 3,
+      },
+    ],
+    retrying: [
+      {
+        issue_id: "issue-retry",
+        issue_identifier: "repo#2",
+        attempt: 2,
+        due_at_ms: 1000,
+        error: "clippy failed",
+      },
+    ],
+    waiting_on_human: [
+      {
+        interaction_request_id: "ask-1",
+        issue_id: "issue-waiting",
+        issue_identifier: "repo#3",
+        requested_at: "2026-07-09T09:10:00Z",
+        step_name: "review",
+      },
+    ],
+    completed: [
+      {
+        issue_id: "issue-completed",
+        issue_identifier: "repo#4",
+        completed_at: "2026-07-09T09:20:00Z",
+        status: "completed_succeeded",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("mission-control model", () => {
+  it("groups runtime snapshot rows into operational columns", () => {
+    const state = deriveMissionControlState(snapshot());
+
+    expect(state.groups.map((group) => [group.id, group.issues.map((issue) => issue.identifier)])).toEqual([
+      ["running", ["repo#1"]],
+      ["retrying", ["repo#2"]],
+      ["waiting_on_human", ["repo#3"]],
+      ["failed_or_blocked", []],
+      ["completed_recently", ["repo#4"]],
+    ]);
+  });
+
+  it("promotes human questions and retry recovery into attention items", () => {
+    const state = deriveMissionControlState(snapshot());
+
+    expect(state.attentionItems.map((item) => [item.issueIdentifier, item.kind, item.primaryAction])).toEqual([
+      ["repo#3", "human_input", "Reply"],
+      ["repo#2", "retry", "Inspect"],
+    ]);
+  });
+
+  it("classifies synthetic halted waits as blocked failures instead of human input", () => {
+    const state = deriveMissionControlState(
+      snapshot({
+        counts: { running: 0, retrying: 0, waiting_on_human: 1, completed: 0 },
+        running: [],
+        retrying: [],
+        waiting_on_human: [
+          {
+            interaction_request_id: "halted:issue-halted:review",
+            issue_id: "issue-halted",
+            issue_identifier: "repo#halted",
+            requested_at: "2026-07-09T09:15:00Z",
+            step_name: "review",
+          },
+        ],
+        completed: [],
+      }),
+    );
+
+    expect(state.groups.find((group) => group.id === "waiting_on_human")?.issues).toEqual([]);
+    expect(state.groups.find((group) => group.id === "failed_or_blocked")?.issues).toEqual([
+      expect.objectContaining({
+        identifier: "repo#halted",
+        statusLabel: "Halted",
+        activity: "Pipeline halted after review failed",
+        attention: true,
+      }),
+    ]);
+    expect(state.attentionItems).toEqual([
+      expect.objectContaining({
+        issueIdentifier: "repo#halted",
+        kind: "failure",
+        title: "Pipeline halted",
+        detail: "Blocked after review failed",
+        primaryAction: "Inspect",
+      }),
+    ]);
+    expect(state.stats).toMatchObject({ waitingOnHuman: 0, failed: 1 });
+  });
+
+  it("derives compact system stats", () => {
+    const state = deriveMissionControlState(snapshot());
+
+    expect(state.stats).toMatchObject({
+      running: 1,
+      retrying: 1,
+      waitingOnHuman: 1,
+      completed: 1,
+      generatedAt: "2026-07-09T09:30:00Z",
+      lastTickAt: "2026-07-09T09:29:58Z",
+      pollIntervalMs: 3000,
+      rateLimitRemaining: 8,
+      rateLimitLimit: 100,
+      rateLimitResetAt: "2026-07-09T10:00:00Z",
+    });
+  });
+
+  it("marks system health stale after three poll intervals with a ten-second floor", () => {
+    const { stats } = deriveMissionControlState(snapshot());
+
+    expect(getSystemFreshness(stats, new Date("2026-07-09T09:30:08Z").getTime())).toBe(
+      "fresh",
+    );
+    expect(getSystemFreshness(stats, new Date("2026-07-09T09:30:08.001Z").getTime())).toBe(
+      "stale",
+    );
+  });
+
+  it("warns when remaining rate capacity is ten percent or lower", () => {
+    expect(isRateLimitLow(10, 100)).toBe(true);
+    expect(isRateLimitLow(11, 100)).toBe(false);
+    expect(isRateLimitLow(null, 100)).toBe(false);
+    expect(isRateLimitLow(0, 0)).toBe(false);
+  });
+
+  it("filters by search text and operational status", () => {
+    const state = deriveMissionControlState(snapshot());
+    const filters: MissionControlFilters = { query: "repo#2", status: "retrying", attentionOnly: false };
+
+    expect(filterMissionControlIssues(state.issues, filters).map((issue) => issue.identifier)).toEqual([
+      "repo#2",
+    ]);
+  });
+
+  it("filters to attention-only issues", () => {
+    const state = deriveMissionControlState(snapshot());
+    const filters: MissionControlFilters = { query: "", status: "all", attentionOnly: true };
+
+    expect(filterMissionControlIssues(state.issues, filters).map((issue) => issue.identifier)).toEqual([
+      "repo#2",
+      "repo#3",
+    ]);
+  });
+
+  it("searches status label, step name, and activity", () => {
+    const state = deriveMissionControlState(snapshot());
+
+    expect(
+      filterMissionControlIssues(state.issues, { query: "completed_succeeded", status: "all", attentionOnly: false })
+        .map((issue) => issue.identifier),
+    ).toEqual(["repo#4"]);
+    expect(
+      filterMissionControlIssues(state.issues, { query: "review", status: "all", attentionOnly: false })
+        .map((issue) => issue.identifier),
+    ).toEqual(["repo#3"]);
+    expect(
+      filterMissionControlIssues(state.issues, { query: "running tests", status: "all", attentionOnly: false })
+        .map((issue) => issue.identifier),
+    ).toEqual(["repo#1"]);
+  });
+
+  it("regroups filtered issues by operational status", () => {
+    const state = deriveMissionControlState(snapshot());
+    const filteredIssues = filterMissionControlIssues(state.issues, { query: "repo#", status: "all", attentionOnly: true });
+
+    expect(regroupMissionControlIssues(filteredIssues).map((group) => [group.id, group.issues.length])).toEqual([
+      ["running", 0],
+      ["retrying", 1],
+      ["waiting_on_human", 1],
+      ["failed_or_blocked", 0],
+      ["completed_recently", 0],
+    ]);
+  });
+
+  it("classifies completed_failed as failed attention instead of recent completion", () => {
+    const state = deriveMissionControlState(
+      snapshot({
+        counts: { running: 0, retrying: 0, waiting_on_human: 0, completed: 2 },
+        running: [],
+        retrying: [],
+        waiting_on_human: [],
+        completed: [
+          {
+            issue_id: "issue-failed",
+            issue_identifier: "repo#failed",
+            completed_at: "2026-07-09T09:25:00Z",
+            status: "completed_failed",
+          },
+          {
+            issue_id: "issue-succeeded",
+            issue_identifier: "repo#succeeded",
+            completed_at: "2026-07-09T09:20:00Z",
+            status: "completed_succeeded",
+          },
+        ],
+      }),
+    );
+
+    expect(state.groups.find((group) => group.id === "failed_or_blocked")?.issues).toEqual([
+      expect.objectContaining({ identifier: "repo#failed", attention: true }),
+    ]);
+    expect(state.groups.find((group) => group.id === "completed_recently")?.issues).toEqual([
+      expect.objectContaining({ identifier: "repo#succeeded", attention: false }),
+    ]);
+    expect(state.attentionItems).toContainEqual(
+      expect.objectContaining({
+        issueIdentifier: "repo#failed",
+        kind: "failure",
+        primaryAction: "Inspect",
+      }),
+    );
+    expect(state.stats).toMatchObject({ completed: 2, failed: 1 });
+  });
+
+  it("includes completed_failed in failed and attention-only filters", () => {
+    const state = deriveMissionControlState(
+      snapshot({
+        counts: { running: 0, retrying: 0, waiting_on_human: 0, completed: 1 },
+        running: [],
+        retrying: [],
+        waiting_on_human: [],
+        completed: [
+          {
+            issue_id: "issue-failed",
+            issue_identifier: "repo#failed",
+            completed_at: "2026-07-09T09:25:00Z",
+            status: "completed_failed",
+          },
+        ],
+      }),
+    );
+
+    expect(
+      filterMissionControlIssues(state.issues, {
+        query: "",
+        status: "failed_or_blocked",
+        attentionOnly: false,
+      }).map((issue) => issue.identifier),
+    ).toEqual(["repo#failed"]);
+    expect(
+      filterMissionControlIssues(state.issues, {
+        query: "",
+        status: "all",
+        attentionOnly: true,
+      }).map((issue) => issue.identifier),
+    ).toEqual(["repo#failed"]);
+  });
+
+  it("does not infer retry exhaustion from unspecified completed statuses", () => {
+    const state = deriveMissionControlState(
+      snapshot({
+        completed: [
+          {
+            issue_id: "issue-unknown",
+            issue_identifier: "repo#unknown",
+            completed_at: "2026-07-09T09:25:00Z",
+            status: "retry_exhausted",
+          },
+        ],
+      }),
+    );
+
+    expect(state.issues.find((issue) => issue.identifier === "repo#unknown")).toMatchObject({
+      status: "completed_recently",
+      attention: false,
+    });
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/model.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/model.ts
@@ -1,0 +1,298 @@
+import type {
+  CompletedRow,
+  RetryRow,
+  RunningSessionRow,
+  RuntimeSnapshot,
+  WaitingInteractionRow,
+} from "@/generated/models";
+import { isSyntheticHaltedInteractionId } from "./interactionIds";
+
+export type MissionIssueStatus =
+  | "running"
+  | "retrying"
+  | "waiting_on_human"
+  | "failed_or_blocked"
+  | "completed_recently";
+export type MissionAttentionKind = "human_input" | "retry" | "failure";
+export type MissionPrimaryAction = "Reply" | "Inspect" | "Open";
+
+export interface MissionIssueSummary {
+  id: string;
+  identifier: string;
+  status: MissionIssueStatus;
+  statusLabel: string;
+  stepName: string | null;
+  activity: string | null;
+  updatedAt: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  retryAttempt: number | null;
+  tokenTotal: number | null;
+  turnCount: number | null;
+  attention: boolean;
+  source: RunningSessionRow | RetryRow | WaitingInteractionRow | CompletedRow;
+}
+
+export interface MissionGroup {
+  id: MissionIssueStatus;
+  title: string;
+  issues: MissionIssueSummary[];
+}
+
+export interface MissionAttentionItem {
+  id: string;
+  issueId: string;
+  issueIdentifier: string;
+  kind: MissionAttentionKind;
+  title: string;
+  detail: string;
+  stepName: string | null;
+  requestedAt: string | null;
+  primaryAction: MissionPrimaryAction;
+}
+
+export interface MissionSystemStats {
+  running: number;
+  retrying: number;
+  waitingOnHuman: number;
+  completed: number;
+  failed: number;
+  generatedAt: string;
+  lastTickAt: string | null;
+  pollIntervalMs: number;
+  rateLimitRemaining: number | null;
+  rateLimitLimit: number | null;
+  rateLimitResetAt: string | null;
+}
+
+export interface MissionControlState {
+  issues: MissionIssueSummary[];
+  groups: MissionGroup[];
+  attentionItems: MissionAttentionItem[];
+  stats: MissionSystemStats;
+}
+
+export interface MissionControlFilters {
+  query: string;
+  status: MissionIssueStatus | "all";
+  attentionOnly: boolean;
+}
+
+const SYSTEM_STALE_POLL_MULTIPLIER = 3;
+const SYSTEM_STALE_MIN_MS = 10_000;
+
+/** A snapshot is fresh only while both generation and orchestrator tick times are current. */
+export function getSystemFreshness(
+  stats: MissionSystemStats,
+  nowMs = Date.now(),
+): "fresh" | "stale" {
+  const staleAfterMs = Math.max(
+    stats.pollIntervalMs * SYSTEM_STALE_POLL_MULTIPLIER,
+    SYSTEM_STALE_MIN_MS,
+  );
+  const generatedAtMs = new Date(stats.generatedAt).getTime();
+  const lastTickAtMs = stats.lastTickAt ? new Date(stats.lastTickAt).getTime() : Number.NaN;
+
+  return Number.isFinite(generatedAtMs) &&
+    Number.isFinite(lastTickAtMs) &&
+    nowMs - generatedAtMs <= staleAfterMs &&
+    nowMs - lastTickAtMs <= staleAfterMs
+    ? "fresh"
+    : "stale";
+}
+
+export function isRateLimitLow(remaining: number | null, limit: number | null): boolean {
+  return remaining != null && limit != null && limit > 0 && remaining / limit <= 0.1;
+}
+
+const GROUP_TITLES: Record<MissionIssueStatus, string> = {
+  running: "Running",
+  retrying: "Retrying",
+  waiting_on_human: "Waiting on Human",
+  failed_or_blocked: "Failed or Blocked",
+  completed_recently: "Completed Recently",
+};
+
+function runningIssue(row: RunningSessionRow): MissionIssueSummary {
+  return {
+    id: row.issue_id,
+    identifier: row.issue_identifier,
+    status: "running",
+    statusLabel: "Running",
+    stepName: row.step_name ?? null,
+    activity: row.last_message ?? row.last_event ?? row.state,
+    updatedAt: row.last_event_at ?? row.started_at,
+    startedAt: row.started_at,
+    completedAt: null,
+    retryAttempt: null,
+    tokenTotal: row.tokens.total_tokens,
+    turnCount: row.turn_count,
+    attention: false,
+    source: row,
+  };
+}
+
+function retryIssue(row: RetryRow): MissionIssueSummary {
+  return {
+    id: row.issue_id,
+    identifier: row.issue_identifier,
+    status: "retrying",
+    statusLabel: "Retrying",
+    stepName: null,
+    activity: row.error ?? `Retry attempt ${row.attempt}`,
+    updatedAt: null,
+    startedAt: null,
+    completedAt: null,
+    retryAttempt: row.attempt,
+    tokenTotal: null,
+    turnCount: null,
+    attention: true,
+    source: row,
+  };
+}
+
+function waitingIssue(row: WaitingInteractionRow): MissionIssueSummary {
+  const halted = isSyntheticHaltedInteractionId(row.interaction_request_id);
+  return {
+    id: row.issue_id,
+    identifier: row.issue_identifier,
+    status: halted ? "failed_or_blocked" : "waiting_on_human",
+    statusLabel: halted ? "Halted" : "Waiting on Human",
+    stepName: row.step_name,
+    activity: halted ? `Pipeline halted after ${row.step_name} failed` : "Agent needs input",
+    updatedAt: row.requested_at,
+    startedAt: null,
+    completedAt: null,
+    retryAttempt: null,
+    tokenTotal: null,
+    turnCount: null,
+    attention: true,
+    source: row,
+  };
+}
+
+function completedIssue(row: CompletedRow): MissionIssueSummary {
+  const failed = row.status === "completed_failed";
+  return {
+    id: row.issue_id,
+    identifier: row.issue_identifier,
+    status: failed ? "failed_or_blocked" : "completed_recently",
+    statusLabel: row.status,
+    stepName: null,
+    activity: row.status,
+    updatedAt: row.completed_at,
+    startedAt: null,
+    completedAt: row.completed_at,
+    retryAttempt: null,
+    tokenTotal: null,
+    turnCount: null,
+    attention: failed,
+    source: row,
+  };
+}
+
+export function deriveMissionControlState(snapshot: RuntimeSnapshot): MissionControlState {
+  const failedRows = snapshot.completed.filter((row) => row.status === "completed_failed");
+  const haltedRows = snapshot.waiting_on_human.filter((row) =>
+    isSyntheticHaltedInteractionId(row.interaction_request_id),
+  );
+  const issues = [
+    ...snapshot.running.map(runningIssue),
+    ...snapshot.retrying.map(retryIssue),
+    ...snapshot.waiting_on_human.map(waitingIssue),
+    ...snapshot.completed.map(completedIssue),
+  ];
+
+  return {
+    issues,
+    groups: regroupMissionControlIssues(issues),
+    attentionItems: [
+      ...snapshot.waiting_on_human.map(
+        (row): MissionAttentionItem =>
+          isSyntheticHaltedInteractionId(row.interaction_request_id)
+            ? {
+                id: row.interaction_request_id,
+                issueId: row.issue_id,
+                issueIdentifier: row.issue_identifier,
+                kind: "failure",
+                title: "Pipeline halted",
+                detail: `Blocked after ${row.step_name} failed`,
+                stepName: row.step_name,
+                requestedAt: row.requested_at,
+                primaryAction: "Inspect",
+              }
+            : {
+                id: row.interaction_request_id,
+                issueId: row.issue_id,
+                issueIdentifier: row.issue_identifier,
+                kind: "human_input",
+                title: "Agent needs input",
+                detail: `Waiting in ${row.step_name}`,
+                stepName: row.step_name,
+                requestedAt: row.requested_at,
+                primaryAction: "Reply",
+              },
+      ),
+      ...snapshot.retrying.map((row): MissionAttentionItem => ({
+        id: `retry:${row.issue_id}`,
+        issueId: row.issue_id,
+        issueIdentifier: row.issue_identifier,
+        kind: "retry",
+        title: "Retry scheduled",
+        detail: row.error ?? `Attempt ${row.attempt} is waiting to retry`,
+        stepName: null,
+        requestedAt: null,
+        primaryAction: "Inspect",
+      })),
+      ...failedRows.map((row): MissionAttentionItem => ({
+        id: `failure:${row.issue_id}`,
+        issueId: row.issue_id,
+        issueIdentifier: row.issue_identifier,
+        kind: "failure",
+        title: "Run failed",
+        detail: row.status,
+        stepName: null,
+        requestedAt: row.completed_at,
+        primaryAction: "Inspect",
+      })),
+    ],
+    stats: {
+      running: snapshot.counts.running,
+      retrying: snapshot.counts.retrying,
+      waitingOnHuman: Math.max(0, snapshot.counts.waiting_on_human - haltedRows.length),
+      completed: snapshot.counts.completed,
+      failed: failedRows.length + haltedRows.length,
+      generatedAt: snapshot.generated_at,
+      lastTickAt: snapshot.last_tick_at ?? null,
+      pollIntervalMs: snapshot.poll_interval_ms,
+      rateLimitRemaining: snapshot.rate_limits?.remaining ?? null,
+      rateLimitLimit: snapshot.rate_limits?.limit ?? null,
+      rateLimitResetAt: snapshot.rate_limits?.reset_at ?? null,
+    },
+  };
+}
+
+export function filterMissionControlIssues(
+  issues: MissionIssueSummary[],
+  filters: MissionControlFilters,
+): MissionIssueSummary[] {
+  const query = filters.query.trim().toLowerCase();
+
+  return issues.filter((issue) => {
+    if (filters.status !== "all" && issue.status !== filters.status) return false;
+    if (filters.attentionOnly && !issue.attention) return false;
+    if (!query) return true;
+
+    return [issue.identifier, issue.statusLabel, issue.stepName, issue.activity]
+      .filter((value): value is string => Boolean(value))
+      .some((value) => value.toLowerCase().includes(query));
+  });
+}
+
+export function regroupMissionControlIssues(issues: MissionIssueSummary[]): MissionGroup[] {
+  return (Object.keys(GROUP_TITLES) as MissionIssueStatus[]).map((id) => ({
+    id,
+    title: GROUP_TITLES[id],
+    issues: issues.filter((issue) => issue.status === id),
+  }));
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/useIssueRuntime.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/useIssueRuntime.ts
@@ -1,0 +1,670 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCancelInteractionMutation,
+  useFinalizeApproveMutation,
+  useFinalizeRetryMutation,
+  useInteractionDetailQuery,
+  useIssueDetailQuery,
+  useRespondToInteractionMutation,
+  useResumeIssueMutation,
+  useRetryMutation,
+  useStepConversationQuery,
+  useStopMutation,
+  useTimelineQuery,
+} from "@/hooks";
+import { connectWs, type WsStatus } from "@/ws";
+import type { WsEventData, WsPipelineEvent } from "@/ws-types";
+import {
+  isCompletionEvent,
+  normalizePipelineEvent,
+  timelineRecordToEventData,
+  transcriptRecordKey,
+} from "@/ws-events";
+import { addNotification, requestPermissionIfNeeded } from "@/notifications";
+import { FetchError } from "@/fetch-client";
+import type {
+  InteractionDetail,
+  InteractionKind,
+  InteractionResponseBody,
+  IssueDetailSnapshot,
+  TranscriptRecord,
+} from "@/generated/models";
+import {
+  reconcileGroupedTranscriptEntries,
+  type GroupedTranscriptEntry,
+} from "@/components/transcript/transcript-model";
+import type { IssueInteractionReply } from "@/components/issue-detail/IssueComposer";
+import { isSyntheticHaltedInteractionId } from "./interactionIds";
+
+export interface PendingRuntimeQuestion {
+  interactionId: string;
+  kind: InteractionKind;
+  status: InteractionDetail["status"];
+  awaitingResume: boolean;
+  question: string;
+  whyBlocked: string;
+  suggestedAnswer: string | null;
+  stepName: string;
+}
+
+export interface IssueRuntimeState {
+  identifier: string;
+  data: IssueDetailSnapshot | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  interaction: InteractionDetail | undefined;
+  interactionIsLoading: boolean;
+  interactionIsError: boolean;
+  interactionError: unknown;
+  pendingQuestion: PendingRuntimeQuestion | null;
+  isLiveRun: boolean;
+  wsStatus: WsStatus;
+  effectiveRunId: string;
+  activeStepName: string | null;
+  events: WsEventData[];
+  transcriptEntries: GroupedTranscriptEntry[];
+  activeTranscriptEntryId: string | null;
+  transcriptSessionKey: string;
+  transcriptIsError: boolean;
+  timelineIsError: boolean;
+  retryMutation: ReturnType<typeof useRetryMutation>;
+  stopMutation: ReturnType<typeof useStopMutation>;
+  respondMutation: ReturnType<typeof useRespondToInteractionMutation>;
+  resumeMutation: ReturnType<typeof useResumeIssueMutation>;
+  cancelMutation: ReturnType<typeof useCancelInteractionMutation>;
+  finalizeApproveMutation: ReturnType<typeof useFinalizeApproveMutation>;
+  finalizeRetryMutation: ReturnType<typeof useFinalizeRetryMutation>;
+  composerError: string | null;
+  resumeQueued: boolean;
+  submitInteractionReply: (reply: IssueInteractionReply) => Promise<boolean>;
+  resumeInteraction: () => Promise<boolean>;
+  submitFollowUpInput: () => Promise<boolean>;
+  setActiveEntryIdForConversationIndex: (index: number) => void;
+  setActiveEntryId: (entryId: string | null) => void;
+}
+
+function triggerNotification(event: WsPipelineEvent, identifier: string) {
+  const detail = event.detail ?? event.event_type;
+
+  if (event.event_type === "error") {
+    addNotification("failure", "Agent error", detail, identifier);
+  } else if (event.event_type === "retry_scheduled") {
+    addNotification("warning", "Retry scheduled", detail, identifier);
+  } else if (event.event_type === "verdict" && event.verdict) {
+    addNotification("info", `Verdict: ${event.verdict}`, detail, identifier);
+  }
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Request failed";
+}
+
+function interactionResponseBody(reply: IssueInteractionReply): InteractionResponseBody {
+  switch (reply.kind) {
+    case "question":
+      return {
+        kind: "question",
+        response_schema_version: 1,
+        selected_option: null,
+        text: reply.text,
+      };
+    case "approval":
+      return {
+        kind: "approval",
+        response_schema_version: 1,
+        approved: reply.approved,
+        reason: reply.reason || null,
+      };
+    case "handoff":
+      return {
+        kind: "handoff",
+        response_schema_version: 1,
+        completed: reply.completed,
+        notes: reply.notes || null,
+      };
+    default: {
+      const exhaustive: never = reply;
+      return exhaustive;
+    }
+  }
+}
+
+function latestTerminalStepName(data: IssueDetailSnapshot | undefined): string | null {
+  if (!data || data.running) return null;
+
+  for (let index = data.workflow_steps.length - 1; index >= 0; index -= 1) {
+    const step = data.workflow_steps[index];
+    if (step && (step.state === "passed" || step.state === "failed")) return step.name;
+  }
+
+  return null;
+}
+
+function persistedTranscriptStepName(data: IssueDetailSnapshot | undefined): string | null {
+  if (!data?.artifacts || data.running) return null;
+
+  const transcripts = data.artifacts.transcripts.filter(
+    (transcript) => transcript.run_id === data.artifacts?.run_id,
+  );
+  // Artifact order is stable; prefer the last persisted transcript before workflow fallback.
+  return transcripts[transcripts.length - 1]?.step_name ?? null;
+}
+
+export function useIssueRuntime(identifier: string): IssueRuntimeState {
+  const { data, isLoading, isError, error } = useIssueDetailQuery(identifier);
+  const candidateInteractionId =
+    data?.pending_input?.ask_id ??
+    data?.current_interaction?.interaction_request_id ??
+    "";
+  const interactionId = isSyntheticHaltedInteractionId(candidateInteractionId)
+    ? ""
+    : candidateInteractionId;
+  const interactionQuery = useInteractionDetailQuery(interactionId);
+  const interaction = interactionQuery.data;
+  const stopMutation = useStopMutation();
+  const retryMutation = useRetryMutation();
+  const respondMutation = useRespondToInteractionMutation(identifier);
+  const resumeMutation = useResumeIssueMutation(identifier);
+  const finalizeApproveMutation = useFinalizeApproveMutation(identifier);
+  const finalizeRetryMutation = useFinalizeRetryMutation(identifier);
+  const cancelMutation = useCancelInteractionMutation(identifier);
+
+  const [liveEventBuffer, setLiveEventBuffer] = useState<{
+    sessionKey: string;
+    events: WsEventData[];
+  }>({ sessionKey: "", events: [] });
+  const [liveTranscriptBuffer, setLiveTranscriptBuffer] = useState<{
+    sessionKey: string;
+    records: TranscriptRecord[];
+  }>({ sessionKey: "", records: [] });
+  const [wsState, setWsState] = useState<{ identifier: string; status: WsStatus }>({
+    identifier,
+    status: "disconnected",
+  });
+  const [activeEntry, setActiveEntry] = useState<{
+    sessionKey: string;
+    entryId: string | null;
+  }>({ sessionKey: "", entryId: null });
+  const [lastKnownRun, setLastKnownRun] = useState({ identifier, value: "" });
+  const [lastKnownStep, setLastKnownStep] = useState({ identifier, runId: "", value: "" });
+  const [composerErrorState, setComposerErrorState] = useState<{
+    sessionKey: string;
+    message: string;
+  } | null>(null);
+  const [awaitingResumeState, setAwaitingResumeState] = useState<{
+    sessionKey: string;
+    interactionId: string;
+  } | null>(null);
+  const [resumeQueuedState, setResumeQueuedState] = useState<{
+    sessionKey: string;
+    interactionId: string;
+  } | null>(null);
+  const [committedTranscriptEntries, setCommittedTranscriptEntries] = useState<{
+    sessionKey: string;
+    entries: GroupedTranscriptEntry[];
+  }>({ sessionKey: "", entries: [] });
+
+  const isLiveRun = data?.running != null;
+  const currentRunId = data?.running?.run_id ?? (data?.running ? undefined : data?.artifacts?.run_id);
+  const currentStepName = data?.running?.step_name ?? null;
+  const selectedStepName =
+    currentStepName ?? persistedTranscriptStepName(data) ?? latestTerminalStepName(data);
+
+  useEffect(() => {
+    setLastKnownRun((previous) => {
+      const value = currentRunId ?? (previous.identifier === identifier ? previous.value : "");
+      return previous.identifier === identifier && previous.value === value
+        ? previous
+        : { identifier, value };
+    });
+  }, [currentRunId, identifier]);
+
+  const effectiveRunId =
+    currentRunId ?? (lastKnownRun.identifier === identifier ? lastKnownRun.value : "");
+
+  useEffect(() => {
+    setLastKnownStep((previous) => {
+      const sameSession =
+        previous.identifier === identifier && previous.runId === effectiveRunId;
+      const value = selectedStepName ?? (sameSession ? previous.value : "");
+      return sameSession && previous.value === value
+        ? previous
+        : { identifier, runId: effectiveRunId, value };
+    });
+  }, [effectiveRunId, identifier, selectedStepName]);
+
+  const activeStepName =
+    selectedStepName ??
+    (lastKnownStep.identifier === identifier && lastKnownStep.runId === effectiveRunId
+      ? lastKnownStep.value
+      : "");
+  const transcriptQuery = useStepConversationQuery(identifier, effectiveRunId, activeStepName ?? "", {
+    limit: 200,
+  });
+  const refetchTranscript = transcriptQuery.refetch;
+  const transcriptSessionKey = `${identifier}:${effectiveRunId || "no-run"}:${activeStepName ?? "no-step"}`;
+  const liveEventSessionKey = `${identifier}:${effectiveRunId || "no-run"}`;
+  const liveEvents =
+    liveEventBuffer.sessionKey === liveEventSessionKey ? liveEventBuffer.events : [];
+  const liveTranscriptRecords =
+    liveTranscriptBuffer.sessionKey === transcriptSessionKey
+      ? liveTranscriptBuffer.records
+      : [];
+  const wsStatus =
+    isLiveRun && wsState.identifier === identifier ? wsState.status : "disconnected";
+  const timelineQuery = useTimelineQuery(identifier, effectiveRunId);
+  const refetchTimeline = timelineQuery.refetch;
+  const persistedEvents = useMemo(
+    () => (timelineQuery.data?.events ?? []).map(timelineRecordToEventData),
+    [timelineQuery.data?.events],
+  );
+
+  const events = useMemo(() => {
+    const merged = [...persistedEvents, ...liveEvents];
+    const seen = new Set<string>();
+    const deduped: WsEventData[] = [];
+
+    for (const event of merged) {
+      const key =
+        event.runId && event.sequence != null
+          ? `${event.runId}:${event.sequence}`
+          : [
+              event.type,
+              event.timestamp,
+              event.detail,
+              event.stepName ?? "",
+              event.attempt ?? "",
+              event.conversationIndex ?? "",
+            ].join(":");
+
+      if (seen.has(key)) continue;
+      seen.add(key);
+      deduped.push(event);
+    }
+
+    return deduped.sort((a, b) => {
+      if (a.runId && b.runId && a.runId === b.runId && a.sequence != null && b.sequence != null) {
+        return a.sequence - b.sequence;
+      }
+
+      const tsDelta = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+      if (tsDelta !== 0) {
+        return tsDelta;
+      }
+
+      return (a.sequence ?? 0) - (b.sequence ?? 0);
+    });
+  }, [liveEvents, persistedEvents]);
+
+  useEffect(() => {
+    if (!identifier) return;
+
+    let active = true;
+    requestPermissionIfNeeded();
+    const disconnect = connectWs({
+      identifier,
+      enabled: isLiveRun,
+      onMessage: (msg) => {
+        if (!active) return;
+
+        if (msg.type === "snapshot") {
+          setLiveEventBuffer({ sessionKey: liveEventSessionKey, events: [] });
+          setLiveTranscriptBuffer({ sessionKey: transcriptSessionKey, records: [] });
+          void refetchTranscript?.();
+          void refetchTimeline?.();
+        } else if (msg.type === "event") {
+          const event = normalizePipelineEvent(msg.data);
+          if (event.runId && effectiveRunId && event.runId !== effectiveRunId) {
+            return;
+          }
+          setLiveEventBuffer((previous) => ({
+            sessionKey: liveEventSessionKey,
+            events: [
+              ...(previous.sessionKey === liveEventSessionKey ? previous.events : []),
+              event,
+            ],
+          }));
+          triggerNotification(msg.data, identifier);
+
+          if (isCompletionEvent(msg.data)) {
+            const severity = msg.data.outcome === "succeeded" ? "success" : "failure";
+            addNotification(
+              severity,
+              `Run ${msg.data.outcome}`,
+              `${identifier} ${msg.data.outcome}`,
+              identifier,
+            );
+          }
+        } else if (msg.type === "transcript_record") {
+          if (
+            msg.data.issue_identifier !== identifier ||
+            msg.data.run_id !== effectiveRunId ||
+            msg.data.step_name !== activeStepName
+          ) {
+            return;
+          }
+          setLiveTranscriptBuffer((previous) => {
+            const records =
+              previous.sessionKey === transcriptSessionKey ? previous.records : [];
+            const next = new Map(
+              records.map((record) => [transcriptRecordKey(record), record] as const),
+            );
+            next.set(transcriptRecordKey(msg.data), msg.data);
+            return {
+              sessionKey: transcriptSessionKey,
+              records: Array.from(next.values()).sort((a, b) => a.sequence - b.sequence),
+            };
+          });
+        }
+      },
+      onStatusChange: (status) => {
+        if (active) setWsState({ identifier, status });
+      },
+    });
+
+    return () => {
+      active = false;
+      disconnect();
+    };
+  }, [
+    activeStepName,
+    effectiveRunId,
+    identifier,
+    isLiveRun,
+    liveEventSessionKey,
+    refetchTimeline,
+    refetchTranscript,
+    transcriptSessionKey,
+  ]);
+
+  const transcriptRecords = useMemo(() => {
+    const byKey = new Map<string, TranscriptRecord>();
+    for (const record of transcriptQuery.data?.records ?? []) {
+      byKey.set(transcriptRecordKey(record), record);
+    }
+    for (const record of liveTranscriptRecords) {
+      if (record.run_id !== effectiveRunId || record.step_name !== activeStepName) continue;
+      byKey.set(transcriptRecordKey(record), record);
+    }
+    return Array.from(byKey.values()).sort((a, b) => a.sequence - b.sequence);
+  }, [activeStepName, effectiveRunId, liveTranscriptRecords, transcriptQuery.data?.records]);
+
+  const activeTranscriptEntryId =
+    activeEntry.sessionKey === transcriptSessionKey ? activeEntry.entryId : null;
+  const previousTranscriptEntries =
+    committedTranscriptEntries.sessionKey === transcriptSessionKey
+      ? committedTranscriptEntries.entries
+      : undefined;
+
+  const transcriptEntries = useMemo(
+    () =>
+      reconcileGroupedTranscriptEntries(previousTranscriptEntries, {
+        conversation: [],
+        transcriptRecords,
+        interactions: interaction ? [interaction] : [],
+        events,
+      }),
+    [previousTranscriptEntries, transcriptRecords, interaction, events],
+  );
+
+  useLayoutEffect(() => {
+    setCommittedTranscriptEntries((previous) => {
+      const entriesUnchanged =
+        previous.sessionKey === transcriptSessionKey &&
+        previous.entries.length === transcriptEntries.length &&
+        previous.entries.every((entry, index) => entry === transcriptEntries[index]);
+      return entriesUnchanged
+        ? previous
+        : { sessionKey: transcriptSessionKey, entries: transcriptEntries };
+    });
+  }, [transcriptEntries, transcriptSessionKey]);
+
+  const transcriptEntryIdForConversationIndex = (index: number) =>
+    activeStepName
+      ? `transcript:${effectiveRunId}:${activeStepName}:${index}`
+      : `message:${index}`;
+
+  useEffect(() => {
+    setActiveEntry({ sessionKey: transcriptSessionKey, entryId: null });
+  }, [transcriptSessionKey]);
+
+  const actionSessionKey = `${identifier}:${interactionId}`;
+  const committedActionSessionKeyRef = useRef(actionSessionKey);
+  const resumeRequestSessionKeyRef = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    committedActionSessionKeyRef.current = actionSessionKey;
+    resumeRequestSessionKeyRef.current = null;
+    setComposerErrorState(null);
+    setAwaitingResumeState(null);
+    setResumeQueuedState(null);
+  }, [actionSessionKey]);
+
+  const composerError =
+    composerErrorState?.sessionKey === actionSessionKey ? composerErrorState.message : null;
+  const awaitingResumeInteractionId =
+    awaitingResumeState?.sessionKey === actionSessionKey
+      ? awaitingResumeState.interactionId
+      : null;
+
+  const isAwaitingResume = Boolean(
+    interaction?.awaiting_resume &&
+      (interaction.status === "resolved" || awaitingResumeInteractionId === interaction.id),
+  );
+  const resumeQueued = Boolean(
+    resumeQueuedState?.sessionKey === actionSessionKey &&
+      resumeQueuedState.interactionId === interactionId,
+  );
+
+  useEffect(() => {
+    if (interaction?.awaiting_resume !== false) return;
+    if (resumeRequestSessionKeyRef.current === actionSessionKey) {
+      resumeRequestSessionKeyRef.current = null;
+    }
+    setResumeQueuedState((previous) =>
+      previous?.sessionKey === actionSessionKey ? null : previous,
+    );
+  }, [actionSessionKey, interaction?.awaiting_resume]);
+
+  const pendingQuestion = interaction && (interaction.status === "open" || isAwaitingResume)
+    ? {
+        interactionId: interaction.id,
+        kind: interaction.kind,
+        status: isAwaitingResume ? "resolved" : interaction.status,
+        awaitingResume: interaction.awaiting_resume,
+        question: interaction.question,
+        whyBlocked: interaction.why_blocked,
+        suggestedAnswer: interaction.suggested_answer ?? null,
+        stepName: interaction.step_name,
+      }
+    : null;
+
+  const queueResume = async (
+    submittedActionSessionKey: string,
+    submittedIdentifier: string,
+    submittedInteractionId: string,
+  ) => {
+    if (resumeRequestSessionKeyRef.current === submittedActionSessionKey) return;
+    resumeRequestSessionKeyRef.current = submittedActionSessionKey;
+    try {
+      await resumeMutation.mutateAsync({
+        identifier: submittedIdentifier,
+        interactionId: submittedInteractionId,
+      });
+    } catch (error) {
+      if (resumeRequestSessionKeyRef.current === submittedActionSessionKey) {
+        resumeRequestSessionKeyRef.current = null;
+      }
+      if (committedActionSessionKeyRef.current === submittedActionSessionKey) {
+        setResumeQueuedState(null);
+      }
+      throw error;
+    }
+    if (
+      committedActionSessionKeyRef.current === submittedActionSessionKey &&
+      resumeRequestSessionKeyRef.current === submittedActionSessionKey
+    ) {
+      setResumeQueuedState({
+        sessionKey: submittedActionSessionKey,
+        interactionId: submittedInteractionId,
+      });
+    }
+  };
+
+  const resumeInteraction = async () => {
+    if (!interactionId || !interaction || !isAwaitingResume) {
+      setComposerErrorState({
+        sessionKey: actionSessionKey,
+        message: "No resolved interaction is awaiting resume.",
+      });
+      return false;
+    }
+
+    const submittedActionSessionKey = actionSessionKey;
+    const submittedIdentifier = identifier;
+    setComposerErrorState(null);
+    try {
+      await queueResume(submittedActionSessionKey, submittedIdentifier, interactionId);
+      if (committedActionSessionKeyRef.current === submittedActionSessionKey) {
+        setAwaitingResumeState(null);
+      }
+      return true;
+    } catch (err) {
+      if (committedActionSessionKeyRef.current === submittedActionSessionKey) {
+        setComposerErrorState({
+          sessionKey: submittedActionSessionKey,
+          message: errorMessage(err),
+        });
+      }
+      return false;
+    }
+  };
+
+  const submitInteractionReply = async (reply: IssueInteractionReply) => {
+    if (!interactionId) {
+      setComposerErrorState({
+        sessionKey: actionSessionKey,
+        message: "No pending interaction to answer.",
+      });
+      return false;
+    }
+    if (!interaction) {
+      setComposerErrorState({
+        sessionKey: actionSessionKey,
+        message: "Interaction details are still loading.",
+      });
+      return false;
+    }
+    if (isAwaitingResume) return resumeInteraction();
+    if (interaction.status !== "open" || interaction.kind !== reply.kind) {
+      setComposerErrorState({
+        sessionKey: actionSessionKey,
+        message: "The interaction response no longer matches the pending request.",
+      });
+      return false;
+    }
+
+    const submittedActionSessionKey = actionSessionKey;
+    const submittedIdentifier = identifier;
+    setComposerErrorState(null);
+    try {
+      if (awaitingResumeInteractionId !== interactionId) {
+        try {
+          await respondMutation.mutateAsync({
+            id: interactionId,
+            ...interactionResponseBody(reply),
+          });
+        } catch (responseError) {
+          if (responseError instanceof FetchError && responseError.status < 500) {
+            throw responseError;
+          }
+          let refreshedInteraction: InteractionDetail | undefined;
+          try {
+            refreshedInteraction = (await interactionQuery.refetch()).data;
+          } catch {
+            // Preserve the response error when authority cannot be refreshed.
+          }
+          if (
+            refreshedInteraction?.status !== "resolved" ||
+            !refreshedInteraction.awaiting_resume
+          ) {
+            throw responseError;
+          }
+        }
+        if (committedActionSessionKeyRef.current === submittedActionSessionKey) {
+          setAwaitingResumeState({
+            sessionKey: submittedActionSessionKey,
+            interactionId,
+          });
+        }
+      }
+      await queueResume(submittedActionSessionKey, submittedIdentifier, interactionId);
+      if (committedActionSessionKeyRef.current === submittedActionSessionKey) {
+        setAwaitingResumeState(null);
+      }
+      return true;
+    } catch (err) {
+      if (committedActionSessionKeyRef.current === submittedActionSessionKey) {
+        setComposerErrorState({
+          sessionKey: submittedActionSessionKey,
+          message: errorMessage(err),
+        });
+      }
+      return false;
+    }
+  };
+
+  const submitFollowUpInput = async () => {
+    setComposerErrorState({
+      sessionKey: actionSessionKey,
+      message: "Follow-up input is not available for this issue state.",
+    });
+    return false;
+  };
+
+  const setActiveEntryId = (entryId: string | null) => {
+    setActiveEntry({ sessionKey: transcriptSessionKey, entryId });
+  };
+
+  const setActiveEntryIdForConversationIndex = (index: number) => {
+    setActiveEntryId(transcriptEntryIdForConversationIndex(index));
+  };
+
+  return {
+    identifier,
+    data,
+    isLoading,
+    isError,
+    error,
+    interaction,
+    interactionIsLoading: interactionQuery.isLoading,
+    interactionIsError: interactionQuery.isError,
+    interactionError: interactionQuery.error,
+    pendingQuestion,
+    isLiveRun,
+    wsStatus,
+    effectiveRunId,
+    activeStepName,
+    events,
+    transcriptEntries,
+    activeTranscriptEntryId,
+    transcriptSessionKey,
+    transcriptIsError: transcriptQuery.isError,
+    timelineIsError: timelineQuery.isError,
+    retryMutation,
+    stopMutation,
+    respondMutation,
+    resumeMutation,
+    cancelMutation,
+    finalizeApproveMutation,
+    finalizeRetryMutation,
+    composerError,
+    resumeQueued,
+    submitInteractionReply,
+    resumeInteraction,
+    submitFollowUpInput,
+    setActiveEntryIdForConversationIndex,
+    setActiveEntryId,
+  };
+}

--- a/docs/superpowers/plans/2026-07-09-mission-control-phase-1.md
+++ b/docs/superpowers/plans/2026-07-09-mission-control-phase-1.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the current simple dashboard with a Mission Control workspace that shows active work, attention items, board/list views, and an inline selected issue command panel.
+**Goal:** Replace the current simple dashboard with a Mission Control workspace that shows active work, attention items, board/list views, and an inline selected issue command panel, while first fixing MVP UI action blockers that Mission Control would otherwise inherit.
 
-**Architecture:** Keep backend contracts unchanged for Phase 1. Add pure frontend normalization helpers that turn `RuntimeSnapshot` into Mission Control summaries, reuse existing issue-detail queries/components inside a new command panel, and keep `/issue/:identifier` as a deep-link detail route. The implementation should be incremental: first build tested data helpers, then presentation components, then wire the dashboard route.
+**Architecture:** Phase 1 does not require the new Phase 2 capability DTOs or global-stream APIs. It does add the required additive `InteractionDetail.kind` and `InteractionDetail.awaiting_resume` fields, with explicit interaction status typing, so the frontend can implement the corrected respond/resume flow. Regenerate the OpenAPI specification and generated client from these compatible additions rather than editing generated files. First fix frontend/API-client correctness for encoded issue identifiers, interaction respond/resume, and minimal finalize approve/retry controls. Then add pure frontend normalization helpers that turn `RuntimeSnapshot` into Mission Control summaries, reuse existing issue-detail queries/components inside a new command panel, and keep `/issue/:identifier` as a deep-link detail route.
 
 **Tech Stack:** React 19, TypeScript, Vite, TanStack Query, React Router, Tailwind 4, shadcn-style local UI primitives, Vitest, Testing Library.
 
@@ -41,10 +41,14 @@ Create these files:
 
 Modify these files:
 
+- `crates/ensemble-ui/src-ui/src/hooks.ts`  
+  Replace stale issue input flow, add or fix encoded wrappers for issue-scoped generated clients, and expose finalize approve/retry mutations.
 - `crates/ensemble-ui/src-ui/src/pages/Dashboard.tsx`  
   Replace implementation with a wrapper that renders `MissionControl`.
 - `crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx`  
-  Replace duplicated runtime/query/WebSocket logic with `useIssueRuntime`; preserve the existing route and layout.
+  Replace stale reply behavior, add minimal finalize controls, then replace duplicated runtime/query/WebSocket logic with `useIssueRuntime`; preserve the existing route and layout.
+- Existing hook/API tests under `crates/ensemble-ui/src-ui/src/`  
+  Add focused coverage for encoded issue identifiers, interaction reply/resume, and finalize approve/retry actions.
 - `crates/ensemble-ui/src-ui/src/components/Layout.tsx`  
   Update shell styling to better support the full-width Mission Control page and use theme tokens instead of hard-coded gray nav colors.
 - `crates/ensemble-ui/src-ui/src/pages/Dashboard.test.tsx`  
@@ -53,6 +57,119 @@ Modify these files:
 Do not modify generated files under `crates/ensemble-ui/src-ui/src/generated/` manually.
 
 Do not commit during implementation unless the user explicitly asks for commits.
+
+---
+
+### Task 0: Fix MVP Issue Action Foundations
+
+**Files:**
+- Modify: `crates/ensemble-ui/src-ui/src/hooks.ts`
+- Modify: `crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx`
+- Modify/Create: focused frontend tests for hooks and `IssueDetail`
+
+This task folds in #305, #306, and the minimal UI portion of #307. It must be completed before extracting `useIssueRuntime`, otherwise Mission Control will share stale reply and action behavior.
+
+- [ ] **Step 1: Add failing tests for encoded issue identifiers**
+
+Add focused frontend tests around the hook/client layer that verify UI request dispatch URL-encodes issue identifiers and step names before calling issue-scoped endpoints.
+
+Cover at least these examples:
+
+- issue identifier `repo#42`
+- issue identifier `org/repo#42`
+- step name with a slash or space if the existing step-detail/conversation path accepts arbitrary step names
+
+The tested paths must include the endpoints the UI uses for:
+
+- issue detail
+- stop
+- retry
+- resume
+- finalize approve
+- finalize retry
+- timeline
+- step detail
+- step conversation/transcript
+
+Expected before the fix: at least one generated or wrapped client call leaves `#` or `/` unencoded in a path segment.
+
+- [ ] **Step 2: Fix encoded issue and step path handling without manually editing generated files**
+
+Do not edit `crates/ensemble-ui/src-ui/src/generated/` manually.
+
+Use one of these implementation routes, choosing the smallest one that survives codegen:
+
+- configure/fix the OpenAPI/codegen input so generated path parameters are encoded, then regenerate; or
+- add handwritten wrapper functions in `hooks.ts` or a small adjacent API helper that use `customFetch` with `encodeURIComponent` for issue-scoped routes, and route UI hooks through those wrappers.
+
+The fix must ensure `repo#42` does not become a URL fragment and `org/repo#42` does not become multiple path segments.
+
+- [ ] **Step 3: Add failing tests for interaction reply/resume**
+
+Update `IssueDetail` tests to cover answering a blocked issue from the composer.
+
+The expected behavior is:
+
+- submit calls `respondToInteraction` or the hook wrapping `POST /api/v1/interactions/{id}/respond`
+- question replies send the correct interaction response body for the current interaction type
+- after a successful response, the UI queues/resumes the issue with `POST /api/v1/issues/{identifier}/resume` when the interaction flow requires resume
+- the stale `/api/v1/issues/{identifier}/input` route is not called
+- failed reply or resume keeps the composer context visible and exposes an inline error
+
+Expected before the fix: the test observes `useIssueInputMutation` or the stale issue-scoped input path.
+
+- [ ] **Step 4: Replace stale issue input flow with interaction respond/resume**
+
+Remove `useIssueInputMutation` from `IssueDetail` usage. Prefer removing the hook entirely if no callers remain; otherwise leave it only if another concrete current caller still needs it.
+
+Use the existing `useRespondToInteractionMutation(identifier)` and `useResumeIssueMutation(identifier)` hooks, or replace them with a combined helper if that makes error handling clearer.
+
+Implementation rules:
+
+- derive the active interaction id from `pending_input.ask_id` or `current_interaction.interaction_request_id`
+- fetch interaction detail with `useInteractionDetailQuery(interactionId)` as today
+- map composer replies to the generated `InteractionResponseBody` shape expected by the interaction type
+- after successful response, call resume for the same encoded issue identifier when the interaction state requires `awaiting_resume` or when the current backend contract requires explicit resume after response
+- invalidate state, open interactions, and issue detail queries after response/resume
+- do not post to `/api/v1/issues/{identifier}/input`
+
+- [ ] **Step 5: Add failing tests for minimal finalize controls**
+
+Add `IssueDetail` tests for finalize states exposed in `IssueDetailSnapshot`.
+
+Cover:
+
+- `pending_approval` renders an approval panel/button and calls finalize approve
+- `failed` renders a retry panel/button and calls finalize retry
+- `skipped_headless` or `in_progress` renders a clear passive/in-progress state, without exposing invalid actions
+- finalize action errors remain visible inline
+
+This is not #303's richer review gate. Keep the UI compact and action-focused.
+
+- [ ] **Step 6: Implement finalize approve/retry mutations and minimal UI**
+
+Add hook-level mutations for:
+
+- `POST /api/v1/{identifier}/finalize/approve`
+- `POST /api/v1/{identifier}/finalize/retry`
+
+Ensure these paths encode the issue identifier. Invalidate state and issue detail queries on success.
+
+Add a small finalize section in `IssueDetail.tsx`, near the existing stop/retry controls or artifacts summary, that reflects current finalize status from issue detail data. The section should be reusable or easy to move into `IssueCommandPanel` later.
+
+- [ ] **Step 7: Run foundation tests**
+
+Run:
+
+```bash
+pnpm test -- src/pages/IssueDetail.test.tsx
+```
+
+Working directory: `crates/ensemble-ui/src-ui`
+
+Also run any hook/API test file added in this task.
+
+Expected: PASS.
 
 ---
 
@@ -1043,8 +1160,12 @@ export interface IssueRuntimeState {
   timelineIsError: boolean;
   retryMutation: ReturnType<typeof useRetryMutation>;
   stopMutation: ReturnType<typeof useStopMutation>;
-  inputMutation: ReturnType<typeof useIssueInputMutation>;
+  respondMutation: ReturnType<typeof useRespondToInteractionMutation>;
+  resumeMutation: ReturnType<typeof useResumeIssueMutation>;
   cancelMutation: ReturnType<typeof useCancelInteractionMutation>;
+  finalizeApproveMutation: ReturnType<typeof useFinalizeApproveMutation>;
+  finalizeRetryMutation: ReturnType<typeof useFinalizeRetryMutation>;
+  submitInteractionReply: (value: string) => void;
   setActiveEntryIdForConversationIndex: (index: number) => void;
   setActiveEntryId: (entryId: string | null) => void;
 }
@@ -1061,8 +1182,8 @@ Important extraction rules:
 - Move `triggerNotification`, `formatTokens` should stay in `IssueDetail.tsx` only if still used there; otherwise move formatting to the consumer.
 - Keep `requestPermissionIfNeeded()` and `connectWs()` behavior unchanged.
 - Keep transcript deduplication and timeline merge behavior unchanged.
-- Keep mutation hooks unchanged.
-- Do not change backend API calls.
+- Keep the corrected mutation behavior from Task 0 unchanged: interaction replies must use respond/resume, and finalize controls must use finalize approve/retry.
+- Do not add new backend API calls.
 
 - [ ] **Step 3: Update `IssueDetail.tsx` to use `useIssueRuntime`**
 
@@ -1088,8 +1209,12 @@ const {
   timelineIsError,
   retryMutation,
   stopMutation,
-  inputMutation,
+  respondMutation,
+  resumeMutation,
   cancelMutation,
+  finalizeApproveMutation,
+  finalizeRetryMutation,
+  submitInteractionReply,
   setActiveEntryIdForConversationIndex,
   setActiveEntryId,
 } = runtime;
@@ -1117,7 +1242,7 @@ Run:
 pnpm test -- src/pages/IssueDetail.test.tsx
 ```
 
-Expected: PASS with no behavior changes.
+Expected: PASS with no behavior changes beyond the Task 0 interaction/finalize fixes already covered by tests.
 
 - [ ] **Step 5: Run TypeScript check for the frontend**
 
@@ -1168,6 +1293,7 @@ vi.mock("./useIssueRuntime", () => ({
       workspace: { path: "/tmp/workspace" },
       workflow_steps: [],
       artifacts: null,
+      finalize: { status: "not_required", repos: [] },
       issue: { title: "Test issue" },
       last_error: null,
     },
@@ -1187,8 +1313,12 @@ vi.mock("./useIssueRuntime", () => ({
     timelineIsError: false,
     retryMutation: { mutate: vi.fn(), isPending: false },
     stopMutation: { mutate: vi.fn(), isPending: false },
-    inputMutation: { mutate: vi.fn(), isPending: false },
+    respondMutation: { mutate: vi.fn(), isPending: false },
+    resumeMutation: { mutate: vi.fn(), isPending: false },
     cancelMutation: { mutate: vi.fn(), isPending: false },
+    finalizeApproveMutation: { mutate: vi.fn(), isPending: false },
+    finalizeRetryMutation: { mutate: vi.fn(), isPending: false },
+    submitInteractionReply: vi.fn(),
     setActiveEntryIdForConversationIndex: vi.fn(),
     setActiveEntryId: vi.fn(),
   })),
@@ -1253,6 +1383,7 @@ describe("IssueCommandPanel", () => {
 
     expect(onActiveTabChange).toHaveBeenCalledWith("transcript");
   });
+
 });
 ```
 
@@ -1341,11 +1472,17 @@ export function IssueCommandPanel({ identifier, activeTab, onActiveTabChange, on
     timelineIsError,
     retryMutation,
     stopMutation,
-    inputMutation,
+    respondMutation,
+    resumeMutation,
     cancelMutation,
+    finalizeApproveMutation,
+    finalizeRetryMutation,
+    submitInteractionReply,
     setActiveEntryIdForConversationIndex,
     setActiveEntryId,
   } = runtime;
+
+  const interactionSubmitting = respondMutation.isPending || resumeMutation.isPending;
 
   if (isLoading) {
     return <aside className="min-h-[28rem] rounded-xl border bg-card p-6 text-sm text-muted-foreground lg:w-[28rem]">Loading issue...</aside>;
@@ -1359,6 +1496,10 @@ export function IssueCommandPanel({ identifier, activeTab, onActiveTabChange, on
       </aside>
     );
   }
+
+  const finalizeStatus = data.finalize?.status;
+  const canApproveFinalize = finalizeStatus === "pending_approval";
+  const canRetryFinalize = finalizeStatus === "failed";
 
   return (
     <aside className="flex h-full min-h-[34rem] w-full flex-col overflow-hidden rounded-xl border bg-card shadow-sm lg:w-[30rem] xl:w-[34rem]">
@@ -1382,6 +1523,16 @@ export function IssueCommandPanel({ identifier, activeTab, onActiveTabChange, on
           {data.retry ? (
             <Button size="sm" onClick={() => retryMutation.mutate({ identifier })} disabled={retryMutation.isPending}>
               Retry
+            </Button>
+          ) : null}
+          {canApproveFinalize ? (
+            <Button size="sm" onClick={() => finalizeApproveMutation.mutate({ identifier })} disabled={finalizeApproveMutation.isPending}>
+              Approve finalize
+            </Button>
+          ) : null}
+          {canRetryFinalize ? (
+            <Button size="sm" onClick={() => finalizeRetryMutation.mutate({ identifier })} disabled={finalizeRetryMutation.isPending}>
+              Retry finalize
             </Button>
           ) : null}
           <span className="rounded-full border px-2 py-1 text-xs text-muted-foreground">WS: {isLiveRun ? wsStatus : "inactive"}</span>
@@ -1426,18 +1577,30 @@ export function IssueCommandPanel({ identifier, activeTab, onActiveTabChange, on
               <div className="rounded-lg border bg-muted/20 p-3"><div className="text-muted-foreground">Turns</div><div className="font-semibold">{data.running?.turn_count ?? 0}</div></div>
               <div className="rounded-lg border bg-muted/20 p-3"><div className="text-muted-foreground">Tokens</div><div className="font-semibold">{formatTokens(data.running?.tokens.total_tokens)}</div></div>
             </div>
+            {finalizeStatus && finalizeStatus !== "not_required" ? (
+              <div className="rounded-lg border bg-muted/20 p-3 text-sm">
+                <div className="font-medium">Finalize</div>
+                <div className="mt-1 text-muted-foreground">{finalizeStatus}</div>
+              </div>
+            ) : null}
             {data.last_error ? <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm">{data.last_error}</div> : null}
           </div>
         ) : null}
 
         {activeTab === "respond" ? (
           <div className="space-y-3">
-            <IssueComposer
-              pendingQuestion={pendingQuestion}
-              onSubmitReply={(value) => inputMutation.mutate(value)}
-              onSubmitFollowUp={(value) => inputMutation.mutate(value)}
-              isSubmitting={inputMutation.isPending}
-            />
+            {pendingQuestion ? (
+              <IssueComposer
+                pendingQuestion={pendingQuestion}
+                onSubmitReply={submitInteractionReply}
+                onSubmitFollowUp={() => {}}
+                isSubmitting={interactionSubmitting}
+              />
+            ) : (
+              <div className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+                No response is currently available. Use Transcript or Steps to inspect the issue.
+              </div>
+            )}
             {interaction && interaction.status !== "resolved" ? (
               <Button variant="outline" size="sm" onClick={() => cancelMutation.mutate({ id: interaction.id })} disabled={cancelMutation.isPending}>
                 Cancel Request
@@ -1971,6 +2134,7 @@ If the implementation changes user-visible behavior beyond the spec, update the 
 
 Spec coverage:
 
+- MVP action foundations: Task 0 covers #305, #306, and minimal #307 before Mission Control shares issue-detail behavior.
 - Mission Control shell: Tasks 6 and 7.
 - System strip: Task 2.
 - Attention queue: Task 2.
@@ -1980,7 +2144,7 @@ Spec coverage:
 - Reuse existing detail components: Task 5.
 - Local storage preferences: Task 6.
 - Existing polling and per-issue WebSocket behavior: Task 4 and Task 6.
-- Phase 2 exclusions: no task adds backend capabilities, global stream, workspace browser, diff review, or keyboard shortcuts.
+- Phase 2 exclusions: no task adds backend capabilities, global stream, workspace browser, diff review, keyboard shortcuts, operator notes, or the richer #303 finalization/review gate. Task 0 only adds minimal finalize approve/retry controls for the existing backend endpoints.
 
 Placeholder scan:
 

--- a/docs/superpowers/specs/2026-07-09-mission-control-phase-1-design.md
+++ b/docs/superpowers/specs/2026-07-09-mission-control-phase-1-design.md
@@ -27,6 +27,7 @@ The UI should avoid becoming primarily a chat app. Chat/transcript remains avail
 
 In scope for Phase 1:
 
+- Fix MVP UI action blockers that Mission Control would otherwise inherit: encoded issue identifiers in UI API calls, human interaction replies through the implemented interaction API, and minimal finalize approve/retry controls.
 - Replace the current dashboard experience with a Mission Control shell.
 - Add a compact system status strip with current orchestration health signals.
 - Promote the attention queue to a first-class region.
@@ -44,7 +45,7 @@ Out of scope for Phase 1:
 - Global live dashboard event streams.
 - Workspace file browsing.
 - Workspace diff review.
-- Rich finalization/review gate redesign.
+- Rich finalization/review gate redesign beyond minimal approve/retry controls needed for MVP.
 - Keyboard shortcut system.
 - Operator notes/annotations.
 - Multi-user routing, assignment, or ownership.
@@ -57,6 +58,12 @@ Phase 2 follow-up issues exist for the out-of-scope items:
 - #302 Mission Control Phase 2: workspace diff review
 - #303 Mission Control Phase 2: richer finalization and review gate
 - #304 Mission Control Phase 2: operator productivity features
+
+Phase 1 also folds in these MVP blockers because the selected issue panel and retained issue detail route depend on them:
+
+- #305 MVP: URL-encode issue identifiers in generated UI clients
+- #306 MVP: fix issue-detail human interaction replies
+- #307 MVP: make finalize approval and retry usable from UI
 
 ## Existing Starting Point
 
@@ -109,6 +116,8 @@ The top strip should surface high-signal operational state from the existing das
 - failed or retry-exhausted count
 - rate-limit warning if present
 
+The strip treats state as stale when either snapshot generation or the last orchestrator tick is older than three poll intervals, with a 10-second minimum threshold. Rate capacity at or below 10% is a warning and includes the reset time when available.
+
 The strip should also contain the main controls:
 
 - refresh
@@ -155,6 +164,8 @@ Board view groups issues by operational state. Initial columns should map to exi
 
 If existing data supports more precise groups, the implementation can split or rename columns, but it should avoid introducing states that are not actually backed by runtime data.
 
+Synthetic `halted:{issue}:{step}` waiting rows represent `on_failure: halt`, not actionable interaction records. Mission Control classifies them as Failed or Blocked, gives them Inspect/Open actions, and presents passive issue inspection without requesting interaction detail.
+
 List view should support dense scanning of the same issues. It should show the same metadata as cards but in rows, with compact status, issue identity, current step, agent, updated time, and attention indicators.
 
 Cards and rows should show:
@@ -166,6 +177,7 @@ Cards and rows should show:
 - active task or current activity if available
 - retry/attempt count if available
 - turns/tokens if already available
+- compact updated time if available
 - waiting/question indicator
 - selected state
 
@@ -206,7 +218,7 @@ It should show:
 - retry/attempt summary
 - latest activity or timeline summary
 - pending question summary if present
-- primary intervention controls using existing action logic
+- primary intervention controls using existing action logic, including stop, retry, minimal finalize approve, and minimal finalize retry where currently supported
 - compact links/buttons to the deeper tabs
 
 #### Respond Tab
@@ -214,6 +226,8 @@ It should show:
 Respond should not be the default mental model, but it should become visually prominent when the issue needs human input.
 
 It should reuse `IssueQuestionBanner` and `IssueComposer` where possible.
+
+Submitting a response must use the implemented interaction flow: respond to the current interaction request, then resume the issue when the backend indicates a resume is required. Phase 1 must not keep or reintroduce the stale issue-scoped `/issues/{identifier}/input` flow.
 
 States:
 
@@ -239,6 +253,8 @@ Logs should reuse `EventTimeline` and existing raw event views. It is for debugg
 
 Artifacts should reuse `ArtifactsPanel` and expose existing finalization output. A richer review gate is Phase 2.
 
+Minimal finalize controls are still in scope for MVP: if current issue detail data shows finalize status `pending_approval`, `failed`, `skipped_headless`, or `in_progress`, the issue detail route and selected issue command panel should surface that state. Operators must be able to approve pending finalize and retry failed finalize using the existing backend endpoints. This is intentionally narrower than the Phase 2 review gate in #303.
+
 ## Data Flow
 
 Phase 1 should prefer existing data contracts:
@@ -247,6 +263,10 @@ Phase 1 should prefer existing data contracts:
 - existing refresh mutation/control for manual refresh
 - per-issue fetches for selected panel detail data
 - existing per-issue WebSocket for live transcript/detail updates where available
+- existing interaction detail/respond/cancel and issue resume APIs for human input flows
+- existing finalize approve/retry APIs for minimal finalization controls
+
+All UI-generated API paths that include issue identifiers or step names must URL-encode path segments before request dispatch. This includes issue detail, stop, retry, resume, finalize approve/retry, timeline, step detail, and conversation/transcript calls. Identifiers such as `repo#42` and `org/repo#42` are core product identifiers and must not be treated as URL fragments or path separators.
 
 The command panel may fetch detail data lazily when an issue is selected. It should avoid subscribing to every issue's detailed stream from the dashboard.
 
@@ -267,6 +287,8 @@ Mission Control should make operational state failures obvious but non-destructi
 - If selected issue details fail, keep the board usable and show an error state in the command panel.
 - If WebSocket disconnects for the selected issue, show stale/disconnected state near the panel header or transcript tab.
 - If a reply/retry/stop action fails, keep the operator's input visible and show the backend error inline.
+- If interaction response succeeds but resume fails, keep the issue selected, show the resume error inline, and let the operator retry or refresh rather than silently discarding the reply context.
+- If finalize approve/retry fails, leave the finalize panel visible and show the backend error inline.
 - Empty states should distinguish "nothing running" from "data failed to load".
 
 ## Visual Direction
@@ -296,10 +318,14 @@ Specific visual improvements:
 
 Phase 1 should include tests appropriate to the UI changes:
 
+- tests that issue identifiers containing `#` or `/` are encoded before UI request dispatch
+- tests that blocked issue replies use the interaction respond/resume flow rather than `/issues/{identifier}/input`
+- tests that minimal finalize approve/retry controls render and call the expected endpoints
 - component tests for filtering/search/view-mode behavior if the current frontend test setup supports them
 - tests for attention queue derivation if that logic is extracted into pure functions
 - tests for local-storage preference parsing/fallbacks if non-trivial
-- existing Rust/API tests should continue to pass because Phase 1 should not require backend contract changes
+- Rust/API tests should cover the additive `InteractionDetail.kind` and `awaiting_resume` fields and explicit status values used by the corrected interaction flow
+- regenerate the OpenAPI specification and generated client after those backward-compatible additions; Phase 1 does not require new Phase 2 capability DTOs or global-stream APIs
 
 If the current frontend test harness cannot cover a behavior without significant new setup, the implementation should prefer pure helper tests plus the manual verification checklist rather than introduce a large testing framework change in this UI redesign.
 
@@ -337,16 +363,18 @@ Existing components should be reused before rewriting:
 
 Phase 1 is complete when:
 
-1. The dashboard route presents a Mission Control workspace instead of the current simple Control Room layout.
-2. Operators can see active work, attention items, and system health from one screen.
-3. Operators can switch between board and list views over active issues.
-4. Operators can search/filter active issues using basic controls.
-5. Selecting an issue opens an inline command panel without losing the operations overview.
-6. The command panel exposes Overview, Respond, Steps, Transcript, Logs, and Artifacts tabs.
-7. Pending human questions are visible from both the attention queue and selected issue panel.
-8. Responding to an agent from the command panel uses the existing interaction flow.
-9. Existing issue detail deep links still work or have a clear replacement path.
-10. The implementation does not require Phase 2 backend APIs.
+1. UI API paths correctly handle issue identifiers containing `#` or `/`.
+2. Issue Detail and Mission Control replies use the implemented interaction respond/resume flow.
+3. Issue Detail and Mission Control expose minimal finalize approve/retry controls when current state supports them.
+4. The dashboard route presents a Mission Control workspace instead of the current simple Control Room layout.
+5. Operators can see active work, attention items, and system health from one screen.
+6. Operators can switch between board and list views over active issues.
+7. Operators can search/filter active issues using basic controls.
+8. Selecting an issue opens an inline command panel without losing the operations overview.
+9. The command panel exposes Overview, Respond, Steps, Transcript, Logs, and Artifacts tabs.
+10. Pending human questions are visible from both the attention queue and selected issue panel.
+11. Existing issue detail deep links still work or have a clear replacement path.
+12. The implementation does not require Phase 2 backend APIs.
 
 ## Open Decisions Resolved For Phase 1
 
@@ -354,4 +382,5 @@ Phase 1 is complete when:
 - Workspace and diff inspection are Phase 2.
 - Backend action capabilities are Phase 2; Phase 1 can use existing action checks.
 - Global dashboard streaming is Phase 2; Phase 1 can use current snapshot/polling behavior.
+- Minimal finalize approve/retry controls are Phase 1 MVP blockers; richer finalization/review evidence and gating remain Phase 2.
 - Mission Control should borrow agent-runner's shell pattern but use Ensemble's pipeline-native ontology.


### PR DESCRIPTION
## Summary
- replace the dashboard with a responsive Mission Control workspace featuring attention, board/list views, filtering, and an inline six-tab issue panel
- fix encoded issue paths and typed interaction respond/resume flows, including approval/handoff decisions and durable resume recovery
- add safe finalize approve/retry controls, API contract coverage, extensive frontend tests, and updated design/implementation docs

## Test Plan
- [x] `pnpm test` (28 files, 283 tests)
- [x] `pnpm run build`
- [x] `cargo test -p ensemble-core --test api_endpoints` (24 tests)
- [x] `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check main...HEAD`

Closes #305
Closes #306
Closes #307