### PR TITLE
Make Rust toolchain and MSRV reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-
       - uses: Swatinem/rust-cache@v2
 
       # Cheapest checks first — fail fast
@@ -46,6 +42,30 @@ jobs:
         env:
           SKIP_UI_BUILD: 1
 
+  msrv:
+    name: MSRV (Rust 1.88.0)
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.88.0
+      RUSTFLAGS: ""
+      SKIP_UI_BUILD: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@1.88.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv-1.88.0
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Check minimum supported Rust version
+        run: cargo +1.88.0 check --workspace --all-targets
+
   frontend:
     name: Frontend Test and Build
     runs-on: ubuntu-latest
@@ -61,8 +81,6 @@ jobs:
           node-version: 24.18.0
           cache: pnpm
           cache-dependency-path: crates/ensemble-ui/src-ui/pnpm-lock.yaml
-
-      - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
 
@@ -107,8 +125,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-
-      - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
 
@@ -155,8 +171,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-
-      - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
 
@@ -248,9 +262,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: Install Rust target
+        run: rustup target add "${{ matrix.target }}"
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,20 +43,20 @@ jobs:
           SKIP_UI_BUILD: 1
 
   msrv:
-    name: MSRV (Rust 1.88.0)
+    name: MSRV (Rust 1.95.0)
     runs-on: ubuntu-latest
     env:
-      RUSTUP_TOOLCHAIN: 1.88.0
+      RUSTUP_TOOLCHAIN: 1.95.0
       RUSTFLAGS: ""
       SKIP_UI_BUILD: 1
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: msrv-1.88.0
+          key: msrv-1.95.0
 
       - name: Install Tauri system dependencies
         run: |
@@ -64,7 +64,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Check minimum supported Rust version
-        run: cargo +1.88.0 check --workspace --all-targets
+        run: cargo +1.95.0 check --workspace --all-targets
 
   frontend:
     name: Frontend Test and Build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,9 @@ This bumps versions in `Cargo.toml` + `tauri.conf.json`, commits, tags, and push
 ## Code conventions
 
 - **Compatibility policy**: Do not preserve backwards compatibility unless it is explicitly requested for the change. When choosing between compatibility and a better long-term design, prefer the option that is cleaner, more scalable, and easier to maintain, even if it requires more work upfront.
-- **Rust 2021 edition**, minimum rust-version 1.95, normal development/CI exact toolchain pinned in `rust-toolchain.toml`
+- **Rust 2021 edition**, minimum rust-version 1.95; normal development and primary CI use the exact
+  Rust 1.97.0 toolchain pinned in `rust-toolchain.toml`; the dedicated MSRV compatibility job uses
+  Rust 1.95.0.
 - **Async traits**: The codebase currently uses the `async-trait` crate/macro. Follow the existing pattern in the surrounding module; prefer native `async fn` in traits only where it fits the existing interface and compatibility requirements.
 - **Error handling**: `thiserror` enums (`EnsembleError`, `ConfigError`, `WorkspaceError`, `TrackerError`). Use `?` propagation, not `.unwrap()` in library code. Tests may unwrap. Return `anyhow::Result<()>` from executable `main` functions to avoid manual `process::exit` boilerplate.
 - **Paths & Filesystem**: Prefer `dunce` for path canonicalization and `ignore` or `walkdir` for directory traversal to avoid complex custom filesystem logic. Prefer `camino::Utf8PathBuf` if string manipulation of paths is heavy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,12 @@ CI will run these checks on your PR; failures block merge.
 
 ## CI
 
-GitHub Actions runs on push to `main` and all PRs. The main CI job runs format, clippy,
-default non-desktop Rust tests, the feature-enabled product E2E test, and a CLI
-`web-ui` feature check. Frontend and desktop jobs run separately. All must pass.
-`RUSTFLAGS=-Dwarnings` is set globally — treat warnings as errors.
+GitHub Actions runs on push to `main` and all PRs. A dedicated MSRV job uses Rust 1.95.0 to
+check all workspace targets. Main, normal, frontend, and desktop jobs use the pinned Rust 1.97.0
+toolchain from `rust-toolchain.toml`. The main CI job runs format, clippy, default non-desktop
+Rust tests, the feature-enabled product E2E test, and a CLI `web-ui` feature check. Frontend and
+desktop jobs run separately. All must pass. Primary jobs use `RUSTFLAGS=-Dwarnings` — treat
+warnings as errors; the MSRV job is a compile-compatibility check.
 
 ## Release
 
@@ -118,7 +120,7 @@ This bumps versions in `Cargo.toml` + `tauri.conf.json`, commits, tags, and push
 ## Code conventions
 
 - **Compatibility policy**: Do not preserve backwards compatibility unless it is explicitly requested for the change. When choosing between compatibility and a better long-term design, prefer the option that is cleaner, more scalable, and easier to maintain, even if it requires more work upfront.
-- **Rust 2021 edition**, minimum rust-version 1.80
+- **Rust 2021 edition**, minimum rust-version 1.95, normal development/CI exact toolchain pinned in `rust-toolchain.toml`
 - **Async traits**: The codebase currently uses the `async-trait` crate/macro. Follow the existing pattern in the surrounding module; prefer native `async fn` in traits only where it fits the existing interface and compatibility requirements.
 - **Error handling**: `thiserror` enums (`EnsembleError`, `ConfigError`, `WorkspaceError`, `TrackerError`). Use `?` propagation, not `.unwrap()` in library code. Tests may unwrap. Return `anyhow::Result<()>` from executable `main` functions to avoid manual `process::exit` boilerplate.
 - **Paths & Filesystem**: Prefer `dunce` for path canonicalization and `ignore` or `walkdir` for directory traversal to avoid complex custom filesystem logic. Prefer `camino::Utf8PathBuf` if string manipulation of paths is heavy.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*"]
 version = "0.0.1"
 edition = "2021"
 license = "MIT"
-rust-version = "1.80"
+rust-version = "1.88"
 repository = "https://github.com/chrisbanes/ensemble"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*"]
 version = "0.0.1"
 edition = "2021"
 license = "MIT"
