### PR TITLE
Restore durable sequencing after restart

### DIFF
--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -106,6 +106,8 @@ pub enum AgentError {
     SessionStartupFailed { reason: String },
     #[error("io error: {reason}")]
     IoError { reason: String },
+    #[error("durable sequence unavailable for run '{run_id}': {reason}")]
+    DurableSequenceUnavailable { run_id: String, reason: String },
     #[error("invalid agent command '{command}': {reason}")]
     InvalidAgentCommand { command: String, reason: String },
     #[error("hook failed: {reason}")]

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -146,6 +146,31 @@ impl HistoryStore {
         .map_err(io::Error::other)?
     }
 
+    pub(crate) async fn max_timeline_sequence(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<u64>, io::Error> {
+        let path = self.db_path.clone();
+        let run_id = run_id.to_string();
+        tokio::task::spawn_blocking(move || -> Result<Option<u64>, io::Error> {
+            let conn = Connection::open(path).map_err(io::Error::other)?;
+            crate::history_store::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            let maximum = conn
+                .query_row(
+                    "SELECT MAX(sequence) FROM run_events WHERE run_id = ?1",
+                    params![run_id],
+                    |row| row.get::<_, Option<i64>>(0),
+                )
+                .map_err(io::Error::other)?;
+            maximum
+                .map(u64::try_from)
+                .transpose()
+                .map_err(io::Error::other)
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
     pub async fn read_history(&self, query: &HistoryQuery) -> Result<HistoryResponse, io::Error> {
         let path = self.db_path.clone();
         let outcome = query.outcome.clone();
@@ -478,6 +503,28 @@ mod tests {
         assert_eq!(response.total, 2);
         assert_eq!(response.events[0].sequence, 1);
         assert_eq!(response.events[1].sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn max_timeline_sequence_is_scoped_to_run() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db"))
+            .await
+            .unwrap();
+
+        for (run_id, sequence) in [("run-1", 8), ("run-1", 3), ("run-2", 21)] {
+            store
+                .append_timeline_event(&sample_event(run_id, "repo#1", sequence))
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(store.max_timeline_sequence("run-1").await.unwrap(), Some(8));
+        assert_eq!(
+            store.max_timeline_sequence("run-2").await.unwrap(),
+            Some(21)
+        );
+        assert_eq!(store.max_timeline_sequence("unknown").await.unwrap(), None);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -758,6 +758,16 @@ impl Orchestrator {
                     self.dispatch_issue(issue, None).await;
                 }
                 Ok(CandidateRestoreOutcome::Parked) => {}
+                Err(
+                    error @ EnsembleError::Agent(AgentError::DurableSequenceUnavailable { .. }),
+                ) => {
+                    warn!(
+                        issue_id = %issue.id,
+                        identifier = %issue.identifier,
+                        error = %error,
+                        "failed to restore live pipeline journal before dispatch, leaving issue undispatched"
+                    );
+                }
                 Err(error) => {
                     warn!(
                         issue_id = %issue.id,
@@ -3940,6 +3950,36 @@ impl Orchestrator {
         if !is_pending_terminal {
             run.normalize_stale_running_steps();
         }
+        {
+            let state = self.state.read().await;
+            if state.get_pipeline_run(&record.issue_id).is_some()
+                || state.is_running(&record.issue_id)
+            {
+                return Ok(());
+            }
+        }
+        let restored_timeline_sequence = if is_pending_terminal {
+            None
+        } else if let Some(run_id) = &record.run_id {
+            let history_store = self.history_store.as_ref().ok_or_else(|| {
+                AgentError::DurableSequenceUnavailable {
+                    run_id: run_id.clone(),
+                    reason: "history store is unavailable".to_string(),
+                }
+            })?;
+            Some(
+                history_store
+                    .max_timeline_sequence(run_id)
+                    .await
+                    .map_err(|error| AgentError::DurableSequenceUnavailable {
+                        run_id: run_id.clone(),
+                        reason: error.to_string(),
+                    })?
+                    .unwrap_or(0),
+            )
+        } else {
+            None
+        };
 
         let mut state = self.state.write().await;
         if state.get_pipeline_run(&record.issue_id).is_some() || state.is_running(&record.issue_id)
@@ -3954,6 +3994,9 @@ impl Orchestrator {
         }
         state.add_claimed(&record.issue_id);
         if let Some(run_id) = record.run_id.clone() {
+            if let Some(maximum) = restored_timeline_sequence {
+                state.seed_timeline_sequence(&run_id, maximum);
+            }
             state.issue_run_ids.insert(record.issue_id.clone(), run_id);
         }
 
@@ -7411,6 +7454,166 @@ agent:
   stall_timeout_ms: 300000
 "#;
         parse_config(yaml).unwrap()
+    }
+
+    fn make_restart_test_orchestrator(
+        temp: &tempfile::TempDir,
+        cfg: &EnsembleConfig,
+        issue: &Issue,
+    ) -> (Orchestrator, Arc<RwLock<OrchestratorState>>) {
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let workspace_root = temp.path().join("workspaces");
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config: Arc::new(RwLock::new(cfg.clone())),
+                tracker,
+                agent_runner: runner,
+                workspace_mgr: WorkspaceManager::new(&workspace_root, None).unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root,
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+        (orchestrator, state)
+    }
+
+    #[tokio::test]
+    async fn restore_pipeline_run_continues_timeline_sequence_across_restarts() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_retry_step_config();
+        let issue = test_issue("1", "Todo");
+        let (setup, _) = make_restart_test_orchestrator(&temp, &cfg, &issue);
+        setup
+            .history_store
+            .as_ref()
+            .unwrap()
+            .append_timeline_event(&crate::timeline::model::TimelineEventRecord {
+                run_id: "run-1".to_string(),
+                issue_identifier: issue.identifier.clone(),
+                sequence: 7,
+                timestamp: Utc::now(),
+                event_type: "output".to_string(),
+                step_name: Some("build".to_string()),
+                attempt: 1,
+                detail: "before restart".to_string(),
+                verdict: None,
+                tool_name: None,
+            })
+            .await
+            .unwrap();
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.step_failed("build", "manual halt".to_string());
+        setup
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::PipelineHalted,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("manual halt".to_string()),
+                retry: None,
+                snapshot: Some(run.to_snapshot()),
+                terminal_transition: None,
+            })
+            .await
+            .unwrap();
+        drop(setup);
+
+        let (mut first_restart, first_state) = make_restart_test_orchestrator(&temp, &cfg, &issue);
+        first_restart.restore_pipeline_runs_from_journal().await;
+        let first_sequence = first_state.write().await.next_timeline_sequence("run-1");
+        assert_eq!(first_sequence, 8);
+        first_restart
+            .publish_pipeline_event(
+                Some("run-1".to_string()),
+                Some(first_sequence),
+                1,
+                PipelineEvent::Output {
+                    issue_identifier: issue.identifier.clone(),
+                    timestamp: Utc::now(),
+                    step_name: "build".to_string(),
+                    detail: "after first restart".to_string(),
+                },
+            )
+            .await;
+        first_restart
+            .timeline_persistence
+            .as_mut()
+            .unwrap()
+            .flush()
+            .await;
+        drop(first_restart);
+
+        let (second_restart, second_state) = make_restart_test_orchestrator(&temp, &cfg, &issue);
+        second_restart.restore_pipeline_runs_from_journal().await;
+        let second_sequence = second_state.write().await.next_timeline_sequence("run-1");
+        assert_eq!(second_sequence, 9);
+    }
+
+    #[tokio::test]
+    async fn handle_tick_does_not_fresh_dispatch_when_timeline_restore_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_retry_step_config();
+        let issue = test_issue("1", "Todo");
+        let (mut orchestrator, state) = make_restart_test_orchestrator(&temp, &cfg, &issue);
+        let dag = build_dag(&cfg.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.step_failed("build", "manual halt".to_string());
+        let halted_record = orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::PipelineHalted,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("manual halt".to_string()),
+                retry: None,
+                snapshot: Some(run.to_snapshot()),
+                terminal_transition: None,
+            })
+            .await
+            .unwrap();
+        orchestrator.history_store = None;
+
+        orchestrator.handle_tick().await;
+
+        let state = state.read().await;
+        assert!(state.get_pipeline_run(&issue.id).is_none());
+        assert!(!state.is_claimed(&issue.id));
+        assert!(!state.is_running(&issue.id));
+        drop(state);
+
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        assert!(!records.iter().any(|record| {
+            record.seq > halted_record.seq && record.kind == PipelineTransitionKind::StepRunning
+        }));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -275,6 +275,14 @@ impl OrchestratorState {
         *entry
     }
 
+    pub fn seed_timeline_sequence(&mut self, run_id: &str, maximum: u64) {
+        let entry = self
+            .timeline_sequences
+            .entry(run_id.to_string())
+            .or_insert(maximum);
+        *entry = (*entry).max(maximum);
+    }
+
     /// Add an issue ID to the claimed set.
     pub fn add_claimed(&mut self, issue_id: &str) {
         self.claimed.insert(issue_id.to_string());

--- a/crates/ensemble-core/src/transcript/persistence.rs
+++ b/crates/ensemble-core/src/transcript/persistence.rs
@@ -10,6 +10,7 @@ use super::events::TranscriptEventBus;
 use super::model::{
     TranscriptRecord, TranscriptRecordKind, TranscriptTruncation, TRANSCRIPT_SCHEMA_VERSION,
 };
+use super::reader::scan_transcript;
 use super::writer::TranscriptWriter;
 
 pub const COALESCE_MAX_BYTES: usize = 16 * 1024;
@@ -202,6 +203,44 @@ impl PersistState {
         event_bus: Option<&TranscriptEventBus>,
     ) {
         let sequence_key = (req.run_id.clone(), req.step_name.clone());
+        if !self.sequences.contains_key(&sequence_key) {
+            let scan =
+                match scan_transcript(writer.workspace_root(), &req.run_id, &req.step_name).await {
+                    Ok(scan) => scan,
+                    Err(error) => {
+                        warn!(
+                            event = "transcript_persist_failed",
+                            run_id = %req.run_id,
+                            step_name = %req.step_name,
+                            error = %error,
+                            "failed to read transcript sequence before append"
+                        );
+                        return;
+                    }
+                };
+            if scan.needs_repair {
+                if let Err(error) = writer
+                    .prepare_append(
+                        &req.run_id,
+                        &req.step_name,
+                        scan.valid_bytes,
+                        scan.needs_separator,
+                    )
+                    .await
+                {
+                    warn!(
+                        event = "transcript_persist_failed",
+                        run_id = %req.run_id,
+                        step_name = %req.step_name,
+                        error = %error,
+                        "failed to prepare transcript before append"
+                    );
+                    return;
+                }
+            }
+            self.sequences
+                .insert(sequence_key.clone(), scan.maximum_sequence);
+        }
         let sequence = self.sequences.entry(sequence_key).or_insert(0);
         *sequence += 1;
 
@@ -373,6 +412,8 @@ fn ceil_char_boundary(value: &str, mut index: usize) -> usize {
 mod tests {
     use super::*;
     use crate::transcript::model::TranscriptRecordKind;
+    use crate::transcript::reader::read_transcript_page;
+    use std::io::Write;
     use tempfile::TempDir;
 
     fn request(kind: TranscriptRecordKind, text: &str) -> TranscriptPersistRequest {
@@ -383,6 +424,21 @@ mod tests {
             attempt: 1,
             timestamp: chrono::Utc::now(),
             kind,
+            payload: serde_json::json!({"text": text}),
+            truncated: None,
+        }
+    }
+
+    fn record(sequence: u64, text: &str) -> TranscriptRecord {
+        TranscriptRecord {
+            schema_version: TRANSCRIPT_SCHEMA_VERSION,
+            run_id: "run-1".to_string(),
+            issue_identifier: "repo#1".to_string(),
+            step_name: "build".to_string(),
+            attempt: 1,
+            sequence,
+            timestamp: Utc::now(),
+            kind: TranscriptRecordKind::ToolCall,
             payload: serde_json::json!({"text": text}),
             truncated: None,
         }
@@ -415,6 +471,116 @@ mod tests {
 
         assert_eq!(records[0].sequence, 1);
         assert_eq!(records[1].sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn persistence_resumes_sequence_across_repeated_recreation() {
+        let temp_dir = TempDir::new().unwrap();
+
+        for text in ["one", "two", "three"] {
+            let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+            persistence.send(request(TranscriptRecordKind::ToolCall, text));
+            persistence.flush().await;
+        }
+
+        let records = read_records(&temp_dir).await;
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.sequence)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[tokio::test]
+    async fn persistence_repairs_malformed_tail_before_append() {
+        let malformed_tails: [&[u8]; 2] = [
+            br#"{"schema_version":1,"run_id":"run-1""#,
+            b"{\"schema_version\":\xff",
+        ];
+
+        for malformed_tail in malformed_tails {
+            let temp_dir = TempDir::new().unwrap();
+            let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+            let path = writer.transcript_path("run-1", "build").unwrap();
+            writer.append(&record(7, "before restart")).await.unwrap();
+            std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap()
+                .write_all(malformed_tail)
+                .unwrap();
+
+            let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+            persistence.send(request(TranscriptRecordKind::ToolCall, "after restart"));
+            persistence.flush().await;
+
+            let response = read_transcript_page(temp_dir.path(), "run-1", "build", None, None)
+                .await
+                .unwrap();
+            assert_eq!(
+                response
+                    .records
+                    .iter()
+                    .map(|record| record.sequence)
+                    .collect::<Vec<_>>(),
+                vec![7, 8]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn persistence_normalizes_missing_final_separator_before_append() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        let path = writer.transcript_path("run-1", "build").unwrap();
+        writer.append(&record(7, "before restart")).await.unwrap();
+        let length = std::fs::metadata(&path).unwrap().len();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_len(length - 1)
+            .unwrap();
+
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+        persistence.send(request(TranscriptRecordKind::ToolCall, "after restart"));
+        persistence.flush().await;
+
+        let response = read_transcript_page(temp_dir.path(), "run-1", "build", None, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            response
+                .records
+                .iter()
+                .map(|record| record.sequence)
+                .collect::<Vec<_>>(),
+            vec![7, 8]
+        );
+    }
+
+    #[tokio::test]
+    async fn persistence_does_not_append_after_non_tail_corruption() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        let path = writer.transcript_path("run-1", "build").unwrap();
+        writer.append(&record(1, "first")).await.unwrap();
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"{broken}\n")
+            .unwrap();
+        writer.append(&record(2, "second")).await.unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        let mut persistence = TranscriptPersistence::new(temp_dir.path().to_path_buf());
+        persistence.send(request(TranscriptRecordKind::ToolCall, "must not append"));
+        persistence.flush().await;
+
+        assert_eq!(std::fs::read(path).unwrap(), before);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/transcript/reader.rs
+++ b/crates/ensemble-core/src/transcript/reader.rs
@@ -12,16 +12,84 @@ pub struct TranscriptResponse {
     pub next_cursor: Option<usize>,
 }
 
-async fn read_transcript_file(path: &Path) -> Result<Option<String>, std::io::Error> {
-    match tokio::fs::read_to_string(path).await {
-        Ok(contents) => Ok(Some(contents)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error),
-    }
+pub(crate) struct TranscriptScan {
+    pub maximum_sequence: u64,
+    pub valid_bytes: usize,
+    pub needs_separator: bool,
+    pub needs_repair: bool,
 }
 
-fn parse_transcript_records(contents: &str) -> Result<Vec<TranscriptRecord>, serde_json::Error> {
-    contents.lines().map(serde_json::from_str).collect()
+fn parse_transcript_records(
+    contents: &[u8],
+    mut on_record: impl FnMut(TranscriptRecord),
+) -> Result<TranscriptScan, serde_json::Error> {
+    let mut lines = contents.split_inclusive(|byte| *byte == b'\n').peekable();
+    let mut maximum_sequence = 0;
+    let mut valid_bytes = 0;
+
+    while let Some(line_with_separator) = lines.next() {
+        let line = line_with_separator
+            .strip_suffix(b"\n")
+            .unwrap_or(line_with_separator);
+        match serde_json::from_slice(line) {
+            Ok(record) => {
+                let record: TranscriptRecord = record;
+                maximum_sequence = maximum_sequence.max(record.sequence);
+                on_record(record);
+                valid_bytes += line_with_separator.len();
+            }
+            Err(_) if lines.peek().is_none() => break,
+            Err(error) => return Err(error),
+        }
+    }
+
+    let needs_separator = valid_bytes > 0 && contents.get(valid_bytes - 1) != Some(&b'\n');
+    Ok(TranscriptScan {
+        maximum_sequence,
+        valid_bytes,
+        needs_separator,
+        needs_repair: valid_bytes != contents.len() || needs_separator,
+    })
+}
+
+async fn scan_transcript_with(
+    workspace_root: &Path,
+    run_id: &str,
+    step_name: &str,
+    on_record: impl FnMut(TranscriptRecord),
+) -> Result<TranscriptScan, Box<dyn std::error::Error + Send + Sync>> {
+    let writer = TranscriptWriter::new(workspace_root.to_path_buf());
+    let Some(contents) = writer.read_snapshot(run_id, step_name).await? else {
+        return Ok(TranscriptScan {
+            maximum_sequence: 0,
+            valid_bytes: 0,
+            needs_separator: false,
+            needs_repair: false,
+        });
+    };
+
+    Ok(parse_transcript_records(&contents, on_record)?)
+}
+
+pub(crate) async fn scan_transcript(
+    workspace_root: &Path,
+    run_id: &str,
+    step_name: &str,
+) -> Result<TranscriptScan, Box<dyn std::error::Error + Send + Sync>> {
+    scan_transcript_with(workspace_root, run_id, step_name, |_| {}).await
+}
+
+pub(crate) async fn read_transcript_records(
+    workspace_root: &Path,
+    run_id: &str,
+    step_name: &str,
+) -> Result<Vec<TranscriptRecord>, Box<dyn std::error::Error + Send + Sync>> {
+    let mut records = Vec::new();
+    scan_transcript_with(workspace_root, run_id, step_name, |record| {
+        records.push(record);
+    })
+    .await?;
+    Ok(records)
 }
 
 pub async fn read_transcript_page(
@@ -31,17 +99,7 @@ pub async fn read_transcript_page(
     cursor: Option<usize>,
     limit: Option<usize>,
 ) -> Result<TranscriptResponse, Box<dyn std::error::Error + Send + Sync>> {
-    let writer = TranscriptWriter::new(workspace_root.to_path_buf());
-    let path = writer.transcript_path(run_id, step_name)?;
-    let Some(contents) = read_transcript_file(&path).await? else {
-        return Ok(TranscriptResponse {
-            records: vec![],
-            total: 0,
-            next_cursor: None,
-        });
-    };
-
-    let records = parse_transcript_records(&contents)?;
+    let records = read_transcript_records(workspace_root, run_id, step_name).await?;
     let total = records.len();
     let cursor = cursor.unwrap_or(0);
     let limit = limit.unwrap_or(50).clamp(1, 200);
@@ -65,13 +123,7 @@ pub async fn read_transcript_record(
     step_name: &str,
     sequence: u64,
 ) -> Result<Option<TranscriptRecord>, Box<dyn std::error::Error + Send + Sync>> {
-    let writer = TranscriptWriter::new(workspace_root.to_path_buf());
-    let path = writer.transcript_path(run_id, step_name)?;
-    let Some(contents) = read_transcript_file(&path).await? else {
-        return Ok(None);
-    };
-
-    let records = parse_transcript_records(&contents)?;
+    let records = read_transcript_records(workspace_root, run_id, step_name).await?;
     Ok(records
         .into_iter()
         .find(|record| record.sequence == sequence))
@@ -85,6 +137,8 @@ mod tests {
     };
     use crate::transcript::writer::TranscriptWriter;
     use chrono::Utc;
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
     use tempfile::TempDir;
 
     fn sample_record(sequence: u64) -> TranscriptRecord {
@@ -100,6 +154,11 @@ mod tests {
             payload: serde_json::json!({"text": format!("message-{sequence}")}),
             truncated: None,
         }
+    }
+
+    fn append_bytes(path: &Path, bytes: &[u8]) {
+        let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(bytes).unwrap();
     }
 
     #[tokio::test]
@@ -177,5 +236,93 @@ mod tests {
             .unwrap();
 
         assert_eq!(record.sequence, 201);
+    }
+
+    #[tokio::test]
+    async fn read_transcript_page_preserves_records_before_malformed_tail() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer.append(&sample_record(1)).await.unwrap();
+        append_bytes(
+            &writer.transcript_path("run-1", "build").unwrap(),
+            br#"{"schema_version":1,"run_id":"run-1""#,
+        );
+
+        let response = read_transcript_page(temp_dir.path(), "run-1", "build", None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(response.total, 1);
+        assert_eq!(response.records[0].sequence, 1);
+    }
+
+    #[tokio::test]
+    async fn read_transcript_page_preserves_records_before_truncated_utf8_tail() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer.append(&sample_record(1)).await.unwrap();
+        append_bytes(
+            &writer.transcript_path("run-1", "build").unwrap(),
+            &[0xf0, 0x9f],
+        );
+
+        let response = read_transcript_page(temp_dir.path(), "run-1", "build", None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(response.total, 1);
+        assert_eq!(response.records[0].sequence, 1);
+    }
+
+    #[tokio::test]
+    async fn read_transcript_page_rejects_non_tail_corruption() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer.append(&sample_record(1)).await.unwrap();
+        append_bytes(
+            &writer.transcript_path("run-1", "build").unwrap(),
+            b"{broken}\n",
+        );
+        writer.append(&sample_record(2)).await.unwrap();
+
+        let result = read_transcript_page(temp_dir.path(), "run-1", "build", None, None).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_transcript_page_waits_for_an_in_progress_append() {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer.append(&sample_record(1)).await.unwrap();
+        let path = writer.transcript_path("run-1", "build").unwrap();
+        let mut second_line = serde_json::to_vec(&sample_record(2)).unwrap();
+        second_line.push(b'\n');
+        let split = second_line.len() / 2;
+        let mut append = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        assert_eq!(unsafe { libc::flock(append.as_raw_fd(), libc::LOCK_EX) }, 0);
+        append.write_all(&second_line[..split]).unwrap();
+        append.flush().unwrap();
+
+        let workspace_root = temp_dir.path().to_path_buf();
+        let read = tokio::spawn(async move {
+            read_transcript_page(&workspace_root, "run-1", "build", None, None).await
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(!read.is_finished());
+
+        append.write_all(&second_line[split..]).unwrap();
+        append.flush().unwrap();
+        assert_eq!(unsafe { libc::flock(append.as_raw_fd(), libc::LOCK_UN) }, 0);
+
+        let response = read.await.unwrap().unwrap();
+        assert_eq!(
+            response
+                .records
+                .iter()
+                .map(|record| record.sequence)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
     }
 }

--- a/crates/ensemble-core/src/transcript/writer.rs
+++ b/crates/ensemble-core/src/transcript/writer.rs
@@ -1,9 +1,35 @@
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
 
-use tokio::fs::OpenOptions;
-use tokio::io::AsyncWriteExt;
-
 use super::model::{sanitize_run_path_segment, sanitize_step_path_segment, TranscriptRecord};
+
+struct AdvisoryFileLock(RawFd);
+
+impl Drop for AdvisoryFileLock {
+    fn drop(&mut self) {
+        // SAFETY: the descriptor remains open until after this guard is dropped.
+        unsafe {
+            libc::flock(self.0, libc::LOCK_UN);
+        }
+    }
+}
+
+fn lock_file(
+    file: &std::fs::File,
+    operation: libc::c_int,
+) -> Result<AdvisoryFileLock, std::io::Error> {
+    loop {
+        // SAFETY: `file` owns a valid descriptor for the duration of this call.
+        if unsafe { libc::flock(file.as_raw_fd(), operation) } == 0 {
+            return Ok(AdvisoryFileLock(file.as_raw_fd()));
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct TranscriptWriter {
@@ -51,14 +77,66 @@ impl TranscriptWriter {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         line.push('\n');
 
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .await?;
-        file.write_all(line.as_bytes()).await?;
-        file.flush().await?;
-        Ok(())
+        tokio::task::spawn_blocking(move || {
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)?;
+            let _lock = lock_file(&file, libc::LOCK_EX)?;
+            file.write_all(line.as_bytes())?;
+            file.flush()
+        })
+        .await
+        .map_err(std::io::Error::other)?
+    }
+
+    pub(crate) async fn read_snapshot(
+        &self,
+        run_id: &str,
+        step_name: &str,
+    ) -> Result<Option<Vec<u8>>, std::io::Error> {
+        let path = self.transcript_path(run_id, step_name)?;
+        tokio::task::spawn_blocking(move || {
+            let mut file = match std::fs::File::open(path) {
+                Ok(file) => file,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(error) => return Err(error),
+            };
+            let _lock = lock_file(&file, libc::LOCK_SH)?;
+            let mut contents = Vec::new();
+            file.read_to_end(&mut contents)?;
+            Ok(Some(contents))
+        })
+        .await
+        .map_err(std::io::Error::other)?
+    }
+
+    pub(crate) async fn prepare_append(
+        &self,
+        run_id: &str,
+        step_name: &str,
+        valid_bytes: usize,
+        needs_separator: bool,
+    ) -> Result<(), std::io::Error> {
+        let path = self.transcript_path(run_id, step_name)?;
+        let valid_bytes = u64::try_from(valid_bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "transcript length does not fit in u64",
+            )
+        })?;
+        tokio::task::spawn_blocking(move || {
+            let mut file = std::fs::OpenOptions::new().write(true).open(path)?;
+            let _lock = lock_file(&file, libc::LOCK_EX)?;
+            file.set_len(valid_bytes)?;
+            if needs_separator {
+                file.seek(std::io::SeekFrom::End(0))?;
+                file.write_all(b"\n")?;
+            }
+            file.flush()
+        })
+        .await
+        .map_err(std::io::Error::other)?
     }
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1548,8 +1548,12 @@ Accepted records are keyed idempotently by `(run_id, sequence)` and read in sequ
 table is the sole durable timeline source for new events: there is no per-run timeline JSONL
 dual-write, fallback read, or historical migration.
 
-The in-memory timeline sequence counter is not restored from persisted maxima after restart.
-Restart sequence recovery is a separate concern.
+When the pipeline journal restores a live run, Ensemble initializes that run's in-memory timeline
+sequence counter from the maximum sequence already stored in `run_events` before the run can emit
+another timeline event. The first post-restart event therefore uses a greater sequence, including
+across repeated restarts. Failure to read the durable maximum prevents that journal record from
+being restored under a potentially reused sequence; the issue remains undispatched rather than
+falling back to a fresh run.
 
 For each pipeline step, Ensemble persists a typed JSONL transcript at:
 
@@ -1564,6 +1568,15 @@ chunks, tool calls, tool results, permission activity, turn completion, prompts,
 Large tool results are truncated with head and tail retention. Adjacent assistant and reasoning
 deltas may be coalesced before persistence. Transcript persistence failures are logged and do not
 fail the agent step.
+
+Before the first post-start append for a `(run_id, step_name)` stream, transcript persistence scans
+the existing JSONL bytes and resumes from the greatest valid durable sequence. A malformed or
+truncated final record is ignored by readers and truncated before the next append; a valid final
+record without a newline is normalized to a JSONL boundary. Malformed UTF-8 or JSON before a later
+record remains an explicit error, leaves the file unchanged, and prevents that append.
+Transcript reads hold a shared advisory file lock while taking their snapshot, while append and
+tail repair hold an exclusive lock, so a reader cannot mistake an in-progress append for durable
+tail corruption.
 
 When a run is recorded in durable history, the history record should include per-step transcript
 metadata so clients can link to completed step logs from issue detail and step detail views after the

--- a/docs/adr/0010-store-step-transcripts-separately-from-the-timeline.md
+++ b/docs/adr/0010-store-step-transcripts-separately-from-the-timeline.md
@@ -4,4 +4,15 @@ status: accepted
 
 # Store step transcripts separately from the timeline
 
-Detailed per-step conversation records are append-only JSONL streams distinct from the compact run timeline. Transcript persistence runs behind a bounded asynchronous channel with message coalescing and tool-result truncation because conversational detail has different volume and debugging needs and must not block the orchestrator hot path.
+Detailed per-step conversation records are append-only JSONL streams distinct from the compact run
+timeline. Transcript persistence runs behind a bounded asynchronous channel with message
+coalescing and tool-result truncation because conversational detail has different volume and
+debugging needs and must not block the orchestrator hot path.
+
+Each persistence worker lazily initializes a `(run_id, step_name)` stream from the greatest
+sequence in its durable file. Transcript reads scan bytes so a malformed JSON or UTF-8 final record
+does not hide the valid prefix. Before the next append, that malformed tail is truncated, while a
+valid final record without a newline is normalized to a JSONL boundary. Corruption before a later
+record remains an error and leaves the file unchanged. Readers take snapshots under a shared
+advisory file lock; append and repair operations hold an exclusive lock so an in-progress append
+cannot be classified as a malformed durable tail.

--- a/docs/adr/0011-journal-live-pipeline-transitions-for-recovery.md
+++ b/docs/adr/0011-journal-live-pipeline-transitions-for-recovery.md
@@ -4,4 +4,14 @@ status: accepted
 
 # Journal live pipeline transitions for recovery
 
-Every recoverable pipeline transition appends a versioned per-issue record containing the resolved pipeline snapshot under the configuration state directory. This journal is separate from completed history because its purpose is to rehydrate halted, interacting, approving, or retrying runs after restart and to mark released runs as no longer live.
+Every recoverable pipeline transition appends a versioned per-issue record containing the resolved
+pipeline snapshot under the configuration state directory. This journal is separate from completed
+history because its purpose is to rehydrate halted, interacting, approving, or retrying runs after
+restart and to mark released runs as no longer live.
+
+When a live record restores its stable run ID, the orchestrator reads that run's greatest persisted
+timeline sequence from the shared SQLite history store and seeds the in-memory counter before the
+run becomes dispatchable. A maximum-sequence read failure fails that restore attempt instead of
+allowing a colliding sequence to be published. A candidate whose live journal cannot be restored
+because its durable timeline sequence is unavailable remains undispatched rather than falling back
+to a fresh run that could repeat completed work.

--- a/docs/adr/0016-persist-timeline-events-off-the-orchestrator-hot-path.md
+++ b/docs/adr/0016-persist-timeline-events-off-the-orchestrator-hot-path.md
@@ -11,5 +11,7 @@ events with a warning, and a database write failure is logged without affecting 
 Orderly shutdown flushes accepted records, trading guaranteed persistence under overload for
 orchestrator progress and ordered best-effort diagnostics.
 
-The queue does not restore its in-memory sequence counter from persisted maxima after restart.
-Restart sequence recovery is a separate concern.
+For a live run rehydrated from the pipeline journal, the orchestrator seeds the in-memory sequence
+counter from that run's SQLite maximum before new events can enter the queue. Brand-new runs retain
+their in-memory counter initialization. This recovery does not add SQLite work to the event
+publication hot path.


### PR DESCRIPTION
## Summary

- resume transcript streams from their durable per-step maximum
- preserve valid JSONL prefixes and repair only a malformed final record before append
- seed restored run timeline counters from SQLite before dispatch, failing closed if history is unavailable
- document the restart sequencing and corruption-recovery contract

## Root cause

Transcript and timeline counters lived only in process memory, so restart could reuse persisted sequence numbers. Transcript reads also decoded the entire file as UTF-8/JSONL, allowing a truncated final record to hide an otherwise valid prefix.

## Impact

Restored runs continue monotonically across repeated process recreation. A malformed or invalid-UTF-8 final transcript record is recoverable, while earlier corruption remains an explicit error and prevents mutation.

## Testing

- `cargo test --workspace --exclude ensemble-desktop`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`

Closes #416