### PR TITLE
Configure GitHub Project queue runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,3 +179,8 @@ Use the default canonical triage labels. See `docs/agents/triage-labels.md`.
 
 This repository uses a single domain context with canonical language in
 `CONTEXT.md` and decisions in `docs/adr/`. See `docs/agents/domain.md`.
+
+### GitHub Project execution
+
+Use `docs/agents/run-github-project.md` for the trusted queue configuration and
+lifecycle contract.

--- a/docs/agents/run-github-project.md
+++ b/docs/agents/run-github-project.md
@@ -1,0 +1,54 @@
+# Run GitHub Project
+
+## Repository
+
+- Host: `github.com`
+- Repository: `chrisbanes/ensemble`
+- Default branch: `main`
+- Base branch: `main`
+
+## Project
+
+- Owner: `chrisbanes`
+- Number: `6`
+- URL: `https://github.com/users/chrisbanes/projects/6`
+- Node ID: `PVT_kwHOAAN4ns4BatgH`
+- Filter: `none`
+- Execution approver logins: `chrisbanes`
+
+## Status
+
+- Field name: `Status`
+- Field ID: `PVTSSF_lAHOAAN4ns4BatgHzhVjFtY`
+- Backlog name: `Backlog`
+- Backlog option ID: `f75ad846`
+- Planning name: `Planning`
+- Planning option ID: `cc2b7773`
+- Ready to implement name: `Ready to implement`
+- Ready to implement option ID: `0732c167`
+- In progress name: `In progress`
+- In progress option ID: `47fc9ee4`
+- Done name: `Done`
+- Done option ID: `98236657`
+
+## Priority
+
+- Field name: `Priority`
+- Field ID: `PVTSSF_lAHOAAN4ns4BatgHzhVjFxQ`
+- Options in descending order:
+  1. `P0`: `79628723`
+  2. `P1`: `0a877460`
+  3. `P2`: `da944a9c`
+
+## Merge Policy
+
+- Method: `squash`
+- Issue closure: `closing-keyword`
+- Required reviews: `none`
+- Required checks: `Check, Test, Clippy, Format`; `Frontend Test and Build`;
+  `Tauri PR (Linux)`; `Tauri PR (Mac)`; `Greptile Review`
+- Done automation: `set-status`
+- Automation description: Enabled Project workflows `Item closed` and
+  `Pull request merged`; verified that merged-and-closed issue #182 moved from
+  `In progress` to `Done` through `github-project-automation` and remained
+  unarchived.


### PR DESCRIPTION
## Summary

- document the verified GitHub Project 6 repository, Status, Priority, and merge-policy binding
- add the trusted AGENTS.md reference required by the queue runner
- record the observed Done automation and non-archival outcome

## Verification

- `git diff origin/main...HEAD --check`
- revalidated every configured Project field and option name against its live ID
- verified `main` and the configured base both resolve to `1709166acdc87ed80c8b3b5323b8bfa4b25af72d`
- verified Project update access for `chrisbanes`
- configuration digest: `319ad5c95334b212690b3502d5f9dac77e8bc5e3a42ef8efe828cd3154439e30`

## Follow-up

After this reaches `main`, the execution approver must move the legacy `ready-for-agent` Backlog items to Planning before the queue runner may claim them.