-rust-version = "1.88"
+rust-version = "1.95"
 repository = "https://github.com/chrisbanes/ensemble"
 
 [workspace.dependencies]

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -1038,7 +1038,7 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
     }
     // Synthesis steps must have explicit non-empty dependencies
     for step in &config.steps {
-        if step.kind == StepKind::Synthesis && step.depends.as_ref().map_or(true, Vec::is_empty) {
+        if step.kind == StepKind::Synthesis && step.depends.as_ref().is_none_or(Vec::is_empty) {
             return Err(PipelineError::InvalidSynthesisStep {
                 step: step.name.clone(),
                 reason: "synthesis steps require explicit non-empty depends".to_string(),

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,8 +3,9 @@
 ## Build and test
 
 Ensemble is a Rust workspace. The minimum supported Rust version (MSRV) is Rust 1.95.
-Normal development and CI use the exact Rust 1.97.0 toolchain pinned in
-[`rust-toolchain.toml`](../rust-toolchain.toml); Rustup selects it automatically.
+Normal development and primary CI use the exact Rust 1.97.0 toolchain pinned in
+[`rust-toolchain.toml`](../rust-toolchain.toml); Rustup selects it automatically. The dedicated
+MSRV compatibility job uses Rust 1.95.0.
 
 With Rustup installed, these commands use the pinned normal toolchain:
 
@@ -37,7 +38,8 @@ rustup toolchain install 1.95.0 --profile minimal
 RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.95.0 check --workspace --all-targets
 ```
 
-Run all four normal checks before pushing — CI enforces them. CI runs the MSRV check separately.
+Run all four normal commands as a recommended local pre-push checklist. CI runs a subset in its
+primary jobs and runs the MSRV check separately.
 Exact Renovate updates to the primary Rust toolchain are review-only; changing the MSRV is a
 separate, intentional compatibility decision.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,11 @@
 
 ## Build and test
 
-Ensemble is a Rust workspace. You need Rust 1.80+ installed.
+Ensemble is a Rust workspace. The minimum supported Rust version (MSRV) is Rust 1.95.
+Normal development and CI use the exact Rust 1.97.0 toolchain pinned in
+[`rust-toolchain.toml`](../rust-toolchain.toml); Rustup selects it automatically.
+
+With Rustup installed, these commands use the pinned normal toolchain:
 
 ```sh
 cargo build --workspace          # compile default targets
@@ -26,7 +30,16 @@ cargo build -p ensemble-cli --features web-ui
 For Rust-only checks that intentionally compile the `web-ui` feature without rebuilding frontend
 assets, set `SKIP_UI_BUILD=1`.
 
-Run all four before pushing — CI enforces them.
+To check MSRV compile compatibility locally, install and use Rust 1.95.0:
+
+```sh
+rustup toolchain install 1.95.0 --profile minimal
+RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.95.0 check --workspace --all-targets
+```
+
+Run all four normal checks before pushing — CI enforces them. CI runs the MSRV check separately.
+Exact Renovate updates to the primary Rust toolchain are review-only; changing the MSRV is a
+separate, intentional compatibility decision.
 
 ## Product E2E
 
@@ -79,10 +92,12 @@ ensemble/
 
 ## CI
 
-GitHub Actions runs on push to `main` and all PRs. The main CI job runs format, clippy,
-default non-desktop Rust tests, the feature-enabled product E2E test, and a CLI
-`web-ui` feature check. Frontend and desktop jobs run separately. All must pass.
-`RUSTFLAGS=-Dwarnings` is set globally.
+GitHub Actions runs on push to `main` and all PRs. A dedicated MSRV job uses Rust 1.95.0 to
+check all workspace targets. Main, normal, frontend, and desktop jobs use the pinned Rust 1.97.0
+toolchain from `rust-toolchain.toml`. The main CI job runs format, clippy, default non-desktop
+Rust tests, the feature-enabled product E2E test, and a CLI `web-ui` feature check. Frontend and
+desktop jobs run separately. All must pass. Primary jobs use `RUSTFLAGS=-Dwarnings`; the MSRV job
+is a compile-compatibility check.
 
 ## Further reading
 

--- a/docs/superpowers/plans/2026-07-10-reproducible-rust-toolchain.md
+++ b/docs/superpowers/plans/2026-07-10-reproducible-rust-toolchain.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make Ensemble's Rust 1.88 MSRV and pinned Rust 1.97.0 development/CI toolchain explicit, reproducible, continuously verified, and intentionally upgraded.
+**Goal:** Make Ensemble's Rust 1.95 MSRV and pinned Rust 1.97.0 development/CI toolchain explicit, reproducible, continuously verified, and intentionally upgraded.
 
-**Architecture:** Use Cargo's workspace `rust-version` as the compatibility declaration and a root `rust-toolchain.toml` as the single source of truth for normal development and CI compiler selection. Add a separate CI job that overrides the repository toolchain with Rust 1.88.0 for an all-targets compatibility check, while normal lint, test, desktop, bundle, and release jobs consume the pinned Rust 1.97.0 toolchain. Let Renovate propose exact primary-toolchain updates, but require review rather than automerge.
+**Architecture:** Use Cargo's workspace `rust-version` as the compatibility declaration and a root `rust-toolchain.toml` as the single source of truth for normal development and CI compiler selection. Add a separate CI job that overrides the repository toolchain with Rust 1.95.0 for an all-targets compatibility check, while normal lint, test, desktop, bundle, and release jobs consume the pinned Rust 1.97.0 toolchain. Let Renovate propose exact primary-toolchain updates, but require review rather than automerge.
 
 **Tech Stack:** Cargo workspace metadata, Rustup toolchain overrides, GitHub Actions, Renovate, Markdown
 
@@ -32,7 +32,7 @@ Run:
 ```sh
 test ! -f rust-toolchain.toml
 cargo metadata --format-version 1 --locked |
-  jq -e '[.packages[] | select(.source == null) | .rust_version] | all(. == "1.88")'
+  jq -e '[.packages[] | select(.source == null) | .rust_version] | all(. == "1.95")'
 ```
 
 Expected: the file assertion passes, then the metadata assertion fails because workspace crates currently inherit `rust-version = "1.80"`.
@@ -46,11 +46,11 @@ In the root `Cargo.toml`, change `[workspace.package]` to:
 version = "0.0.1"
 edition = "2021"
 license = "MIT"
-rust-version = "1.88"
+rust-version = "1.95"
 repository = "https://github.com/chrisbanes/ensemble"
 ```
 
-Do not change dependency versions. Rust 1.88 is the highest declared minimum in the current locked graph, including `agent-client-protocol-schema 0.14.0`, `serde_with 3.21.0`, `plist 1.10.0`, and `time 0.3.53`.
+Do not change dependency versions. The current locked graph's highest declared metadata requirement is Rust 1.88, but `libsqlite3-sys 0.38.1` declares no `rust-version` and uses `cfg_select!` in its bundled build script. Rust 1.94 fails there and Rust 1.95 passes the complete workspace check, so Rust 1.95 is the tested compiler boundary.
 
 - [ ] **Step 3: Add the pinned primary toolchain**
 
@@ -72,7 +72,7 @@ Run:
 ```sh
 rustc --version
 cargo metadata --format-version 1 --locked |
-  jq -e '[.packages[] | select(.source == null) | .rust_version] | all(. == "1.88")'
+  jq -e '[.packages[] | select(.source == null) | .rust_version] | all(. == "1.95")'
 ```
 
 Expected: `rustc 1.97.0 (...)` and a successful `jq` assertion.
@@ -130,20 +130,20 @@ Insert the following job after `ci` and before `frontend`:
 
 ```yaml
   msrv:
-    name: MSRV (Rust 1.88.0)
+    name: MSRV (Rust 1.95.0)
     runs-on: ubuntu-latest
     env:
-      RUSTUP_TOOLCHAIN: 1.88.0
+      RUSTUP_TOOLCHAIN: 1.95.0
       RUSTFLAGS: ""
       SKIP_UI_BUILD: 1
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: msrv-1.88.0
+          key: msrv-1.95.0
 
       - name: Install Tauri system dependencies
         run: |
@@ -151,7 +151,7 @@ Insert the following job after `ci` and before `frontend`:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Check minimum supported Rust version
-        run: cargo +1.88.0 check --workspace --all-targets
+        run: cargo +1.95.0 check --workspace --all-targets
 ```
 
 The job-level `RUSTUP_TOOLCHAIN` ensures setup and cache helpers do not activate or download the repository's Rust 1.97.0 override. Clearing the global `RUSTFLAGS=-Dwarnings` keeps this job focused on compatibility; Clippy and warning policy remain enforced by the primary `ci` job. Installing the existing Tauri Linux dependencies allows `--workspace` to verify `ensemble-desktop` rather than excluding a crate that inherits the MSRV.
@@ -182,8 +182,8 @@ Run:
 ```sh
 brew install actionlint
 test "$(rg -c 'dtolnay/rust-toolchain@stable' .github/workflows/ci.yml || true)" -eq 0
-test "$(rg -c 'dtolnay/rust-toolchain@1.88.0' .github/workflows/ci.yml)" -eq 1
-test "$(rg -c 'cargo \+1.88.0 check --workspace --all-targets' .github/workflows/ci.yml)" -eq 1
+test "$(rg -c 'dtolnay/rust-toolchain@1.95.0' .github/workflows/ci.yml)" -eq 1
+test "$(rg -c 'cargo \+1.95.0 check --workspace --all-targets' .github/workflows/ci.yml)" -eq 1
 test "$(rg -c 'rustup target add' .github/workflows/ci.yml)" -eq 1
 actionlint .github/workflows/ci.yml
 ```
@@ -195,11 +195,11 @@ Expected: all four assertions pass and `actionlint` emits no diagnostics.
 Run:
 
 ```sh
-rustup toolchain install 1.88.0 --profile minimal
-RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.88.0 check --workspace --all-targets
+rustup toolchain install 1.95.0 --profile minimal
+RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.95.0 check --workspace --all-targets
 ```
 
-Expected: all workspace targets, including `ensemble-desktop`, compile successfully with Rust 1.88.0.
+Expected: all workspace targets, including `ensemble-desktop`, compile successfully with Rust 1.95.0.
 
 - [ ] **Step 7: Commit CI enforcement**
 
@@ -226,7 +226,7 @@ Run:
 
 ```sh
 jq -e '.packageRules[] | select(.matchManagers == ["rust-toolchain"])' renovate.json
-rg -n 'Rust 1\.80|Rust 1\.88|rust-toolchain\.toml|MSRV' docs/contributing.md AGENTS.md
+rg -n 'Rust 1\.80|Rust 1\.95|rust-toolchain\.toml|MSRV' docs/contributing.md AGENTS.md
 ```
 
 Expected: the `jq` command fails because no Rust toolchain package rule exists; the documentation search finds the stale Rust 1.80 statements and no complete pinned-toolchain/MSRV policy.
@@ -254,7 +254,7 @@ Replace `docs/contributing.md:3-29` with:
 ````markdown
 ## Build and test
 
-Ensemble's minimum supported Rust version (MSRV) is Rust 1.88. The repository pins Rust 1.97.0
+Ensemble's minimum supported Rust version (MSRV) is Rust 1.95. The repository pins Rust 1.97.0
 for normal development and CI in `rust-toolchain.toml`; Rustup selects and installs that toolchain
 automatically when commands run in the repository.
 
@@ -280,11 +280,11 @@ cargo build -p ensemble-cli --features web-ui
 For Rust-only checks that intentionally compile the `web-ui` feature without rebuilding frontend
 assets, set `SKIP_UI_BUILD=1`.
 
-To verify MSRV compatibility locally, install Rust 1.88.0 and override the pinned toolchain:
+To verify MSRV compatibility locally, install Rust 1.95.0 and override the pinned toolchain:
 
 ```sh
-rustup toolchain install 1.88.0 --profile minimal
-RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.88.0 check --workspace --all-targets
+rustup toolchain install 1.95.0 --profile minimal
+RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.95.0 check --workspace --all-targets
 ```
 
 Run the normal format, Clippy, and test checks before pushing. CI also runs the separate MSRV
@@ -301,7 +301,7 @@ Replace `docs/contributing.md:80-85` with:
 ```markdown
 ## CI
 
-GitHub Actions runs on push to `main` and all PRs. A dedicated Rust 1.88.0 job checks every
+GitHub Actions runs on push to `main` and all PRs. A dedicated Rust 1.95.0 job checks every
 workspace target for MSRV compatibility. The main CI job uses the Rust 1.97.0 toolchain pinned in
 `rust-toolchain.toml` for format, Clippy, default non-desktop Rust tests, the feature-enabled product
 E2E test, and the CLI `web-ui` feature check. Frontend and desktop jobs use the same pinned primary
@@ -316,7 +316,7 @@ In `AGENTS.md`, replace the CI paragraph at lines 91-96 with:
 ```markdown
 ## CI
 
-GitHub Actions runs on push to `main` and all PRs. A dedicated Rust 1.88.0 job checks all
+GitHub Actions runs on push to `main` and all PRs. A dedicated Rust 1.95.0 job checks all
 workspace targets for MSRV compatibility. Primary Rust jobs use the exact toolchain pinned in
 `rust-toolchain.toml`; the main job runs format, clippy, default non-desktop Rust tests, the
 feature-enabled product E2E test, and a CLI `web-ui` feature check. Frontend and desktop jobs run
@@ -327,7 +327,7 @@ jobs, so treat warnings as errors.
 Replace the Rust convention bullet at line 121 with:
 
 ```markdown
-- **Rust 2021 edition**, minimum rust-version 1.88; normal development and CI use the exact toolchain pinned in `rust-toolchain.toml`
+- **Rust 2021 edition**, minimum rust-version 1.95; normal development and CI use the exact toolchain pinned in `rust-toolchain.toml`
 ```
 
 - [ ] **Step 6: Validate Renovate configuration and documentation consistency**
@@ -342,7 +342,7 @@ jq -e '.packageRules[] | select(
   .automerge == false
 )' renovate.json
 ! rg -n 'Rust 1\.80|rust-version 1\.80' docs/contributing.md AGENTS.md
-rg -n 'Rust 1\.88|Rust 1\.97\.0|rust-toolchain\.toml|MSRV' docs/contributing.md AGENTS.md
+rg -n 'Rust 1\.95|Rust 1\.97\.0|rust-toolchain\.toml|MSRV' docs/contributing.md AGENTS.md
 pnpm dlx renovate@43.257.5 renovate-config-validator renovate.json
 ```
 
@@ -382,10 +382,10 @@ Run:
 
 ```sh
 cargo clean
-RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.88.0 check --workspace --all-targets
+RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.95.0 check --workspace --all-targets
 ```
 
-Expected: the complete workspace compiles successfully with Rust 1.88.0.
+Expected: the complete workspace compiles successfully with Rust 1.95.0.
 
 - [ ] **Step 3: Run all primary Rust gates on the pinned toolchain**
 
@@ -423,4 +423,4 @@ git log --oneline --decorate -4
 git diff HEAD~3..HEAD -- Cargo.toml rust-toolchain.toml .github/workflows/ci.yml renovate.json docs/contributing.md AGENTS.md
 ```
 
-Expected: the three implementation commits show an MSRV matching the current resolved graph, an explicit MSRV CI check, one pinned primary toolchain across local development and CI, warning-free Clippy on that toolchain, and review-only toolchain upgrades. No application source files or dependency versions change.
+Expected: the three implementation commits show an MSRV matching the tested compiler boundary of the current resolved graph, an explicit MSRV CI check, one pinned primary toolchain across local development and CI, warning-free Clippy on that toolchain, and review-only toolchain upgrades. No application source files or dependency versions change.

--- a/docs/superpowers/plans/2026-07-10-reproducible-rust-toolchain.md
+++ b/docs/superpowers/plans/2026-07-10-reproducible-rust-toolchain.md
@@ -1,0 +1,426 @@
+# Reproducible Rust Toolchain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Ensemble's Rust 1.88 MSRV and pinned Rust 1.97.0 development/CI toolchain explicit, reproducible, continuously verified, and intentionally upgraded.
+
+**Architecture:** Use Cargo's workspace `rust-version` as the compatibility declaration and a root `rust-toolchain.toml` as the single source of truth for normal development and CI compiler selection. Add a separate CI job that overrides the repository toolchain with Rust 1.88.0 for an all-targets compatibility check, while normal lint, test, desktop, bundle, and release jobs consume the pinned Rust 1.97.0 toolchain. Let Renovate propose exact primary-toolchain updates, but require review rather than automerge.
+
+**Tech Stack:** Cargo workspace metadata, Rustup toolchain overrides, GitHub Actions, Renovate, Markdown
+
+---
+
+## File Structure
+
+- Create `rust-toolchain.toml`: select the exact primary Rust release and required developer/CI components.
+- Modify `Cargo.toml`: raise the workspace MSRV inherited by all four crates.
+- Modify `.github/workflows/ci.yml`: remove floating primary toolchain installs, add the explicit MSRV check, and install release cross-targets on the pinned toolchain.
+- Modify `renovate.json`: make exact Rust toolchain upgrades review-only.
+- Modify `docs/contributing.md`: document the compatibility and primary toolchain contracts and their verification commands.
+- Modify `AGENTS.md`: keep repository automation guidance aligned with the new MSRV and CI policy.
+
+### Task 1: Declare the MSRV and Pin the Primary Toolchain
+
+**Files:**
+- Create: `rust-toolchain.toml`
+- Modify: `Cargo.toml:5-10`
+
+- [ ] **Step 1: Verify the current version contract is inconsistent**
+
+Run:
+
+```sh
+test ! -f rust-toolchain.toml
+cargo metadata --format-version 1 --locked |
+  jq -e '[.packages[] | select(.source == null) | .rust_version] | all(. == "1.88")'
+```
+
+Expected: the file assertion passes, then the metadata assertion fails because workspace crates currently inherit `rust-version = "1.80"`.
+
+- [ ] **Step 2: Raise the workspace MSRV**
+
+In the root `Cargo.toml`, change `[workspace.package]` to:
+
+```toml
+[workspace.package]
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+rust-version = "1.88"
+repository = "https://github.com/chrisbanes/ensemble"
+```
+
+Do not change dependency versions. Rust 1.88 is the highest declared minimum in the current locked graph, including `agent-client-protocol-schema 0.14.0`, `serde_with 3.21.0`, `plist 1.10.0`, and `time 0.3.53`.
+
+- [ ] **Step 3: Add the pinned primary toolchain**
+
+Create `rust-toolchain.toml` with:
+
+```toml
+[toolchain]
+channel = "1.97.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]
+```
+
+The exact patch version prevents local and CI compiler behavior from changing when Rust publishes a new stable release.
+
+- [ ] **Step 4: Verify Rustup and Cargo resolve the new contracts**
+
+Run:
+
+```sh
+rustc --version
+cargo metadata --format-version 1 --locked |
+  jq -e '[.packages[] | select(.source == null) | .rust_version] | all(. == "1.88")'
+```
+
+Expected: `rustc 1.97.0 (...)` and a successful `jq` assertion.
+
+- [ ] **Step 5: Check formatting and commit the version contract**
+
+Run:
+
+```sh
+cargo fmt --all -- --check
+git diff --check
+git add Cargo.toml rust-toolchain.toml
+git commit -m "build: pin Rust toolchain and raise MSRV"
+```
+
+Expected: both checks pass and the commit contains only `Cargo.toml` and `rust-toolchain.toml`.
+
+### Task 2: Enforce Primary and MSRV Toolchains in CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:16-267`
+
+- [ ] **Step 1: Record failing assertions for the current floating CI policy**
+
+Run:
+
+```sh
+test "$(rg -c 'dtolnay/rust-toolchain@stable' .github/workflows/ci.yml)" -eq 0
+rg -n '^  msrv:' .github/workflows/ci.yml
+```
+
+Expected: the first assertion fails because five jobs install floating `stable`; the second command finds no MSRV job.
+
+- [ ] **Step 2: Remove floating toolchain setup from normal jobs**
+
+Delete these blocks from the `ci`, `frontend`, `tauri-pr`, and `tauri-bundle` jobs:
+
+```yaml
+      - uses: dtolnay/rust-toolchain@stable
+```
+
+Delete the component-bearing block from the `ci` job in full:
+
+```yaml
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+```
+
+After deletion, each job should move directly from checkout to its next non-toolchain setup step. Plain `cargo`, `rustc`, `cargo fmt`, and `cargo clippy` commands will resolve Rust 1.97.0 and the declared components from `rust-toolchain.toml`.
+
+- [ ] **Step 3: Add a dedicated all-workspace MSRV job**
+
+Insert the following job after `ci` and before `frontend`:
+
+```yaml
+  msrv:
+    name: MSRV (Rust 1.88.0)
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.88.0
+      RUSTFLAGS: ""
+      SKIP_UI_BUILD: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@1.88.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv-1.88.0
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Check minimum supported Rust version
+        run: cargo +1.88.0 check --workspace --all-targets
+```
+
+The job-level `RUSTUP_TOOLCHAIN` ensures setup and cache helpers do not activate or download the repository's Rust 1.97.0 override. Clearing the global `RUSTFLAGS=-Dwarnings` keeps this job focused on compatibility; Clippy and warning policy remain enforced by the primary `ci` job. Installing the existing Tauri Linux dependencies allows `--workspace` to verify `ensemble-desktop` rather than excluding a crate that inherits the MSRV.
+
+- [ ] **Step 4: Install release targets on the pinned primary toolchain**
+
+In `build-cli`, replace:
+
+```yaml
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+```
+
+with:
+
+```yaml
+      - name: Install Rust target
+        run: rustup target add "${{ matrix.target }}"
+```
+
+Keep the target-specific Rust cache and release build command unchanged.
+
+- [ ] **Step 5: Verify the workflow contract locally**
+
+Run:
+
+```sh
+brew install actionlint
+test "$(rg -c 'dtolnay/rust-toolchain@stable' .github/workflows/ci.yml || true)" -eq 0
+test "$(rg -c 'dtolnay/rust-toolchain@1.88.0' .github/workflows/ci.yml)" -eq 1
+test "$(rg -c 'cargo \+1.88.0 check --workspace --all-targets' .github/workflows/ci.yml)" -eq 1
+test "$(rg -c 'rustup target add' .github/workflows/ci.yml)" -eq 1
+actionlint .github/workflows/ci.yml
+```
+
+Expected: all four assertions pass and `actionlint` emits no diagnostics.
+
+- [ ] **Step 6: Run the MSRV check before committing**
+
+Run:
+
+```sh
+rustup toolchain install 1.88.0 --profile minimal
+RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.88.0 check --workspace --all-targets
+```
+
+Expected: all workspace targets, including `ensemble-desktop`, compile successfully with Rust 1.88.0.
+
+- [ ] **Step 7: Commit CI enforcement**
+
+Run:
+
+```sh
+git diff --check
+git add .github/workflows/ci.yml
+git commit -m "ci: verify pinned Rust and MSRV toolchains"
+```
+
+Expected: the check passes and the commit contains only the workflow change.
+
+### Task 3: Make Upgrades Intentional and Document the Contract
+
+**Files:**
+- Modify: `renovate.json:21-106`
+- Modify: `docs/contributing.md:3-29,80-85`
+- Modify: `AGENTS.md:91-96,118-122`
+
+- [ ] **Step 1: Verify the repository does not yet document or govern the new policy**
+
+Run:
+
+```sh
+jq -e '.packageRules[] | select(.matchManagers == ["rust-toolchain"])' renovate.json
+rg -n 'Rust 1\.80|Rust 1\.88|rust-toolchain\.toml|MSRV' docs/contributing.md AGENTS.md
+```
+
+Expected: the `jq` command fails because no Rust toolchain package rule exists; the documentation search finds the stale Rust 1.80 statements and no complete pinned-toolchain/MSRV policy.
+
+- [ ] **Step 2: Add a review-only Renovate rule for exact toolchain updates**
+
+Add this object as the first entry in `packageRules` in `renovate.json`:
+
+```json
+    {
+      "description": "Require review for pinned Rust toolchain updates",
+      "matchManagers": ["rust-toolchain"],
+      "matchDepTypes": ["toolchain"],
+      "rangeStrategy": "pin",
+      "automerge": false
+    },
+```
+
+Keep the existing global `"labels": ["dependencies"]` and `"ignoreDeps": ["rust-version"]`. The built-in `rust-toolchain` manager will update `rust-toolchain.toml`; ignoring Cargo's `rust-version` prevents automatic MSRV raises.
+
+- [ ] **Step 3: Document toolchain selection and local checks for contributors**
+
+Replace `docs/contributing.md:3-29` with:
+
+````markdown
+## Build and test
+
+Ensemble's minimum supported Rust version (MSRV) is Rust 1.88. The repository pins Rust 1.97.0
+for normal development and CI in `rust-toolchain.toml`; Rustup selects and installs that toolchain
+automatically when commands run in the repository.
+
+```sh
+cargo build --workspace          # compile default targets with the pinned toolchain
+cargo test --workspace           # run default Rust tests
+cargo clippy --workspace -- -D warnings   # lint with the pinned toolchain
+cargo fmt --all -- --check       # check formatting with the pinned toolchain
+```
+
+The CLI's embedded dashboard is optional. Default `ensemble-cli` builds are headless and do not
+require Node, pnpm, OpenAPI generation, or frontend assets. To compile the web UI command from
+source, generate the frontend inputs and enable the feature:
+
+```sh
+cd crates/ensemble-ui/src-ui
+pnpm install --frozen-lockfile
+pnpm run codegen
+cd ../../..
+cargo build -p ensemble-cli --features web-ui
+```
+
+For Rust-only checks that intentionally compile the `web-ui` feature without rebuilding frontend
+assets, set `SKIP_UI_BUILD=1`.
+
+To verify MSRV compatibility locally, install Rust 1.88.0 and override the pinned toolchain:
+
+```sh
+rustup toolchain install 1.88.0 --profile minimal
+RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.88.0 check --workspace --all-targets
+```
+
+Run the normal format, Clippy, and test checks before pushing. CI also runs the separate MSRV
+check. Renovate proposes exact primary-toolchain updates to `rust-toolchain.toml`, but those changes
+do not automerge and must pass review. Raising the MSRV is a separate compatibility decision.
+````
+
+Preserve the existing `Product E2E` and later sections after this replacement.
+
+- [ ] **Step 4: Update the contributor-facing CI description**
+
+Replace `docs/contributing.md:80-85` with:
+
+```markdown
+## CI
+
+GitHub Actions runs on push to `main` and all PRs. A dedicated Rust 1.88.0 job checks every
+workspace target for MSRV compatibility. The main CI job uses the Rust 1.97.0 toolchain pinned in
+`rust-toolchain.toml` for format, Clippy, default non-desktop Rust tests, the feature-enabled product
+E2E test, and the CLI `web-ui` feature check. Frontend and desktop jobs use the same pinned primary
+toolchain and run separately. All must pass. `RUSTFLAGS=-Dwarnings` applies to the primary jobs;
+the MSRV job is a compile-compatibility check.
+```
+
+- [ ] **Step 5: Align repository agent guidance**
+
+In `AGENTS.md`, replace the CI paragraph at lines 91-96 with:
+
+```markdown
+## CI
+
+GitHub Actions runs on push to `main` and all PRs. A dedicated Rust 1.88.0 job checks all
+workspace targets for MSRV compatibility. Primary Rust jobs use the exact toolchain pinned in
+`rust-toolchain.toml`; the main job runs format, clippy, default non-desktop Rust tests, the
+feature-enabled product E2E test, and a CLI `web-ui` feature check. Frontend and desktop jobs run
+separately on the same pinned toolchain. All must pass. `RUSTFLAGS=-Dwarnings` applies to primary
+jobs, so treat warnings as errors.
+```
+
+Replace the Rust convention bullet at line 121 with:
+
+```markdown
+- **Rust 2021 edition**, minimum rust-version 1.88; normal development and CI use the exact toolchain pinned in `rust-toolchain.toml`
+```
+
+- [ ] **Step 6: Validate Renovate configuration and documentation consistency**
+
+Run:
+
+```sh
+jq -e '.packageRules[] | select(
+  .matchManagers == ["rust-toolchain"] and
+  .matchDepTypes == ["toolchain"] and
+  .rangeStrategy == "pin" and
+  .automerge == false
+)' renovate.json
+! rg -n 'Rust 1\.80|rust-version 1\.80' docs/contributing.md AGENTS.md
+rg -n 'Rust 1\.88|Rust 1\.97\.0|rust-toolchain\.toml|MSRV' docs/contributing.md AGENTS.md
+pnpm dlx renovate@43.257.5 renovate-config-validator renovate.json
+```
+
+Expected: the `jq` assertion passes, no stale Rust 1.80 reference remains in current guidance, both documents describe the new contracts, and Renovate reports valid configuration.
+
+- [ ] **Step 7: Commit upgrade policy and documentation**
+
+Run:
+
+```sh
+git diff --check
+git add renovate.json docs/contributing.md AGENTS.md
+git commit -m "docs: define Rust compatibility and upgrade policy"
+```
+
+Expected: the check passes and the commit contains only Renovate policy and contributor guidance.
+
+### Task 4: Run the Complete Toolchain Verification
+
+**Files:**
+- Verify only; no files should change.
+
+- [ ] **Step 1: Verify the repository selects the exact primary compiler**
+
+Run:
+
+```sh
+rustc --version
+rustup show active-toolchain
+```
+
+Expected: both identify Rust 1.97.0 selected by the repository's `rust-toolchain.toml` override.
+
+- [ ] **Step 2: Verify the MSRV contract from a clean compatibility build**
+
+Run:
+
+```sh
+cargo clean
+RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.88.0 check --workspace --all-targets
+```
+
+Expected: the complete workspace compiles successfully with Rust 1.88.0.
+
+- [ ] **Step 3: Run all primary Rust gates on the pinned toolchain**
+
+Run:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+cargo test --workspace --exclude ensemble-desktop
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
+```
+
+Expected: formatting, Clippy, all non-desktop tests, product E2E, and the CLI web UI feature check pass on Rust 1.97.0.
+
+- [ ] **Step 4: Re-run policy and workflow validation**
+
+Run:
+
+```sh
+actionlint .github/workflows/ci.yml
+pnpm dlx renovate@43.257.5 renovate-config-validator renovate.json
+git diff --check
+git status --short
+```
+
+Expected: both validators and `git diff --check` pass. `git status --short` is empty after the three task commits.
+
+- [ ] **Step 5: Review the branch against issue 319**
+
+Run:
+
+```sh
+git log --oneline --decorate -4
+git diff HEAD~3..HEAD -- Cargo.toml rust-toolchain.toml .github/workflows/ci.yml renovate.json docs/contributing.md AGENTS.md
+```
+
+Expected: the three implementation commits show an MSRV matching the current resolved graph, an explicit MSRV CI check, one pinned primary toolchain across local development and CI, warning-free Clippy on that toolchain, and review-only toolchain upgrades. No application source files or dependency versions change.

--- a/docs/superpowers/plans/2026-07-10-reproducible-rust-toolchain.md
+++ b/docs/superpowers/plans/2026-07-10-reproducible-rust-toolchain.md
@@ -343,7 +343,7 @@ jq -e '.packageRules[] | select(
 )' renovate.json
 ! rg -n 'Rust 1\.80|rust-version 1\.80' docs/contributing.md AGENTS.md
 rg -n 'Rust 1\.95|Rust 1\.97\.0|rust-toolchain\.toml|MSRV' docs/contributing.md AGENTS.md
-pnpm dlx renovate@43.257.5 renovate-config-validator renovate.json
+pnpm --package=renovate@43.257.5 dlx renovate-config-validator renovate.json
 ```
 
 Expected: the `jq` assertion passes, no stale Rust 1.80 reference remains in current guidance, both documents describe the new contracts, and Renovate reports valid configuration.
@@ -407,7 +407,7 @@ Run:
 
 ```sh
 actionlint .github/workflows/ci.yml
-pnpm dlx renovate@43.257.5 renovate-config-validator renovate.json
+pnpm --package=renovate@43.257.5 dlx renovate-config-validator renovate.json
 git diff --check
 git status --short
 ```

--- a/docs/superpowers/specs/2026-07-10-reproducible-rust-toolchain-design.md
+++ b/docs/superpowers/specs/2026-07-10-reproducible-rust-toolchain-design.md
@@ -2,13 +2,13 @@
 
 ## Problem
 
-The workspace declares Rust 1.80 as its minimum supported Rust version (MSRV), but the locked dependency graph includes packages that require newer compilers. `clap 4.6.1` and `reqwest 0.13.4` require Rust 1.85, while the current graph's highest declared minimum is Rust 1.88 from packages including `agent-client-protocol-schema 0.14.0`, `serde_with 3.21.0`, `plist 1.10.0`, and `time 0.3.53`. CI installs the floating `stable` channel in every Rust job, so compiler and Clippy upgrades can change build behavior without a repository change or review. Rust 1.97 exposed this failure mode when new Clippy diagnostics broke main while local Rust 1.96 still passed.
+The workspace declared Rust 1.80 as its minimum supported Rust version (MSRV), but the locked dependency graph includes packages that require newer compilers. The current graph's highest declared metadata requirement is Rust 1.88, including `agent-client-protocol-schema 0.14.0`, `serde_with 3.21.0`, `plist 1.10.0`, and `time 0.3.53`. That metadata is insufficient: `libsqlite3-sys 0.38.1` declares no `rust-version` yet uses `cfg_select!` in its bundled build script. Rust 1.94 fails on that macro and Rust 1.95 passes the complete all-target workspace check, establishing Rust 1.95 as the actual compilable minimum for the locked graph. CI installs the floating `stable` channel in every Rust job, so compiler and Clippy upgrades can change build behavior without a repository change or review. Rust 1.97 exposed this failure mode when new Clippy diagnostics broke main while local Rust 1.96 still passed.
 
 Pull request #329 fixed the immediate Rust 1.97 Clippy diagnostics. This design addresses the underlying version contracts so future toolchain changes are explicit and reproducible.
 
 ## Goals
 
-- Declare an MSRV that matches the resolved dependency graph.
+- Declare an MSRV that matches the tested, compilable dependency graph.
 - Verify the declared MSRV in CI.
 - Pin one exact Rust release for normal development, linting, testing, packaging, and releases.
 - Ensure toolchain upgrades happen through reviewed repository changes rather than changes to the floating `stable` channel.
@@ -25,7 +25,7 @@ Pull request #329 fixed the immediate Rust 1.97 Clippy diagnostics. This design 
 
 Ensemble will maintain two explicit Rust version contracts:
 
-1. **MSRV: Rust 1.88.0.** The workspace `rust-version` is `1.88`, and CI compiles all workspace targets with Rust 1.88.0. This establishes the oldest compiler the locked source and dependency graph must support.
+1. **MSRV: Rust 1.95.0.** The workspace `rust-version` is `1.95`, and CI compiles all workspace targets with Rust 1.95.0. This establishes the oldest compiler the locked source and dependency graph must support. The highest declared dependency metadata requirement remains Rust 1.88, but the locked `libsqlite3-sys 0.38.1` build script requires Rust 1.95 for `cfg_select!`; Rust 1.94 fails and Rust 1.95 passes.
 2. **Primary toolchain: Rust 1.97.0.** A checked-in `rust-toolchain.toml` selects Rust 1.97.0 for local development and normal CI jobs. Clippy, formatting, tests, product E2E checks, desktop builds, bundles, and release artifacts use this exact version.
 
 The primary toolchain may advance independently of the MSRV. Raising the MSRV requires an intentional compatibility decision and corresponding `Cargo.toml`, CI, and documentation changes.
@@ -50,11 +50,11 @@ Normal CI jobs will stop invoking `dtolnay/rust-toolchain@stable`. This removes 
 Add an independent `msrv` job to `.github/workflows/ci.yml`. It will:
 
 1. Check out the repository.
-2. Install Rust 1.88.0 with `dtolnay/rust-toolchain@1.88.0`.
+2. Install Rust 1.95.0 with `dtolnay/rust-toolchain@1.95.0`.
 3. Restore a Rust cache isolated for the MSRV job.
-4. Run `cargo +1.88.0 check --workspace --all-targets` with `SKIP_UI_BUILD=1`.
+4. Run `cargo +1.95.0 check --workspace --all-targets` with `SKIP_UI_BUILD=1`.
 
-The explicit `+1.88.0` override takes precedence over `rust-toolchain.toml`, making the compiler used by the compatibility check visible in the command itself. `--all-targets` compiles library, binary, example, benchmark, and test targets without paying the cost of executing every test on the oldest compiler. `SKIP_UI_BUILD=1` keeps Rust target compilation independent of generated frontend assets. On Linux, the job installs the same WebKitGTK and AppIndicator development packages as the existing desktop check so the all-workspace check includes `ensemble-desktop` rather than silently excluding a crate that inherits the workspace MSRV.
+The explicit `+1.95.0` override takes precedence over `rust-toolchain.toml`, making the compiler used by the compatibility check visible in the command itself. `--all-targets` compiles library, binary, example, benchmark, and test targets without paying the cost of executing every test on the oldest compiler. `SKIP_UI_BUILD=1` keeps Rust target compilation independent of generated frontend assets. On Linux, the job installs the same WebKitGTK and AppIndicator development packages as the existing desktop check so the all-workspace check includes `ensemble-desktop` rather than silently excluding a crate that inherits the workspace MSRV.
 
 Clippy remains exclusive to Rust 1.97.0 because lint sets change between compiler releases. The compatibility contract requires successful compilation on the MSRV, while the quality contract requires warning-free code on the pinned primary compiler.
 
@@ -73,10 +73,10 @@ Renovate may then propose primary toolchain upgrades, but each upgrade must pass
 
 Update `docs/contributing.md` to state:
 
-- Rust 1.88 is the MSRV;
+- Rust 1.95 is the MSRV;
 - Rustup automatically selects the pinned Rust 1.97.0 development toolchain from `rust-toolchain.toml`;
 - normal local checks and CI use the pinned toolchain;
-- the MSRV command is `cargo +1.88.0 check --workspace --all-targets`; and
+- the MSRV command is `cargo +1.95.0 check --workspace --all-targets`; and
 - primary toolchain upgrades are Renovate-proposed, reviewed changes.
 
 Update `AGENTS.md` so repository guidance no longer claims Rust 1.80 and so its CI description includes the explicit MSRV check and pinned primary toolchain.
@@ -88,7 +88,7 @@ No application specification update is needed because this change affects build 
 Implementation is complete when the following pass:
 
 ```sh
-cargo +1.88.0 check --workspace --all-targets
+cargo +1.95.0 check --workspace --all-targets
 cargo fmt --all -- --check
 cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
 cargo test --workspace --exclude ensemble-desktop
@@ -100,8 +100,8 @@ The implementation should also confirm that plain `rustc --version` resolves to 
 
 ## Acceptance Criteria Mapping
 
-- The workspace `rust-version = "1.88"` matches the highest declared minimum in the resolved dependency graph.
-- The dedicated MSRV job runs an explicit Rust 1.88.0 all-targets check, including the desktop crate.
+- The workspace `rust-version = "1.95"` matches the tested compiler boundary for the locked graph: its highest declared metadata requirement is Rust 1.88, but `libsqlite3-sys 0.38.1` uses undeclared `cfg_select!`, which fails on Rust 1.94 and passes on Rust 1.95. No dependency downgrade is chosen because it would forgo dependency and security updates.
+- The dedicated MSRV job runs an explicit Rust 1.95.0 all-targets check, including the desktop crate.
 - `rust-toolchain.toml` pins primary development and CI behavior to Rust 1.97.0.
 - Existing `-D warnings` Clippy checks run on the pinned primary toolchain; pull request #329 already resolves the currently known Rust 1.97 diagnostics.
 - Renovate proposes exact toolchain updates without automerging them, making upgrades intentional and reviewable.

--- a/docs/superpowers/specs/2026-07-10-reproducible-rust-toolchain-design.md
+++ b/docs/superpowers/specs/2026-07-10-reproducible-rust-toolchain-design.md
@@ -1,0 +1,107 @@
+# Reproducible Rust Toolchain Design
+
+## Problem
+
+The workspace declares Rust 1.80 as its minimum supported Rust version (MSRV), but the locked dependency graph includes packages that require newer compilers. `clap 4.6.1` and `reqwest 0.13.4` require Rust 1.85, while the current graph's highest declared minimum is Rust 1.88 from packages including `agent-client-protocol-schema 0.14.0`, `serde_with 3.21.0`, `plist 1.10.0`, and `time 0.3.53`. CI installs the floating `stable` channel in every Rust job, so compiler and Clippy upgrades can change build behavior without a repository change or review. Rust 1.97 exposed this failure mode when new Clippy diagnostics broke main while local Rust 1.96 still passed.
+
+Pull request #329 fixed the immediate Rust 1.97 Clippy diagnostics. This design addresses the underlying version contracts so future toolchain changes are explicit and reproducible.
+
+## Goals
+
+- Declare an MSRV that matches the resolved dependency graph.
+- Verify the declared MSRV in CI.
+- Pin one exact Rust release for normal development, linting, testing, packaging, and releases.
+- Ensure toolchain upgrades happen through reviewed repository changes rather than changes to the floating `stable` channel.
+- Document the distinction between compatibility and development toolchains.
+
+## Non-Goals
+
+- Preserve Rust 1.80 by downgrading or pinning dependencies.
+- Run Clippy, the complete test suite, or release packaging on the MSRV.
+- Change application behavior or dependency versions.
+- Rework the GitHub Actions workflow beyond Rust toolchain selection and MSRV verification.
+
+## Version Contracts
+
+Ensemble will maintain two explicit Rust version contracts:
+
+1. **MSRV: Rust 1.88.0.** The workspace `rust-version` is `1.88`, and CI compiles all workspace targets with Rust 1.88.0. This establishes the oldest compiler the locked source and dependency graph must support.
+2. **Primary toolchain: Rust 1.97.0.** A checked-in `rust-toolchain.toml` selects Rust 1.97.0 for local development and normal CI jobs. Clippy, formatting, tests, product E2E checks, desktop builds, bundles, and release artifacts use this exact version.
+
+The primary toolchain may advance independently of the MSRV. Raising the MSRV requires an intentional compatibility decision and corresponding `Cargo.toml`, CI, and documentation changes.
+
+## Repository Toolchain
+
+Add a root `rust-toolchain.toml` containing:
+
+```toml
+[toolchain]
+channel = "1.97.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]
+```
+
+Rustup automatically discovers this file for local commands and GitHub-hosted runner commands executed inside the repository. The minimal profile avoids unnecessary CI downloads while the explicit components support the existing formatting and Clippy gates.
+
+Normal CI jobs will stop invoking `dtolnay/rust-toolchain@stable`. This removes the floating version selector and avoids duplicating `1.97.0` across jobs. The release CLI matrix will install its dynamic cross-compilation target with `rustup target add "${{ matrix.target }}"` before building; the host target remains supplied by the pinned toolchain.
+
+## MSRV Verification
+
+Add an independent `msrv` job to `.github/workflows/ci.yml`. It will:
+
+1. Check out the repository.
+2. Install Rust 1.88.0 with `dtolnay/rust-toolchain@1.88.0`.
+3. Restore a Rust cache isolated for the MSRV job.
+4. Run `cargo +1.88.0 check --workspace --all-targets` with `SKIP_UI_BUILD=1`.
+
+The explicit `+1.88.0` override takes precedence over `rust-toolchain.toml`, making the compiler used by the compatibility check visible in the command itself. `--all-targets` compiles library, binary, example, benchmark, and test targets without paying the cost of executing every test on the oldest compiler. `SKIP_UI_BUILD=1` keeps Rust target compilation independent of generated frontend assets. On Linux, the job installs the same WebKitGTK and AppIndicator development packages as the existing desktop check so the all-workspace check includes `ensemble-desktop` rather than silently excluding a crate that inherits the workspace MSRV.
+
+Clippy remains exclusive to Rust 1.97.0 because lint sets change between compiler releases. The compatibility contract requires successful compilation on the MSRV, while the quality contract requires warning-free code on the pinned primary compiler.
+
+## Intentional Upgrades
+
+Renovate already ignores the Cargo `rust-version` dependency, so it will not raise the MSRV automatically. Add a package rule for the built-in `rust-toolchain` manager that:
+
+- matches the `toolchain` dependency type;
+- uses `rangeStrategy: "pin"` so updates retain an exact patch release;
+- disables automerge for toolchain updates; and
+- labels the update as a dependency change.
+
+Renovate may then propose primary toolchain upgrades, but each upgrade must pass CI and receive normal review before merge. The upgrade PR will surface new compiler and Clippy behavior without silently changing unrelated CI runs.
+
+## Documentation
+
+Update `docs/contributing.md` to state:
+
+- Rust 1.88 is the MSRV;
+- Rustup automatically selects the pinned Rust 1.97.0 development toolchain from `rust-toolchain.toml`;
+- normal local checks and CI use the pinned toolchain;
+- the MSRV command is `cargo +1.88.0 check --workspace --all-targets`; and
+- primary toolchain upgrades are Renovate-proposed, reviewed changes.
+
+Update `AGENTS.md` so repository guidance no longer claims Rust 1.80 and so its CI description includes the explicit MSRV check and pinned primary toolchain.
+
+No application specification update is needed because this change affects build and contribution policy rather than runtime behavior or user-facing contracts.
+
+## Verification
+
+Implementation is complete when the following pass:
+
+```sh
+cargo +1.88.0 check --workspace --all-targets
+cargo fmt --all -- --check
+cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+cargo test --workspace --exclude ensemble-desktop
+SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
+SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
+```
+
+The implementation should also confirm that plain `rustc --version` resolves to 1.97.0 inside the repository and that `renovate-config-validator renovate.json` passes if the validator is available.
+
+## Acceptance Criteria Mapping
+
+- The workspace `rust-version = "1.88"` matches the highest declared minimum in the resolved dependency graph.
+- The dedicated MSRV job runs an explicit Rust 1.88.0 all-targets check, including the desktop crate.
+- `rust-toolchain.toml` pins primary development and CI behavior to Rust 1.97.0.
+- Existing `-D warnings` Clippy checks run on the pinned primary toolchain; pull request #329 already resolves the currently known Rust 1.97 diagnostics.
+- Renovate proposes exact toolchain updates without automerging them, making upgrades intentional and reviewable.

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,13 @@
   "ignoreDeps": ["rust-version"],
   "packageRules": [
     {
+      "description": "Require review for pinned Rust toolchain updates",
+      "matchManagers": ["rust-toolchain"],
+      "matchDepTypes": ["toolchain"],
+      "rangeStrategy": "pin",
+      "automerge": false
+    },
+    {
       "description": "Group Rust workspace ecosystem packages",
       "matchManagers": ["cargo"],
       "groupName": "Rust dependencies",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
- declare the tested Rust 1.95 MSRV and pin normal development/CI to Rust 1.97.0
- add an explicit all-target MSRV job and remove floating stable toolchains from primary CI and releases
- require reviewed Renovate toolchain updates and document the compatibility policy
- fix the Rust 1.97 Clippy diagnostic exposed by the pinned toolchain

## Testing
- `RUSTFLAGS= SKIP_UI_BUILD=1 cargo +1.95.0 check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo test --workspace --exclude ensemble-desktop`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `actionlint .github/workflows/ci.yml`
- `pnpm --package=renovate@43.257.5 dlx renovate-config-validator renovate.json`

Closes #319