### PR TITLE
Prevent reentrant orchestrator locking during finalization

### DIFF
--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -103,6 +103,27 @@ struct InteractionRequestContext {
     step_tracker_state: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunningAttemptIdentity {
+    run_id: Option<String>,
+    started_at: chrono::DateTime<Utc>,
+}
+
+impl RunningAttemptIdentity {
+    fn capture(state: &OrchestratorState, issue_id: &str) -> Option<Self> {
+        state.get_running(issue_id).map(|entry| Self {
+            run_id: entry.run_id.clone(),
+            started_at: entry.started_at,
+        })
+    }
+
+    fn is_current(&self, state: &OrchestratorState, issue_id: &str) -> bool {
+        state
+            .get_running(issue_id)
+            .is_some_and(|entry| entry.run_id == self.run_id && entry.started_at == self.started_at)
+    }
+}
+
 const HISTORY_OUTCOME_SUCCEEDED: &str = "succeeded";
 const HISTORY_OUTCOME_FAILED: &str = "failed";
 const HISTORY_OUTCOME_STOPPED: &str = "stopped";
@@ -1570,6 +1591,8 @@ impl Orchestrator {
                                 .as_ref()
                                 .map(|issue| issue.identifier.clone())
                                 .unwrap_or_else(|| issue_id.to_string());
+                            let finalize_attempt =
+                                RunningAttemptIdentity::capture(&state, issue_id);
                             let config_snapshot = config.clone();
                             drop(config);
                             drop(state);
@@ -1585,6 +1608,16 @@ impl Orchestrator {
                                 history,
                             ) = {
                                 let mut state = self.state.write().await;
+                                if !finalize_attempt
+                                    .as_ref()
+                                    .is_some_and(|attempt| attempt.is_current(&state, issue_id))
+                                {
+                                    warn!(
+                                        issue_id = %issue_id,
+                                        "discarding stale finalization result because the running attempt changed"
+                                    );
+                                    return;
+                                }
                                 let completed_at = Utc::now();
                                 let history_record = state
                                     .running
@@ -7307,6 +7340,25 @@ agent:
         assert!(state.is_claimed("1"));
 
         drop(repo_temp);
+    }
+
+    #[test]
+    fn finalization_attempt_rejects_missing_or_replaced_running_entry() {
+        let config = make_config();
+        let mut state = OrchestratorState::new(1_000, &config.concurrency);
+        state.add_running(&test_issue("1", "Todo"), None);
+
+        let attempt = RunningAttemptIdentity::capture(&state, "1").unwrap();
+        assert!(attempt.is_current(&state, "1"));
+
+        let mut replacement = state.remove_running("1").unwrap();
+        assert!(!attempt.is_current(&state, "1"));
+
+        let original_run_id = replacement.run_id.clone();
+        replacement.started_at += chrono::Duration::seconds(1);
+        state.running.insert("1".to_string(), replacement);
+        assert_eq!(state.get_running("1").unwrap().run_id, original_run_id);
+        assert!(!attempt.is_current(&state, "1"));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1645,6 +1645,9 @@ impl Orchestrator {
                                                 | FinalizeStatus::SkippedHeadless
                                         ))
                                     .then(|| config_snapshot.on_failure.clone());
+                                    if let Some(entry) = state.remove_running(issue_id) {
+                                        state.add_runtime_seconds(&entry);
+                                    }
                                     state.set_finalize_state(issue_id, finalize_state);
                                     state.remove_pipeline_run(issue_id);
 
@@ -7300,6 +7303,8 @@ agent:
             state.artifacts["1"].repos[0].finalize_status,
             "pending_approval"
         );
+        assert!(!state.is_running("1"));
+        assert!(state.is_claimed("1"));
 
         drop(repo_temp);
     }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -151,6 +151,9 @@ pub struct Orchestrator {
     worker_tx: mpsc::Sender<WorkerEvent>,
     worker_rx: mpsc::Receiver<WorkerEvent>,
     shutdown_rx: mpsc::Receiver<()>,
+    #[cfg(test)]
+    finalization_commit_test_barriers:
+        Option<(Arc<tokio::sync::Barrier>, Arc<tokio::sync::Barrier>)>,
 }
 
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -192,6 +195,14 @@ struct WaitingHistoryRecordInput<'a> {
 impl Orchestrator {
     fn effective_step_timeout_ms(timeout_ms: Option<u64>, config: &EnsembleConfig) -> u64 {
         timeout_ms.unwrap_or(config.agent.turn_timeout_ms)
+    }
+
+    fn finalization_attempt_is_current(
+        attempt: Option<&RunningAttemptIdentity>,
+        state: &OrchestratorState,
+        issue_id: &str,
+    ) -> bool {
+        attempt.is_some_and(|attempt| attempt.is_current(state, issue_id))
     }
 
     /// Create a new Orchestrator.
@@ -271,6 +282,25 @@ impl Orchestrator {
             worker_tx,
             worker_rx,
             shutdown_rx,
+            #[cfg(test)]
+            finalization_commit_test_barriers: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn set_finalization_commit_test_barriers(
+        &mut self,
+        before_commit: Arc<tokio::sync::Barrier>,
+        resume_commit: Arc<tokio::sync::Barrier>,
+    ) {
+        self.finalization_commit_test_barriers = Some((before_commit, resume_commit));
+    }
+
+    #[cfg(test)]
+    async fn wait_for_finalization_commit_test_barriers(&self) {
+        if let Some((before_commit, resume_commit)) = &self.finalization_commit_test_barriers {
+            before_commit.wait().await;
+            resume_commit.wait().await;
         }
     }
 
@@ -778,7 +808,7 @@ impl Orchestrator {
             if state.get_pipeline_run(&issue.id).is_some() {
                 drop(state);
 
-                let (config_snapshot, action, effective_cycle, effective_attempt) = {
+                let (config_snapshot, action, effective_cycle, effective_attempt, finalize_attempt) = {
                     let mut state = self.state.write().await;
                     let existing_cycle = state
                         .get_pipeline_run(&issue.id)
@@ -796,7 +826,14 @@ impl Orchestrator {
                             run.start()
                         })
                         .unwrap_or(PipelineAction::Waiting);
-                    (config, action, effective_cycle, effective_attempt)
+                    let finalize_attempt = RunningAttemptIdentity::capture(&state, &issue.id);
+                    (
+                        config,
+                        action,
+                        effective_cycle,
+                        effective_attempt,
+                        finalize_attempt,
+                    )
                 };
 
                 let Some(config_snapshot) = config_snapshot else {
@@ -825,9 +862,22 @@ impl Orchestrator {
                         let finalize_state = self
                             .run_finalize_phase(&issue.id, &issue.identifier, &config_snapshot)
                             .await;
+                        #[cfg(test)]
+                        self.wait_for_finalization_commit_test_barriers().await;
                         let completed_at = Utc::now();
                         let (history_record, history_run_id, release_run_id, should_release) = {
                             let mut state = self.state.write().await;
+                            if !Self::finalization_attempt_is_current(
+                                finalize_attempt.as_ref(),
+                                &state,
+                                &issue.id,
+                            ) {
+                                warn!(
+                                    issue_id = %issue.id,
+                                    "discarding stale finalization result because the running attempt changed"
+                                );
+                                return;
+                            }
                             let history_record = state
                                 .running
                                 .get(&issue.id)
@@ -1608,10 +1658,11 @@ impl Orchestrator {
                                 history,
                             ) = {
                                 let mut state = self.state.write().await;
-                                if !finalize_attempt
-                                    .as_ref()
-                                    .is_some_and(|attempt| attempt.is_current(&state, issue_id))
-                                {
+                                if !Self::finalization_attempt_is_current(
+                                    finalize_attempt.as_ref(),
+                                    &state,
+                                    issue_id,
+                                ) {
                                     warn!(
                                         issue_id = %issue_id,
                                         "discarding stale finalization result because the running attempt changed"
@@ -8649,6 +8700,86 @@ agent:
             run.step_states.get("test"),
             Some(StepState::Running { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn restored_finalization_discards_stale_attempt_before_owned_writes() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let state_writes = Arc::new(RwLock::new(Vec::new()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(RecordingTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+            state_writes: Arc::clone(&state_writes),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let issue = test_issue("1", "Todo");
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+            pipeline_run.step_completed("build", succeeded_step_output(), false);
+
+            let mut state = orchestrator.state.write().await;
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+        }
+
+        let before_commit = Arc::new(tokio::sync::Barrier::new(2));
+        let resume_commit = Arc::new(tokio::sync::Barrier::new(2));
+        orchestrator.set_finalization_commit_test_barriers(
+            Arc::clone(&before_commit),
+            Arc::clone(&resume_commit),
+        );
+        let state = Arc::clone(&orchestrator.state);
+        let journal_path = orchestrator.pipeline_journal.path_for_issue("1");
+        let history_store = orchestrator.history_store.clone().unwrap();
+
+        let dispatch = tokio::spawn(async move {
+            orchestrator.dispatch_issue(&issue, None).await;
+        });
+        before_commit.wait().await;
+
+        {
+            let mut state = state.write().await;
+            let mut replacement = state.remove_running("1").unwrap();
+            replacement.started_at += chrono::Duration::seconds(1);
+            state.running.insert("1".to_string(), replacement);
+        }
+        resume_commit.wait().await;
+        dispatch.await.unwrap();
+
+        let state = state.read().await;
+        assert!(state.is_running("1"));
+        assert!(state.get_pipeline_run("1").is_some());
+        assert!(!state.completed.contains_key("1"));
+        assert!(state.get_finalize_state("1").is_none());
+        assert!(state_writes.read().await.is_empty());
+        assert!(!journal_path.exists());
+        assert_eq!(
+            history_store
+                .read_history(&crate::history::reader::HistoryQuery::default())
+                .await
+                .unwrap()
+                .total,
+            0
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -915,6 +915,9 @@ impl Orchestrator {
                                 state.clear_finalize_state(&issue.id);
                                 (history_record, history_run_id, release_run_id, true)
                             } else {
+                                if let Some(entry) = state.remove_running(&issue.id) {
+                                    state.add_runtime_seconds(&entry);
+                                }
                                 state.set_finalize_state(&issue.id, finalize_state);
                                 state.remove_pipeline_run(&issue.id);
                                 (history_record, history_run_id, release_run_id, false)
@@ -8780,6 +8783,74 @@ agent:
                 .total,
             0
         );
+    }
+
+    #[tokio::test]
+    async fn restored_pending_approval_finalization_releases_running_slot() {
+        let (repo_temp, repo_config) = create_finalize_repo().await;
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let workspace_temp = tempfile::TempDir::new().unwrap();
+        let workspace_mgr =
+            WorkspaceManager::new(workspace_temp.path(), Some(vec![repo_config])).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            workspace_temp.path(),
+            shutdown_rx,
+        );
+        let issue = test_issue("1", "Todo");
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+            pipeline_run.step_completed("build", succeeded_step_output(), false);
+
+            let mut state = orchestrator.state.write().await;
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+            state.artifacts.insert(
+                "1".to_string(),
+                RunArtifacts {
+                    run_id: "run-1".to_string(),
+                    workspace_path: workspace_temp.path().display().to_string(),
+                    repos: vec![crate::history::artifacts::RepoArtifact {
+                        repo: "source-repo".to_string(),
+                        finalize_status: "pending".to_string(),
+                        ..Default::default()
+                    }],
+                    transcripts: vec![],
+                },
+            );
+        }
+
+        orchestrator.dispatch_issue(&issue, None).await;
+
+        let state = orchestrator.state.read().await;
+        let finalize = state.get_finalize_state("1").unwrap();
+        assert_eq!(finalize.status, FinalizeStatus::PendingApproval);
+        assert!(!state.is_running("1"));
+        assert!(state.is_claimed("1"));
+        assert!(state.get_pipeline_run("1").is_none());
+        assert_eq!(
+            state.artifacts["1"].repos[0].finalize_status,
+            "pending_approval"
+        );
+
+        drop(repo_temp);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1570,72 +1570,105 @@ impl Orchestrator {
                                 .as_ref()
                                 .map(|issue| issue.identifier.clone())
                                 .unwrap_or_else(|| issue_id.to_string());
+                            let config_snapshot = config.clone();
+                            drop(config);
+                            drop(state);
                             let finalize_state = self
-                                .run_finalize_phase(issue_id, &issue_identifier, &config)
+                                .run_finalize_phase(issue_id, &issue_identifier, &config_snapshot)
                                 .await;
 
-                            let completed_at = Utc::now();
-                            let history_record = state
-                                .running
-                                .get(issue_id)
-                                .zip(state.get_pipeline_run(issue_id))
-                                .map(|(entry, run)| {
-                                    self.build_history_record(RunningHistoryRecordInput {
-                                        issue_id,
-                                        outcome: HISTORY_OUTCOME_SUCCEEDED,
-                                        last_error: None,
-                                        running_entry: entry,
-                                        run,
-                                        completed_at,
-                                        artifacts: state.artifacts.get(issue_id).cloned(),
-                                    })
-                                });
+                            let (
+                                tracker_state,
+                                tracker_error_message,
+                                transition,
+                                release,
+                                history,
+                            ) = {
+                                let mut state = self.state.write().await;
+                                let completed_at = Utc::now();
+                                let history_record = state
+                                    .running
+                                    .get(issue_id)
+                                    .zip(state.get_pipeline_run(issue_id))
+                                    .map(|(entry, run)| {
+                                        self.build_history_record(RunningHistoryRecordInput {
+                                            issue_id,
+                                            outcome: HISTORY_OUTCOME_SUCCEEDED,
+                                            last_error: None,
+                                            running_entry: entry,
+                                            run,
+                                            completed_at,
+                                            artifacts: state.artifacts.get(issue_id).cloned(),
+                                        })
+                                    });
+                                let running_entry = state.get_running(issue_id).cloned();
 
-                            // Get running entry data before removing
-                            let running_entry = state.get_running(issue_id).cloned();
-
-                            if finalize_state.status == FinalizeStatus::Succeeded
-                                || finalize_state.status == FinalizeStatus::NotRequired
-                            {
-                                // Add to completed BEFORE removing from running
-                                if let Some(ref entry) = running_entry {
-                                    state.add_completed(
-                                        issue_id.to_string(),
-                                        entry.identifier.clone(),
-                                        "completed_succeeded".to_string(),
-                                    );
-                                }
-
-                                if self.tracker.supports_writes() {
-                                    if let Err(e) = self
-                                        .tracker
-                                        .set_issue_state(issue_id, &config.on_success)
-                                        .await
-                                    {
-                                        warn!(issue_id = %issue_id, error = %e, "failed to set tracker success state");
+                                if matches!(
+                                    finalize_state.status,
+                                    FinalizeStatus::Succeeded | FinalizeStatus::NotRequired
+                                ) {
+                                    if let Some(ref entry) = running_entry {
+                                        state.add_completed(
+                                            issue_id.to_string(),
+                                            entry.identifier.clone(),
+                                            "completed_succeeded".to_string(),
+                                        );
                                     }
-                                }
-                                state.release_claim(issue_id);
-                                state.remove_pipeline_run(issue_id);
+                                    state.release_claim(issue_id);
+                                    state.remove_pipeline_run(issue_id);
+                                    if let Some(entry) = state.remove_running(issue_id) {
+                                        state.add_runtime_seconds(&entry);
+                                    }
+                                    state.clear_finalize_state(issue_id);
 
-                                // Now remove from running and add runtime seconds
-                                if let Some(entry) = state.remove_running(issue_id) {
-                                    state.add_runtime_seconds(&entry);
-                                }
-                                state.clear_finalize_state(issue_id);
+                                    let history_run_id = running_entry
+                                        .as_ref()
+                                        .and_then(|entry| entry.run_id.clone());
+                                    let release_identifier = running_entry
+                                        .as_ref()
+                                        .map(|entry| entry.identifier.clone())
+                                        .unwrap_or_else(|| issue_identifier.clone());
+                                    (
+                                        self.tracker
+                                            .supports_writes()
+                                            .then(|| config_snapshot.on_success.clone()),
+                                        "failed to set tracker success state",
+                                        step_transition,
+                                        Some((release_identifier, history_run_id.clone())),
+                                        history_record.map(|record| (history_run_id, record)),
+                                    )
+                                } else {
+                                    let tracker_state = (self.tracker.supports_writes()
+                                        && matches!(
+                                            finalize_state.status,
+                                            FinalizeStatus::Failed
+                                                | FinalizeStatus::SkippedHeadless
+                                        ))
+                                    .then(|| config_snapshot.on_failure.clone());
+                                    state.set_finalize_state(issue_id, finalize_state);
+                                    state.remove_pipeline_run(issue_id);
 
-                                let history_run_id = running_entry
-                                    .as_ref()
-                                    .and_then(|entry| entry.run_id.clone());
-                                let release_identifier = running_entry
-                                    .as_ref()
-                                    .map(|entry| entry.identifier.clone())
-                                    .unwrap_or_else(|| issue_identifier.clone());
-                                let release_run_id = history_run_id.clone();
-                                drop(state);
-                                if let Some(input) = step_transition {
-                                    self.append_pipeline_transition(input).await;
+                                    (
+                                        tracker_state,
+                                        "failed to set tracker failure state after finalize failure",
+                                        None,
+                                        None,
+                                        None,
+                                    )
                                 }
+                            };
+
+                            if let Some(tracker_state) = tracker_state {
+                                if let Err(error) =
+                                    self.tracker.set_issue_state(issue_id, &tracker_state).await
+                                {
+                                    warn!(issue_id = %issue_id, error = %error, "{tracker_error_message}");
+                                }
+                            }
+                            if let Some(input) = transition {
+                                self.append_pipeline_transition(input).await;
+                            }
+                            if let Some((release_identifier, release_run_id)) = release {
                                 self.append_pipeline_release(
                                     issue_id,
                                     &release_identifier,
@@ -1643,27 +1676,10 @@ impl Orchestrator {
                                     "completed",
                                 )
                                 .await;
-                                if let Some(record) = history_record {
-                                    self.append_history_record(history_run_id.as_deref(), record)
-                                        .await;
-                                }
-                            } else {
-                                if self.tracker.supports_writes()
-                                    && matches!(
-                                        finalize_state.status,
-                                        FinalizeStatus::Failed | FinalizeStatus::SkippedHeadless
-                                    )
-                                {
-                                    if let Err(e) = self
-                                        .tracker
-                                        .set_issue_state(issue_id, &config.on_failure)
-                                        .await
-                                    {
-                                        warn!(issue_id = %issue_id, error = %e, "failed to set tracker failure state after finalize failure");
-                                    }
-                                }
-                                state.set_finalize_state(issue_id, finalize_state);
-                                state.remove_pipeline_run(issue_id);
+                            }
+                            if let Some((history_run_id, record)) = history {
+                                self.append_history_record(history_run_id.as_deref(), record)
+                                    .await;
                             }
                         }
                         PipelineAction::Failed { step, reason } => {
@@ -5702,6 +5718,61 @@ mod tests {
         crate::tracker::model::test_helpers::test_issue(id, state)
     }
 
+    async fn create_finalize_repo() -> (tempfile::TempDir, crate::config::ensemble::RepoConfig) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo_path = temp.path().join("source-repo");
+        tokio::fs::create_dir_all(&repo_path).await.unwrap();
+
+        for args in [
+            vec!["init", "--initial-branch=main"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test User"],
+        ] {
+            let output = tokio::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo_path)
+                .output()
+                .await
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git command failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        tokio::fs::write(repo_path.join("README.md"), "# source repo\n")
+            .await
+            .unwrap();
+        for args in [vec!["add", "README.md"], vec!["commit", "-m", "initial"]] {
+            let output = tokio::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo_path)
+                .output()
+                .await
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git command failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        (
+            temp,
+            crate::config::ensemble::RepoConfig {
+                path: repo_path.display().to_string(),
+                branch: "main".to_string(),
+                git_remote: "origin".to_string(),
+                finalize: crate::workspace::finalize::RepoFinalizeConfig {
+                    enabled: true,
+                    mode: FinalizeMode::Push,
+                    approval_required: true,
+                },
+            },
+        )
+    }
+
     fn make_config() -> EnsembleConfig {
         let yaml = r#"
 tracker:
@@ -7152,6 +7223,85 @@ agent:
             state.completed.contains_key("1") || state.retry_attempts.contains_key("1"),
             "should be completed or retrying"
         );
+    }
+
+    #[tokio::test]
+    async fn enabled_finalization_returns_without_reentrant_state_locking() {
+        let (repo_temp, repo_config) = create_finalize_repo().await;
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let workspace_temp = tempfile::TempDir::new().unwrap();
+        let workspace_mgr =
+            WorkspaceManager::new(workspace_temp.path(), Some(vec![repo_config])).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            workspace_temp.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.mark_running("build", "session-1".to_string());
+
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+            state.artifacts.insert(
+                "1".to_string(),
+                RunArtifacts {
+                    run_id: "run-1".to_string(),
+                    workspace_path: workspace_temp.path().display().to_string(),
+                    repos: vec![crate::history::artifacts::RepoArtifact {
+                        repo: "source-repo".to_string(),
+                        finalize_status: "pending".to_string(),
+                        ..Default::default()
+                    }],
+                    transcripts: vec![],
+                },
+            );
+        }
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            orchestrator.handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Success {
+                    output: succeeded_step_output(),
+                    approval_request: None,
+                },
+            ),
+        )
+        .await
+        .expect("finalization should not deadlock on the state lock");
+
+        let state = orchestrator.state.read().await;
+        let finalize = state
+            .get_finalize_state("1")
+            .expect("finalize state should be retained while awaiting approval");
+        assert_eq!(finalize.status, FinalizeStatus::PendingApproval);
+        assert_eq!(finalize.repos[0].status, FinalizeStatus::PendingApproval);
+        assert_eq!(
+            state.artifacts["1"].repos[0].finalize_status,
+            "pending_approval"
+        );
+
+        drop(repo_temp);
     }
 
     #[tokio::test]

--- a/docs/superpowers/plans/2026-07-11-finalization-locking.md
+++ b/docs/superpowers/plans/2026-07-11-finalization-locking.md
@@ -538,6 +538,8 @@ Use the same private validation gate in both paths. The early return must occur 
 
 Add a deterministic test seam immediately after `run_finalize_phase` returns, then pause the restored-pipeline path, replace its running entry with the same run ID and a later `started_at`, and resume the commit. Assert the restored pipeline remains running and retained, completion/finalize state is unchanged, and tracker, pipeline-release journal, and history writes are absent. This must invoke `dispatch_issue` so removing the restored-path guard makes the test fail; do not rely only on `RunningAttemptIdentity::is_current`.
 
+Add a separate restored pending-approval lifecycle test with a matching artifact fixture. In the non-stale unresolved branch, assert `PendingApproval`, no running entry, a retained claim, a removed pipeline run, and artifact status `pending_approval`. The branch must remove the running entry and add its runtime before persisting finalize state; it must retain the claim, workspace, and artifacts for existing finalize controls.
+
 - [ ] **Step 7: Run focused tests to verify GREEN**
 
 Run:

--- a/docs/superpowers/plans/2026-07-11-finalization-locking.md
+++ b/docs/superpowers/plans/2026-07-11-finalization-locking.md
@@ -207,14 +207,15 @@ The cloned `EnsembleConfig` prevents configuration reloads from being blocked by
 Replace the remainder of the branch with a state-only block that builds owned post-commit work:
 
 ```rust
-let completed_at = Utc::now();
 let (
     tracker_state,
-    history_record,
-    history_run_id,
-    release_record,
+    tracker_error_message,
+    transition,
+    release,
+    history,
 ) = {
     let mut state = self.state.write().await;
+    let completed_at = Utc::now();
     let history_record = state
         .running
         .get(issue_id)
@@ -231,9 +232,6 @@ let (
             })
         });
     let running_entry = state.get_running(issue_id).cloned();
-    let history_run_id = running_entry
-        .as_ref()
-        .and_then(|entry| entry.run_id.clone());
 
     if matches!(
         finalize_state.status,
@@ -253,6 +251,9 @@ let (
         }
         state.clear_finalize_state(issue_id);
 
+        let history_run_id = running_entry
+            .as_ref()
+            .and_then(|entry| entry.run_id.clone());
         let release_identifier = running_entry
             .as_ref()
             .map(|entry| entry.identifier.clone())
@@ -261,9 +262,10 @@ let (
             self.tracker
                 .supports_writes()
                 .then(|| config_snapshot.on_success.clone()),
-            history_record,
-            history_run_id.clone(),
+            "failed to set tracker success state",
+            step_transition,
             Some((release_identifier, history_run_id.clone())),
+            history_record.map(|record| (history_run_id, record)),
         )
     } else {
         let tracker_state = (self.tracker.supports_writes()
@@ -272,14 +274,23 @@ let (
                 FinalizeStatus::Failed | FinalizeStatus::SkippedHeadless
             ))
         .then(|| config_snapshot.on_failure.clone());
+        if let Some(entry) = state.remove_running(issue_id) {
+            state.add_runtime_seconds(&entry);
+        }
         state.set_finalize_state(issue_id, finalize_state);
         state.remove_pipeline_run(issue_id);
-        (tracker_state, None, history_run_id, None)
+        (
+            tracker_state,
+            "failed to set tracker failure state after finalize failure",
+            None,
+            None,
+            None,
+        )
     }
 };
 ```
 
-Keep this block synchronous: it may read or mutate `state`, but it must contain no `.await`.
+Once acquired, this guard only reads or mutates `state`; it performs no external I/O. Unresolved finalization removes the running entry and adds its runtime seconds before parking the finalize state, releasing the running slot while retaining the claim, workspace, and artifacts.
 
 - [ ] **Step 3: Perform tracker and persistence I/O after the guard is gone**
 
@@ -287,23 +298,15 @@ Immediately after the state-only block, perform the owned work without a state g
 
 ```rust
 if let Some(tracker_state) = tracker_state {
-    if let Err(error) = self
-        .tracker
-        .set_issue_state(issue_id, &tracker_state)
-        .await
-    {
-        warn!(
-            issue_id = %issue_id,
-            error = %error,
-            "failed to set tracker state after finalization"
-        );
+    if let Err(error) = self.tracker.set_issue_state(issue_id, &tracker_state).await {
+        warn!(issue_id = %issue_id, error = %error, "{tracker_error_message}");
     }
 }
 
-if let Some((release_identifier, release_run_id)) = release_record {
-    if let Some(input) = step_transition {
-        self.append_pipeline_transition(input).await;
-    }
+if let Some(input) = transition {
+    self.append_pipeline_transition(input).await;
+}
+if let Some((release_identifier, release_run_id)) = release {
     self.append_pipeline_release(
         issue_id,
         &release_identifier,
@@ -311,10 +314,10 @@ if let Some((release_identifier, release_run_id)) = release_record {
         "completed",
     )
     .await;
-    if let Some(record) = history_record {
-        self.append_history_record(history_run_id.as_deref(), record)
-            .await;
-    }
+}
+if let Some((history_run_id, record)) = history {
+    self.append_history_record(history_run_id.as_deref(), record)
+        .await;
 }
 ```
 

--- a/docs/superpowers/plans/2026-07-11-finalization-locking.md
+++ b/docs/superpowers/plans/2026-07-11-finalization-locking.md
@@ -1,0 +1,418 @@
+# Finalization Locking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure initial finalization after pipeline success never performs workspace, git, artifact-helper, tracker, journal, or history awaits while retaining the orchestrator state write guard.
+
+**Architecture:** Refactor the existing `PipelineAction::Succeeded` branch into an external-I/O phase and a short state-commit phase, following the already-correct restored-pipeline and finalize-retry patterns. Add a timeout regression test using an approval-required local repository so it deterministically reaches the reentrant artifact update without network access.
+
+**Tech Stack:** Rust 2021, Tokio `RwLock` and `time::timeout`, existing `WorkspaceManager`, `PipelineRun`, and in-module orchestrator test infrastructure.
+
+---
+
+## File Structure
+
+- Modify `crates/ensemble-core/src/orchestrator/mod.rs`: add the regression fixture/test and refactor successful worker-exit finalization. Keep the change in this existing module because both the private method under test and its established test infrastructure live there.
+- No production files are created. No config, API, or documented behavior changes.
+
+### Task 1: Reproduce the Reentrant Finalization Deadlock
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs:5346-5780`
+- Test: `crates/ensemble-core/src/orchestrator/mod.rs` in the existing `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Add a local git repository helper to the orchestrator tests**
+
+Add this helper near `make_config` so the regression test can create a valid source repository without network access:
+
+```rust
+fn setup_finalize_repo(root: &std::path::Path) -> RepoConfig {
+    let repo_path = root.join("source-repo");
+    std::fs::create_dir_all(&repo_path).unwrap();
+
+    for args in [
+        &["init", "-b", "main"][..],
+        &["config", "user.email", "test@example.com"][..],
+        &["config", "user.name", "Test User"][..],
+    ] {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "git {args:?} failed");
+    }
+
+    std::fs::write(repo_path.join("README.md"), "# source-repo\n").unwrap();
+    for args in [&["add", "."][..], &["commit", "-m", "initial"][..]] {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "git {args:?} failed");
+    }
+
+    RepoConfig {
+        path: repo_path.display().to_string(),
+        branch: "main".to_string(),
+        git_remote: "origin".to_string(),
+        finalize: crate::workspace::finalize::RepoFinalizeConfig {
+            enabled: true,
+            mode: FinalizeMode::Push,
+            approval_required: true,
+        },
+    }
+}
+```
+
+Extend the existing config import in the test module from:
+
+```rust
+use crate::config::ensemble::{parse_config, ConcurrencyConfig, StepConfig};
+```
+
+to:
+
+```rust
+use crate::config::ensemble::{parse_config, ConcurrencyConfig, RepoConfig, StepConfig};
+```
+
+- [ ] **Step 2: Add the timeout regression test**
+
+Place the test near the existing `handle_worker_exit` tests. It must seed an active one-step pipeline and a matching repository artifact, then invoke final-step completion through the same private method used in production:
+
+```rust
+#[tokio::test]
+async fn enabled_finalization_returns_without_reentrant_state_locking() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo_config = setup_finalize_repo(temp.path());
+    let workspace_root = temp.path().join("workspaces");
+    let workspace_mgr =
+        WorkspaceManager::new(&workspace_root, Some(vec![repo_config])).unwrap();
+    let config = Arc::new(RwLock::new(make_config()));
+    let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+        issues: Arc::new(RwLock::new(Vec::new())),
+    });
+    let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+        delay_ms: 0,
+        observed_commands: None,
+        observed_timeouts: None,
+        cancellation_probe: None,
+    });
+    let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+    let orchestrator = Orchestrator::new(
+        config.clone(),
+        tracker,
+        runner,
+        workspace_mgr,
+        temp.path(),
+        shutdown_rx,
+    );
+
+    let mut issue = test_issue("1", "Todo");
+    issue.identifier = "repo#1".to_string();
+    {
+        let cfg = config.read().await;
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.start();
+        run.mark_running("build", "session-1".to_string());
+
+        let mut state = orchestrator.state.write().await;
+        state.add_claimed(&issue.id);
+        state.add_running(&issue, None);
+        state.insert_pipeline_run(&issue.id, run, Arc::new(cfg.clone()));
+        state.artifacts.insert(
+            issue.id.clone(),
+            RunArtifacts {
+                run_id: "run-1".to_string(),
+                workspace_path: workspace_root.display().to_string(),
+                repos: vec![crate::history::artifacts::RepoArtifact {
+                    repo: "source-repo".to_string(),
+                    finalize_mode: "push".to_string(),
+                    finalize_status: "pending".to_string(),
+                    ..Default::default()
+                }],
+                transcripts: Vec::new(),
+            },
+        );
+    }
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        orchestrator.handle_worker_exit(
+            &issue.id,
+            "build",
+            WorkerResult::Success {
+                output: succeeded_step_output(),
+                approval_request: None,
+            },
+        ),
+    )
+    .await
+    .expect("enabled finalization must not deadlock");
+
+    let state = orchestrator.state.read().await;
+    let finalize = state.get_finalize_state(&issue.id).unwrap();
+    assert_eq!(finalize.status, FinalizeStatus::PendingApproval);
+    assert_eq!(finalize.repos[0].status, FinalizeStatus::PendingApproval);
+    assert_eq!(
+        state.artifacts[&issue.id].repos[0].finalize_status,
+        "pending_approval"
+    );
+}
+```
+
+Use the existing `Duration` import available through `super::*`. If the compiler reports it is not in scope, add `use std::time::Duration;` to the test module rather than fully qualifying each use.
+
+- [ ] **Step 3: Run the regression test and confirm the timeout proves the bug**
+
+Run:
+
+```bash
+cargo test -p ensemble-core enabled_finalization_returns_without_reentrant_state_locking -- --nocapture
+```
+
+Expected: FAIL after approximately five seconds with `enabled finalization must not deadlock: Elapsed(())`. Do not weaken or remove the timeout.
+
+### Task 2: Move Finalization I/O Outside the State Guard
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs:1567-1667`
+- Test: `crates/ensemble-core/src/orchestrator/mod.rs`
+
+- [ ] **Step 1: Release state before initial finalization**
+
+At the start of the `PipelineAction::Succeeded` branch, clone the current config, release both guards, and only then call finalization:
+
+```rust
+let issue_identifier = issue_snapshot
+    .as_ref()
+    .map(|issue| issue.identifier.clone())
+    .unwrap_or_else(|| issue_id.to_string());
+let config_snapshot = config.clone();
+drop(config);
+drop(state);
+
+let finalize_state = self
+    .run_finalize_phase(issue_id, &issue_identifier, &config_snapshot)
+    .await;
+```
+
+The cloned `EnsembleConfig` prevents configuration reloads from being blocked by workspace or git I/O. Do not call any state-dependent code until a new state guard is acquired.
+
+- [ ] **Step 2: Commit finalization results under a fresh short guard**
+
+Replace the remainder of the branch with a state-only block that builds owned post-commit work:
+
+```rust
+let completed_at = Utc::now();
+let (
+    tracker_state,
+    history_record,
+    history_run_id,
+    release_record,
+) = {
+    let mut state = self.state.write().await;
+    let history_record = state
+        .running
+        .get(issue_id)
+        .zip(state.get_pipeline_run(issue_id))
+        .map(|(entry, run)| {
+            self.build_history_record(RunningHistoryRecordInput {
+                issue_id,
+                outcome: HISTORY_OUTCOME_SUCCEEDED,
+                last_error: None,
+                running_entry: entry,
+                run,
+                completed_at,
+                artifacts: state.artifacts.get(issue_id).cloned(),
+            })
+        });
+    let running_entry = state.get_running(issue_id).cloned();
+    let history_run_id = running_entry
+        .as_ref()
+        .and_then(|entry| entry.run_id.clone());
+
+    if matches!(
+        finalize_state.status,
+        FinalizeStatus::Succeeded | FinalizeStatus::NotRequired
+    ) {
+        if let Some(ref entry) = running_entry {
+            state.add_completed(
+                issue_id.to_string(),
+                entry.identifier.clone(),
+                "completed_succeeded".to_string(),
+            );
+        }
+        state.release_claim(issue_id);
+        state.remove_pipeline_run(issue_id);
+        if let Some(entry) = state.remove_running(issue_id) {
+            state.add_runtime_seconds(&entry);
+        }
+        state.clear_finalize_state(issue_id);
+
+        let release_identifier = running_entry
+            .as_ref()
+            .map(|entry| entry.identifier.clone())
+            .unwrap_or_else(|| issue_identifier.clone());
+        (
+            self.tracker
+                .supports_writes()
+                .then(|| config_snapshot.on_success.clone()),
+            history_record,
+            history_run_id.clone(),
+            Some((release_identifier, history_run_id.clone())),
+        )
+    } else {
+        let tracker_state = (self.tracker.supports_writes()
+            && matches!(
+                finalize_state.status,
+                FinalizeStatus::Failed | FinalizeStatus::SkippedHeadless
+            ))
+        .then(|| config_snapshot.on_failure.clone());
+        state.set_finalize_state(issue_id, finalize_state);
+        state.remove_pipeline_run(issue_id);
+        (tracker_state, None, history_run_id, None)
+    }
+};
+```
+
+Keep this block synchronous: it may read or mutate `state`, but it must contain no `.await`.
+
+- [ ] **Step 3: Perform tracker and persistence I/O after the guard is gone**
+
+Immediately after the state-only block, perform the owned work without a state guard:
+
+```rust
+if let Some(tracker_state) = tracker_state {
+    if let Err(error) = self
+        .tracker
+        .set_issue_state(issue_id, &tracker_state)
+        .await
+    {
+        warn!(
+            issue_id = %issue_id,
+            error = %error,
+            "failed to set tracker state after finalization"
+        );
+    }
+}
+
+if let Some((release_identifier, release_run_id)) = release_record {
+    if let Some(input) = step_transition {
+        self.append_pipeline_transition(input).await;
+    }
+    self.append_pipeline_release(
+        issue_id,
+        &release_identifier,
+        release_run_id,
+        "completed",
+    )
+    .await;
+    if let Some(record) = history_record {
+        self.append_history_record(history_run_id.as_deref(), record)
+            .await;
+    }
+}
+```
+
+This deliberately preserves the current behavior of writing completion journal/history records only when finalization reaches `succeeded` or `not_required`. Do not broaden issue #324 into transition-journal behavior changes.
+
+- [ ] **Step 4: Run the focused regression test**
+
+Run:
+
+```bash
+cargo test -p ensemble-core enabled_finalization_returns_without_reentrant_state_locking -- --nocapture
+```
+
+Expected: PASS. The finalize state and artifact status assertions must also pass, proving the method returned because the artifact helper acquired and released its own state guard.
+
+- [ ] **Step 5: Run nearby successful-exit and finalization control tests**
+
+Run:
+
+```bash
+cargo test -p ensemble-core handle_worker_exit -- --nocapture
+cargo test -p ensemble-core finalize -- --nocapture
+```
+
+Expected: all selected tests PASS. Confirm approval and retry API tests still transition repository state to `in_progress`.
+
+- [ ] **Step 6: Commit the focused fix**
+
+```bash
+git add crates/ensemble-core/src/orchestrator/mod.rs
+git commit -m "Prevent reentrant finalization locking"
+```
+
+### Task 3: Verify the Complete Change
+
+**Files:**
+- Verify: `crates/ensemble-core/src/orchestrator/mod.rs`
+- Verify: `docs/superpowers/specs/2026-07-11-finalization-locking-design.md`
+
+- [ ] **Step 1: Format and inspect the final diff**
+
+Run:
+
+```bash
+cargo fmt --all
+git diff --check
+git diff HEAD^ -- crates/ensemble-core/src/orchestrator/mod.rs
+```
+
+Expected: formatting completes, `git diff --check` prints nothing, and the diff contains only the regression fixture/test and two-phase success-branch change.
+
+- [ ] **Step 2: Run the core test suite**
+
+Run:
+
+```bash
+cargo test -p ensemble-core
+```
+
+Expected: all `ensemble-core` unit and integration tests PASS.
+
+- [ ] **Step 3: Run workspace clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+```
+
+Expected: command exits successfully with no warnings.
+
+- [ ] **Step 4: Verify formatting**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: command exits successfully with no formatting differences.
+
+- [ ] **Step 5: Confirm documentation scope**
+
+Compare the final diff against `docs/superpowers/specs/2026-07-11-finalization-locking-design.md`. Confirm no configuration schema, API contract, tracker semantics, or user-visible lifecycle behavior changed. No updates to `docs/SPEC.md`, `docs/configuration.md`, or `docs/pipelines.md` are required.
+
+- [ ] **Step 6: Commit formatting changes only if formatting modified the source after Task 2**
+
+First run:
+
+```bash
+git status --short
+```
+
+If `cargo fmt` changed `crates/ensemble-core/src/orchestrator/mod.rs`, commit only that file:
+
+```bash
+git add crates/ensemble-core/src/orchestrator/mod.rs
+git commit -m "Format finalization locking fix"
+```
+
+If the worktree is clean, do not create an empty commit.

--- a/docs/superpowers/plans/2026-07-11-finalization-locking.md
+++ b/docs/superpowers/plans/2026-07-11-finalization-locking.md
@@ -424,6 +424,7 @@ If the worktree is clean, do not create an empty commit.
 
 **Files:**
 - Modify: `crates/ensemble-core/src/orchestrator/mod.rs:78-105`
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs:773-910`
 - Modify: `crates/ensemble-core/src/orchestrator/mod.rs:1567-1685`
 - Test: `crates/ensemble-core/src/orchestrator/mod.rs` in the existing `#[cfg(test)] mod tests`
 
@@ -498,9 +499,9 @@ impl RunningAttemptIdentity {
 
 The timestamp intentionally participates in equality because `issue_run_ids` may preserve and reuse the same run ID after a stop.
 
-- [ ] **Step 4: Capture identity before releasing state**
+- [ ] **Step 4: Capture identity before releasing state in both success paths**
 
-In the `PipelineAction::Succeeded` branch, capture the identity while the original state write guard still proves ownership:
+In both the initial worker-exit and restored-pipeline `PipelineAction::Succeeded` branches, capture the identity while the original state write guard still proves ownership. The worker-exit path captures before cloning and dropping its guards; the restored path captures before leaving the state-write block that calls `add_running`:
 
 ```rust
 let finalize_attempt = RunningAttemptIdentity::capture(&state, issue_id);
@@ -509,18 +510,20 @@ drop(config);
 drop(state);
 ```
 
+```rust
+state.add_running(issue, effective_attempt);
+let finalize_attempt = RunningAttemptIdentity::capture(&state, &issue.id);
+```
+
 Keep the existing call to `run_finalize_phase` immediately after the guards are dropped.
 
-- [ ] **Step 5: Reject stale results before committing state**
+- [ ] **Step 5: Reject stale results before either path commits state**
 
 At the beginning of the post-finalization state block, immediately after acquiring the fresh write guard, validate the captured identity:
 
 ```rust
 let mut state = self.state.write().await;
-if !finalize_attempt
-    .as_ref()
-    .is_some_and(|attempt| attempt.is_current(&state, issue_id))
-{
+if !Self::finalization_attempt_is_current(finalize_attempt.as_ref(), &state, issue_id) {
     warn!(
         issue_id = %issue_id,
         "discarding stale finalization result because the running attempt changed"
@@ -529,21 +532,26 @@ if !finalize_attempt
 }
 ```
 
-The early return must occur before building history, applying completion/finalize state, or collecting tracker/journal/history work. Do not change `run_finalize_phase`, artifact helper APIs, API lookup precedence, or unrelated failure paths.
+Use the same private validation gate in both paths. The early return must occur before building history, applying completion/finalize state, or collecting tracker/journal/history work. Do not change `run_finalize_phase`, artifact helper APIs, API lookup precedence, or unrelated failure paths.
 
-- [ ] **Step 6: Run focused tests to verify GREEN**
+- [ ] **Step 6: Add restored-pipeline lifecycle coverage**
+
+Add a deterministic test seam immediately after `run_finalize_phase` returns, then pause the restored-pipeline path, replace its running entry with the same run ID and a later `started_at`, and resume the commit. Assert the restored pipeline remains running and retained, completion/finalize state is unchanged, and tracker, pipeline-release journal, and history writes are absent. This must invoke `dispatch_issue` so removing the restored-path guard makes the test fail; do not rely only on `RunningAttemptIdentity::is_current`.
+
+- [ ] **Step 7: Run focused tests to verify GREEN**
 
 Run:
 
 ```bash
 cargo test -p ensemble-core finalization_attempt_rejects_missing_or_replaced_running_entry -- --nocapture
+cargo test -p ensemble-core restored_finalization_discards_stale_attempt_before_owned_writes -- --nocapture
 cargo test -p ensemble-core enabled_finalization_returns_without_reentrant_state_locking -- --nocapture
 cargo test -p ensemble-core finalize -- --nocapture
 ```
 
 Expected: all selected tests PASS. The original deadlock/parking regression must continue to assert pending approval, updated artifacts, no running slot, and a retained claim.
 
-- [ ] **Step 7: Run complete verification**
+- [ ] **Step 8: Run complete verification**
 
 Run:
 
@@ -556,7 +564,7 @@ git diff --check
 
 Expected: 0 test failures, no clippy warnings, no formatting changes, and no whitespace errors.
 
-- [ ] **Step 8: Commit the stale-result fix**
+- [ ] **Step 9: Commit the stale-result fix**
 
 ```bash
 git add crates/ensemble-core/src/orchestrator/mod.rs docs/superpowers/plans/2026-07-11-finalization-locking.md

--- a/docs/superpowers/plans/2026-07-11-finalization-locking.md
+++ b/docs/superpowers/plans/2026-07-11-finalization-locking.md
@@ -419,3 +419,146 @@ git commit -m "Format finalization locking fix"
 ```
 
 If the worktree is clean, do not create an empty commit.
+
+### Task 4: Reject Stale Finalization Results
+
+**Files:**
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs:78-105`
+- Modify: `crates/ensemble-core/src/orchestrator/mod.rs:1567-1685`
+- Test: `crates/ensemble-core/src/orchestrator/mod.rs` in the existing `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the running-attempt identity regression test**
+
+Add this test near `enabled_finalization_returns_without_reentrant_state_locking`. It proves that an issue-level run ID is not sufficient to identify the attempt that entered finalization:
+
+```rust
+#[test]
+fn finalization_attempt_rejects_missing_or_replaced_running_entry() {
+    let config = make_config();
+    let mut state = OrchestratorState::new(config.polling.interval_ms, &config.concurrency);
+    let issue = test_issue("1", "Todo");
+    state.add_running(&issue, None);
+
+    let identity = RunningAttemptIdentity::capture(&state, &issue.id).unwrap();
+    assert!(identity.is_current(&state, &issue.id));
+
+    let mut replacement = state.remove_running(&issue.id).unwrap();
+    assert!(!identity.is_current(&state, &issue.id));
+
+    replacement.started_at += chrono::Duration::seconds(1);
+    state.running.insert(issue.id.clone(), replacement);
+    assert_eq!(
+        identity.run_id.as_deref(),
+        state
+            .get_running(&issue.id)
+            .unwrap()
+            .run_id
+            .as_deref()
+    );
+    assert!(!identity.is_current(&state, &issue.id));
+}
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+cargo test -p ensemble-core finalization_attempt_rejects_missing_or_replaced_running_entry -- --nocapture
+```
+
+Expected: compilation fails because `RunningAttemptIdentity` is not defined. This confirms the test names the missing ownership contract before production code is added.
+
+- [ ] **Step 3: Add the minimal attempt identity type**
+
+Add this private type near the other orchestrator input/context types:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunningAttemptIdentity {
+    run_id: Option<String>,
+    started_at: chrono::DateTime<Utc>,
+}
+
+impl RunningAttemptIdentity {
+    fn capture(state: &OrchestratorState, issue_id: &str) -> Option<Self> {
+        state.get_running(issue_id).map(|entry| Self {
+            run_id: entry.run_id.clone(),
+            started_at: entry.started_at,
+        })
+    }
+
+    fn is_current(&self, state: &OrchestratorState, issue_id: &str) -> bool {
+        state.get_running(issue_id).is_some_and(|entry| {
+            entry.run_id == self.run_id && entry.started_at == self.started_at
+        })
+    }
+}
+```
+
+The timestamp intentionally participates in equality because `issue_run_ids` may preserve and reuse the same run ID after a stop.
+
+- [ ] **Step 4: Capture identity before releasing state**
+
+In the `PipelineAction::Succeeded` branch, capture the identity while the original state write guard still proves ownership:
+
+```rust
+let finalize_attempt = RunningAttemptIdentity::capture(&state, issue_id);
+let config_snapshot = config.clone();
+drop(config);
+drop(state);
+```
+
+Keep the existing call to `run_finalize_phase` immediately after the guards are dropped.
+
+- [ ] **Step 5: Reject stale results before committing state**
+
+At the beginning of the post-finalization state block, immediately after acquiring the fresh write guard, validate the captured identity:
+
+```rust
+let mut state = self.state.write().await;
+if !finalize_attempt
+    .as_ref()
+    .is_some_and(|attempt| attempt.is_current(&state, issue_id))
+{
+    warn!(
+        issue_id = %issue_id,
+        "discarding stale finalization result because the running attempt changed"
+    );
+    return;
+}
+```
+
+The early return must occur before building history, applying completion/finalize state, or collecting tracker/journal/history work. Do not change `run_finalize_phase`, artifact helper APIs, API lookup precedence, or unrelated failure paths.
+
+- [ ] **Step 6: Run focused tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p ensemble-core finalization_attempt_rejects_missing_or_replaced_running_entry -- --nocapture
+cargo test -p ensemble-core enabled_finalization_returns_without_reentrant_state_locking -- --nocapture
+cargo test -p ensemble-core finalize -- --nocapture
+```
+
+Expected: all selected tests PASS. The original deadlock/parking regression must continue to assert pending approval, updated artifacts, no running slot, and a retained claim.
+
+- [ ] **Step 7: Run complete verification**
+
+Run:
+
+```bash
+cargo test --workspace --exclude ensemble-desktop
+cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
+cargo fmt --all -- --check
+git diff --check
+```
+
+Expected: 0 test failures, no clippy warnings, no formatting changes, and no whitespace errors.
+
+- [ ] **Step 8: Commit the stale-result fix**
+
+```bash
+git add crates/ensemble-core/src/orchestrator/mod.rs docs/superpowers/plans/2026-07-11-finalization-locking.md
+git commit -m "Discard stale finalization results"
+```

--- a/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
+++ b/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
@@ -20,6 +20,8 @@ The change covers initial worker-exit and restored-pipeline finalization after a
 
 The change does not redesign the finalization state model, alter completion semantics, or refactor unrelated worker-failure handling.
 
+For a non-stale restored-pipeline result that is pending approval or otherwise unresolved, the commit releases the running entry and records its runtime before retaining finalize state and removing the completed pipeline run. The claim, workspace, and artifacts remain so existing finalize controls can approve or retry the parked result.
+
 ## Design
 
 ### Two-phase successful-exit handling
@@ -93,6 +95,8 @@ The test must:
 Add a focused identity regression test that demonstrates a replacement running entry is not the same finalization owner even when the issue-level run ID is reused. Cover both a missing running entry and a replacement with the same `run_id` but a different `started_at` value.
 
 Add a deterministic restored-pipeline lifecycle test. Pause immediately after finalization and replace the running entry before the commit phase; verify that the restored pipeline remains active and that no completion/finalize mutation, tracker write, pipeline-release journal write, or history record occurs. This exercises the production restored-pipeline finalization path rather than only the identity helper.
+
+Add a restored pending-approval lifecycle test using a matching artifact fixture. Verify the result is parked with `PendingApproval`, no running entry, a retained claim, a removed pipeline run, and an updated artifact finalization status.
 
 Use a local temporary git repository and workspace fixture so the test does not depend on network access. An approval-required rule is acceptable for the primary deadlock reproduction because it reaches the artifact status helper without requiring a remote push. Existing approval/retry API tests remain in place; add a focused timeout assertion for retry processing only if it can reuse the same fixture without introducing substantial test-only infrastructure.
 

--- a/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
+++ b/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
@@ -36,7 +36,7 @@ The `PipelineAction::Succeeded` branch will use two distinct phases.
    - Reacquire the orchestrator state write guard after finalization returns.
    - Build the history record after artifact results have been applied so the record includes finalization output.
    - For `succeeded` or `not_required`, mark the issue completed, release its claim, remove running and pipeline state, and clear transient finalize state.
-   - For unresolved or failed finalization, persist the returned finalize state and remove the completed pipeline run while retaining the claim and workspace for approval or retry.
+    - For unresolved or failed finalization, remove the running entry and record its runtime before persisting the returned finalize state and removing the completed pipeline run. This releases the running slot while retaining the claim, workspace, and artifacts for approval or retry.
    - Collect tracker, journal, release, and history operations as owned values.
    - Release the state guard before awaiting any of those operations.
 

--- a/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
+++ b/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
@@ -58,6 +58,19 @@ Approval and retry API handlers only mutate in-memory state and notify the orche
 
 `retry_finalize_for_issue` already follows the required three-step sequence: snapshot retry work under a read guard, perform workspace and git/GitHub I/O without a guard, then commit finalize and artifact outcomes under a short write guard. Tracker writes happen afterward. This path should remain structurally unchanged unless regression testing exposes a separate defect.
 
+### Stale result protection
+
+Releasing the state guard allows control requests to observe the issue while finalization performs external I/O. The final state commit must therefore verify that it still belongs to the running attempt that entered finalization.
+
+Before releasing state, capture an identity containing both the running entry's `run_id` and `started_at`. The run ID alone is insufficient because Ensemble may reuse the issue-level run ID after a stop and redispatch. After finalization returns and state is reacquired, compare both fields with the current running entry. If the entry is missing or either field differs, log that the finalization result is stale and return without applying completion/finalize state or performing tracker, transition, release, or history writes.
+
+This is preferred over two broader alternatives:
+
+- Changing finalize-control lookup precedence would hide the race without proving that the committing run still owns the issue.
+- Publishing an explicit `InProgress` finalize state before I/O would improve UI visibility but requires a larger lifecycle and history-snapshot redesign that is not needed for issue #324.
+
+The artifact helpers remain unchanged. Under current orchestration, worker events and redispatch run on the same event loop, while public controls cannot replace an active running entry without first stopping it. Identity validation protects the final state and external side effects if that ownership changes.
+
 ## Error Handling
 
 Workspace preparation and git/GitHub failures continue to produce `FinalizeStatus::Failed` with per-repository error details. The state commit phase persists that result and leaves the issue recoverable through the existing retry flow.
@@ -76,6 +89,8 @@ The test must:
 - pass after the fix because worker-exit handling returns,
 - assert the resulting issue-level and repository-level finalize state or completed state,
 - assert the artifact finalization status was updated.
+
+Add a focused identity regression test that demonstrates a replacement running entry is not the same finalization owner even when the issue-level run ID is reused. Cover both a missing running entry and a replacement with the same `run_id` but a different `started_at` value.
 
 Use a local temporary git repository and workspace fixture so the test does not depend on network access. An approval-required rule is acceptable for the primary deadlock reproduction because it reaches the artifact status helper without requiring a remote push. Existing approval/retry API tests remain in place; add a focused timeout assertion for retry processing only if it can reuse the same fixture without introducing substantial test-only infrastructure.
 

--- a/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
+++ b/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
@@ -1,0 +1,86 @@
+# Finalization Locking Design
+
+## Goal
+
+Prevent enabled finalization from deadlocking the orchestrator while preserving the existing pipeline, tracker, artifact, approval, and retry semantics described in the finalization workflow design.
+
+This design addresses GitHub issue #324.
+
+## Root Cause
+
+`Orchestrator::handle_worker_exit` holds the orchestrator state write guard while handling `PipelineAction::Succeeded`. It then awaits `run_finalize_phase`, which performs workspace and git operations and calls artifact update helpers that acquire the same state write guard. Tokio's `RwLock` is not reentrant, so enabled finalization can wait forever for a guard held by its own task.
+
+The same success branch currently awaits tracker writes while retaining the state guard. Even when those calls do not reenter orchestrator state, they unnecessarily block every other state reader and writer for the duration of external I/O.
+
+Restored-pipeline completion, approval resume, and finalize retry already demonstrate the intended pattern: perform external work without a state guard, acquire the guard briefly to commit outcomes, then release it before tracker and persistence I/O.
+
+## Scope
+
+The change covers initial finalization after a successful pipeline, including successful finalization, finalization failure, pending approval, and skipped-headless outcomes. It also verifies that approval and retry processing terminate without lock inversion.
+
+The change does not redesign the finalization state model, alter completion semantics, or refactor unrelated worker-failure handling.
+
+## Design
+
+### Two-phase successful-exit handling
+
+The `PipelineAction::Succeeded` branch will use two distinct phases.
+
+1. External finalization phase:
+   - Copy the issue identifier and any configuration values needed after the current state calculation.
+   - Release the existing orchestrator state write guard.
+   - Run `run_finalize_phase`.
+   - Allow workspace preparation, git/GitHub commands, and the artifact helpers' own short state mutations to finish without an outer state guard.
+
+2. State commit phase:
+   - Reacquire the orchestrator state write guard after finalization returns.
+   - Build the history record after artifact results have been applied so the record includes finalization output.
+   - For `succeeded` or `not_required`, mark the issue completed, release its claim, remove running and pipeline state, and clear transient finalize state.
+   - For unresolved or failed finalization, persist the returned finalize state and remove the completed pipeline run while retaining the claim and workspace for approval or retry.
+   - Collect tracker, journal, release, and history operations as owned values.
+   - Release the state guard before awaiting any of those operations.
+
+The existing `run_finalize_phase` interface and artifact update helpers remain unchanged. Their state guards are limited to synchronous in-memory mutation and no longer nest inside another state guard.
+
+### Tracker updates
+
+The success branch will decide the required tracker transition while committing state:
+
+- `on_success` when finalization succeeded or was not required.
+- `on_failure` when finalization failed or was skipped in headless mode.
+- No tracker transition while finalization is pending approval.
+
+The tracker write will occur only after the state guard is released. Tracker errors remain best-effort warnings and do not roll back the already-committed orchestrator state, matching the restored-pipeline and finalize-retry paths.
+
+### Approval and retry
+
+Approval and retry API handlers only mutate in-memory state and notify the orchestrator. They do not perform finalization I/O while holding the state guard.
+
+`retry_finalize_for_issue` already follows the required three-step sequence: snapshot retry work under a read guard, perform workspace and git/GitHub I/O without a guard, then commit finalize and artifact outcomes under a short write guard. Tracker writes happen afterward. This path should remain structurally unchanged unless regression testing exposes a separate defect.
+
+## Error Handling
+
+Workspace preparation and git/GitHub failures continue to produce `FinalizeStatus::Failed` with per-repository error details. The state commit phase persists that result and leaves the issue recoverable through the existing retry flow.
+
+Failure to update the tracker remains non-fatal and is logged. The orchestrator must always release its state guard and return from worker-exit handling regardless of finalization or tracker outcome.
+
+## Testing
+
+Add a timeout-based orchestrator regression test that configures at least one enabled repository finalization rule, seeds a successful pipeline and matching artifact state, and invokes `handle_worker_exit` for the final step.
+
+The test must:
+
+- wrap worker-exit handling in `tokio::time::timeout`,
+- exercise an enabled finalization path that reaches an artifact update helper,
+- fail on the current implementation because the nested state write cannot complete,
+- pass after the fix because worker-exit handling returns,
+- assert the resulting issue-level and repository-level finalize state or completed state,
+- assert the artifact finalization status was updated.
+
+Use a local temporary git repository and workspace fixture so the test does not depend on network access. An approval-required rule is acceptable for the primary deadlock reproduction because it reaches the artifact status helper without requiring a remote push. Existing approval/retry API tests remain in place; add a focused timeout assertion for retry processing only if it can reuse the same fixture without introducing substantial test-only infrastructure.
+
+Run the focused regression test, the `ensemble-core` test suite, formatting, and clippy before completion.
+
+## Documentation Impact
+
+No user-facing documentation changes are required. The finalization workflow documentation already requires finalization to complete or enter a recoverable approval/failure state. This change restores that contract without changing configuration or API behavior.

--- a/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
+++ b/docs/superpowers/specs/2026-07-11-finalization-locking-design.md
@@ -12,11 +12,11 @@ This design addresses GitHub issue #324.
 
 The same success branch currently awaits tracker writes while retaining the state guard. Even when those calls do not reenter orchestrator state, they unnecessarily block every other state reader and writer for the duration of external I/O.
 
-Restored-pipeline completion, approval resume, and finalize retry already demonstrate the intended pattern: perform external work without a state guard, acquire the guard briefly to commit outcomes, then release it before tracker and persistence I/O.
+Restored-pipeline completion, approval resume, and finalize retry use the intended broad pattern: perform external work without a state guard, acquire the guard briefly to commit outcomes, then release it before tracker and persistence I/O. Both the initial worker-exit and restored-pipeline success paths must additionally prove that their original running attempt still owns the issue before committing.
 
 ## Scope
 
-The change covers initial finalization after a successful pipeline, including successful finalization, finalization failure, pending approval, and skipped-headless outcomes. It also verifies that approval and retry processing terminate without lock inversion.
+The change covers initial worker-exit and restored-pipeline finalization after a successful pipeline, including successful finalization, finalization failure, pending approval, and skipped-headless outcomes. It also verifies that approval and retry processing terminate without lock inversion.
 
 The change does not redesign the finalization state model, alter completion semantics, or refactor unrelated worker-failure handling.
 
@@ -62,7 +62,7 @@ Approval and retry API handlers only mutate in-memory state and notify the orche
 
 Releasing the state guard allows control requests to observe the issue while finalization performs external I/O. The final state commit must therefore verify that it still belongs to the running attempt that entered finalization.
 
-Before releasing state, capture an identity containing both the running entry's `run_id` and `started_at`. The run ID alone is insufficient because Ensemble may reuse the issue-level run ID after a stop and redispatch. After finalization returns and state is reacquired, compare both fields with the current running entry. If the entry is missing or either field differs, log that the finalization result is stale and return without applying completion/finalize state or performing tracker, transition, release, or history writes.
+Before releasing state, both `PipelineAction::Succeeded` paths capture an identity containing both the running entry's `run_id` and `started_at`. The run ID alone is insufficient because Ensemble may reuse the issue-level run ID after a stop and redispatch. After finalization returns and state is reacquired, both paths compare both fields with the current running entry. If the entry is missing or either field differs, log that the finalization result is stale and return without applying completion/finalize state or performing tracker, transition, release, or history writes.
 
 This is preferred over two broader alternatives:
 
@@ -91,6 +91,8 @@ The test must:
 - assert the artifact finalization status was updated.
 
 Add a focused identity regression test that demonstrates a replacement running entry is not the same finalization owner even when the issue-level run ID is reused. Cover both a missing running entry and a replacement with the same `run_id` but a different `started_at` value.
+
+Add a deterministic restored-pipeline lifecycle test. Pause immediately after finalization and replace the running entry before the commit phase; verify that the restored pipeline remains active and that no completion/finalize mutation, tracker write, pipeline-release journal write, or history record occurs. This exercises the production restored-pipeline finalization path rather than only the identity helper.
 
 Use a local temporary git repository and workspace fixture so the test does not depend on network access. An approval-required rule is acceptable for the primary deadlock reproduction because it reaches the artifact status helper without requiring a remote push. Existing approval/retry API tests remain in place; add a focused timeout assertion for retry processing only if it can reuse the same fixture without introducing substantial test-only infrastructure.
 


### PR DESCRIPTION
## Summary
- release orchestrator state and config guards before initial finalization I/O
- commit finalization outcomes under a short state guard, then perform tracker and persistence writes afterward
- add a timeout regression test for enabled approval-required finalization

## Test Plan
- [x] cargo test --workspace --exclude ensemble-desktop
- [x] cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- [x] cargo fmt --all -- --check

Fixes #324