### PR TITLE
Make interaction command acceptance atomic

### DIFF
--- a/crates/ensemble-core/src/api/interactions.rs
+++ b/crates/ensemble-core/src/api/interactions.rs
@@ -2,9 +2,10 @@ use crate::api::handlers::ApiError;
 use crate::api::router::AppState;
 use crate::interaction::error::InteractionError;
 use crate::interaction::model::{
-    InteractionKind, InteractionRequest, InteractionResponse, InteractionStatus,
+    AcceptedInteractionCommand, InteractionKind, InteractionRequest, InteractionResponse,
+    InteractionStatus,
 };
-use crate::interaction::store::InteractionStore;
+use crate::interaction::store::{InteractionAcceptance, InteractionStore};
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -12,6 +13,9 @@ use axum::response::IntoResponse;
 use axum::Json;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static LOCAL_API_INPUT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct InteractionDetail {
@@ -50,7 +54,7 @@ impl From<&InteractionRequest> for InteractionDetail {
     }
 }
 
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum InteractionResponseBody {
     Question {
@@ -119,9 +123,6 @@ fn interaction_error_response(error: InteractionError) -> (StatusCode, Json<serd
         InteractionError::NotFound { .. } => (StatusCode::NOT_FOUND, "interaction_not_found"),
         InteractionError::AlreadyResolved { .. } => (StatusCode::CONFLICT, "already_resolved"),
         InteractionError::AlreadyCancelled { .. } => (StatusCode::CONFLICT, "already_cancelled"),
-        InteractionError::CommandAlreadyAccepted { .. } => {
-            (StatusCode::CONFLICT, "command_already_accepted")
-        }
         InteractionError::InvalidResponse { .. } => (StatusCode::BAD_REQUEST, "invalid_response"),
         InteractionError::OpenBlockingInteractionExists { .. }
         | InteractionError::ConcurrentModification { .. }
@@ -238,13 +239,56 @@ pub async fn respond_to_interaction(
         }
     };
 
-    match interaction_store(&state).resolve(&id, body.into()).await {
-        Ok(interaction) => (
+    let raw_body = serde_json::to_string(&body).unwrap_or_default();
+    let response: InteractionResponse = body.into();
+    let received_at = Utc::now();
+    let input_id = format!(
+        "local-api-{}-{}",
+        received_at.timestamp_nanos_opt().unwrap_or_default(),
+        LOCAL_API_INPUT_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    );
+    let command = AcceptedInteractionCommand {
+        command: api_command_name(&response).to_string(),
+        raw_body,
+        author: "local-api".to_string(),
+        comment_id: input_id,
+        received_at,
+    };
+
+    match interaction_store(&state)
+        .accept_response(&id, command, response)
+        .await
+    {
+        Ok(InteractionAcceptance::Accepted(interaction)) => (
             StatusCode::OK,
             Json(serde_json::to_value(interaction).unwrap()),
         )
             .into_response(),
+        Ok(InteractionAcceptance::Ignored(interaction)) => {
+            let error = if interaction.status == InteractionStatus::Cancelled {
+                InteractionError::AlreadyCancelled { id }
+            } else {
+                InteractionError::AlreadyResolved { id }
+            };
+            interaction_error_response(error).into_response()
+        }
         Err(error) => interaction_error_response(error).into_response(),
+    }
+}
+
+fn api_command_name(response: &InteractionResponse) -> &'static str {
+    match response {
+        InteractionResponse::Question { .. } => "/answer",
+        InteractionResponse::Approval { approved: true, .. }
+        | InteractionResponse::Handoff {
+            completed: true, ..
+        } => "/approve",
+        InteractionResponse::Approval {
+            approved: false, ..
+        }
+        | InteractionResponse::Handoff {
+            completed: false, ..
+        } => "/reject",
     }
 }
 

--- a/crates/ensemble-core/src/interaction/commands.rs
+++ b/crates/ensemble-core/src/interaction/commands.rs
@@ -12,6 +12,20 @@ pub enum ParseInteractionCommandError {
     MissingArgument,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopedInteractionCommand {
+    pub interaction_id: String,
+    pub command: InteractionCommand,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseScopedInteractionCommandError {
+    MissingMarker,
+    InvalidMarker,
+    DuplicateMarker,
+    InvalidCommand(ParseInteractionCommandError),
+}
+
 pub fn parse_interaction_command(
     raw_body: &str,
 ) -> Result<InteractionCommand, ParseInteractionCommandError> {
@@ -55,9 +69,50 @@ pub fn parse_interaction_command(
     Err(ParseInteractionCommandError::UnknownCommand)
 }
 
+pub fn parse_scoped_interaction_command(
+    raw_body: &str,
+) -> Result<ScopedInteractionCommand, ParseScopedInteractionCommandError> {
+    const MARKER_PREFIX: &str = "<!-- ensemble:interaction:";
+    const MARKER_SUFFIX: &str = " -->";
+
+    let body = raw_body.trim();
+    let marker_count = body.matches(MARKER_PREFIX).count();
+    if marker_count > 1 {
+        return Err(ParseScopedInteractionCommandError::DuplicateMarker);
+    }
+
+    let (command_body, marker) = body
+        .rsplit_once("\n\n")
+        .ok_or(ParseScopedInteractionCommandError::MissingMarker)?;
+    let interaction_id = marker
+        .strip_prefix(MARKER_PREFIX)
+        .and_then(|marker| marker.strip_suffix(MARKER_SUFFIX))
+        .filter(|id| {
+            !id.is_empty()
+                && id
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+        })
+        .ok_or(ParseScopedInteractionCommandError::InvalidMarker)?;
+
+    if marker_count == 0 || command_body.contains(MARKER_PREFIX) {
+        return Err(ParseScopedInteractionCommandError::InvalidMarker);
+    }
+
+    let command = parse_interaction_command(command_body)
+        .map_err(ParseScopedInteractionCommandError::InvalidCommand)?;
+    Ok(ScopedInteractionCommand {
+        interaction_id: interaction_id.to_string(),
+        command,
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{parse_interaction_command, InteractionCommand, ParseInteractionCommandError};
+    use super::{
+        parse_interaction_command, parse_scoped_interaction_command, InteractionCommand,
+        ParseInteractionCommandError, ParseScopedInteractionCommandError,
+    };
 
     #[test]
     fn parses_approve() {
@@ -142,6 +197,86 @@ mod tests {
             InteractionCommand::Answer {
                 text: "\"staging".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn scoped_interaction_command_parses_supported_commands() {
+        assert_eq!(
+            parse_scoped_interaction_command(
+                "/approve\n\n<!-- ensemble:interaction:interaction-1 -->"
+            )
+            .unwrap()
+            .command,
+            InteractionCommand::Approve
+        );
+        assert_eq!(
+            parse_scoped_interaction_command(
+                "/reject needs docs\n\n<!-- ensemble:interaction:interaction-2 -->"
+            )
+            .unwrap()
+            .command,
+            InteractionCommand::Reject {
+                reason: "needs docs".to_string()
+            }
+        );
+        let answer = parse_scoped_interaction_command(
+            "/answer use staging\n\n<!-- ensemble:interaction:interaction-3 -->",
+        )
+        .unwrap();
+        assert_eq!(answer.interaction_id, "interaction-3");
+        assert_eq!(
+            answer.command,
+            InteractionCommand::Answer {
+                text: "use staging".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn scoped_interaction_command_rejects_missing_duplicate_and_malformed_markers() {
+        assert_eq!(
+            parse_scoped_interaction_command("/approve").unwrap_err(),
+            ParseScopedInteractionCommandError::MissingMarker
+        );
+        assert_eq!(
+            parse_scoped_interaction_command(
+                "/approve\n\n<!-- ensemble:interaction:interaction-1 -->\n\n<!-- ensemble:interaction:interaction-1 -->"
+            )
+            .unwrap_err(),
+            ParseScopedInteractionCommandError::DuplicateMarker
+        );
+        assert_eq!(
+            parse_scoped_interaction_command(
+                "/approve\n\nmarker: <!-- ensemble:interaction:interaction-1 -->"
+            )
+            .unwrap_err(),
+            ParseScopedInteractionCommandError::InvalidMarker
+        );
+        assert_eq!(
+            parse_scoped_interaction_command(
+                "/approve\n<!-- ensemble:interaction:interaction-1 -->"
+            )
+            .unwrap_err(),
+            ParseScopedInteractionCommandError::MissingMarker
+        );
+        assert_eq!(
+            parse_scoped_interaction_command("/approve\n\n<!-- ensemble:interaction: -->")
+                .unwrap_err(),
+            ParseScopedInteractionCommandError::InvalidMarker
+        );
+    }
+
+    #[test]
+    fn scoped_interaction_command_rejects_prose_wrapped_commands() {
+        assert_eq!(
+            parse_scoped_interaction_command(
+                "please approve\n/approve\n\n<!-- ensemble:interaction:interaction-1 -->"
+            )
+            .unwrap_err(),
+            ParseScopedInteractionCommandError::InvalidCommand(
+                ParseInteractionCommandError::NotSlashCommand
+            )
         );
     }
 }

--- a/crates/ensemble-core/src/interaction/error.rs
+++ b/crates/ensemble-core/src/interaction/error.rs
@@ -14,8 +14,6 @@ pub enum InteractionError {
     OpenBlockingInteractionExists { issue_id: String },
     #[error("interaction already exists: {id}")]
     ConcurrentModification { id: String },
-    #[error("interaction already accepted a command: {id}")]
-    CommandAlreadyAccepted { id: String },
     #[error("interaction I/O error: {reason}")]
     Io { reason: String },
     #[error("interaction serialization error: {reason}")]

--- a/crates/ensemble-core/src/interaction/mod.rs
+++ b/crates/ensemble-core/src/interaction/mod.rs
@@ -3,10 +3,13 @@ pub mod error;
 pub mod model;
 pub mod store;
 
-pub use commands::{parse_interaction_command, InteractionCommand, ParseInteractionCommandError};
+pub use commands::{
+    parse_interaction_command, parse_scoped_interaction_command, InteractionCommand,
+    ParseInteractionCommandError, ParseScopedInteractionCommandError, ScopedInteractionCommand,
+};
 pub use error::InteractionError;
 pub use model::{
     InteractionKind, InteractionRequest, InteractionResponse, InteractionResumeStrategy,
     InteractionStatus,
 };
-pub use store::InteractionStore;
+pub use store::{InteractionAcceptance, InteractionStore};

--- a/crates/ensemble-core/src/interaction/store.rs
+++ b/crates/ensemble-core/src/interaction/store.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock, Weak};
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
@@ -12,28 +13,48 @@ use crate::interaction::model::{
     InteractionResponse, InteractionStatus,
 };
 
+type RecordLock = Arc<Mutex<()>>;
+type RecordLockRegistry = std::sync::Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>;
+
+static RECORD_LOCKS: OnceLock<RecordLockRegistry> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InteractionAcceptance {
+    Accepted(InteractionRequest),
+    Ignored(InteractionRequest),
+}
+
 #[derive(Debug, Clone)]
 pub struct InteractionStore {
     config_dir: PathBuf,
-    create_mutex: std::sync::Arc<Mutex<()>>,
-    command_locks: std::sync::Arc<std::sync::Mutex<HashMap<String, std::sync::Arc<Mutex<()>>>>>,
+    create_mutex: Arc<Mutex<()>>,
 }
 
 impl InteractionStore {
     pub fn new(config_dir: PathBuf) -> Self {
         Self {
             config_dir,
-            create_mutex: std::sync::Arc::new(Mutex::new(())),
-            command_locks: std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+            create_mutex: Arc::new(Mutex::new(())),
         }
     }
 
-    fn command_lock_for(&self, id: &str) -> std::sync::Arc<Mutex<()>> {
-        let mut locks = self.command_locks.lock().unwrap();
-        locks
-            .entry(id.to_string())
-            .or_insert_with(|| std::sync::Arc::new(Mutex::new(())))
-            .clone()
+    fn record_lock_for(&self, id: &str) -> RecordLock {
+        let path = self.path_for_id(id);
+        let key = std::fs::canonicalize(&path)
+            .or_else(|_| std::path::absolute(&path))
+            .unwrap_or(path);
+        let registry = RECORD_LOCKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+        let mut locks = registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(key, Arc::downgrade(&lock));
+        lock
     }
 
     pub fn config_dir(&self) -> &Path {
@@ -106,6 +127,8 @@ impl InteractionStore {
         id: &str,
         response: InteractionResponse,
     ) -> Result<InteractionRequest, InteractionError> {
+        let lock = self.record_lock_for(id);
+        let _guard = lock.lock().await;
         let mut interaction = self
             .get(id)
             .await?
@@ -137,6 +160,8 @@ impl InteractionStore {
         root_comment_id: String,
         root_comment_url: Option<String>,
     ) -> Result<InteractionRequest, InteractionError> {
+        let lock = self.record_lock_for(id);
+        let _guard = lock.lock().await;
         let mut interaction = self
             .get(id)
             .await?
@@ -152,6 +177,8 @@ impl InteractionStore {
         id: &str,
         comment_id: String,
     ) -> Result<InteractionRequest, InteractionError> {
+        let lock = self.record_lock_for(id);
+        let _guard = lock.lock().await;
         let mut interaction = self
             .get(id)
             .await?
@@ -161,35 +188,61 @@ impl InteractionStore {
         Ok(interaction)
     }
 
-    pub async fn accept_first_command(
+    pub async fn accept_response(
         &self,
         id: &str,
         command: AcceptedInteractionCommand,
-    ) -> Result<InteractionRequest, InteractionError> {
-        let lock = self.command_lock_for(id);
+        response: InteractionResponse,
+    ) -> Result<InteractionAcceptance, InteractionError> {
+        let lock = self.record_lock_for(id);
         let _guard = lock.lock().await;
         let mut interaction = self
             .get(id)
             .await?
             .ok_or_else(|| InteractionError::NotFound { id: id.to_string() })?;
 
-        match interaction.status {
-            InteractionStatus::Resolved => {
-                return Err(InteractionError::AlreadyResolved { id: id.to_string() });
-            }
-            InteractionStatus::Cancelled => {
-                return Err(InteractionError::AlreadyCancelled { id: id.to_string() });
-            }
-            InteractionStatus::Open => {}
+        validate_response_kind(&interaction.kind, &response)?;
+
+        if interaction
+            .accepted_command
+            .as_ref()
+            .is_some_and(|accepted| accepted.comment_id == command.comment_id)
+            || interaction
+                .ignored_commands
+                .iter()
+                .any(|ignored| ignored.comment_id == command.comment_id)
+        {
+            return Ok(InteractionAcceptance::Ignored(interaction));
         }
 
-        if interaction.accepted_command.is_some() {
-            return Err(InteractionError::CommandAlreadyAccepted { id: id.to_string() });
+        if interaction.status != InteractionStatus::Open || interaction.accepted_command.is_some() {
+            let reason = match interaction.status {
+                InteractionStatus::Cancelled => "interaction_already_cancelled",
+                InteractionStatus::Open | InteractionStatus::Resolved => {
+                    "interaction_already_resolved"
+                }
+            };
+            interaction
+                .ignored_commands
+                .push(IgnoredInteractionCommand {
+                    command: Some(command.command),
+                    raw_body: command.raw_body,
+                    author: command.author,
+                    comment_id: command.comment_id,
+                    received_at: command.received_at,
+                    reason: reason.to_string(),
+                });
+            self.write_interaction(&interaction).await?;
+            return Ok(InteractionAcceptance::Ignored(interaction));
         }
 
         interaction.accepted_command = Some(command);
+        interaction.status = InteractionStatus::Resolved;
+        interaction.awaiting_resume = true;
+        interaction.response = Some(response);
+        interaction.resolved_at = Some(Utc::now());
         self.write_interaction(&interaction).await?;
-        Ok(interaction)
+        Ok(InteractionAcceptance::Accepted(interaction))
     }
 
     pub async fn append_ignored_command(
@@ -197,7 +250,7 @@ impl InteractionStore {
         id: &str,
         command: IgnoredInteractionCommand,
     ) -> Result<InteractionRequest, InteractionError> {
-        let lock = self.command_lock_for(id);
+        let lock = self.record_lock_for(id);
         let _guard = lock.lock().await;
         let mut interaction = self
             .get(id)
@@ -209,6 +262,8 @@ impl InteractionStore {
     }
 
     pub async fn cancel(&self, id: &str) -> Result<InteractionRequest, InteractionError> {
+        let lock = self.record_lock_for(id);
+        let _guard = lock.lock().await;
         let mut interaction = self
             .get(id)
             .await?
@@ -232,6 +287,8 @@ impl InteractionStore {
     }
 
     pub async fn mark_resumed(&self, id: &str) -> Result<InteractionRequest, InteractionError> {
+        let lock = self.record_lock_for(id);
+        let _guard = lock.lock().await;
         let mut interaction = self
             .get(id)
             .await?
@@ -246,17 +303,25 @@ impl InteractionStore {
         &self,
         id: &str,
     ) -> Result<InteractionRequest, InteractionError> {
-        let interaction = self
+        let lock = self.record_lock_for(id);
+        let _guard = lock.lock().await;
+        let mut interaction = self
             .get(id)
             .await?
             .ok_or_else(|| InteractionError::NotFound { id: id.to_string() })?;
 
         match interaction.status {
-            InteractionStatus::Open => self.cancel(id).await,
+            InteractionStatus::Open => {
+                interaction.status = InteractionStatus::Cancelled;
+                interaction.awaiting_resume = false;
+                interaction.resolved_at = Some(Utc::now());
+            }
             InteractionStatus::Resolved | InteractionStatus::Cancelled => {
-                self.mark_resumed(id).await
+                interaction.awaiting_resume = false;
             }
         }
+        self.write_interaction(&interaction).await?;
+        Ok(interaction)
     }
 
     async fn list_all(&self) -> Result<Vec<InteractionRequest>, InteractionError> {
@@ -411,7 +476,7 @@ fn unique_temp_path(dir: &Path, id: &str) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::InteractionStore;
+    use super::{InteractionAcceptance, InteractionStore};
     use crate::interaction::error::InteractionError;
     use crate::interaction::model::{
         AcceptedInteractionCommand, IgnoredInteractionCommand, InteractionKind, InteractionRequest,
@@ -765,46 +830,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn accepts_first_command_and_rejects_second() {
-        let dir = tempdir().unwrap();
-        let store = InteractionStore::new(dir.path().to_path_buf());
-        store
-            .create(sample_question("int_cmd", "issue-1", "ACME-1"))
-            .await
-            .unwrap();
-
-        let accepted = AcceptedInteractionCommand {
-            command: "/approve".to_string(),
-            raw_body: "/approve".to_string(),
-            author: "alice".to_string(),
-            comment_id: "c1".to_string(),
-            received_at: Utc::now(),
-        };
-        store
-            .accept_first_command("int_cmd", accepted)
-            .await
-            .unwrap();
-
-        let err = store
-            .accept_first_command(
-                "int_cmd",
-                AcceptedInteractionCommand {
-                    command: "/reject".to_string(),
-                    raw_body: "/reject nope".to_string(),
-                    author: "bob".to_string(),
-                    comment_id: "c2".to_string(),
-                    received_at: Utc::now(),
-                },
-            )
-            .await
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            InteractionError::CommandAlreadyAccepted { .. }
-        ));
-    }
-
-    #[tokio::test]
     async fn appends_ignored_commands() {
         let dir = tempdir().unwrap();
         let store = InteractionStore::new(dir.path().to_path_buf());
@@ -834,60 +859,276 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cannot_accept_command_when_interaction_is_resolved_or_cancelled() {
+    async fn interaction_acceptance_is_atomic_across_store_instances() {
+        let dir = tempdir().unwrap();
+        let creator = InteractionStore::new(dir.path().to_path_buf());
+        creator
+            .create(sample_question("int_race", "issue-1", "ACME-1"))
+            .await
+            .unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let first_store = InteractionStore::new(dir.path().to_path_buf());
+        let second_store = InteractionStore::new(dir.path().to_path_buf());
+        let first_barrier = Arc::clone(&barrier);
+        let second_barrier = Arc::clone(&barrier);
+
+        let first = tokio::spawn(async move {
+            first_barrier.wait().await;
+            first_store
+                .accept_response(
+                    "int_race",
+                    AcceptedInteractionCommand {
+                        command: "/answer".to_string(),
+                        raw_body: "/answer staging".to_string(),
+                        author: "alice".to_string(),
+                        comment_id: "c1".to_string(),
+                        received_at: Utc::now(),
+                    },
+                    InteractionResponse::Question {
+                        response_schema_version: 1,
+                        text: "staging".to_string(),
+                        selected_option: None,
+                    },
+                )
+                .await
+        });
+        let second = tokio::spawn(async move {
+            second_barrier.wait().await;
+            second_store
+                .accept_response(
+                    "int_race",
+                    AcceptedInteractionCommand {
+                        command: "/answer".to_string(),
+                        raw_body: "/answer production".to_string(),
+                        author: "bob".to_string(),
+                        comment_id: "c2".to_string(),
+                        received_at: Utc::now(),
+                    },
+                    InteractionResponse::Question {
+                        response_schema_version: 1,
+                        text: "production".to_string(),
+                        selected_option: None,
+                    },
+                )
+                .await
+        });
+
+        let outcomes = [
+            first.await.unwrap().unwrap(),
+            second.await.unwrap().unwrap(),
+        ];
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, InteractionAcceptance::Accepted(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, InteractionAcceptance::Ignored(_)))
+                .count(),
+            1
+        );
+
+        let stored = creator.get("int_race").await.unwrap().unwrap();
+        assert_eq!(stored.status, InteractionStatus::Resolved);
+        assert!(stored.response.is_some());
+        assert!(stored.accepted_command.is_some());
+        assert_eq!(stored.ignored_commands.len(), 1);
+        assert_eq!(
+            stored.ignored_commands[0].reason,
+            "interaction_already_resolved"
+        );
+        assert_ne!(
+            stored.accepted_command.as_ref().unwrap().comment_id,
+            stored.ignored_commands[0].comment_id
+        );
+    }
+
+    #[tokio::test]
+    async fn interaction_acceptance_preserves_concurrent_cursor_update() {
+        let dir = tempdir().unwrap();
+        let creator = InteractionStore::new(dir.path().to_path_buf());
+        creator
+            .create(sample_question("int_cursor", "issue-1", "ACME-1"))
+            .await
+            .unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let acceptance_store = InteractionStore::new(dir.path().to_path_buf());
+        let cursor_store = InteractionStore::new(dir.path().to_path_buf());
+        let acceptance_barrier = Arc::clone(&barrier);
+        let cursor_barrier = Arc::clone(&barrier);
+
+        let acceptance = tokio::spawn(async move {
+            acceptance_barrier.wait().await;
+            acceptance_store
+                .accept_response(
+                    "int_cursor",
+                    AcceptedInteractionCommand {
+                        command: "/answer".to_string(),
+                        raw_body: "/answer staging".to_string(),
+                        author: "alice".to_string(),
+                        comment_id: "c1".to_string(),
+                        received_at: Utc::now(),
+                    },
+                    InteractionResponse::Question {
+                        response_schema_version: 1,
+                        text: "staging".to_string(),
+                        selected_option: None,
+                    },
+                )
+                .await
+        });
+        let cursor = tokio::spawn(async move {
+            cursor_barrier.wait().await;
+            cursor_store
+                .update_last_processed_comment("int_cursor", "c1".to_string())
+                .await
+        });
+
+        acceptance.await.unwrap().unwrap();
+        cursor.await.unwrap().unwrap();
+
+        let stored = creator.get("int_cursor").await.unwrap().unwrap();
+        assert_eq!(stored.status, InteractionStatus::Resolved);
+        assert!(stored.accepted_command.is_some());
+        assert!(stored.response.is_some());
+        assert_eq!(stored.last_processed_comment_id.as_deref(), Some("c1"));
+    }
+
+    #[tokio::test]
+    async fn interaction_acceptance_preserves_concurrent_ignored_audit() {
+        let dir = tempdir().unwrap();
+        let creator = InteractionStore::new(dir.path().to_path_buf());
+        creator
+            .create(sample_question("int_audit", "issue-1", "ACME-1"))
+            .await
+            .unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let acceptance_store = InteractionStore::new(dir.path().to_path_buf());
+        let audit_store = InteractionStore::new(dir.path().to_path_buf());
+        let acceptance_barrier = Arc::clone(&barrier);
+        let audit_barrier = Arc::clone(&barrier);
+
+        let acceptance = tokio::spawn(async move {
+            acceptance_barrier.wait().await;
+            acceptance_store
+                .accept_response(
+                    "int_audit",
+                    AcceptedInteractionCommand {
+                        command: "/answer".to_string(),
+                        raw_body: "/answer staging".to_string(),
+                        author: "alice".to_string(),
+                        comment_id: "c1".to_string(),
+                        received_at: Utc::now(),
+                    },
+                    InteractionResponse::Question {
+                        response_schema_version: 1,
+                        text: "staging".to_string(),
+                        selected_option: None,
+                    },
+                )
+                .await
+        });
+        let audit = tokio::spawn(async move {
+            audit_barrier.wait().await;
+            audit_store
+                .append_ignored_command(
+                    "int_audit",
+                    IgnoredInteractionCommand {
+                        command: None,
+                        raw_body: "not a command".to_string(),
+                        author: "bob".to_string(),
+                        comment_id: "c2".to_string(),
+                        received_at: Utc::now(),
+                        reason: "not_a_supported_command".to_string(),
+                    },
+                )
+                .await
+        });
+
+        acceptance.await.unwrap().unwrap();
+        audit.await.unwrap().unwrap();
+
+        let stored = creator.get("int_audit").await.unwrap().unwrap();
+        assert_eq!(stored.status, InteractionStatus::Resolved);
+        assert!(stored.accepted_command.is_some());
+        assert!(stored.response.is_some());
+        assert_eq!(stored.ignored_commands.len(), 1);
+        assert_eq!(stored.ignored_commands[0].comment_id, "c2");
+    }
+
+    #[tokio::test]
+    async fn interaction_acceptance_lock_is_scoped_to_one_interaction() {
         let dir = tempdir().unwrap();
         let store = InteractionStore::new(dir.path().to_path_buf());
         store
-            .create(sample_question("int_closed", "issue-1", "ACME-1"))
+            .create(sample_question("int_a", "issue-1", "ACME-1"))
             .await
             .unwrap();
         store
-            .resolve(
-                "int_closed",
-                InteractionResponse::Question {
-                    response_schema_version: 1,
-                    text: "answer".to_string(),
-                    selected_option: None,
-                },
-            )
+            .create(sample_question("int_b", "issue-2", "ACME-2"))
             .await
             .unwrap();
 
-        let err = store
-            .accept_first_command(
-                "int_closed",
-                AcceptedInteractionCommand {
-                    command: "/approve".to_string(),
-                    raw_body: "/approve".to_string(),
-                    author: "alice".to_string(),
-                    comment_id: "c1".to_string(),
-                    received_at: Utc::now(),
-                },
-            )
-            .await
-            .unwrap_err();
-        assert!(matches!(err, InteractionError::AlreadyResolved { .. }));
+        let lock_a = store.record_lock_for("int_a");
+        let _guard_a = lock_a.lock().await;
+        let other_store = InteractionStore::new(dir.path().to_path_buf());
 
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            other_store.update_last_processed_comment("int_b", "c2".to_string()),
+        )
+        .await
+        .expect("interaction B must not wait for interaction A")
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn interaction_acceptance_audits_response_after_cancellation() {
+        let dir = tempdir().unwrap();
+        let store = InteractionStore::new(dir.path().to_path_buf());
         store
             .create(sample_question("int_cancelled", "issue-2", "ACME-2"))
             .await
             .unwrap();
-        store.cancel("int_cancelled").await.unwrap();
 
-        let err = store
-            .accept_first_command(
+        let cancel_store = InteractionStore::new(dir.path().to_path_buf());
+        let acceptance_store = InteractionStore::new(dir.path().to_path_buf());
+        let (cancelled, outcome) = tokio::join!(
+            cancel_store.cancel("int_cancelled"),
+            acceptance_store.accept_response(
                 "int_cancelled",
                 AcceptedInteractionCommand {
-                    command: "/approve".to_string(),
-                    raw_body: "/approve".to_string(),
+                    command: "/answer".to_string(),
+                    raw_body: "/answer staging".to_string(),
                     author: "alice".to_string(),
                     comment_id: "c2".to_string(),
                     received_at: Utc::now(),
                 },
+                InteractionResponse::Question {
+                    response_schema_version: 1,
+                    text: "staging".to_string(),
+                    selected_option: None,
+                },
             )
-            .await
-            .unwrap_err();
-        assert!(matches!(err, InteractionError::AlreadyCancelled { .. }));
+        );
+        assert_eq!(cancelled.unwrap().status, InteractionStatus::Cancelled);
+        let outcome = outcome.unwrap();
+        assert!(matches!(outcome, InteractionAcceptance::Ignored(_)));
+
+        let stored = store.get("int_cancelled").await.unwrap().unwrap();
+        assert_eq!(stored.status, InteractionStatus::Cancelled);
+        assert_eq!(stored.ignored_commands.len(), 1);
+        assert_eq!(
+            stored.ignored_commands[0].reason,
+            "interaction_already_cancelled"
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/interaction/store.rs
+++ b/crates/ensemble-core/src/interaction/store.rs
@@ -1,6 +1,8 @@
 use chrono::Utc;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock, Weak};
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
@@ -28,6 +30,8 @@ pub enum InteractionAcceptance {
 pub struct InteractionStore {
     config_dir: PathBuf,
     create_mutex: Arc<Mutex<()>>,
+    #[cfg(test)]
+    write_failures: Arc<AtomicUsize>,
 }
 
 impl InteractionStore {
@@ -35,7 +39,14 @@ impl InteractionStore {
         Self {
             config_dir,
             create_mutex: Arc::new(Mutex::new(())),
+            #[cfg(test)]
+            write_failures: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_writes(&self, count: usize) {
+        self.write_failures.store(count, Ordering::Relaxed);
     }
 
     fn record_lock_for(&self, id: &str) -> RecordLock {
@@ -118,6 +129,15 @@ impl InteractionStore {
     pub async fn list_awaiting_resume(&self) -> Result<Vec<InteractionRequest>, InteractionError> {
         let mut interactions = self.list_all().await?;
         interactions.retain(|interaction| interaction.blocking && interaction.awaiting_resume);
+        interactions.sort_by_key(|interaction| interaction.requested_at);
+        Ok(interactions)
+    }
+
+    pub async fn list_with_thread_roots(
+        &self,
+    ) -> Result<Vec<InteractionRequest>, InteractionError> {
+        let mut interactions = self.list_all().await?;
+        interactions.retain(|interaction| interaction.thread_root_comment_id.is_some());
         interactions.sort_by_key(|interaction| interaction.requested_at);
         Ok(interactions)
     }
@@ -364,6 +384,17 @@ impl InteractionStore {
         &self,
         interaction: &InteractionRequest,
     ) -> Result<(), InteractionError> {
+        #[cfg(test)]
+        if self
+            .write_failures
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(std::io::Error::other("injected interaction write failure").into());
+        }
+
         let dir = self.interactions_dir();
         tokio::fs::create_dir_all(&dir).await?;
         let path = self.path_for_id(&interaction.id);

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -38,8 +38,9 @@ use crate::interaction::model::{
     AcceptedInteractionCommand, IgnoredInteractionCommand, InteractionKind, InteractionResponse,
 };
 use crate::interaction::{
-    parse_interaction_command, InteractionCommand, InteractionResumeStrategy, InteractionStatus,
-    InteractionStore,
+    parse_scoped_interaction_command, InteractionAcceptance, InteractionCommand,
+    InteractionResumeStrategy, InteractionStatus, InteractionStore,
+    ParseScopedInteractionCommandError,
 };
 use crate::observability::events::{EventBus, PipelineEvent};
 use crate::observability::events_contract::{
@@ -3042,35 +3043,6 @@ impl Orchestrator {
                     continue;
                 }
 
-                let marker_prefix = "<!-- ensemble:interaction:";
-                let interaction_marker = format!("{marker_prefix}{} -->", interaction.id);
-                if comment.body.contains(marker_prefix)
-                    && !comment.body.contains(&interaction_marker)
-                {
-                    interaction = self
-                        .append_ignored_command(
-                            &interaction,
-                            None,
-                            &comment,
-                            "interaction_marker_mismatch",
-                        )
-                        .await;
-                    continue;
-                }
-
-                if !comment.body.contains(marker_prefix) && !comment.body.contains(&interaction.id)
-                {
-                    interaction = self
-                        .append_ignored_command(
-                            &interaction,
-                            None,
-                            &comment,
-                            "comment_not_scoped_to_interaction",
-                        )
-                        .await;
-                    continue;
-                }
-
                 if comment
                     .updated_at
                     .zip(comment.created_at)
@@ -3087,8 +3059,30 @@ impl Orchestrator {
                     continue;
                 }
 
-                let parsed = match parse_interaction_command(&comment.body) {
-                    Ok(parsed) => parsed,
+                let parsed = match parse_scoped_interaction_command(&comment.body) {
+                    Ok(parsed) if parsed.interaction_id == interaction.id => parsed.command,
+                    Ok(_) => {
+                        interaction = self
+                            .append_ignored_command(
+                                &interaction,
+                                None,
+                                &comment,
+                                "interaction_marker_mismatch",
+                            )
+                            .await;
+                        continue;
+                    }
+                    Err(ParseScopedInteractionCommandError::MissingMarker) => {
+                        interaction = self
+                            .append_ignored_command(
+                                &interaction,
+                                None,
+                                &comment,
+                                "comment_not_scoped_to_interaction",
+                            )
+                            .await;
+                        continue;
+                    }
                     Err(_) => {
                         interaction = self
                             .append_ignored_command(
@@ -3117,21 +3111,9 @@ impl Orchestrator {
                     }
                 };
 
-                if interaction.accepted_command.is_some() {
-                    interaction = self
-                        .append_ignored_command(
-                            &interaction,
-                            Some(parsed.command_name()),
-                            &comment,
-                            "interaction_already_locked",
-                        )
-                        .await;
-                    continue;
-                }
-
                 let accepted_result = self
                     .interaction_store
-                    .accept_first_command(
+                    .accept_response(
                         &interaction.id,
                         AcceptedInteractionCommand {
                             command: parsed.command_name().to_string(),
@@ -3140,11 +3122,19 @@ impl Orchestrator {
                             comment_id: comment.comment_id.clone(),
                             received_at: comment.created_at.unwrap_or_else(Utc::now),
                         },
+                        response,
                     )
                     .await;
 
                 match accepted_result {
-                    Ok(updated) => interaction = updated,
+                    Ok(InteractionAcceptance::Accepted(updated)) => {
+                        interaction = updated;
+                        let mut state = self.state.write().await;
+                        state.queue_resume(&interaction.issue_id);
+                    }
+                    Ok(InteractionAcceptance::Ignored(updated)) => {
+                        interaction = updated;
+                    }
                     Err(error) => {
                         warn!(
                             interaction_id = %interaction.id,
@@ -3156,31 +3146,11 @@ impl Orchestrator {
                                 &interaction,
                                 Some(parsed.command_name()),
                                 &comment,
-                                "interaction_already_locked",
+                                "interaction_acceptance_failed",
                             )
                             .await;
-                        continue;
                     }
                 }
-
-                match self
-                    .interaction_store
-                    .resolve(&interaction.id, response)
-                    .await
-                {
-                    Ok(updated) => interaction = updated,
-                    Err(error) => {
-                        warn!(
-                            interaction_id = %interaction.id,
-                            error = %error,
-                            "failed to resolve interaction from thread command"
-                        );
-                        continue;
-                    }
-                }
-
-                let mut state = self.state.write().await;
-                state.queue_resume(&interaction.issue_id);
             }
 
             if let Some(last_id) = last_comment_id {
@@ -5778,17 +5748,29 @@ fn build_interaction_request(
 fn format_interaction_thread_root_comment(
     interaction: &crate::interaction::InteractionRequest,
 ) -> String {
+    let commands = match interaction.kind {
+        InteractionKind::Question => &["/answer <text>"][..],
+        InteractionKind::Approval => &["/approve", "/reject <reason>"][..],
+        InteractionKind::Handoff => &["/approve", "/reject <reason>", "/answer <text>"][..],
+    };
+    let snippets = commands
+        .iter()
+        .map(|command| {
+            format!(
+                "```text\n{command}\n\n<!-- ensemble:interaction:{} -->\n```",
+                interaction.id
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
     format!(
         concat!(
             "Ensemble requires input to continue.\n\n",
             "**Interaction ID:** `{}`\n",
             "**Kind:** `{}`\n\n",
             "{}\n\n",
-            "Valid commands:\n",
-            "- `/approve`\n",
-            "- `/reject <reason>`\n",
-            "- `/answer <text>`\n\n",
-            "<!-- ensemble:interaction:{} -->"
+            "Valid commands (copy one complete block):\n\n",
+            "{}"
         ),
         interaction.id,
         match interaction.kind {
@@ -5797,7 +5779,7 @@ fn format_interaction_thread_root_comment(
             InteractionKind::Handoff => "handoff",
         },
         interaction.body,
-        interaction.id
+        snippets
     )
 }
 
@@ -5948,6 +5930,7 @@ mod tests {
     struct CommandMockTracker {
         issues: Arc<RwLock<Vec<Issue>>>,
         comments: Arc<RwLock<Vec<crate::tracker::model::TrackerComment>>>,
+        list_barrier: Option<Arc<tokio::sync::Barrier>>,
     }
 
     #[async_trait]
@@ -6046,6 +6029,9 @@ mod tests {
             _id: &str,
             _after_comment_id: &str,
         ) -> Result<Vec<crate::tracker::model::TrackerComment>, TrackerError> {
+            if let Some(barrier) = &self.list_barrier {
+                barrier.wait().await;
+            }
             Ok(self.comments.read().await.clone())
         }
     }
@@ -11144,7 +11130,7 @@ agent:
     }
 
     #[tokio::test]
-    async fn thread_answer_command_resolves_open_interaction_on_tick() {
+    async fn interaction_thread_command_resolves_open_interaction_on_tick() {
         let config = Arc::new(RwLock::new(make_config()));
         let issues = Arc::new(RwLock::new(vec![test_issue("1", "Todo")]));
         let comment_ts = Utc::now();
@@ -11155,7 +11141,11 @@ agent:
             created_at: Some(comment_ts),
             updated_at: Some(comment_ts),
         }]));
-        let tracker: Arc<dyn IssueTracker> = Arc::new(CommandMockTracker { issues, comments });
+        let tracker: Arc<dyn IssueTracker> = Arc::new(CommandMockTracker {
+            issues,
+            comments,
+            list_barrier: None,
+        });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,
@@ -11199,9 +11189,141 @@ agent:
         }
 
         let store = InteractionStore::new(dir.path().to_path_buf());
+        let interaction = crate::interaction::InteractionRequest {
+            id: "interaction-1".to_string(),
+            schema_version: 1,
+            issue_id: "1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            pipeline_cycle: 1,
+            completed_steps: vec![],
+            step_name: "build".to_string(),
+            agent_name: "builder".to_string(),
+            step_depends: vec![],
+            step_tracker_state: None,
+            kind: InteractionKind::Question,
+            status: InteractionStatus::Open,
+            blocking: true,
+            awaiting_resume: true,
+            resume_strategy: InteractionResumeStrategy::default(),
+            title: "Need input".to_string(),
+            body: "Choose environment".to_string(),
+            options: vec![],
+            artifacts: vec![],
+            response: None,
+            waiting_started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: Utc::now(),
+            resolved_at: None,
+            thread_root_comment_id: Some("root-1".to_string()),
+            thread_root_comment_url: None,
+            last_processed_comment_id: None,
+            accepted_command: None,
+            ignored_commands: vec![],
+        };
+        let root_comment = format_interaction_thread_root_comment(&interaction);
+        assert!(root_comment.contains(
+            "```text\n/answer <text>\n\n<!-- ensemble:interaction:interaction-1 -->\n```"
+        ));
+        assert!(!root_comment.contains("```text\n/approve"));
+        let mut approval = interaction.clone();
+        approval.kind = InteractionKind::Approval;
+        let approval_root = format_interaction_thread_root_comment(&approval);
+        assert!(approval_root.contains("```text\n/approve\n\n"));
+        assert!(approval_root.contains("```text\n/reject <reason>\n\n"));
+        assert!(!approval_root.contains("```text\n/answer <text>\n\n"));
+        let mut handoff = interaction.clone();
+        handoff.kind = InteractionKind::Handoff;
+        let handoff_root = format_interaction_thread_root_comment(&handoff);
+        assert!(handoff_root.contains("```text\n/approve\n\n"));
+        assert!(handoff_root.contains("```text\n/reject <reason>\n\n"));
+        assert!(handoff_root.contains("```text\n/answer <text>\n\n"));
+        store.create(interaction).await.unwrap();
+
+        orchestrator.handle_tick().await;
+
+        let interaction = store.get("interaction-1").await.unwrap().unwrap();
+        assert_eq!(interaction.status, InteractionStatus::Resolved);
+        assert!(interaction.accepted_command.is_some());
+        assert!(matches!(
+            interaction.response,
+            Some(InteractionResponse::Question { .. })
+        ));
+
+        orchestrator.process_waiting_interaction_commands().await;
+        let replayed = store.get("interaction-1").await.unwrap().unwrap();
+        assert!(replayed.ignored_commands.is_empty());
+        assert_eq!(
+            replayed.accepted_command.as_ref().unwrap().comment_id,
+            "c-1"
+        );
+    }
+
+    #[tokio::test]
+    async fn interaction_thread_command_races_api_atomically_across_stores() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let issues = Arc::new(RwLock::new(vec![test_issue("1", "Todo")]));
+        let comment_ts = Utc::now();
+        let comments = Arc::new(RwLock::new(vec![crate::tracker::model::TrackerComment {
+            comment_id: "tracker-c1".to_string(),
+            body: "/answer use staging\n\n<!-- ensemble:interaction:interaction-race -->"
+                .to_string(),
+            author: "alice".to_string(),
+            created_at: Some(comment_ts),
+            updated_at: Some(comment_ts),
+        }]));
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(CommandMockTracker {
+            issues,
+            comments: Arc::clone(&comments),
+            list_barrier: Some(Arc::clone(&barrier)),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            config.clone(),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let mut state = orchestrator.state.write().await;
+            let cfg = config.read().await;
+            state.init_state_lists(&cfg);
+            state.add_waiting_on_human(crate::orchestrator::state::WaitingOnHumanEntry {
+                issue_id: "1".to_string(),
+                identifier: "repo#1".to_string(),
+                interaction_request_id: "interaction-race".to_string(),
+                step_name: "build".to_string(),
+                kind: InteractionKind::Question,
+                prompt: "Need input".to_string(),
+                agent_name: "builder".to_string(),
+                retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: Utc::now(),
+                run_id: None,
+                issue: None,
+            });
+        }
+
+        let store = InteractionStore::new(dir.path().to_path_buf());
         store
             .create(crate::interaction::InteractionRequest {
-                id: "interaction-1".to_string(),
+                id: "interaction-race".to_string(),
                 schema_version: 1,
                 issue_id: "1".to_string(),
                 issue_identifier: "repo#1".to_string(),
@@ -11236,30 +11358,133 @@ agent:
             .await
             .unwrap();
 
-        orchestrator.handle_tick().await;
+        let api_store = InteractionStore::new(dir.path().to_path_buf());
+        let api_attempt = async {
+            barrier.wait().await;
+            api_store
+                .accept_response(
+                    "interaction-race",
+                    AcceptedInteractionCommand {
+                        command: "/answer".to_string(),
+                        raw_body: r#"{"kind":"question","text":"production"}"#.to_string(),
+                        author: "local-api".to_string(),
+                        comment_id: "local-api-1".to_string(),
+                        received_at: Utc::now(),
+                    },
+                    InteractionResponse::Question {
+                        response_schema_version: 1,
+                        text: "production".to_string(),
+                        selected_option: None,
+                    },
+                )
+                .await
+                .unwrap()
+        };
+        let (_, api_outcome) = tokio::join!(
+            orchestrator.process_waiting_interaction_commands(),
+            api_attempt
+        );
 
-        let interaction = store.get("interaction-1").await.unwrap().unwrap();
+        let interaction = store.get("interaction-race").await.unwrap().unwrap();
         assert_eq!(interaction.status, InteractionStatus::Resolved);
-        assert!(interaction.accepted_command.is_some());
-        assert!(matches!(
-            interaction.response,
-            Some(InteractionResponse::Question { .. })
-        ));
+        assert_eq!(interaction.ignored_commands.len(), 1);
+        assert_eq!(
+            interaction.ignored_commands[0].reason,
+            "interaction_already_resolved"
+        );
+        let tracker_won = interaction.accepted_command.as_ref().unwrap().author == "alice";
+        assert_eq!(
+            tracker_won,
+            matches!(api_outcome, InteractionAcceptance::Ignored(_))
+        );
+        assert_eq!(
+            orchestrator.state.read().await.is_resume_requested("1"),
+            tracker_won
+        );
+
+        let mut cancelled_interaction = interaction.clone();
+        cancelled_interaction.id = "interaction-cancel-race".to_string();
+        cancelled_interaction.issue_id = "2".to_string();
+        cancelled_interaction.issue_identifier = "repo#2".to_string();
+        cancelled_interaction.status = InteractionStatus::Open;
+        cancelled_interaction.awaiting_resume = true;
+        cancelled_interaction.thread_root_comment_id = Some("root-2".to_string());
+        cancelled_interaction.last_processed_comment_id = None;
+        cancelled_interaction.accepted_command = None;
+        cancelled_interaction.ignored_commands.clear();
+        cancelled_interaction.response = None;
+        cancelled_interaction.resolved_at = None;
+        store.create(cancelled_interaction).await.unwrap();
+        {
+            let mut state = orchestrator.state.write().await;
+            state.remove_waiting_on_human("1");
+            state.add_waiting_on_human(crate::orchestrator::state::WaitingOnHumanEntry {
+                issue_id: "2".to_string(),
+                identifier: "repo#2".to_string(),
+                interaction_request_id: "interaction-cancel-race".to_string(),
+                step_name: "build".to_string(),
+                kind: InteractionKind::Question,
+                prompt: "Need input".to_string(),
+                agent_name: "builder".to_string(),
+                retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: Utc::now(),
+                run_id: None,
+                issue: None,
+            });
+        }
+        *comments.write().await = vec![crate::tracker::model::TrackerComment {
+            comment_id: "tracker-cancel-c1".to_string(),
+            body: "/answer use staging\n\n<!-- ensemble:interaction:interaction-cancel-race -->"
+                .to_string(),
+            author: "alice".to_string(),
+            created_at: Some(comment_ts),
+            updated_at: Some(comment_ts),
+        }];
+
+        let cancel_store = InteractionStore::new(dir.path().to_path_buf());
+        let cancel_attempt = async {
+            let cancelled = cancel_store.cancel("interaction-cancel-race").await;
+            barrier.wait().await;
+            cancelled
+        };
+        let (cancelled, _) = tokio::join!(
+            cancel_attempt,
+            orchestrator.process_waiting_interaction_commands()
+        );
+        assert_eq!(cancelled.unwrap().status, InteractionStatus::Cancelled);
+
+        let cancelled = store.get("interaction-cancel-race").await.unwrap().unwrap();
+        assert_eq!(cancelled.status, InteractionStatus::Cancelled);
+        assert!(cancelled.accepted_command.is_none());
+        assert_eq!(cancelled.ignored_commands.len(), 1);
+        assert_eq!(
+            cancelled.ignored_commands[0].reason,
+            "interaction_already_cancelled"
+        );
+        assert!(!orchestrator.state.read().await.is_resume_requested("2"));
     }
 
     #[tokio::test]
-    async fn thread_command_with_mismatched_interaction_marker_is_ignored() {
+    async fn interaction_thread_command_with_mismatched_marker_is_ignored() {
         let config = Arc::new(RwLock::new(make_config()));
         let issues = Arc::new(RwLock::new(vec![test_issue("1", "Todo")]));
         let comment_ts = Utc::now();
         let comments = Arc::new(RwLock::new(vec![crate::tracker::model::TrackerComment {
             comment_id: "c-2".to_string(),
-            body: "/answer use staging\n<!-- ensemble:interaction:other-id -->".to_string(),
+            body: "/answer use staging\n\n<!-- ensemble:interaction:other-id -->".to_string(),
             author: "alice".to_string(),
             created_at: Some(comment_ts),
             updated_at: Some(comment_ts),
         }]));
-        let tracker: Arc<dyn IssueTracker> = Arc::new(CommandMockTracker { issues, comments });
+        let tracker: Arc<dyn IssueTracker> = Arc::new(CommandMockTracker {
+            issues,
+            comments,
+            list_barrier: None,
+        });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
             delay_ms: 0,
             observed_commands: None,

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -481,7 +481,7 @@ impl Orchestrator {
         self.restore_pipeline_runs_from_journal().await;
         self.reconcile_pending_terminal_transitions().await;
         self.hydrate_waiting_on_human_from_store().await;
-        self.process_waiting_interaction_commands().await;
+        self.process_interaction_thread_commands().await;
         self.process_finalize_retries().await;
 
         // Pre-compute lowercase state lists once per tick
@@ -2971,34 +2971,19 @@ impl Orchestrator {
         Ok(())
     }
 
-    async fn process_waiting_interaction_commands(&self) {
-        let waiting_entries = {
-            let state = self.state.read().await;
-            state
-                .waiting_on_human
-                .values()
-                .cloned()
-                .collect::<Vec<WaitingOnHumanEntry>>()
+    async fn process_interaction_thread_commands(&self) {
+        let interactions = match self.interaction_store.list_with_thread_roots().await {
+            Ok(interactions) => interactions,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "failed to list interaction threads while processing commands"
+                );
+                return;
+            }
         };
 
-        for waiting in waiting_entries {
-            let mut interaction = match self
-                .interaction_store
-                .get(&waiting.interaction_request_id)
-                .await
-            {
-                Ok(Some(interaction)) => interaction,
-                Ok(None) => continue,
-                Err(error) => {
-                    warn!(
-                        interaction_id = %waiting.interaction_request_id,
-                        error = %error,
-                        "failed to load interaction while processing thread commands"
-                    );
-                    continue;
-                }
-            };
-
+        for mut interaction in interactions {
             let Some(root_comment_id) = interaction.thread_root_comment_id.clone() else {
                 continue;
             };
@@ -3024,11 +3009,10 @@ impl Orchestrator {
                     continue;
                 }
             };
-            // v1 currently asks the tracker adapter for comments after the root anchor.
-            // If this becomes expensive on very long-lived issues, add a persisted
-            // per-interaction checkpoint to avoid repeated full-history scans.
+            // Each persisted thread retains its own cursor, so completed interactions
+            // request only comments after the last durably processed input.
 
-            let last_comment_id = comments.last().map(|c| c.comment_id.clone());
+            let mut last_persisted_comment_id = None;
 
             for comment in comments {
                 if interaction
@@ -3040,6 +3024,7 @@ impl Orchestrator {
                         .iter()
                         .any(|ignored| ignored.comment_id == comment.comment_id)
                 {
+                    last_persisted_comment_id = Some(comment.comment_id.clone());
                     continue;
                 }
 
@@ -3048,50 +3033,70 @@ impl Orchestrator {
                     .zip(comment.created_at)
                     .is_some_and(|(updated, created)| updated > created)
                 {
-                    interaction = self
+                    let Some(updated) = self
                         .append_ignored_command(
                             &interaction,
                             None,
                             &comment,
                             "edited_comments_not_supported",
                         )
-                        .await;
+                        .await
+                    else {
+                        break;
+                    };
+                    interaction = updated;
+                    last_persisted_comment_id = Some(comment.comment_id.clone());
                     continue;
                 }
 
                 let parsed = match parse_scoped_interaction_command(&comment.body) {
                     Ok(parsed) if parsed.interaction_id == interaction.id => parsed.command,
                     Ok(_) => {
-                        interaction = self
+                        let Some(updated) = self
                             .append_ignored_command(
                                 &interaction,
                                 None,
                                 &comment,
                                 "interaction_marker_mismatch",
                             )
-                            .await;
+                            .await
+                        else {
+                            break;
+                        };
+                        interaction = updated;
+                        last_persisted_comment_id = Some(comment.comment_id.clone());
                         continue;
                     }
                     Err(ParseScopedInteractionCommandError::MissingMarker) => {
-                        interaction = self
+                        let Some(updated) = self
                             .append_ignored_command(
                                 &interaction,
                                 None,
                                 &comment,
                                 "comment_not_scoped_to_interaction",
                             )
-                            .await;
+                            .await
+                        else {
+                            break;
+                        };
+                        interaction = updated;
+                        last_persisted_comment_id = Some(comment.comment_id.clone());
                         continue;
                     }
                     Err(_) => {
-                        interaction = self
+                        let Some(updated) = self
                             .append_ignored_command(
                                 &interaction,
                                 None,
                                 &comment,
                                 "not_a_supported_command",
                             )
-                            .await;
+                            .await
+                        else {
+                            break;
+                        };
+                        interaction = updated;
+                        last_persisted_comment_id = Some(comment.comment_id.clone());
                         continue;
                     }
                 };
@@ -3099,14 +3104,19 @@ impl Orchestrator {
                 let response = match response_from_command(&interaction.kind, &parsed) {
                     Some(response) => response,
                     None => {
-                        interaction = self
+                        let Some(updated) = self
                             .append_ignored_command(
                                 &interaction,
                                 Some(parsed.command_name()),
                                 &comment,
                                 "command_invalid_for_interaction_kind",
                             )
-                            .await;
+                            .await
+                        else {
+                            break;
+                        };
+                        interaction = updated;
+                        last_persisted_comment_id = Some(comment.comment_id.clone());
                         continue;
                     }
                 };
@@ -3129,11 +3139,13 @@ impl Orchestrator {
                 match accepted_result {
                     Ok(InteractionAcceptance::Accepted(updated)) => {
                         interaction = updated;
+                        last_persisted_comment_id = Some(comment.comment_id.clone());
                         let mut state = self.state.write().await;
                         state.queue_resume(&interaction.issue_id);
                     }
                     Ok(InteractionAcceptance::Ignored(updated)) => {
                         interaction = updated;
+                        last_persisted_comment_id = Some(comment.comment_id.clone());
                     }
                     Err(error) => {
                         warn!(
@@ -3141,19 +3153,24 @@ impl Orchestrator {
                             error = %error,
                             "failed to accept interaction command"
                         );
-                        interaction = self
+                        let Some(updated) = self
                             .append_ignored_command(
                                 &interaction,
                                 Some(parsed.command_name()),
                                 &comment,
                                 "interaction_acceptance_failed",
                             )
-                            .await;
+                            .await
+                        else {
+                            break;
+                        };
+                        interaction = updated;
+                        last_persisted_comment_id = Some(comment.comment_id.clone());
                     }
                 }
             }
 
-            if let Some(last_id) = last_comment_id {
+            if let Some(last_id) = last_persisted_comment_id {
                 if interaction.last_processed_comment_id.as_deref() != Some(&last_id) {
                     if let Err(error) = self
                         .interaction_store
@@ -3177,7 +3194,7 @@ impl Orchestrator {
         command: Option<&str>,
         comment: &crate::tracker::model::TrackerComment,
         reason: &str,
-    ) -> crate::interaction::model::InteractionRequest {
+    ) -> Option<crate::interaction::model::InteractionRequest> {
         match self
             .interaction_store
             .append_ignored_command(
@@ -3193,14 +3210,14 @@ impl Orchestrator {
             )
             .await
         {
-            Ok(updated) => updated,
+            Ok(updated) => Some(updated),
             Err(error) => {
                 warn!(
                     interaction_id = %interaction.id,
                     error = %error,
                     "failed to append ignored interaction command"
                 );
-                interaction.clone()
+                None
             }
         }
     }
@@ -11130,7 +11147,7 @@ agent:
     }
 
     #[tokio::test]
-    async fn interaction_thread_command_resolves_open_interaction_on_tick() {
+    async fn interaction_thread_command_audits_valid_reply_after_resume() {
         let config = Arc::new(RwLock::new(make_config()));
         let issues = Arc::new(RwLock::new(vec![test_issue("1", "Todo")]));
         let comment_ts = Utc::now();
@@ -11143,7 +11160,7 @@ agent:
         }]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(CommandMockTracker {
             issues,
-            comments,
+            comments: Arc::clone(&comments),
             list_barrier: None,
         });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
@@ -11251,12 +11268,163 @@ agent:
             Some(InteractionResponse::Question { .. })
         ));
 
-        orchestrator.process_waiting_interaction_commands().await;
+        orchestrator.process_interaction_thread_commands().await;
         let replayed = store.get("interaction-1").await.unwrap().unwrap();
         assert!(replayed.ignored_commands.is_empty());
         assert_eq!(
             replayed.accepted_command.as_ref().unwrap().comment_id,
             "c-1"
+        );
+
+        {
+            let mut state = orchestrator.state.write().await;
+            state.remove_waiting_on_human("1");
+            assert!(!state.is_resume_requested("1"));
+        }
+        let resumed = store.mark_resumed("interaction-1").await.unwrap();
+        assert!(!resumed.awaiting_resume);
+        comments
+            .write()
+            .await
+            .push(crate::tracker::model::TrackerComment {
+                comment_id: "c-2".to_string(),
+                body: "/answer use production\n\n<!-- ensemble:interaction:interaction-1 -->"
+                    .to_string(),
+                author: "bob".to_string(),
+                created_at: Some(comment_ts),
+                updated_at: Some(comment_ts),
+            });
+
+        orchestrator.process_interaction_thread_commands().await;
+
+        let audited = store.get("interaction-1").await.unwrap().unwrap();
+        assert_eq!(audited.ignored_commands.len(), 1);
+        assert_eq!(audited.ignored_commands[0].comment_id, "c-2");
+        assert_eq!(
+            audited.ignored_commands[0].reason,
+            "interaction_already_resolved"
+        );
+        assert_eq!(audited.last_processed_comment_id.as_deref(), Some("c-2"));
+        assert!(!orchestrator.state.read().await.is_resume_requested("1"));
+    }
+
+    #[tokio::test]
+    async fn interaction_thread_command_retries_when_acceptance_and_audit_writes_fail() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let issues = Arc::new(RwLock::new(vec![test_issue("1", "Todo")]));
+        let comment_ts = Utc::now();
+        let comments = Arc::new(RwLock::new(vec![crate::tracker::model::TrackerComment {
+            comment_id: "c-retry".to_string(),
+            body: "/answer use staging\n\n<!-- ensemble:interaction:interaction-retry -->"
+                .to_string(),
+            author: "alice".to_string(),
+            created_at: Some(comment_ts),
+            updated_at: Some(comment_ts),
+        }]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(CommandMockTracker {
+            issues,
+            comments,
+            list_barrier: None,
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            config.clone(),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let mut state = orchestrator.state.write().await;
+            let cfg = config.read().await;
+            state.init_state_lists(&cfg);
+            state.add_waiting_on_human(crate::orchestrator::state::WaitingOnHumanEntry {
+                issue_id: "1".to_string(),
+                identifier: "repo#1".to_string(),
+                interaction_request_id: "interaction-retry".to_string(),
+                step_name: "build".to_string(),
+                kind: InteractionKind::Question,
+                prompt: "Need input".to_string(),
+                agent_name: "builder".to_string(),
+                retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: Utc::now(),
+                run_id: None,
+                issue: None,
+            });
+        }
+
+        let store = orchestrator.interaction_store.clone();
+        store
+            .create(crate::interaction::InteractionRequest {
+                id: "interaction-retry".to_string(),
+                schema_version: 1,
+                issue_id: "1".to_string(),
+                issue_identifier: "repo#1".to_string(),
+                pipeline_cycle: 1,
+                completed_steps: vec![],
+                step_name: "build".to_string(),
+                agent_name: "builder".to_string(),
+                step_depends: vec![],
+                step_tracker_state: None,
+                kind: InteractionKind::Question,
+                status: InteractionStatus::Open,
+                blocking: true,
+                awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::default(),
+                title: "Need input".to_string(),
+                body: "Choose environment".to_string(),
+                options: vec![],
+                artifacts: vec![],
+                response: None,
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: Utc::now(),
+                resolved_at: None,
+                thread_root_comment_id: Some("root-retry".to_string()),
+                thread_root_comment_url: None,
+                last_processed_comment_id: None,
+                accepted_command: None,
+                ignored_commands: vec![],
+            })
+            .await
+            .unwrap();
+
+        store.fail_next_writes(2);
+        orchestrator.process_interaction_thread_commands().await;
+
+        let failed = store.get("interaction-retry").await.unwrap().unwrap();
+        assert_eq!(failed.status, InteractionStatus::Open);
+        assert!(failed.accepted_command.is_none());
+        assert!(failed.ignored_commands.is_empty());
+        assert_eq!(failed.last_processed_comment_id, None);
+
+        orchestrator.process_interaction_thread_commands().await;
+
+        let retried = store.get("interaction-retry").await.unwrap().unwrap();
+        assert_eq!(retried.status, InteractionStatus::Resolved);
+        assert_eq!(
+            retried.accepted_command.as_ref().unwrap().comment_id,
+            "c-retry"
+        );
+        assert_eq!(
+            retried.last_processed_comment_id.as_deref(),
+            Some("c-retry")
         );
     }
 
@@ -11381,7 +11549,7 @@ agent:
                 .unwrap()
         };
         let (_, api_outcome) = tokio::join!(
-            orchestrator.process_waiting_interaction_commands(),
+            orchestrator.process_interaction_thread_commands(),
             api_attempt
         );
 
@@ -11414,6 +11582,9 @@ agent:
         cancelled_interaction.ignored_commands.clear();
         cancelled_interaction.response = None;
         cancelled_interaction.resolved_at = None;
+        tokio::fs::remove_file(store.interactions_dir().join("interaction-race.json"))
+            .await
+            .unwrap();
         store.create(cancelled_interaction).await.unwrap();
         {
             let mut state = orchestrator.state.write().await;
@@ -11453,7 +11624,7 @@ agent:
         };
         let (cancelled, _) = tokio::join!(
             cancel_attempt,
-            orchestrator.process_waiting_interaction_commands()
+            orchestrator.process_interaction_thread_commands()
         );
         assert_eq!(cancelled.unwrap().status, InteractionStatus::Cancelled);
 

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -974,6 +974,147 @@ async fn respond_to_question_marks_interaction_resolved() {
 }
 
 #[tokio::test]
+async fn concurrent_interaction_api_responses_have_one_winner_and_one_durable_audit() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("ensemble_test_config.yaml");
+    let first_state = build_app_state(
+        &temp_dir,
+        OrchestratorState::new(30000, &ConcurrencyConfig::default()),
+        parsed_document_state(config_path.clone()),
+    );
+    let second_state = build_app_state(
+        &temp_dir,
+        OrchestratorState::new(30000, &ConcurrencyConfig::default()),
+        parsed_document_state(config_path),
+    );
+    create_interaction(
+        &first_state,
+        test_interaction("interaction-api-race", "NODE_789", "my-repo#77"),
+    )
+    .await;
+
+    let first_url = start_test_server(first_state.clone()).await;
+    let second_url = start_test_server(second_state).await;
+    let client = reqwest::Client::new();
+    let first = client
+        .post(format!(
+            "{first_url}/api/v1/interactions/interaction-api-race/respond"
+        ))
+        .json(&serde_json::json!({
+            "kind": "question",
+            "response_schema_version": 1,
+            "text": "Use staging",
+            "selected_option": "staging"
+        }))
+        .send();
+    let second = client
+        .post(format!(
+            "{second_url}/api/v1/interactions/interaction-api-race/respond"
+        ))
+        .json(&serde_json::json!({
+            "kind": "question",
+            "response_schema_version": 1,
+            "text": "Use production",
+            "selected_option": "production"
+        }))
+        .send();
+
+    let (first, second) = tokio::join!(first, second);
+    let statuses = [first.unwrap().status(), second.unwrap().status()];
+    assert_eq!(
+        statuses
+            .iter()
+            .filter(|status| **status == reqwest::StatusCode::OK)
+            .count(),
+        1
+    );
+    assert_eq!(
+        statuses
+            .iter()
+            .filter(|status| **status == reqwest::StatusCode::CONFLICT)
+            .count(),
+        1
+    );
+
+    let config_dir = first_state
+        .config_runtime
+        .config_path
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let stored = InteractionStore::new(config_dir)
+        .get("interaction-api-race")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.status, InteractionStatus::Resolved);
+    assert!(stored.response.is_some());
+    let accepted = stored.accepted_command.as_ref().unwrap();
+    assert_eq!(accepted.author, "local-api");
+    assert!(accepted.comment_id.starts_with("local-api-"));
+    assert!(accepted.raw_body.contains("\"kind\":\"question\""));
+    assert_eq!(stored.ignored_commands.len(), 1);
+    let ignored = &stored.ignored_commands[0];
+    assert_eq!(ignored.author, "local-api");
+    assert!(ignored.comment_id.starts_with("local-api-"));
+    assert_ne!(ignored.comment_id, accepted.comment_id);
+    assert!(ignored.raw_body.contains("\"kind\":\"question\""));
+    assert_eq!(ignored.reason, "interaction_already_resolved");
+}
+
+#[tokio::test]
+async fn interaction_api_response_after_cancellation_is_audited_before_conflict() {
+    let (app_state, _temp_dir) = build_populated_app_state();
+    create_interaction(
+        &app_state,
+        test_interaction("interaction-api-cancelled", "NODE_789", "my-repo#77"),
+    )
+    .await;
+    let config_dir = app_state
+        .config_runtime
+        .config_path
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    InteractionStore::new(config_dir.clone())
+        .cancel("interaction-api-cancelled")
+        .await
+        .unwrap();
+
+    let base_url = start_test_server(app_state).await;
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{base_url}/api/v1/interactions/interaction-api-cancelled/respond"
+        ))
+        .json(&serde_json::json!({
+            "kind": "question",
+            "response_schema_version": 1,
+            "text": "Use staging",
+            "selected_option": "staging"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "already_cancelled");
+
+    let stored = InteractionStore::new(config_dir)
+        .get("interaction-api-cancelled")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.status, InteractionStatus::Cancelled);
+    assert_eq!(stored.ignored_commands.len(), 1);
+    assert_eq!(stored.ignored_commands[0].author, "local-api");
+    assert_eq!(
+        stored.ignored_commands[0].reason,
+        "interaction_already_cancelled"
+    );
+}
+
+#[tokio::test]
 async fn cancel_interaction_returns_conflict_when_already_resolved() {
     let (app_state, _temp_dir) = build_populated_app_state();
     create_interaction(

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1636,13 +1636,27 @@ Human interaction requirement:
 
 - If an agent run blocks for human input, Ensemble persists an interaction request in its own state.
 - Ensemble mirrors that request to the tracker as a dedicated root comment thread.
-- Only thread replies are eligible for command intake, using strict slash commands:
-  - `/approve`
-  - `/reject <reason>`
-  - `/answer <text>`
+- Only thread replies are eligible for command intake. A GitHub command consists of one strict slash
+  command, one blank line, and the interaction marker on its own final line:
+
+  ```text
+  /approve
+
+  <!-- ensemble:interaction:interaction-123 -->
+  ```
+
+  The supported slash commands remain `/approve`, `/reject <reason>`, and `/answer <text>`.
+  The root interaction comment provides kind-appropriate, copyable blocks containing the real
+  interaction ID. Missing, duplicate, mismatched, prose-wrapped, or non-final markers are invalid.
 - Command parsing uses original posted body text only; edited comment content is ignored.
-- First valid command wins immediately (request-level lock). Later valid/invalid commands are ignored
-  for state transitions and may be audited as ignored events.
+- The first valid response across tracker comments and the local HTTP API wins one atomic
+  compare-and-set against the durable interaction record. Every store instance in the process shares
+  the same lock for that interaction file, while unrelated interactions use independent locks and do
+  not wait for one another's file I/O.
+- The winning command, typed response, resolved status, and resolution timestamp are written
+  together. A later valid attempt is written as an attributed ignored audit before its caller
+  observes the loss, including when cancellation closed the interaction first. Invalid comments are
+  also audited and never transition the interaction.
 
 ### 10.7 Timeouts and Error Mapping
 
@@ -2173,7 +2187,8 @@ Minimum endpoints:
     ```
 
 - `POST /api/v1/interactions/{id}/respond`
-  - Resolves a specific open human interaction. The body is typed by interaction kind.
+  - Attempts to resolve a specific open human interaction. The body is typed by interaction kind and
+    participates in the same first-valid-response compare-and-set as tracker commands.
   - Question response body:
 
     ```json
@@ -2208,7 +2223,14 @@ Minimum endpoints:
     ```
 
   - Suggested response (`200 OK`) shape: the resolved interaction request.
-  - If the interaction is missing or already resolved, return a JSON error with `404` or `409`.
+  - Trusted-local API attempts are audited with author `local-api`, a unique server-generated input
+    ID in `comment_id`, and the serialized typed request in `raw_body`.
+  - If the interaction is missing, return a JSON error with `404`.
+  - If another valid response wins first, durably append the losing API attempt to
+    `ignored_commands` and only then return `409 Conflict`.
+  - If cancellation wins first, durably append the API attempt with an
+    `interaction_already_cancelled` reason before returning the existing `already_cancelled` `409`
+    error.
 
 - `POST /api/v1/issues/{identifier}/resume`
   - Releases a blocked issue after its human interaction has been resolved so the next orchestrator

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1657,6 +1657,9 @@ Human interaction requirement:
   together. A later valid attempt is written as an attributed ignored audit before its caller
   observes the loss, including when cancellation closed the interaction first. Invalid comments are
   also audited and never transition the interaction.
+- Persisted interaction threads remain eligible for cursor-driven command intake after the issue
+  resumes. The cursor advances only through comments whose acceptance or ignored audit is durable,
+  so transient persistence failures leave the first unaudited comment available for retry.
 
 ### 10.7 Timeouts and Error Mapping
 


### PR DESCRIPTION
## Summary

- make tracker comments and local API responses compete through one atomic per-interaction acceptance path
- require strict interaction-scoped command markers and render copyable kind-specific command blocks
- durably audit valid losing responses, including cancellation races, while preserving unrelated interaction concurrency

## Tests

- cargo test --workspace --exclude ensemble-desktop
- SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
- SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check

Closes #74