### PR TITLE
Preserve retry ownership through exhaustion

### DIFF
--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -6,8 +6,13 @@ use crate::config::ensemble::{default_workspace_root, ConcurrencyConfig, Polling
 use crate::error::{ConfigError, EnsembleError};
 use crate::history_store::store::HistoryStore;
 use crate::observability::events::EventBus;
+use crate::orchestrator::retry::ManualStepRetryError;
 use crate::orchestrator::state::OrchestratorState;
-use crate::orchestrator::{Orchestrator, OrchestratorRuntimeParts, QuiescingLatch};
+use crate::orchestrator::{
+    ManualStepRetryCommand, Orchestrator, OrchestratorCommand, OrchestratorRuntimeParts,
+    QuiescingLatch,
+};
+use crate::tracker::model::RetryEntry;
 use crate::tracker::{create_tracker, IssueTracker};
 use crate::transcript::events::TranscriptEventBus;
 use crate::workspace::manager::WorkspaceManager;
@@ -36,6 +41,7 @@ pub struct OrchestratorRuntime {
     shutdown_tx: mpsc::Sender<()>,
     completion: watch::Receiver<bool>,
     quiescing: QuiescingLatch,
+    command_tx: mpsc::Sender<OrchestratorCommand>,
     _worker_event_receiver:
         Arc<tokio::sync::Mutex<mpsc::Receiver<crate::agent::events::OrchestratorWorkerEvent>>>,
     task: JoinHandle<()>,
@@ -57,15 +63,64 @@ struct RegisteredRuntime {
 /// and never holds the mutex guard across `.await`. A tokio mutex would add async overhead
 /// without improving correctness for these tiny critical sections.
 #[derive(Clone, Default)]
-pub struct RegisteredOrchestrator(Arc<std::sync::Mutex<Option<RegisteredRuntime>>>);
+pub struct RegisteredOrchestrator {
+    inner: Arc<std::sync::Mutex<Option<RegisteredRuntime>>>,
+    #[cfg(test)]
+    test_command_tx: Arc<std::sync::Mutex<Option<mpsc::Sender<OrchestratorCommand>>>>,
+}
 
 impl RegisteredOrchestrator {
     #[cfg(test)]
     pub(crate) fn is_registered(&self) -> bool {
-        self.0
+        self.inner
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .is_some()
+    }
+
+    pub(crate) async fn queue_manual_step_retry(
+        &self,
+        command: ManualStepRetryCommand,
+    ) -> Result<RetryEntry, ManualStepRetryError> {
+        let command_tx = {
+            let registered = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            registered
+                .as_ref()
+                .filter(|registered| registered.phase == RuntimePhase::Running)
+                .map(|registered| registered.runtime.command_tx.clone())
+        };
+        #[cfg(test)]
+        let command_tx = command_tx.or_else(|| {
+            self.test_command_tx
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        });
+        let Some(command_tx) = command_tx else {
+            return Err(ManualStepRetryError::RuntimeUnavailable);
+        };
+        let (response, result) = tokio::sync::oneshot::channel();
+        command_tx
+            .send(OrchestratorCommand::QueueManualStepRetry { command, response })
+            .await
+            .map_err(|_| ManualStepRetryError::RuntimeUnavailable)?;
+        result
+            .await
+            .map_err(|_| ManualStepRetryError::RuntimeUnavailable)?
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_test_command_sender(
+        &self,
+        command_tx: mpsc::Sender<OrchestratorCommand>,
+    ) {
+        *self
+            .test_command_tx
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(command_tx);
     }
 }
 
@@ -185,7 +240,7 @@ fn registered_orchestrator_guard(
 ) -> MutexGuard<'_, Option<RegisteredRuntime>> {
     app_state
         .orchestrator_runtime
-        .0
+        .inner
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
@@ -251,6 +306,7 @@ fn launch_orchestrator_runtime(prepared: PreparedOrchestratorRuntime) -> Orchest
     } = prepared;
     let worker_event_receiver = orchestrator.worker_event_receiver_owner();
     let quiescing = orchestrator.quiescing_latch_owner();
+    let command_tx = orchestrator.command_sender_owner();
     let (completion_tx, completion) = watch::channel(false);
     let task = tokio::spawn(async move {
         let quiesced = orchestrator.run().await;
@@ -264,6 +320,7 @@ fn launch_orchestrator_runtime(prepared: PreparedOrchestratorRuntime) -> Orchest
         shutdown_tx,
         completion,
         quiescing,
+        command_tx,
         _worker_event_receiver: worker_event_receiver,
         task,
     }
@@ -533,6 +590,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn orchestrator_runtime_processes_manual_retry_commands() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let todo_path = temp_dir.path().join("TODO.md");
+        let config_path = temp_dir.path().join("config.yaml");
+        let yaml = format!(
+            "tracker:\n  kind: todo_file\n  path: {}\n  active_states: [Todo]\n  terminal_states: [Done]\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\npolling:\n  interval_ms: 60000\n",
+            todo_path.display()
+        );
+        let document_state = parse_raw_yaml(config_path.clone(), yaml);
+        let built = build_app_state(config_path, document_state, EventBus::new());
+        let runtime = start_orchestrator_for_app(&built.app_state)
+            .await
+            .unwrap()
+            .unwrap();
+        let (response, result) = tokio::sync::oneshot::channel();
+
+        runtime
+            .command_tx
+            .send(OrchestratorCommand::QueueManualStepRetry {
+                command: ManualStepRetryCommand {
+                    issue_id: "missing".to_string(),
+                    identifier: "repo#404".to_string(),
+                    step_name: "build".to_string(),
+                },
+                response,
+            })
+            .await
+            .unwrap();
+        let command_result = tokio::time::timeout(Duration::from_secs(2), result)
+            .await
+            .expect("orchestrator command should be handled")
+            .expect("orchestrator should return a command result");
+
+        runtime.shutdown().await;
+        assert!(matches!(
+            command_result,
+            Err(ManualStepRetryError::NoPipelineRun)
+        ));
+    }
+
+    #[tokio::test]
     async fn clear_registered_orchestrator_removes_stored_runtime() {
         let temp_dir = tempfile::tempdir().unwrap();
         let todo_path = temp_dir.path().join("TODO.md");
@@ -628,6 +726,7 @@ mod tests {
         );
 
         let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, _command_rx) = mpsc::channel(1);
         let (completion_tx, completion) = watch::channel(false);
         let (_worker_event_tx, worker_event_rx) = mpsc::channel(1);
         let (quiesce_tx, quiesce_rx) = tokio::sync::oneshot::channel();
@@ -642,6 +741,7 @@ mod tests {
             shutdown_tx,
             completion,
             quiescing: QuiescingLatch::default(),
+            command_tx,
             _worker_event_receiver: Arc::new(tokio::sync::Mutex::new(worker_event_rx)),
             task,
         };
@@ -733,6 +833,7 @@ mod tests {
         let built = build_app_state(config_path, document_state, EventBus::new());
 
         let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, _command_rx) = mpsc::channel(1);
         let (completion_tx, completion) = watch::channel(false);
         let (_worker_event_tx, worker_event_rx) = mpsc::channel(1);
         let (release_tx, release_rx) = tokio::sync::oneshot::channel();
@@ -745,6 +846,7 @@ mod tests {
             shutdown_tx,
             completion,
             quiescing: QuiescingLatch::default(),
+            command_tx,
             _worker_event_receiver: Arc::new(tokio::sync::Mutex::new(worker_event_rx)),
             task,
         };
@@ -828,6 +930,7 @@ mod tests {
         let built = build_app_state(config_path, document_state, EventBus::new());
 
         let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, _command_rx) = mpsc::channel(1);
         let (completion_tx, completion) = watch::channel(false);
         let (_worker_event_tx, worker_event_rx) = mpsc::channel(1);
         let (release_tx, release_rx) = tokio::sync::oneshot::channel();
@@ -840,6 +943,7 @@ mod tests {
             shutdown_tx,
             completion,
             quiescing: QuiescingLatch::default(),
+            command_tx,
             _worker_event_receiver: Arc::new(tokio::sync::Mutex::new(worker_event_rx)),
             task,
         };
@@ -892,6 +996,7 @@ mod tests {
         let built = build_app_state(config_path, document_state, EventBus::new());
 
         let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, _command_rx) = mpsc::channel(1);
         let (completion_tx, completion) = watch::channel(false);
         drop(completion_tx);
         let (_worker_event_tx, worker_event_rx) = mpsc::channel(1);
@@ -901,6 +1006,7 @@ mod tests {
             shutdown_tx,
             completion,
             quiescing: QuiescingLatch::default(),
+            command_tx,
             _worker_event_receiver: Arc::new(tokio::sync::Mutex::new(worker_event_rx)),
             task,
         };
@@ -940,7 +1046,7 @@ mod tests {
         let runtime_registry = built.app_state.orchestrator_runtime.clone();
 
         let _ = catch_unwind(AssertUnwindSafe(|| {
-            let _guard = runtime_registry.0.lock().unwrap();
+            let _guard = runtime_registry.inner.lock().unwrap();
             panic!("poison orchestrator runtime mutex");
         }));
 

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -3,8 +3,9 @@ use crate::api::handlers::{api_error, ApiError};
 use crate::api::router::AppState;
 use crate::interaction::{InteractionStatus, InteractionStore};
 use crate::orchestrator::pipeline_journal::PipelineRunJournal;
-use crate::orchestrator::retry::{next_attempt, schedule_failure_retry, FailureRetryRequest};
+use crate::orchestrator::retry::ManualStepRetryError;
 use crate::orchestrator::state::{FinalizeStatus, OrchestratorState};
+use crate::orchestrator::ManualStepRetryCommand;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -316,7 +317,9 @@ pub async fn post_stop(
     responses(
         (status = 200, description = "Retry queued", body = RetryResponse),
         (status = 404, description = "Not found", body = ApiError),
-        (status = 409, description = "Not retrying", body = ApiError)
+        (status = 409, description = "Not retrying", body = ApiError),
+        (status = 500, description = "Retry could not be persisted", body = ApiError),
+        (status = 503, description = "Orchestrator runtime unavailable", body = ApiError)
     ),
     tag = "controls"
 )]
@@ -325,23 +328,18 @@ pub async fn post_retry(
     Path(identifier): Path<String>,
     Query(query): Query<RetryQuery>,
 ) -> impl IntoResponse {
-    let retry_settings = if query.step.is_some() {
+    if query.step.is_some() {
         let document_state = state.config_runtime.document_state.read().await;
-        match document_state.active_config.as_ref() {
-            Some(config) => Some((config.agent.max_retry_backoff_ms, config.max_cycles)),
-            None => {
-                return issue_error_response(
-                    StatusCode::CONFLICT,
-                    "no_active_config",
-                    "cannot schedule step-level retry without an active config",
-                );
-            }
+        if document_state.active_config.is_none() {
+            return issue_error_response(
+                StatusCode::CONFLICT,
+                "no_active_config",
+                "cannot schedule step-level retry without an active config",
+            );
         }
-    } else {
-        None
-    };
+    }
 
-    let mut lock = state.orchestrator_state.write().await;
+    let lock = state.orchestrator_state.write().await;
 
     let issue_id = match find_issue_presence(&lock, &identifier) {
         IssuePresence::Retrying(id) => id,
@@ -377,69 +375,78 @@ pub async fn post_retry(
         },
     };
 
-    let mut release_record: Option<(String, String, Option<String>, &'static str)> = None;
-
     if let Some(step_name) = query.step.as_ref() {
-        let Some(run) = lock.get_pipeline_run_mut(&issue_id) else {
-            return issue_error_response(
-                StatusCode::CONFLICT,
-                "no_pipeline_run",
-                format!("issue '{}' has no resumable pipeline run", identifier),
-            );
-        };
-        if !run.step_states.contains_key(step_name) {
-            return issue_error_response(
-                StatusCode::NOT_FOUND,
-                "step_not_found",
-                format!(
-                    "issue '{}' has no pipeline step '{}'",
-                    identifier, step_name
-                ),
-            );
+        drop(lock);
+        match state
+            .orchestrator_runtime
+            .queue_manual_step_retry(ManualStepRetryCommand {
+                issue_id: issue_id.clone(),
+                identifier: identifier.clone(),
+                step_name: step_name.clone(),
+            })
+            .await
+        {
+            Ok(_) => {}
+            Err(ManualStepRetryError::RuntimeUnavailable) => {
+                return issue_error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "orchestrator_unavailable",
+                    "the orchestrator runtime is not available to queue this retry",
+                );
+            }
+            Err(ManualStepRetryError::NoPipelineRun) => {
+                return issue_error_response(
+                    StatusCode::CONFLICT,
+                    "no_pipeline_run",
+                    format!("issue '{}' has no resumable pipeline run", identifier),
+                );
+            }
+            Err(ManualStepRetryError::StepNotFound) => {
+                return issue_error_response(
+                    StatusCode::NOT_FOUND,
+                    "step_not_found",
+                    format!(
+                        "issue '{}' has no pipeline step '{}'",
+                        identifier, step_name
+                    ),
+                );
+            }
+            Err(ManualStepRetryError::MaxCyclesExhausted) => {
+                return issue_error_response(
+                    StatusCode::CONFLICT,
+                    "max_cycles_exhausted",
+                    format!(
+                        "issue '{}' has reached the configured maximum pipeline cycles",
+                        identifier
+                    ),
+                );
+            }
+            Err(ManualStepRetryError::OwnerChanged) => {
+                return issue_error_response(
+                    StatusCode::CONFLICT,
+                    "not_retrying",
+                    format!("issue '{}' is no longer retryable", identifier),
+                );
+            }
+            Err(ManualStepRetryError::Persistence(error)) => {
+                tracing::warn!(
+                    issue_id = %issue_id,
+                    error = %error,
+                    "failed to persist manual step retry"
+                );
+                return issue_error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "retry_persistence_failed",
+                    format!(
+                        "failed to durably queue step-level retry for issue '{}'",
+                        identifier
+                    ),
+                );
+            }
         }
-        run.retry_from_step(step_name);
-
-        let identifier_copy = lock
-            .retry_attempts
-            .get(&issue_id)
-            .map(|entry| entry.identifier.clone())
-            .or_else(|| {
-                lock.waiting_on_human
-                    .get(&issue_id)
-                    .map(|entry| entry.identifier.clone())
-            })
-            .unwrap_or_else(|| identifier.clone());
-        let attempt = lock
-            .retry_attempts
-            .get(&issue_id)
-            .map(|entry| entry.attempt + 1)
-            .or_else(|| {
-                lock.waiting_on_human
-                    .get(&issue_id)
-                    .map(|entry| next_attempt(entry.retry_attempt))
-            })
-            .unwrap_or(1);
-        let (max_backoff_ms, max_cycles) =
-            retry_settings.expect("retry settings loaded for step-level retry");
-
-        lock.remove_retry(&issue_id);
-        lock.remove_waiting_on_human(&issue_id);
-        schedule_failure_retry(
-            &mut lock,
-            FailureRetryRequest {
-                issue_id: &issue_id,
-                identifier: &identifier_copy,
-                attempt,
-                max_backoff_ms,
-                max_cycles,
-                error: "manual step-level retry",
-                retry_from_step: Some(step_name.clone()),
-                with_fixup: false,
-            },
-        );
     } else {
+        let mut lock = lock;
         // Whole-issue retry: release the claim so the next poll can pick it up fresh.
-        let release_identifier = identifier.clone();
         let release_run_id = lock
             .get_running(&issue_id)
             .and_then(|entry| entry.run_id.clone())
@@ -452,17 +459,15 @@ pub async fn post_retry(
         lock.remove_waiting_on_human(&issue_id);
         lock.remove_claimed(&issue_id);
         lock.remove_pipeline_run(&issue_id);
-        release_record = Some((
-            issue_id.clone(),
-            release_identifier,
+        drop(lock);
+        append_release_record(
+            &state,
+            &issue_id,
+            &identifier,
             release_run_id,
             "whole_issue_retry",
-        ));
-    }
-    drop(lock);
-
-    if let Some((issue_id, identifier, run_id, reason)) = release_record {
-        append_release_record(&state, &issue_id, &identifier, run_id, reason).await;
+        )
+        .await;
     }
 
     // Signal the orchestrator to poll immediately so it picks up the now-unclaimed issue
@@ -824,11 +829,13 @@ mod tests {
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
     use crate::config::ensemble::{ConcurrencyConfig, OnFailure, StepConfig, StepKind};
     use crate::interaction::model::InteractionKind;
-    use crate::orchestrator::pipeline_journal::PipelineTransitionKind;
+    use crate::orchestrator::pipeline_journal::{PipelineTransitionInput, PipelineTransitionKind};
+    use crate::orchestrator::retry::{queue_manual_step_retry, ManualStepRetryRequest};
     use crate::orchestrator::state::{
         FinalizeStatus, IssueFinalizeState, OrchestratorState, RepoFinalizeState,
         WaitingOnHumanEntry,
     };
+    use crate::orchestrator::OrchestratorCommand;
     use crate::pipeline::dag::build_dag;
     use crate::pipeline::engine::PipelineRun;
     use crate::tracker::model::{Issue, RetryEntry};
@@ -1023,6 +1030,36 @@ mod tests {
         let mut app_state = app_state_with_document_state(document_state);
         app_state.orchestrator_state = Arc::new(RwLock::new(state));
         app_state
+    }
+
+    fn install_test_retry_runtime(state: &AppState) {
+        let (command_tx, mut command_rx) = tokio::sync::mpsc::channel(16);
+        state
+            .orchestrator_runtime
+            .install_test_command_sender(command_tx);
+        let orchestrator_state = Arc::clone(&state.orchestrator_state);
+        let journal = pipeline_journal(state);
+        tokio::spawn(async move {
+            while let Some(command) = command_rx.recv().await {
+                match command {
+                    OrchestratorCommand::QueueManualStepRetry { command, response } => {
+                        let result = queue_manual_step_retry(
+                            &orchestrator_state,
+                            &journal,
+                            ManualStepRetryRequest {
+                                issue_id: &command.issue_id,
+                                identifier: &command.identifier,
+                                step_name: &command.step_name,
+                                max_backoff_ms: 300_000,
+                                max_cycles: 3,
+                            },
+                        )
+                        .await;
+                        let _ = response.send(result);
+                    }
+                }
+            }
+        });
     }
 
     fn build_app_state_with_finalize_failed() -> AppState {
@@ -1281,7 +1318,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_waiting_issue_with_step_queues_step_retry() {
-        let state = build_app_state_with_waiting_pipeline();
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_app_state_with_waiting_pipeline();
+        state.config_runtime.config_path = temp.path().join("config.yaml");
+        install_test_retry_runtime(&state);
         let response = post_retry(
             State(state.clone()),
             Path("my-repo#42".to_string()),
@@ -1307,6 +1347,141 @@ mod tests {
         assert!(!retry.with_fixup);
         assert_eq!(retry.attempt, 2);
         assert!(lock.is_claimed("NODE_123"));
+        drop(lock);
+
+        let record = PipelineRunJournal::new(temp.path())
+            .latest_live_record_for_issue("NODE_123")
+            .await
+            .unwrap()
+            .expect("manual step retry should be durable");
+        assert_eq!(record.kind, PipelineTransitionKind::StepRetryScheduled);
+        assert_eq!(record.retry.map(|retry| retry.attempt), Some(2));
+    }
+
+    #[tokio::test]
+    async fn manual_step_retry_exhaustion_preserves_the_existing_owner() {
+        let state = build_app_state_with_waiting_pipeline();
+        install_test_retry_runtime(&state);
+        {
+            let mut lock = state.orchestrator_state.write().await;
+            lock.waiting_on_human
+                .get_mut("NODE_123")
+                .unwrap()
+                .retry_attempt = Some(2);
+        }
+
+        let response = post_retry(
+            State(state.clone()),
+            Path("my-repo#42".to_string()),
+            Query(RetryQuery {
+                step: Some("build".to_string()),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "max_cycles_exhausted");
+
+        let lock = state.orchestrator_state.read().await;
+        assert!(lock.waiting_on_human.contains_key("NODE_123"));
+        assert!(!lock.retry_attempts.contains_key("NODE_123"));
+        assert!(lock.get_pipeline_run("NODE_123").is_some());
+        assert!(lock.is_claimed("NODE_123"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn manual_step_retry_persistence_failure_restores_restart_safe_owner() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_app_state_with_waiting_pipeline();
+        state.config_runtime.config_path = temp.path().join("config.yaml");
+        let journal = PipelineRunJournal::new(temp.path());
+        let previous_snapshot = state
+            .orchestrator_state
+            .read()
+            .await
+            .get_pipeline_run("NODE_123")
+            .unwrap()
+            .to_snapshot();
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::PipelineHalted,
+                issue_id: "NODE_123".to_string(),
+                identifier: "my-repo#42".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("build".to_string()),
+                reason: Some("manual repair needed".to_string()),
+                retry: None,
+                snapshot: Some(previous_snapshot.clone()),
+                terminal_transition: None,
+            })
+            .await
+            .unwrap();
+        let journal_path = journal.path_for_issue("NODE_123");
+        std::fs::set_permissions(&journal_path, std::fs::Permissions::from_mode(0o444)).unwrap();
+        install_test_retry_runtime(&state);
+
+        let response = post_retry(
+            State(state.clone()),
+            Path("my-repo#42".to_string()),
+            Query(RetryQuery {
+                step: Some("build".to_string()),
+            }),
+        )
+        .await
+        .into_response();
+
+        std::fs::set_permissions(&journal_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "retry_persistence_failed");
+
+        let lock = state.orchestrator_state.read().await;
+        assert!(lock.waiting_on_human.contains_key("NODE_123"));
+        assert!(!lock.retry_attempts.contains_key("NODE_123"));
+        assert!(lock.is_claimed("NODE_123"));
+        assert_eq!(
+            lock.get_pipeline_run("NODE_123").unwrap().to_snapshot(),
+            previous_snapshot
+        );
+        drop(lock);
+
+        let latest = journal
+            .latest_live_record_for_issue("NODE_123")
+            .await
+            .unwrap()
+            .expect("previous durable owner remains recoverable after restart");
+        assert_eq!(latest.kind, PipelineTransitionKind::PipelineHalted);
+        assert!(latest.retry.is_none());
+        assert_eq!(latest.snapshot, Some(previous_snapshot));
+    }
+
+    #[tokio::test]
+    async fn manual_step_retry_requires_runtime_authority_and_preserves_owner() {
+        let state = build_app_state_with_waiting_pipeline();
+
+        let response = post_retry(
+            State(state.clone()),
+            Path("my-repo#42".to_string()),
+            Query(RetryQuery {
+                step: Some("build".to_string()),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "orchestrator_unavailable");
+        let lock = state.orchestrator_state.read().await;
+        assert!(lock.waiting_on_human.contains_key("NODE_123"));
+        assert!(!lock.retry_attempts.contains_key("NODE_123"));
+        assert!(lock.get_pipeline_run("NODE_123").is_some());
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -75,7 +75,9 @@ use reconciler::{
     startup_terminal_cleanup, ReconcileAction,
 };
 use retry::{
-    current_time_ms, get_due_retries, next_attempt, schedule_failure_retry, FailureRetryRequest,
+    current_time_ms, defer_retry, get_due_retries, next_attempt, queue_manual_step_retry,
+    schedule_failure_retry, FailureRetryDisposition, FailureRetryRequest, ManualStepRetryError,
+    ManualStepRetryRequest,
 };
 use scheduler::{
     has_available_slots, is_dispatch_eligible, is_resume_dispatch_eligible, sort_for_dispatch,
@@ -95,6 +97,37 @@ struct StepDispatchContext<'a> {
     interaction_response: Option<InteractionResponseEnvelope>,
     workspace_path: std::path::PathBuf,
     step_outputs: StepOutputTemplateContext,
+}
+
+struct ExhaustedRetryTerminal {
+    issue: Issue,
+    target_state: String,
+    history_record: Option<HistoryRecord>,
+}
+
+enum WholeIssueFailureRetry {
+    Scheduled(Option<Box<PipelineTransitionInput>>),
+    Exhausted(Box<ExhaustedRetryTerminal>),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ManualStepRetryCommand {
+    pub issue_id: String,
+    pub identifier: String,
+    pub step_name: String,
+}
+
+pub(crate) enum OrchestratorCommand {
+    QueueManualStepRetry {
+        command: ManualStepRetryCommand,
+        response: tokio::sync::oneshot::Sender<Result<RetryEntry, ManualStepRetryError>>,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum ScheduledRetryPipeline {
+    Preserve,
+    Release,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -213,6 +246,8 @@ pub struct Orchestrator {
     transcript_persistence: Option<TranscriptPersistence>,
     worker_tx: mpsc::Sender<OrchestratorWorkerEvent>,
     worker_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<OrchestratorWorkerEvent>>>,
+    command_tx: mpsc::Sender<OrchestratorCommand>,
+    command_rx: mpsc::Receiver<OrchestratorCommand>,
     shutdown_rx: mpsc::Receiver<()>,
     quiescing: QuiescingLatch,
     #[cfg(test)]
@@ -346,6 +381,7 @@ impl Orchestrator {
         shutdown_rx: mpsc::Receiver<()>,
     ) -> Self {
         let (worker_tx, worker_rx) = mpsc::channel(1000);
+        let (command_tx, command_rx) = mpsc::channel(100);
         let history_store = futures::executor::block_on(HistoryStore::new(
             parts.workspace_root.join(".ensemble").join("history.db"),
         ))
@@ -380,6 +416,8 @@ impl Orchestrator {
             )),
             worker_tx,
             worker_rx: Arc::new(tokio::sync::Mutex::new(worker_rx)),
+            command_tx,
+            command_rx,
             shutdown_rx,
             quiescing: QuiescingLatch::default(),
             #[cfg(test)]
@@ -419,6 +457,38 @@ impl Orchestrator {
 
     pub(crate) fn quiescing_latch_owner(&self) -> QuiescingLatch {
         self.quiescing.clone()
+    }
+
+    pub(crate) fn command_sender_owner(&self) -> mpsc::Sender<OrchestratorCommand> {
+        self.command_tx.clone()
+    }
+
+    async fn handle_command(&self, command: OrchestratorCommand) {
+        match command {
+            OrchestratorCommand::QueueManualStepRetry { command, response } => {
+                if self.quiescing.is_requested() {
+                    let _ = response.send(Err(ManualStepRetryError::RuntimeUnavailable));
+                    return;
+                }
+                let (max_backoff_ms, max_cycles) = {
+                    let config = self.config.read().await;
+                    (config.agent.max_retry_backoff_ms, config.max_cycles)
+                };
+                let result = queue_manual_step_retry(
+                    &self.state,
+                    &self.pipeline_journal,
+                    ManualStepRetryRequest {
+                        issue_id: &command.issue_id,
+                        identifier: &command.identifier,
+                        step_name: &command.step_name,
+                        max_backoff_ms,
+                        max_cycles,
+                    },
+                )
+                .await;
+                let _ = response.send(result);
+            }
+        }
     }
 
     /// Run the orchestrator main loop.
@@ -504,6 +574,10 @@ impl Orchestrator {
                     let quiesced = self.cancel_active_runs().await;
                     info!("received shutdown signal, stopping orchestrator");
                     break quiesced;
+                }
+
+                Some(command) = self.command_rx.recv() => {
+                    self.handle_command(command).await;
                 }
 
                 // Poll timer
@@ -882,6 +956,32 @@ impl Orchestrator {
         attempt: Option<u32>,
         permit: &DispatchPermit,
     ) {
+        self.dispatch_issue_with_owned_retry(issue, attempt, None, permit)
+            .await;
+    }
+
+    async fn dispatch_retry_issue_with_permit(
+        &self,
+        issue: &Issue,
+        retry_entry: &RetryEntry,
+        permit: &DispatchPermit,
+    ) {
+        self.dispatch_issue_with_owned_retry(
+            issue,
+            Some(retry_entry.attempt),
+            Some(retry_entry),
+            permit,
+        )
+        .await;
+    }
+
+    async fn dispatch_issue_with_owned_retry(
+        &self,
+        issue: &Issue,
+        attempt: Option<u32>,
+        expected_retry: Option<&RetryEntry>,
+        permit: &DispatchPermit,
+    ) {
         let cycle = attempt.unwrap_or(1);
 
         {
@@ -891,6 +991,11 @@ impl Orchestrator {
 
                 let (config_snapshot, action, effective_cycle, effective_attempt, finalize_attempt) = {
                     let mut state = self.state.write().await;
+                    if expected_retry.is_some_and(|expected| {
+                        state.retry_attempts.get(&issue.id) != Some(expected)
+                    }) {
+                        return;
+                    }
                     let existing_cycle = state
                         .get_pipeline_run(&issue.id)
                         .map(|run| run.cycle)
@@ -1038,25 +1143,18 @@ impl Orchestrator {
                                         if let Some(run) = state.get_pipeline_run_mut(&issue.id) {
                                             run.step_failed(&req.step_name, error.to_string());
                                         }
-                                        if let Some(entry) = state.remove_running(&issue.id) {
-                                            state.add_runtime_seconds(&entry);
-                                            schedule_failure_retry(
-                                                &mut state,
-                                                FailureRetryRequest {
-                                                    issue_id: &issue.id,
-                                                    identifier: &entry.identifier,
-                                                    attempt: next_attempt(entry.retry_attempt),
-                                                    max_backoff_ms: config_snapshot
-                                                        .agent
-                                                        .max_retry_backoff_ms,
-                                                    max_cycles: config_snapshot.max_cycles,
-                                                    error: &error.to_string(),
-                                                    retry_from_step: None,
-                                                    with_fixup: false,
-                                                },
-                                            );
-                                        }
-                                        state.remove_pipeline_run(&issue.id);
+                                        let terminal =
+                                            state.remove_running(&issue.id).map(|entry| {
+                                                self.schedule_whole_issue_failure_retry(
+                                                    &mut state,
+                                                    &config_snapshot,
+                                                    entry,
+                                                    &error.to_string(),
+                                                    ScheduledRetryPipeline::Release,
+                                                )
+                                            });
+                                        drop(state);
+                                        self.commit_whole_issue_failure_retry(terminal).await;
                                         return;
                                     }
                                 };
@@ -1133,6 +1231,11 @@ impl Orchestrator {
 
         let run_started_transition = {
             let mut state = self.state.write().await;
+            if expected_retry
+                .is_some_and(|expected| state.retry_attempts.get(&issue.id) != Some(expected))
+            {
+                return;
+            }
             state.add_running(issue, attempt);
             state.insert_pipeline_run(&issue.id, pipeline_run, Arc::clone(&config_snapshot));
             Self::transition_input_for_run(
@@ -1166,23 +1269,17 @@ impl Orchestrator {
                             if let Some(run) = state.get_pipeline_run_mut(&issue.id) {
                                 run.step_failed(&req.step_name, error.to_string());
                             }
-                            if let Some(entry) = state.remove_running(&issue.id) {
-                                state.add_runtime_seconds(&entry);
-                                schedule_failure_retry(
+                            let terminal = state.remove_running(&issue.id).map(|entry| {
+                                self.schedule_whole_issue_failure_retry(
                                     &mut state,
-                                    FailureRetryRequest {
-                                        issue_id: &issue.id,
-                                        identifier: &entry.identifier,
-                                        attempt: next_attempt(entry.retry_attempt),
-                                        max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
-                                        max_cycles: config_snapshot.max_cycles,
-                                        error: &error.to_string(),
-                                        retry_from_step: None,
-                                        with_fixup: false,
-                                    },
-                                );
-                            }
-                            state.remove_pipeline_run(&issue.id);
+                                    &config_snapshot,
+                                    entry,
+                                    &error.to_string(),
+                                    ScheduledRetryPipeline::Release,
+                                )
+                            });
+                            drop(state);
+                            self.commit_whole_issue_failure_retry(terminal).await;
                             return;
                         }
                     };
@@ -1862,9 +1959,9 @@ impl Orchestrator {
                 } else {
                     "worker cancelled during reconciliation"
                 };
-                let (max_retry_backoff_ms, max_cycles) = {
+                let retry_config = {
                     let config = self.config.read().await;
-                    (config.agent.max_retry_backoff_ms, config.max_cycles)
+                    config.clone()
                 };
                 let mut state = self.state.write().await;
                 if !drained.owner.is_current(&state, issue_id) {
@@ -1874,23 +1971,17 @@ impl Orchestrator {
                     );
                     return;
                 }
-                if let Some(entry) = state.remove_running(issue_id) {
-                    state.add_runtime_seconds(&entry);
-                    schedule_failure_retry(
+                let terminal = state.remove_running(issue_id).map(|entry| {
+                    self.schedule_whole_issue_failure_retry(
                         &mut state,
-                        FailureRetryRequest {
-                            issue_id,
-                            identifier: &entry.identifier,
-                            attempt: next_attempt(entry.retry_attempt),
-                            max_backoff_ms: max_retry_backoff_ms,
-                            max_cycles,
-                            error,
-                            retry_from_step: None,
-                            with_fixup: false,
-                        },
-                    );
-                }
+                        &retry_config,
+                        entry,
+                        error,
+                        ScheduledRetryPipeline::Preserve,
+                    )
+                });
                 drop(state);
+                self.commit_whole_issue_failure_retry(terminal).await;
                 remove_drained_workers(&self.cancellation_registry, &drained.handles);
             }
         }
@@ -2206,25 +2297,18 @@ impl Orchestrator {
                                             {
                                                 run.step_failed(&req.step_name, error.to_string());
                                             }
-                                            if let Some(entry) = state.remove_running(issue_id) {
-                                                state.add_runtime_seconds(&entry);
-                                                schedule_failure_retry(
-                                                    &mut state,
-                                                    FailureRetryRequest {
-                                                        issue_id,
-                                                        identifier: &entry.identifier,
-                                                        attempt: next_attempt(entry.retry_attempt),
-                                                        max_backoff_ms: config_snapshot
-                                                            .agent
-                                                            .max_retry_backoff_ms,
-                                                        max_cycles: config_snapshot.max_cycles,
-                                                        error: &error.to_string(),
-                                                        retry_from_step: None,
-                                                        with_fixup: false,
-                                                    },
-                                                );
-                                            }
-                                            state.remove_pipeline_run(issue_id);
+                                            let terminal =
+                                                state.remove_running(issue_id).map(|entry| {
+                                                    self.schedule_whole_issue_failure_retry(
+                                                        &mut state,
+                                                        &config_snapshot,
+                                                        entry,
+                                                        &error.to_string(),
+                                                        ScheduledRetryPipeline::Release,
+                                                    )
+                                                });
+                                            drop(state);
+                                            self.commit_whole_issue_failure_retry(terminal).await;
                                             return;
                                         }
                                     };
@@ -2384,7 +2468,6 @@ impl Orchestrator {
                                         run.retry_from_step(&step);
                                     }
                                     if let Some(entry) = state.remove_running(issue_id) {
-                                        state.add_runtime_seconds(&entry);
                                         terminal_issue = Some(entry.issue.clone());
                                         let attempt = next_attempt(entry.retry_attempt);
                                         let retry_scheduled = schedule_failure_retry(
@@ -2400,7 +2483,7 @@ impl Orchestrator {
                                                 with_fixup: false,
                                             },
                                         );
-                                        final_failure = retry_scheduled.is_none();
+                                        final_failure = retry_scheduled.is_exhausted();
                                         if final_failure {
                                             history_record =
                                                 state.get_pipeline_run(issue_id).map(|run| {
@@ -2424,7 +2507,7 @@ impl Orchestrator {
                                                     )
                                                 });
                                         }
-                                        if let Some(due_at_ms) = retry_scheduled {
+                                        if let Some(retry_entry) = retry_scheduled.scheduled() {
                                             if let Some(input) = Self::transition_input_for_run(
                                                 &state,
                                                 issue_id,
@@ -2432,18 +2515,15 @@ impl Orchestrator {
                                                 PipelineTransitionKind::StepRetryScheduled,
                                                 Some(step.clone()),
                                                 Some(reason.clone()),
-                                                Some(RetryEntry {
-                                                    issue_id: issue_id.to_string(),
-                                                    identifier: entry.identifier.clone(),
-                                                    attempt,
-                                                    due_at_ms,
-                                                    error: Some(reason.clone()),
-                                                    retry_from_step: Some(step.clone()),
-                                                    with_fixup: false,
-                                                }),
+                                                Some(retry_entry.clone()),
                                             ) {
                                                 post_failure_transitions.push(input);
                                             }
+                                        }
+                                        if final_failure {
+                                            state.running.insert(issue_id.to_string(), entry);
+                                        } else {
+                                            state.add_runtime_seconds(&entry);
                                         }
                                     }
                                 }
@@ -2471,7 +2551,6 @@ impl Orchestrator {
                                         run.retry_from_step_with_fixup(&step, fixup_agent);
                                     }
                                     if let Some(entry) = state.remove_running(issue_id) {
-                                        state.add_runtime_seconds(&entry);
                                         terminal_issue = Some(entry.issue.clone());
                                         let attempt = next_attempt(entry.retry_attempt);
                                         let retry_scheduled = schedule_failure_retry(
@@ -2487,7 +2566,7 @@ impl Orchestrator {
                                                 with_fixup: true,
                                             },
                                         );
-                                        final_failure = retry_scheduled.is_none();
+                                        final_failure = retry_scheduled.is_exhausted();
                                         if final_failure {
                                             history_record =
                                                 state.get_pipeline_run(issue_id).map(|run| {
@@ -2511,7 +2590,7 @@ impl Orchestrator {
                                                     )
                                                 });
                                         }
-                                        if let Some(due_at_ms) = retry_scheduled {
+                                        if let Some(retry_entry) = retry_scheduled.scheduled() {
                                             if let Some(input) = Self::transition_input_for_run(
                                                 &state,
                                                 issue_id,
@@ -2519,18 +2598,15 @@ impl Orchestrator {
                                                 PipelineTransitionKind::FixupRetryScheduled,
                                                 Some(step.clone()),
                                                 Some(reason.clone()),
-                                                Some(RetryEntry {
-                                                    issue_id: issue_id.to_string(),
-                                                    identifier: entry.identifier.clone(),
-                                                    attempt,
-                                                    due_at_ms,
-                                                    error: Some(reason.clone()),
-                                                    retry_from_step: Some(step.clone()),
-                                                    with_fixup: true,
-                                                }),
+                                                Some(retry_entry.clone()),
                                             ) {
                                                 post_failure_transitions.push(input);
                                             }
+                                        }
+                                        if final_failure {
+                                            state.running.insert(issue_id.to_string(), entry);
+                                        } else {
+                                            state.add_runtime_seconds(&entry);
                                         }
                                     }
                                 }
@@ -2582,7 +2658,6 @@ impl Orchestrator {
                                 }
                                 OnFailure::RetryIssue => {
                                     if let Some(entry) = state.remove_running(issue_id) {
-                                        state.add_runtime_seconds(&entry);
                                         terminal_issue = Some(entry.issue.clone());
                                         let attempt = next_attempt(entry.retry_attempt);
                                         let retry_scheduled = schedule_failure_retry(
@@ -2598,7 +2673,7 @@ impl Orchestrator {
                                                 with_fixup: false,
                                             },
                                         );
-                                        final_failure = retry_scheduled.is_none();
+                                        final_failure = retry_scheduled.is_exhausted();
                                         if final_failure {
                                             history_record =
                                                 state.get_pipeline_run(issue_id).map(|run| {
@@ -2622,9 +2697,23 @@ impl Orchestrator {
                                                     )
                                                 });
                                         }
-                                    }
-                                    if !final_failure {
-                                        state.remove_pipeline_run(issue_id);
+                                        if let Some(retry_entry) = retry_scheduled.scheduled() {
+                                            if let Some(input) = Self::prepare_whole_issue_retry(
+                                                &mut state,
+                                                &config,
+                                                issue_id,
+                                                &entry.identifier,
+                                                &reason,
+                                                retry_entry.clone(),
+                                            ) {
+                                                post_failure_transitions.push(input);
+                                            }
+                                        }
+                                        if final_failure {
+                                            state.running.insert(issue_id.to_string(), entry);
+                                        } else {
+                                            state.add_runtime_seconds(&entry);
+                                        }
                                     }
                                 }
                             }
@@ -2683,23 +2772,17 @@ impl Orchestrator {
                                 if let Some(run) = state.get_pipeline_run_mut(issue_id) {
                                     run.step_failed(&step, error.to_string());
                                 }
-                                if let Some(entry) = state.remove_running(issue_id) {
-                                    state.add_runtime_seconds(&entry);
-                                    schedule_failure_retry(
+                                let terminal = state.remove_running(issue_id).map(|entry| {
+                                    self.schedule_whole_issue_failure_retry(
                                         &mut state,
-                                        FailureRetryRequest {
-                                            issue_id,
-                                            identifier: &entry.identifier,
-                                            attempt: next_attempt(entry.retry_attempt),
-                                            max_backoff_ms: config.agent.max_retry_backoff_ms,
-                                            max_cycles: config.max_cycles,
-                                            error: &error.to_string(),
-                                            retry_from_step: None,
-                                            with_fixup: false,
-                                        },
-                                    );
-                                }
-                                state.remove_pipeline_run(issue_id);
+                                        &config,
+                                        entry,
+                                        &error.to_string(),
+                                        ScheduledRetryPipeline::Release,
+                                    )
+                                });
+                                drop(state);
+                                self.commit_whole_issue_failure_retry(terminal).await;
                             }
                         }
                         PipelineAction::Waiting => {
@@ -2740,23 +2823,17 @@ impl Orchestrator {
                     if let Some(run) = state.get_pipeline_run_mut(issue_id) {
                         run.step_failed(step_name, error.to_string());
                     }
-                    if let Some(entry) = state.remove_running(issue_id) {
-                        state.add_runtime_seconds(&entry);
-                        schedule_failure_retry(
+                    let terminal = state.remove_running(issue_id).map(|entry| {
+                        self.schedule_whole_issue_failure_retry(
                             &mut state,
-                            FailureRetryRequest {
-                                issue_id,
-                                identifier: &entry.identifier,
-                                attempt: next_attempt(entry.retry_attempt),
-                                max_backoff_ms: config.agent.max_retry_backoff_ms,
-                                max_cycles: config.max_cycles,
-                                error: &error.to_string(),
-                                retry_from_step: None,
-                                with_fixup: false,
-                            },
-                        );
-                    }
-                    state.remove_pipeline_run(issue_id);
+                            &config,
+                            entry,
+                            &error.to_string(),
+                            ScheduledRetryPipeline::Release,
+                        )
+                    });
+                    drop(state);
+                    self.commit_whole_issue_failure_retry(terminal).await;
                 }
             }
             WorkerResult::Failed { error, kind } => {
@@ -2789,13 +2866,14 @@ impl Orchestrator {
                 let mut final_failure = false;
                 let mut history_record = None;
                 let mut terminal_issue = None;
+                let mut retry_transition = None;
 
                 if let Some(entry) = state.running.get(issue_id).cloned() {
                     terminal_issue = Some(entry.issue.clone());
                     let retry_scheduled = if retry::is_non_retryable_failure(&error) {
                         None
                     } else {
-                        schedule_failure_retry(
+                        Some(schedule_failure_retry(
                             &mut state,
                             FailureRetryRequest {
                                 issue_id,
@@ -2807,9 +2885,11 @@ impl Orchestrator {
                                 retry_from_step: None,
                                 with_fixup: false,
                             },
-                        )
+                        ))
                     };
-                    final_failure = retry_scheduled.is_none();
+                    final_failure = retry_scheduled
+                        .as_ref()
+                        .is_none_or(FailureRetryDisposition::is_exhausted);
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             self.build_history_record(RunningHistoryRecordInput {
@@ -2822,18 +2902,29 @@ impl Orchestrator {
                                 artifacts: state.artifacts.get(issue_id).cloned(),
                             })
                         });
+                    } else if let Some(retry_entry) =
+                        retry_scheduled.as_ref().and_then(|retry| retry.scheduled())
+                    {
+                        if let Some(entry) = state.remove_running(issue_id) {
+                            state.add_runtime_seconds(&entry);
+                        }
+                        retry_transition = Self::prepare_whole_issue_retry(
+                            &mut state,
+                            &config,
+                            issue_id,
+                            &entry.identifier,
+                            &error,
+                            retry_entry.clone(),
+                        );
                     }
-                    if let Some(entry) = state.remove_running(issue_id) {
-                        state.add_runtime_seconds(&entry);
-                    }
-                }
-                if !final_failure {
-                    state.remove_pipeline_run(issue_id);
                 }
 
                 let target_state = config.on_failure.clone();
                 drop(state);
                 drop(config);
+                if let Some(input) = retry_transition {
+                    self.append_pipeline_transition(input).await;
+                }
                 if final_failure {
                     if let Some(issue) = terminal_issue {
                         self.begin_terminal_transition(
@@ -2846,6 +2937,120 @@ impl Orchestrator {
                     }
                 }
             }
+        }
+    }
+
+    fn schedule_whole_issue_failure_retry(
+        &self,
+        state: &mut OrchestratorState,
+        config: &EnsembleConfig,
+        entry: crate::tracker::model::RunningEntry,
+        error: &str,
+        scheduled_pipeline: ScheduledRetryPipeline,
+    ) -> WholeIssueFailureRetry {
+        let issue_id = entry.issue.id.clone();
+        let disposition = schedule_failure_retry(
+            state,
+            FailureRetryRequest {
+                issue_id: &issue_id,
+                identifier: &entry.identifier,
+                attempt: next_attempt(entry.retry_attempt),
+                max_backoff_ms: config.agent.max_retry_backoff_ms,
+                max_cycles: config.max_cycles,
+                error,
+                retry_from_step: None,
+                with_fixup: false,
+            },
+        );
+
+        match disposition {
+            FailureRetryDisposition::Scheduled(retry_entry) => {
+                state.add_runtime_seconds(&entry);
+                let transition = if matches!(scheduled_pipeline, ScheduledRetryPipeline::Release) {
+                    Self::prepare_whole_issue_retry(
+                        state,
+                        config,
+                        &issue_id,
+                        &entry.identifier,
+                        error,
+                        retry_entry,
+                    )
+                } else {
+                    Self::transition_input_for_run(
+                        state,
+                        &issue_id,
+                        &entry.identifier,
+                        PipelineTransitionKind::StepRetryScheduled,
+                        None,
+                        Some(error.to_string()),
+                        Some(retry_entry),
+                    )
+                };
+                WholeIssueFailureRetry::Scheduled(transition.map(Box::new))
+            }
+            FailureRetryDisposition::Exhausted => {
+                state.running.insert(issue_id.clone(), entry.clone());
+                let history_record = state.get_pipeline_run(&issue_id).map(|run| {
+                    self.build_history_record(RunningHistoryRecordInput {
+                        issue_id: &issue_id,
+                        outcome: HISTORY_OUTCOME_FAILED,
+                        last_error: Some(error.to_string()),
+                        running_entry: &entry,
+                        run,
+                        completed_at: Utc::now(),
+                        artifacts: state.artifacts.get(&issue_id).cloned(),
+                    })
+                });
+                WholeIssueFailureRetry::Exhausted(Box::new(ExhaustedRetryTerminal {
+                    issue: entry.issue.clone(),
+                    target_state: config.on_failure.clone(),
+                    history_record,
+                }))
+            }
+        }
+    }
+
+    fn prepare_whole_issue_retry(
+        state: &mut OrchestratorState,
+        config: &EnsembleConfig,
+        issue_id: &str,
+        identifier: &str,
+        error: &str,
+        retry_entry: RetryEntry,
+    ) -> Option<PipelineTransitionInput> {
+        let dag = build_dag(&config.steps).ok()?;
+        state.insert_pipeline_run(
+            issue_id,
+            PipelineRun::new(issue_id.to_string(), retry_entry.attempt, dag),
+            Arc::new(config.clone()),
+        );
+        Self::transition_input_for_run(
+            state,
+            issue_id,
+            identifier,
+            PipelineTransitionKind::StepRetryScheduled,
+            None,
+            Some(error.to_string()),
+            Some(retry_entry),
+        )
+    }
+
+    async fn commit_whole_issue_failure_retry(&self, outcome: Option<WholeIssueFailureRetry>) {
+        match outcome {
+            Some(WholeIssueFailureRetry::Scheduled(Some(input))) => {
+                self.append_pipeline_transition(*input).await;
+            }
+            Some(WholeIssueFailureRetry::Exhausted(terminal)) => {
+                let terminal = *terminal;
+                self.begin_terminal_transition(
+                    &terminal.issue,
+                    TerminalOutcome::Failed,
+                    terminal.target_state,
+                    terminal.history_record,
+                )
+                .await;
+            }
+            Some(WholeIssueFailureRetry::Scheduled(None)) | None => {}
         }
     }
 
@@ -2897,7 +3102,6 @@ impl Orchestrator {
                     run.retry_from_step(step);
                 }
                 if let Some(entry) = state.remove_running(issue_id) {
-                    state.add_runtime_seconds(&entry);
                     terminal_issue = Some(entry.issue.clone());
                     let attempt = next_attempt(entry.retry_attempt);
                     let retry_scheduled = schedule_failure_retry(
@@ -2913,7 +3117,7 @@ impl Orchestrator {
                             with_fixup: false,
                         },
                     );
-                    final_failure = retry_scheduled.is_none();
+                    final_failure = retry_scheduled.is_exhausted();
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             rejection_comment = Self::rejection_comment_for_step(run, step);
@@ -2928,7 +3132,7 @@ impl Orchestrator {
                             })
                         });
                     }
-                    if let Some(due_at_ms) = retry_scheduled {
+                    if let Some(retry_entry) = retry_scheduled.scheduled() {
                         if let Some(input) = Self::transition_input_for_run(
                             &state,
                             issue_id,
@@ -2936,18 +3140,15 @@ impl Orchestrator {
                             PipelineTransitionKind::StepRetryScheduled,
                             Some(step_name.clone()),
                             Some(reason.clone()),
-                            Some(RetryEntry {
-                                issue_id: issue_id.to_string(),
-                                identifier: entry.identifier.clone(),
-                                attempt,
-                                due_at_ms,
-                                error: Some(reason.clone()),
-                                retry_from_step: Some(step_name.clone()),
-                                with_fixup: false,
-                            }),
+                            Some(retry_entry.clone()),
                         ) {
                             post_failure_transitions.push(input);
                         }
+                    }
+                    if final_failure {
+                        state.running.insert(issue_id.to_string(), entry);
+                    } else {
+                        state.add_runtime_seconds(&entry);
                     }
                 }
             }
@@ -2973,7 +3174,6 @@ impl Orchestrator {
                     run.retry_from_step_with_fixup(step, fixup_agent);
                 }
                 if let Some(entry) = state.remove_running(issue_id) {
-                    state.add_runtime_seconds(&entry);
                     terminal_issue = Some(entry.issue.clone());
                     let attempt = next_attempt(entry.retry_attempt);
                     let retry_scheduled = schedule_failure_retry(
@@ -2989,7 +3189,7 @@ impl Orchestrator {
                             with_fixup: true,
                         },
                     );
-                    final_failure = retry_scheduled.is_none();
+                    final_failure = retry_scheduled.is_exhausted();
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             rejection_comment = Self::rejection_comment_for_step(run, step);
@@ -3004,7 +3204,7 @@ impl Orchestrator {
                             })
                         });
                     }
-                    if let Some(due_at_ms) = retry_scheduled {
+                    if let Some(retry_entry) = retry_scheduled.scheduled() {
                         if let Some(input) = Self::transition_input_for_run(
                             &state,
                             issue_id,
@@ -3012,18 +3212,15 @@ impl Orchestrator {
                             PipelineTransitionKind::FixupRetryScheduled,
                             Some(step_name.clone()),
                             Some(reason.clone()),
-                            Some(RetryEntry {
-                                issue_id: issue_id.to_string(),
-                                identifier: entry.identifier.clone(),
-                                attempt,
-                                due_at_ms,
-                                error: Some(reason.clone()),
-                                retry_from_step: Some(step_name.clone()),
-                                with_fixup: true,
-                            }),
+                            Some(retry_entry.clone()),
                         ) {
                             post_failure_transitions.push(input);
                         }
+                    }
+                    if final_failure {
+                        state.running.insert(issue_id.to_string(), entry);
+                    } else {
+                        state.add_runtime_seconds(&entry);
                     }
                 }
             }
@@ -3073,7 +3270,6 @@ impl Orchestrator {
             }
             OnFailure::RetryIssue => {
                 if let Some(entry) = state.remove_running(issue_id) {
-                    state.add_runtime_seconds(&entry);
                     terminal_issue = Some(entry.issue.clone());
                     let attempt = next_attempt(entry.retry_attempt);
                     let retry_scheduled = schedule_failure_retry(
@@ -3089,7 +3285,7 @@ impl Orchestrator {
                             with_fixup: false,
                         },
                     );
-                    final_failure = retry_scheduled.is_none();
+                    final_failure = retry_scheduled.is_exhausted();
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             rejection_comment = Self::rejection_comment_for_step(run, step);
@@ -3104,9 +3300,23 @@ impl Orchestrator {
                             })
                         });
                     }
-                }
-                if !final_failure {
-                    state.remove_pipeline_run(issue_id);
+                    if let Some(retry_entry) = retry_scheduled.scheduled() {
+                        if let Some(input) = Self::prepare_whole_issue_retry(
+                            &mut state,
+                            &config,
+                            issue_id,
+                            &entry.identifier,
+                            &reason,
+                            retry_entry.clone(),
+                        ) {
+                            post_failure_transitions.push(input);
+                        }
+                    }
+                    if final_failure {
+                        state.running.insert(issue_id.to_string(), entry);
+                    } else {
+                        state.add_runtime_seconds(&entry);
+                    }
                 }
             }
         }
@@ -6093,16 +6303,12 @@ impl Orchestrator {
     /// Handle a single retry fire.
     async fn handle_single_retry(&self, retry_entry: &crate::tracker::model::RetryEntry) {
         if self.quiescing.is_requested() {
+            self.defer_single_retry(retry_entry, "orchestrator quiescing")
+                .await;
             return;
         }
 
         let issue_id = &retry_entry.issue_id;
-
-        // Remove the retry entry
-        {
-            let mut state = self.state.write().await;
-            state.remove_retry(issue_id);
-        }
 
         // Fetch active candidates
         let candidates = match self.tracker.fetch_candidate_issues().await {
@@ -6113,21 +6319,8 @@ impl Orchestrator {
                     error = %e,
                     "retry poll failed, rescheduling"
                 );
-                let mut state = self.state.write().await;
-                let config = self.config.read().await;
-                schedule_failure_retry(
-                    &mut state,
-                    FailureRetryRequest {
-                        issue_id,
-                        identifier: &retry_entry.identifier,
-                        attempt: retry_entry.attempt + 1,
-                        max_backoff_ms: config.agent.max_retry_backoff_ms,
-                        max_cycles: config.max_cycles,
-                        error: "retry poll failed",
-                        retry_from_step: retry_entry.retry_from_step.clone(),
-                        with_fixup: retry_entry.with_fixup,
-                    },
-                );
+                self.defer_single_retry(retry_entry, "retry poll failed")
+                    .await;
                 return;
             }
         };
@@ -6143,47 +6336,131 @@ impl Orchestrator {
                     identifier = %retry_entry.identifier,
                     "issue not found in candidates on retry, releasing claim"
                 );
-                let mut state = self.state.write().await;
-                state.release_claim(issue_id);
-            }
-            Some(issue) => {
-                // Check if we have slots
-                let has_slots = {
+                let release_run_id = {
                     let state = self.state.read().await;
-                    has_available_slots(&state)
+                    (state.retry_attempts.get(issue_id) == Some(retry_entry))
+                        .then(|| state.issue_run_ids.get(issue_id).cloned())
                 };
-
-                if has_slots {
-                    let Some(permit) = self.quiescing.begin_dispatch() else {
-                        self.state.write().await.add_retry(retry_entry.clone());
-                        return;
+                if let Some(run_id) = release_run_id {
+                    let release_appended = match self
+                        .pipeline_journal
+                        .append_released_if_latest_retry_matches(
+                            retry_entry,
+                            run_id,
+                            "retry_candidate_missing",
+                        )
+                        .await
+                    {
+                        Ok(Some(_)) => true,
+                        Ok(None) => {
+                            warn!(
+                                issue_id = %issue_id,
+                                "durable retry owner changed before release; retaining current ownership"
+                            );
+                            false
+                        }
+                        Err(error) => {
+                            warn!(
+                                issue_id = %issue_id,
+                                error = %error,
+                                "failed to durably release missing retry candidate; retaining ownership"
+                            );
+                            false
+                        }
                     };
-                    self.dispatch_issue_with_permit(issue, Some(retry_entry.attempt), &permit)
-                        .await;
-                } else {
-                    // No slots — requeue
-                    info!(
-                        issue_id = %issue_id,
-                        identifier = %retry_entry.identifier,
-                        "no slots available for retry, requeuing"
-                    );
-                    let mut state = self.state.write().await;
-                    let config = self.config.read().await;
-                    schedule_failure_retry(
-                        &mut state,
-                        FailureRetryRequest {
-                            issue_id,
-                            identifier: &retry_entry.identifier,
-                            attempt: retry_entry.attempt + 1,
-                            max_backoff_ms: config.agent.max_retry_backoff_ms,
-                            max_cycles: config.max_cycles,
-                            error: "no available orchestrator slots",
-                            retry_from_step: retry_entry.retry_from_step.clone(),
-                            with_fixup: retry_entry.with_fixup,
-                        },
-                    );
+
+                    if release_appended {
+                        let mut state = self.state.write().await;
+                        if state.retry_attempts.get(issue_id) == Some(retry_entry) {
+                            state.release_claim(issue_id);
+                            state.remove_pipeline_run(issue_id);
+                        } else {
+                            warn!(
+                                issue_id = %issue_id,
+                                "retry owner changed during durable release; retaining current ownership"
+                            );
+                        }
+                    }
                 }
             }
+            Some(issue) => {
+                let max_backoff_ms = self.config.read().await.agent.max_retry_backoff_ms;
+                let (ready_for_dispatch, transition) = {
+                    let mut state = self.state.write().await;
+                    if state.retry_attempts.get(issue_id) != Some(retry_entry) {
+                        return;
+                    }
+                    if has_available_slots(&state) {
+                        (true, None)
+                    } else {
+                        info!(
+                            issue_id = %issue_id,
+                            identifier = %retry_entry.identifier,
+                            "no slots available for retry, requeuing"
+                        );
+                        let transition = Self::defer_owned_retry(
+                            &mut state,
+                            retry_entry,
+                            max_backoff_ms,
+                            "no available orchestrator slots",
+                        );
+                        (false, transition)
+                    }
+                };
+                if let Some(input) = transition {
+                    self.append_pipeline_transition(input).await;
+                }
+
+                if ready_for_dispatch {
+                    let Some(permit) = self.quiescing.begin_dispatch() else {
+                        self.defer_single_retry(retry_entry, "orchestrator quiescing")
+                            .await;
+                        return;
+                    };
+                    self.dispatch_retry_issue_with_permit(issue, retry_entry, &permit)
+                        .await;
+                }
+            }
+        }
+    }
+
+    fn defer_owned_retry(
+        state: &mut OrchestratorState,
+        retry_entry: &RetryEntry,
+        max_backoff_ms: u64,
+        reason: &str,
+    ) -> Option<PipelineTransitionInput> {
+        if state.retry_attempts.get(&retry_entry.issue_id) != Some(retry_entry) {
+            return None;
+        }
+        let deferred = defer_retry(state, retry_entry, max_backoff_ms, reason);
+        let issue_id = deferred.issue_id.clone();
+        let identifier = deferred.identifier.clone();
+        let retry_from_step = deferred.retry_from_step.clone();
+        let transition_reason = deferred.error.clone();
+        Self::transition_input_for_run(
+            state,
+            &issue_id,
+            &identifier,
+            if deferred.with_fixup {
+                PipelineTransitionKind::FixupRetryScheduled
+            } else {
+                PipelineTransitionKind::StepRetryScheduled
+            },
+            retry_from_step,
+            transition_reason,
+            Some(deferred),
+        )
+    }
+
+    async fn defer_single_retry(&self, retry_entry: &RetryEntry, reason: &str) {
+        let max_backoff_ms = self.config.read().await.agent.max_retry_backoff_ms;
+        let transition = {
+            let mut state = self.state.write().await;
+            Self::defer_owned_retry(&mut state, retry_entry, max_backoff_ms, reason)
+        };
+        if let Some(input) = transition {
+            self.append_pipeline_transition(input).await;
         }
     }
 
@@ -6645,6 +6922,8 @@ mod tests {
         release_fetch: Arc<tokio::sync::Notify>,
     }
 
+    struct FailingCandidateTracker;
+
     struct CommandMockTracker {
         issues: Arc<RwLock<Vec<Issue>>>,
         comments: Arc<RwLock<Vec<crate::tracker::model::TrackerComment>>>,
@@ -6778,6 +7057,29 @@ mod tests {
                 .filter(|issue| ids.contains(&issue.id))
                 .cloned()
                 .collect())
+        }
+    }
+
+    #[async_trait]
+    impl IssueTracker for FailingCandidateTracker {
+        async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+            Err(TrackerError::ApiRequestFailed {
+                reason: "candidate fetch failed".to_string(),
+            })
+        }
+
+        async fn fetch_issues_by_states(
+            &self,
+            _states: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            Ok(Vec::new())
+        }
+
+        async fn fetch_issue_states_by_ids(
+            &self,
+            _ids: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            Ok(Vec::new())
         }
     }
 
@@ -7305,6 +7607,7 @@ mod tests {
             retry_from_step: None,
             with_fixup: false,
         };
+        let original_due_at_ms = retry.due_at_ms;
         orchestrator.state.write().await.add_retry(retry.clone());
         let quiescing = orchestrator.quiescing_latch_owner();
 
@@ -7320,7 +7623,8 @@ mod tests {
         let state = orchestrator.state.read().await;
         let retained = state.retry_attempts.get("1").unwrap();
         assert_eq!(retained.attempt, 2);
-        assert_eq!(retained.error.as_deref(), Some("retry"));
+        assert_eq!(retained.error.as_deref(), Some("orchestrator quiescing"));
+        assert!(retained.due_at_ms > original_due_at_ms);
         assert_eq!(runs.load(Ordering::SeqCst), 0);
     }
 
@@ -9609,7 +9913,7 @@ agent:
     }
 
     #[tokio::test]
-    async fn terminal_rejection_posts_one_tracker_comment_after_retries_are_exhausted() {
+    async fn retry_exhaustion_posts_one_terminal_rejection_comment() {
         let mut raw_config = make_config();
         raw_config.max_cycles = 2;
         let config = Arc::new(RwLock::new(raw_config));
@@ -9638,13 +9942,13 @@ agent:
             shutdown_rx,
         );
 
-        for attempt in [None, Some(1)] {
+        for attempt in [None, Some(2)] {
             {
                 let cfg = config.read().await;
                 let mut state = orchestrator.state.write().await;
                 state.add_running(&test_issue("1", "Todo"), attempt);
                 let dag = build_dag(&cfg.steps).unwrap();
-                let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+                let mut pipeline_run = PipelineRun::new("1".to_string(), attempt.unwrap_or(1), dag);
                 pipeline_run.start();
                 pipeline_run.mark_running("build", "session-1".to_string());
                 state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
@@ -10006,9 +10310,10 @@ agent:
         let retry = state.retry_attempts.get("1").unwrap();
         assert_eq!(retry.attempt, 3); // incremented from 2
         assert_eq!(retry.error.as_deref(), Some("agent crashed"));
-        assert!(
-            state.get_pipeline_run("1").is_none(),
-            "pipeline run should be removed"
+        assert_eq!(
+            state.get_pipeline_run("1").map(|run| run.cycle),
+            Some(3),
+            "whole-issue retry should install the fresh pipeline cycle"
         );
     }
 
@@ -10186,21 +10491,6 @@ agent:
             shutdown_rx,
         );
 
-        // Add a claimed retry
-        {
-            let mut state = orchestrator.state.write().await;
-            state.add_retry(crate::tracker::model::RetryEntry {
-                issue_id: "gone".to_string(),
-                identifier: "repo#gone".to_string(),
-                attempt: 1,
-                due_at_ms: 0,
-                error: None,
-                retry_from_step: None,
-                with_fixup: false,
-            });
-        }
-
-        // Handle the retry
         let retry_entry = crate::tracker::model::RetryEntry {
             issue_id: "gone".to_string(),
             identifier: "repo#gone".to_string(),
@@ -10210,6 +10500,30 @@ agent:
             retry_from_step: None,
             with_fixup: false,
         };
+
+        // Add a claimed retry with its durable owner record.
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_retry(retry_entry.clone());
+        }
+        orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepRetryScheduled,
+                issue_id: retry_entry.issue_id.clone(),
+                identifier: retry_entry.identifier.clone(),
+                run_id: None,
+                cycle: retry_entry.attempt,
+                step: None,
+                reason: retry_entry.error.clone(),
+                retry: Some(retry_entry.clone()),
+                snapshot: None,
+                terminal_transition: None,
+            })
+            .await
+            .unwrap();
+
+        // Handle the retry
         orchestrator.handle_single_retry(&retry_entry).await;
 
         let state = orchestrator.state.read().await;
@@ -16018,6 +16332,51 @@ agent:
     }
 
     #[tokio::test]
+    async fn retry_exhaustion_waits_for_reconciliation_drain_before_terminal_transition() {
+        let (orchestrator, _dir, _issues, cancelled, release) =
+            blocking_drain_test_orchestrator().await;
+        {
+            let mut config = orchestrator.config.write().await;
+            config.agent.stall_timeout_ms = 1;
+            config.max_cycles = 1;
+        }
+        {
+            let mut state = orchestrator.state.write().await;
+            state.running.get_mut("1").unwrap().last_agent_timestamp =
+                Some(Utc::now() - chrono::Duration::seconds(1));
+        }
+
+        let tick = tokio::spawn({
+            let orchestrator = Arc::clone(&orchestrator);
+            async move { orchestrator.handle_tick().await }
+        });
+        tokio::time::timeout(Duration::from_secs(1), cancelled)
+            .await
+            .expect("stall reconciliation should cancel the active worker")
+            .unwrap();
+        tokio::task::yield_now().await;
+
+        assert!(!tick.is_finished());
+        {
+            let state = orchestrator.state.read().await;
+            assert!(state.is_running("1"));
+            assert!(state.is_claimed("1"));
+            assert!(state.get_pipeline_run("1").is_some());
+            assert!(!state.retry_attempts.contains_key("1"));
+            assert!(!state.pending_terminal_transitions.contains_key("1"));
+        }
+
+        release.add_permits(1);
+        tick.await.unwrap();
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.is_running("1"));
+        assert!(!state.is_claimed("1"));
+        assert!(state.get_pipeline_run("1").is_none());
+        assert!(!state.retry_attempts.contains_key("1"));
+    }
+
+    #[tokio::test]
     async fn reconciliation_drain_stalled_timeout_retains_owner_then_retries_once() {
         let (orchestrator, _dir, _issues, cancelled, release) =
             blocking_drain_test_orchestrator().await;
@@ -16199,5 +16558,656 @@ agent:
             0,
             "shutdown must discard queued events"
         );
+    }
+
+    #[tokio::test]
+    async fn retry_fire_tracker_failure_defers_the_same_pipeline_cycle() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(FailingCandidateTracker);
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let retry = RetryEntry {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 3,
+            due_at_ms: 0,
+            error: Some("agent crashed".to_string()),
+            retry_from_step: Some("review".to_string()),
+            with_fixup: true,
+        };
+        orchestrator.state.write().await.add_retry(retry.clone());
+
+        orchestrator.handle_single_retry(&retry).await;
+
+        let state = orchestrator.state.read().await;
+        let deferred = state.retry_attempts.get("1").unwrap();
+        assert_eq!(deferred.attempt, retry.attempt);
+        assert_eq!(deferred.error.as_deref(), Some("retry poll failed"));
+        assert_eq!(deferred.retry_from_step, retry.retry_from_step);
+        assert_eq!(deferred.with_fixup, retry.with_fixup);
+        assert!(state.is_claimed("1"));
+    }
+
+    #[tokio::test]
+    async fn retry_fire_stale_candidate_result_does_not_release_a_newer_retry() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let fetch_started = Arc::new(tokio::sync::Notify::new());
+        let release_fetch = Arc::new(tokio::sync::Notify::new());
+        let tracker: Arc<dyn IssueTracker> = Arc::new(BlockingCandidateTracker {
+            issues: Arc::new(RwLock::new(Vec::new())),
+            fetch_started: Arc::clone(&fetch_started),
+            release_fetch: Arc::clone(&release_fetch),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Arc::new(Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        ));
+        let fired = RetryEntry {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 2,
+            due_at_ms: 0,
+            error: Some("old failure".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
+        };
+        orchestrator.state.write().await.add_retry(fired.clone());
+
+        let retry_fire = tokio::spawn({
+            let orchestrator = Arc::clone(&orchestrator);
+            async move { orchestrator.handle_single_retry(&fired).await }
+        });
+        fetch_started.notified().await;
+        let replacement = RetryEntry {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 4,
+            due_at_ms: current_time_ms() + 60_000,
+            error: Some("new failure".to_string()),
+            retry_from_step: Some("review".to_string()),
+            with_fixup: true,
+        };
+        orchestrator
+            .state
+            .write()
+            .await
+            .add_retry(replacement.clone());
+        release_fetch.notify_one();
+        retry_fire.await.unwrap();
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(state.retry_attempts.get("1"), Some(&replacement));
+        assert!(state.is_claimed("1"));
+    }
+
+    #[tokio::test]
+    async fn retry_fire_quiescing_defers_the_same_pipeline_cycle() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let fetch_started = Arc::new(tokio::sync::Notify::new());
+        let release_fetch = Arc::new(tokio::sync::Notify::new());
+        let tracker: Arc<dyn IssueTracker> = Arc::new(BlockingCandidateTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+            fetch_started: Arc::clone(&fetch_started),
+            release_fetch: Arc::clone(&release_fetch),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Arc::new(Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        ));
+        let retry = RetryEntry {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 3,
+            due_at_ms: 0,
+            error: Some("agent crashed".to_string()),
+            retry_from_step: Some("review".to_string()),
+            with_fixup: true,
+        };
+        orchestrator.state.write().await.add_retry(retry.clone());
+
+        let retry_fire = tokio::spawn({
+            let orchestrator = Arc::clone(&orchestrator);
+            let retry = retry.clone();
+            async move { orchestrator.handle_single_retry(&retry).await }
+        });
+        fetch_started.notified().await;
+        orchestrator.quiescing.request();
+        release_fetch.notify_one();
+        retry_fire.await.unwrap();
+
+        let state = orchestrator.state.read().await;
+        let deferred = state.retry_attempts.get("1").unwrap();
+        assert_eq!(deferred.issue_id, retry.issue_id);
+        assert_eq!(deferred.identifier, retry.identifier);
+        assert_eq!(deferred.attempt, retry.attempt);
+        assert_eq!(deferred.error.as_deref(), Some("orchestrator quiescing"));
+        assert_eq!(deferred.retry_from_step, retry.retry_from_step);
+        assert_eq!(deferred.with_fixup, retry.with_fixup);
+        assert!(deferred.due_at_ms > retry.due_at_ms);
+        assert!(state.is_claimed("1"));
+        assert!(!state.is_running("1"));
+    }
+
+    #[tokio::test]
+    async fn retry_fire_capacity_deferral_does_not_consume_a_pipeline_cycle() {
+        let mut raw_config = make_config();
+        raw_config.concurrency.max_concurrent_agents = 1;
+        let config = Arc::new(RwLock::new(raw_config));
+        let issues = Arc::new(RwLock::new(vec![test_issue("1", "Todo")]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let retry = RetryEntry {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 3,
+            due_at_ms: 0,
+            error: Some("agent crashed".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
+        };
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("2", "Todo"), None);
+            state.add_retry(retry.clone());
+        }
+
+        orchestrator.handle_single_retry(&retry).await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(
+            state.retry_attempts.get("1").map(|entry| entry.attempt),
+            Some(retry.attempt)
+        );
+        assert!(state.is_claimed("1"));
+    }
+
+    #[tokio::test]
+    async fn retry_fire_eventual_dispatch_uses_the_intended_attempt_once() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let retry = RetryEntry {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 3,
+            due_at_ms: 0,
+            error: Some("agent crashed".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
+        };
+        orchestrator.state.write().await.add_retry(retry.clone());
+
+        orchestrator.handle_single_retry(&retry).await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(
+            state.get_running("1").and_then(|entry| entry.retry_attempt),
+            Some(retry.attempt)
+        );
+        assert!(!state.retry_attempts.contains_key("1"));
+    }
+
+    #[tokio::test]
+    async fn retry_exhaustion_during_workspace_setup_becomes_durable_terminal_state() {
+        let mut raw_config = make_config();
+        raw_config.max_cycles = 1;
+        raw_config.hooks.after_create = Some("exit 1".to_string());
+        let config = Arc::new(RwLock::new(raw_config));
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(FailingWriteTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        orchestrator.dispatch_issue(&issue, Some(1)).await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.pending_terminal_transitions.contains_key("1"));
+        assert!(state.is_claimed("1"));
+        assert!(state.get_pipeline_run("1").is_some());
+        assert!(!state.retry_attempts.contains_key("1"));
+        drop(state);
+
+        let record = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue("1")
+            .await
+            .unwrap()
+            .expect("durable pending terminal record");
+        assert_eq!(
+            record.kind,
+            PipelineTransitionKind::PendingTerminalTransition
+        );
+        assert_eq!(
+            record
+                .terminal_transition
+                .as_ref()
+                .map(|transition| transition.outcome),
+            Some(TerminalOutcome::Failed)
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_recovery_restores_exhausted_terminal_intent_after_restart() {
+        let mut raw_config = make_config();
+        raw_config.max_cycles = 1;
+        raw_config.hooks.after_create = Some("exit 1".to_string());
+        let config = Arc::new(RwLock::new(raw_config));
+        let issue = test_issue("1", "Todo");
+        let issues = Arc::new(RwLock::new(vec![issue.clone()]));
+        let dir = tempfile::TempDir::new().unwrap();
+
+        {
+            let tracker: Arc<dyn IssueTracker> = Arc::new(FailingWriteTracker {
+                issues: Arc::clone(&issues),
+            });
+            let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            });
+            let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+            let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+            let orchestrator = Orchestrator::new(
+                Arc::clone(&config),
+                tracker,
+                runner,
+                workspace_mgr,
+                dir.path(),
+                shutdown_rx,
+            );
+            orchestrator.dispatch_issue(&issue, Some(1)).await;
+            assert!(orchestrator
+                .state
+                .read()
+                .await
+                .pending_terminal_transitions
+                .contains_key("1"));
+        }
+
+        let tracker: Arc<dyn IssueTracker> = Arc::new(FailingWriteTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let restarted = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        restarted.restore_pipeline_runs_from_journal().await;
+        restarted.reconcile_pending_terminal_transitions().await;
+
+        let state = restarted.state.read().await;
+        assert!(state.pending_terminal_transitions.contains_key("1"));
+        assert!(state.is_claimed("1"));
+        assert!(state.get_pipeline_run("1").is_some());
+        assert!(!state.retry_attempts.contains_key("1"));
+    }
+
+    #[tokio::test]
+    async fn retry_recovery_restores_same_cycle_deferred_retry_after_restart() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let dir = tempfile::TempDir::new().unwrap();
+        let retry = RetryEntry {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 3,
+            due_at_ms: 0,
+            error: Some("agent crashed".to_string()),
+            retry_from_step: Some("build".to_string()),
+            with_fixup: true,
+        };
+
+        {
+            let tracker: Arc<dyn IssueTracker> = Arc::new(FailingCandidateTracker);
+            let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            });
+            let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+            let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+            let orchestrator = Orchestrator::new(
+                Arc::clone(&config),
+                tracker,
+                runner,
+                workspace_mgr,
+                dir.path(),
+                shutdown_rx,
+            );
+            {
+                let cfg = config.read().await;
+                let dag = build_dag(&cfg.steps).unwrap();
+                let mut run = PipelineRun::new("1".to_string(), 2, dag);
+                run.start();
+                run.retry_from_step_with_fixup("build", "builder");
+                let mut state = orchestrator.state.write().await;
+                state.insert_pipeline_run("1", run, Arc::new(cfg.clone()));
+                state.add_retry(retry.clone());
+            }
+            orchestrator.handle_single_retry(&retry).await;
+        }
+
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let restarted = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        restarted.restore_pipeline_runs_from_journal().await;
+
+        let state = restarted.state.read().await;
+        let restored = state.retry_attempts.get("1").unwrap();
+        assert_eq!(restored.attempt, retry.attempt);
+        assert_eq!(restored.retry_from_step, retry.retry_from_step);
+        assert_eq!(restored.with_fixup, retry.with_fixup);
+        assert_eq!(restored.error.as_deref(), Some("retry poll failed"));
+        assert!(state.is_claimed("1"));
+    }
+
+    #[tokio::test]
+    async fn retry_recovery_does_not_restore_a_missing_candidate_release() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let dir = tempfile::TempDir::new().unwrap();
+        let retry = RetryEntry {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 2,
+            due_at_ms: 0,
+            error: Some("agent crashed".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
+        };
+
+        {
+            let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+                issues: Arc::new(RwLock::new(vec![])),
+            });
+            let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            });
+            let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+            let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+            let orchestrator = Orchestrator::new(
+                Arc::clone(&config),
+                tracker,
+                runner,
+                workspace_mgr,
+                dir.path(),
+                shutdown_rx,
+            );
+            let transition = {
+                let cfg = config.read().await;
+                let dag = build_dag(&cfg.steps).unwrap();
+                let mut state = orchestrator.state.write().await;
+                state.insert_pipeline_run(
+                    "1",
+                    PipelineRun::new("1".to_string(), retry.attempt, dag),
+                    Arc::new(cfg.clone()),
+                );
+                state.add_retry(retry.clone());
+                Orchestrator::transition_input_for_run(
+                    &state,
+                    "1",
+                    "repo#1",
+                    PipelineTransitionKind::StepRetryScheduled,
+                    None,
+                    retry.error.clone(),
+                    Some(retry.clone()),
+                )
+                .unwrap()
+            };
+            orchestrator.append_pipeline_transition(transition).await;
+
+            orchestrator.handle_single_retry(&retry).await;
+
+            let state = orchestrator.state.read().await;
+            assert!(!state.retry_attempts.contains_key("1"));
+            assert!(!state.is_claimed("1"));
+            assert!(state.get_pipeline_run("1").is_none());
+            drop(state);
+
+            let record = orchestrator
+                .pipeline_journal
+                .read_records_for_issue("1")
+                .await
+                .unwrap()
+                .pop()
+                .unwrap();
+            assert_eq!(record.kind, PipelineTransitionKind::Released);
+        }
+
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let restarted = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        restarted.restore_pipeline_runs_from_journal().await;
+
+        let state = restarted.state.read().await;
+        assert!(!state.retry_attempts.contains_key("1"));
+        assert!(!state.is_claimed("1"));
+        assert!(state.get_pipeline_run("1").is_none());
+    }
+
+    #[tokio::test]
+    async fn whole_issue_retry_recovery_restores_the_fresh_pipeline_cycle() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let issue = test_issue("1", "Todo");
+        let issues = Arc::new(RwLock::new(vec![issue.clone()]));
+        let dir = tempfile::TempDir::new().unwrap();
+
+        {
+            let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+                issues: Arc::clone(&issues),
+            });
+            let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            });
+            let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+            let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+            let orchestrator = Orchestrator::new(
+                Arc::clone(&config),
+                tracker,
+                runner,
+                workspace_mgr,
+                dir.path(),
+                shutdown_rx,
+            );
+            {
+                let cfg = config.read().await;
+                let dag = build_dag(&cfg.steps).unwrap();
+                let mut run = PipelineRun::new("1".to_string(), 1, dag);
+                run.start();
+                run.mark_running("build", "session-1".to_string());
+                let mut state = orchestrator.state.write().await;
+                state.add_running(&issue, None);
+                state.insert_pipeline_run("1", run, Arc::new(cfg.clone()));
+            }
+
+            orchestrator
+                .handle_worker_exit(
+                    "1",
+                    "build",
+                    WorkerResult::Failed {
+                        error: "agent crashed".to_string(),
+                        kind: WorkerFailureKind::Runtime,
+                    },
+                )
+                .await;
+
+            let state = orchestrator.state.read().await;
+            assert_eq!(
+                state.retry_attempts.get("1").map(|entry| entry.attempt),
+                Some(2)
+            );
+            assert_eq!(state.get_pipeline_run("1").map(|run| run.cycle), Some(2));
+        }
+
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let restarted = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        restarted.restore_pipeline_runs_from_journal().await;
+
+        let state = restarted.state.read().await;
+        assert_eq!(
+            state.retry_attempts.get("1").map(|entry| entry.attempt),
+            Some(2)
+        );
+        assert_eq!(state.get_pipeline_run("1").map(|run| run.cycle), Some(2));
+        assert!(state.is_claimed("1"));
     }
 }

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncSeekExt, AsyncWriteExt, BufReader};
 use tracing::warn;
 
 use crate::history::model::HistoryRecord;
@@ -10,6 +12,55 @@ use crate::pipeline::engine::PipelineRunSnapshot;
 use crate::tracker::model::RetryEntry;
 
 const SCHEMA_VERSION: u32 = 1;
+type IssueAppendLock = tokio::sync::Mutex<()>;
+type IssueAppendLockRegistry = Mutex<HashMap<PathBuf, Weak<IssueAppendLock>>>;
+static ISSUE_APPEND_LOCKS: OnceLock<IssueAppendLockRegistry> = OnceLock::new();
+
+pub(crate) struct PipelineIssueJournalTransaction<'a> {
+    journal: &'a PipelineRunJournal,
+    issue_id: String,
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+impl PipelineIssueJournalTransaction<'_> {
+    pub(crate) async fn append(
+        &self,
+        input: PipelineTransitionInput,
+    ) -> Result<PipelineTransitionRecord, std::io::Error> {
+        if input.issue_id != self.issue_id {
+            return Err(invalid_data(format!(
+                "issue transaction for '{}' cannot append record for '{}'",
+                self.issue_id, input.issue_id
+            )));
+        }
+        #[cfg(test)]
+        if let Some((ready, release)) = &self.journal.transaction_append_test_barriers {
+            ready.wait().await;
+            release.wait().await;
+        }
+        let record = self.journal.append_unlocked(input).await?;
+        #[cfg(test)]
+        if self.journal.transaction_append_late_error {
+            return Err(std::io::Error::other(
+                "injected error after a valid record became visible",
+            ));
+        }
+        Ok(record)
+    }
+
+    pub(crate) async fn latest_record_matches(
+        &self,
+        input: &PipelineTransitionInput,
+    ) -> Result<bool, std::io::Error> {
+        let latest = self
+            .journal
+            .read_last_valid_record(&self.journal.path_for_issue(&self.issue_id))
+            .await?;
+        Ok(latest
+            .as_ref()
+            .is_some_and(|record| record.matches_input(input)))
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -69,6 +120,21 @@ pub struct PipelineTransitionRecord {
     pub written_at: DateTime<Utc>,
 }
 
+impl PipelineTransitionRecord {
+    fn matches_input(&self, input: &PipelineTransitionInput) -> bool {
+        self.kind == input.kind
+            && self.issue_id == input.issue_id
+            && self.identifier == input.identifier
+            && self.run_id == input.run_id
+            && self.cycle == input.cycle
+            && self.step == input.step
+            && self.reason == input.reason
+            && self.retry == input.retry
+            && self.snapshot == input.snapshot
+            && self.terminal_transition == input.terminal_transition
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PipelineTransitionInput {
     pub kind: PipelineTransitionKind,
@@ -86,12 +152,26 @@ pub struct PipelineTransitionInput {
 #[derive(Debug, Clone)]
 pub struct PipelineRunJournal {
     root: PathBuf,
+    #[cfg(test)]
+    conditional_release_test_barriers:
+        Option<(Arc<tokio::sync::Barrier>, Arc<tokio::sync::Barrier>)>,
+    #[cfg(test)]
+    pub(super) transaction_append_test_barriers:
+        Option<(Arc<tokio::sync::Barrier>, Arc<tokio::sync::Barrier>)>,
+    #[cfg(test)]
+    pub(super) transaction_append_late_error: bool,
 }
 
 impl PipelineRunJournal {
     pub fn new(config_dir: impl Into<PathBuf>) -> Self {
         Self {
             root: config_dir.into().join("state").join("pipeline-runs"),
+            #[cfg(test)]
+            conditional_release_test_barriers: None,
+            #[cfg(test)]
+            transaction_append_test_barriers: None,
+            #[cfg(test)]
+            transaction_append_late_error: false,
         }
     }
 
@@ -108,8 +188,30 @@ impl PipelineRunJournal {
         &self,
         input: PipelineTransitionInput,
     ) -> Result<PipelineTransitionRecord, std::io::Error> {
+        self.begin_issue_transition(&input.issue_id)
+            .await
+            .append(input)
+            .await
+    }
+
+    pub(crate) async fn begin_issue_transition(
+        &self,
+        issue_id: &str,
+    ) -> PipelineIssueJournalTransaction<'_> {
+        PipelineIssueJournalTransaction {
+            journal: self,
+            issue_id: issue_id.to_string(),
+            _guard: self.issue_append_lock(issue_id).lock_owned().await,
+        }
+    }
+
+    async fn append_unlocked(
+        &self,
+        input: PipelineTransitionInput,
+    ) -> Result<PipelineTransitionRecord, std::io::Error> {
         tokio::fs::create_dir_all(&self.root).await?;
         let path = self.path_for_issue(&input.issue_id);
+        self.repair_trailing_record(&path).await?;
         let seq = self
             .read_last_valid_record(&path)
             .await?
@@ -135,14 +237,65 @@ impl PipelineRunJournal {
         let mut file = tokio::fs::OpenOptions::new()
             .create(true)
             .append(true)
+            .write(true)
             .open(path)
             .await?;
-        let line =
-            serde_json::to_string(&record).map_err(|error| invalid_data(error.to_string()))?;
-        file.write_all(line.as_bytes()).await?;
-        file.write_all(b"\n").await?;
+        let original_len = file.metadata().await?.len();
+        let mut line =
+            serde_json::to_vec(&record).map_err(|error| invalid_data(error.to_string()))?;
+        line.push(b'\n');
+        if let Err(write_error) = file.write_all(&line).await {
+            if let Err(truncate_error) = file.set_len(original_len).await {
+                return Err(std::io::Error::other(format!(
+                    "journal append failed: {write_error}; failed to truncate partial record: {truncate_error}"
+                )));
+            }
+            return Err(write_error);
+        }
         file.flush().await?;
         Ok(record)
+    }
+
+    async fn repair_trailing_record(&self, path: &Path) -> Result<(), std::io::Error> {
+        let bytes = match tokio::fs::read(path).await {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        if bytes.is_empty() || bytes.ends_with(b"\n") {
+            return Ok(());
+        }
+
+        let tail_start = bytes
+            .iter()
+            .rposition(|byte| *byte == b'\n')
+            .map_or(0, |position| position + 1);
+        let tail = &bytes[tail_start..];
+        let valid_complete_record = serde_json::from_slice::<PipelineTransitionRecord>(tail)
+            .is_ok_and(|record| record.schema_version == SCHEMA_VERSION);
+        let mut file = tokio::fs::OpenOptions::new().write(true).open(path).await?;
+        if valid_complete_record {
+            file.seek(std::io::SeekFrom::End(0)).await?;
+            file.write_all(b"\n").await?;
+        } else {
+            file.set_len(tail_start as u64).await?;
+        }
+        file.flush().await
+    }
+
+    fn issue_append_lock(&self, issue_id: &str) -> Arc<IssueAppendLock> {
+        let path = self.path_for_issue(issue_id);
+        let mut locks = ISSUE_APPEND_LOCKS
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(&path).and_then(Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(IssueAppendLock::new(()));
+        locks.insert(path, Arc::downgrade(&lock));
+        lock
     }
 
     pub async fn append_released(
@@ -165,6 +318,44 @@ impl PipelineRunJournal {
             terminal_transition: None,
         })
         .await
+    }
+
+    pub async fn append_released_if_latest_retry_matches(
+        &self,
+        expected_retry: &RetryEntry,
+        run_id: Option<String>,
+        reason: &str,
+    ) -> Result<Option<PipelineTransitionRecord>, std::io::Error> {
+        let issue_lock = self.issue_append_lock(&expected_retry.issue_id);
+        let _guard = issue_lock.lock().await;
+        let path = self.path_for_issue(&expected_retry.issue_id);
+        let latest_retry = self
+            .read_last_valid_record(&path)
+            .await?
+            .and_then(|record| record.retry);
+        if latest_retry.as_ref() != Some(expected_retry) {
+            return Ok(None);
+        }
+        #[cfg(test)]
+        if let Some((ready, release)) = &self.conditional_release_test_barriers {
+            ready.wait().await;
+            release.wait().await;
+        }
+
+        self.append_unlocked(PipelineTransitionInput {
+            kind: PipelineTransitionKind::Released,
+            issue_id: expected_retry.issue_id.clone(),
+            identifier: expected_retry.identifier.clone(),
+            run_id,
+            cycle: 0,
+            step: None,
+            reason: Some(reason.to_string()),
+            retry: None,
+            snapshot: None,
+            terminal_transition: None,
+        })
+        .await
+        .map(Some)
     }
 
     pub async fn read_records_for_issue(
@@ -403,6 +594,161 @@ mod tests {
         assert_eq!(records[0].seq, 1);
         assert_eq!(records[1].seq, 2);
         assert_eq!(records[1].kind, PipelineTransitionKind::StepCompleted);
+    }
+
+    #[tokio::test]
+    async fn conditional_release_cannot_erase_a_concurrent_newer_retry() {
+        let dir = tempdir().unwrap();
+        let ready = Arc::new(tokio::sync::Barrier::new(2));
+        let release = Arc::new(tokio::sync::Barrier::new(2));
+        let mut journal = PipelineRunJournal::new(dir.path());
+        journal.conditional_release_test_barriers =
+            Some((Arc::clone(&ready), Arc::clone(&release)));
+        let old_retry = RetryEntry {
+            issue_id: "issue/1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 2,
+            due_at_ms: 1,
+            error: Some("old failure".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
+        };
+        let newer_retry = RetryEntry {
+            attempt: 3,
+            due_at_ms: 2,
+            error: Some("new failure".to_string()),
+            ..old_retry.clone()
+        };
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepRetryScheduled,
+                issue_id: old_retry.issue_id.clone(),
+                identifier: old_retry.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: old_retry.attempt,
+                step: None,
+                reason: old_retry.error.clone(),
+                retry: Some(old_retry.clone()),
+                snapshot: Some(snapshot()),
+                terminal_transition: None,
+            })
+            .await
+            .unwrap();
+
+        let release_task = tokio::spawn({
+            let journal = journal.clone();
+            let old_retry = old_retry.clone();
+            async move {
+                journal
+                    .append_released_if_latest_retry_matches(
+                        &old_retry,
+                        Some("run-1".to_string()),
+                        "retry_candidate_missing",
+                    )
+                    .await
+            }
+        });
+        ready.wait().await;
+
+        let mut newer_retry_task = tokio::spawn({
+            let journal = PipelineRunJournal::new(dir.path());
+            let newer_retry = newer_retry.clone();
+            async move {
+                journal
+                    .append(PipelineTransitionInput {
+                        kind: PipelineTransitionKind::StepRetryScheduled,
+                        issue_id: newer_retry.issue_id.clone(),
+                        identifier: newer_retry.identifier.clone(),
+                        run_id: Some("run-1".to_string()),
+                        cycle: newer_retry.attempt,
+                        step: None,
+                        reason: newer_retry.error.clone(),
+                        retry: Some(newer_retry),
+                        snapshot: Some(snapshot()),
+                        terminal_transition: None,
+                    })
+                    .await
+            }
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut newer_retry_task)
+                .await
+                .is_err(),
+            "newer retry append must wait for the same issue's conditional release"
+        );
+
+        release.wait().await;
+        assert!(release_task.await.unwrap().unwrap().is_some());
+        newer_retry_task.await.unwrap().unwrap();
+
+        let latest = journal
+            .latest_live_record_for_issue("issue/1")
+            .await
+            .unwrap()
+            .expect("newer retry remains live for restart");
+        assert_eq!(latest.kind, PipelineTransitionKind::StepRetryScheduled);
+        assert_eq!(latest.retry, Some(newer_retry));
+    }
+
+    #[tokio::test]
+    async fn append_repairs_a_malformed_partial_tail_before_the_next_owner() {
+        let dir = tempdir().unwrap();
+        let journal = PipelineRunJournal::new(dir.path());
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::RunStarted,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: None,
+                reason: None,
+                retry: None,
+                snapshot: Some(snapshot()),
+                terminal_transition: None,
+            })
+            .await
+            .unwrap();
+        let mut file = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(journal.path_for_issue("issue/1"))
+            .await
+            .unwrap();
+        file.write_all(br#"{"schema_version":1,"seq":"#)
+            .await
+            .unwrap();
+        file.flush().await.unwrap();
+        drop(file);
+
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepRetryScheduled,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 2,
+                step: Some("build".to_string()),
+                reason: Some("retry".to_string()),
+                retry: Some(RetryEntry {
+                    issue_id: "issue/1".to_string(),
+                    identifier: "repo#1".to_string(),
+                    attempt: 2,
+                    due_at_ms: 1,
+                    error: Some("retry".to_string()),
+                    retry_from_step: Some("build".to_string()),
+                    with_fixup: false,
+                }),
+                snapshot: Some(snapshot()),
+                terminal_transition: None,
+            })
+            .await
+            .unwrap();
+
+        let records = journal.read_records_for_issue("issue/1").await.unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].seq, 1);
+        assert_eq!(records[1].seq, 2);
+        assert_eq!(records[1].kind, PipelineTransitionKind::StepRetryScheduled);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -1,8 +1,14 @@
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
 use tracing::{info, warn};
 
 use crate::observability::events_contract::{ISSUE_RETRY_CANCELLED, ISSUE_RETRY_SCHEDULED};
 use crate::tracker::model::RetryEntry;
 
+use super::pipeline_journal::{
+    PipelineRunJournal, PipelineTransitionInput, PipelineTransitionKind,
+};
 use super::state::OrchestratorState;
 
 /// Continuation retry delay in milliseconds (after clean worker exit).
@@ -20,6 +26,219 @@ pub struct FailureRetryRequest<'a> {
     pub error: &'a str,
     pub retry_from_step: Option<String>,
     pub with_fixup: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub enum FailureRetryDisposition {
+    Scheduled(RetryEntry),
+    Exhausted,
+}
+
+#[derive(Debug)]
+pub(crate) enum ManualStepRetryError {
+    RuntimeUnavailable,
+    NoPipelineRun,
+    StepNotFound,
+    MaxCyclesExhausted,
+    OwnerChanged,
+    Persistence(std::io::Error),
+}
+
+pub(crate) struct ManualStepRetryRequest<'a> {
+    pub issue_id: &'a str,
+    pub identifier: &'a str,
+    pub step_name: &'a str,
+    pub max_backoff_ms: u64,
+    pub max_cycles: u32,
+}
+
+/// Queue a manual step retry under the same per-issue ordering reservation as
+/// its durable transition. The global orchestrator state lock is never held
+/// during journal I/O. A demonstrably absent transition restores the exact
+/// previous owner; an ambiguous read failure retains the new owner so recovery
+/// can never conflict with a visible new record.
+pub(crate) async fn queue_manual_step_retry(
+    state: &Arc<RwLock<OrchestratorState>>,
+    journal: &PipelineRunJournal,
+    request: ManualStepRetryRequest<'_>,
+) -> Result<RetryEntry, ManualStepRetryError> {
+    let transaction = journal.begin_issue_transition(request.issue_id).await;
+    let (
+        retry_entry,
+        transition,
+        previous_retry,
+        previous_waiting,
+        previous_run,
+        was_claimed,
+        mutated_run,
+    ) = {
+        let mut state = state.write().await;
+        let Some(run) = state.get_pipeline_run(request.issue_id) else {
+            return Err(ManualStepRetryError::NoPipelineRun);
+        };
+        if !run.step_states.contains_key(request.step_name) {
+            return Err(ManualStepRetryError::StepNotFound);
+        }
+
+        let previous_retry = state.retry_attempts.get(request.issue_id).cloned();
+        let previous_waiting = state.waiting_on_human.get(request.issue_id).cloned();
+        if previous_retry.is_none() && previous_waiting.is_none() {
+            return Err(ManualStepRetryError::OwnerChanged);
+        }
+        let previous_run = run.clone();
+        let was_claimed = state.is_claimed(request.issue_id);
+        let identifier = previous_retry
+            .as_ref()
+            .map(|entry| entry.identifier.clone())
+            .or_else(|| {
+                previous_waiting
+                    .as_ref()
+                    .map(|entry| entry.identifier.clone())
+            })
+            .unwrap_or_else(|| request.identifier.to_string());
+        let attempt = previous_retry
+            .as_ref()
+            .map(|entry| entry.attempt + 1)
+            .or_else(|| {
+                previous_waiting
+                    .as_ref()
+                    .map(|entry| entry.retry_attempt.map(|attempt| attempt + 1).unwrap_or(1))
+            })
+            .unwrap_or(1);
+        let run_id = previous_waiting
+            .as_ref()
+            .and_then(|entry| entry.run_id.clone())
+            .or_else(|| state.issue_run_ids.get(request.issue_id).cloned());
+
+        let disposition = schedule_manual_failure_retry(
+            &mut state,
+            FailureRetryRequest {
+                issue_id: request.issue_id,
+                identifier: &identifier,
+                attempt,
+                max_backoff_ms: request.max_backoff_ms,
+                max_cycles: request.max_cycles,
+                error: "manual step-level retry",
+                retry_from_step: Some(request.step_name.to_string()),
+                with_fixup: false,
+            },
+        );
+        let FailureRetryDisposition::Scheduled(retry_entry) = disposition else {
+            return Err(ManualStepRetryError::MaxCyclesExhausted);
+        };
+
+        state
+            .get_pipeline_run_mut(request.issue_id)
+            .expect("pipeline run was validated before retry scheduling")
+            .retry_from_step(request.step_name);
+        state.remove_waiting_on_human(request.issue_id);
+        let run = state
+            .get_pipeline_run(request.issue_id)
+            .expect("pipeline run remains present while retry is scheduled");
+        let mutated_run = run.to_snapshot();
+        let transition = PipelineTransitionInput {
+            kind: PipelineTransitionKind::StepRetryScheduled,
+            issue_id: request.issue_id.to_string(),
+            identifier,
+            run_id,
+            cycle: run.cycle,
+            step: Some(request.step_name.to_string()),
+            reason: retry_entry.error.clone(),
+            retry: Some(retry_entry.clone()),
+            snapshot: Some(mutated_run.clone()),
+            terminal_transition: None,
+        };
+        (
+            retry_entry,
+            transition,
+            previous_retry,
+            previous_waiting,
+            previous_run,
+            was_claimed,
+            mutated_run,
+        )
+    };
+
+    let transition_for_reconciliation = transition.clone();
+    if let Err(error) = transaction.append(transition).await {
+        match transaction
+            .latest_record_matches(&transition_for_reconciliation)
+            .await
+        {
+            Ok(true) => return Ok(retry_entry),
+            Err(reconciliation_error) => {
+                warn!(
+                    issue_id = request.issue_id,
+                    append_error = %error,
+                    reconciliation_error = %reconciliation_error,
+                    "manual retry append outcome is ambiguous; retaining the new owner"
+                );
+                return Err(ManualStepRetryError::Persistence(error));
+            }
+            Ok(false) => {}
+        }
+
+        let mut state = state.write().await;
+        let retry_is_current = state.retry_attempts.get(request.issue_id) == Some(&retry_entry);
+        let run_is_current = state
+            .get_pipeline_run(request.issue_id)
+            .is_some_and(|run| run.to_snapshot() == mutated_run);
+        let waiting_is_current = !state.waiting_on_human.contains_key(request.issue_id);
+        let claim_is_current = state.is_claimed(request.issue_id);
+        if retry_is_current && run_is_current && waiting_is_current && claim_is_current {
+            match previous_retry {
+                Some(entry) => {
+                    state
+                        .retry_attempts
+                        .insert(request.issue_id.to_string(), entry);
+                }
+                None => {
+                    state.retry_attempts.remove(request.issue_id);
+                }
+            }
+            match previous_waiting {
+                Some(entry) => {
+                    state
+                        .waiting_on_human
+                        .insert(request.issue_id.to_string(), entry);
+                }
+                None => {
+                    state.waiting_on_human.remove(request.issue_id);
+                }
+            }
+            state
+                .pipeline_runs
+                .insert(request.issue_id.to_string(), previous_run);
+            if was_claimed {
+                state.claimed.insert(request.issue_id.to_string());
+            } else {
+                state.claimed.remove(request.issue_id);
+            }
+        }
+        return Err(ManualStepRetryError::Persistence(error));
+    }
+
+    Ok(retry_entry)
+}
+
+#[derive(Clone, Copy)]
+enum FailureRetrySemantics {
+    PipelineCycle,
+    LegacyManual,
+}
+
+impl FailureRetryDisposition {
+    pub fn is_exhausted(&self) -> bool {
+        matches!(self, Self::Exhausted)
+    }
+
+    pub fn scheduled(&self) -> Option<&RetryEntry> {
+        match self {
+            Self::Scheduled(entry) => Some(entry),
+            Self::Exhausted => None,
+        }
+    }
 }
 
 /// Calculate exponential backoff delay for a failure retry.
@@ -66,12 +285,28 @@ pub fn schedule_continuation_retry(
 }
 
 /// Schedule a failure retry with exponential backoff.
-/// Returns `Some(due_at_ms)` if the retry was scheduled, or `None` if `max_cycles`
-/// has been reached and the issue should not be retried.
+/// Returns the exact scheduled entry or an explicit exhausted disposition.
 pub fn schedule_failure_retry(
     state: &mut OrchestratorState,
     request: FailureRetryRequest<'_>,
-) -> Option<u64> {
+) -> FailureRetryDisposition {
+    schedule_failure_retry_with_semantics(state, request, FailureRetrySemantics::PipelineCycle)
+}
+
+/// Schedule a manual step retry using the endpoint's established attempt,
+/// exhaustion, and backoff semantics.
+fn schedule_manual_failure_retry(
+    state: &mut OrchestratorState,
+    request: FailureRetryRequest<'_>,
+) -> FailureRetryDisposition {
+    schedule_failure_retry_with_semantics(state, request, FailureRetrySemantics::LegacyManual)
+}
+
+fn schedule_failure_retry_with_semantics(
+    state: &mut OrchestratorState,
+    request: FailureRetryRequest<'_>,
+    semantics: FailureRetrySemantics,
+) -> FailureRetryDisposition {
     let FailureRetryRequest {
         issue_id,
         identifier,
@@ -83,7 +318,11 @@ pub fn schedule_failure_retry(
         with_fixup,
     } = request;
 
-    if attempt >= max_cycles {
+    let exhausted = match semantics {
+        FailureRetrySemantics::PipelineCycle => attempt > max_cycles,
+        FailureRetrySemantics::LegacyManual => attempt >= max_cycles,
+    };
+    if exhausted {
         warn!(
             event = ISSUE_RETRY_CANCELLED,
             issue_id = issue_id,
@@ -93,10 +332,14 @@ pub fn schedule_failure_retry(
             reason = normalize_reason(error),
             "max retry cycles reached, not scheduling further retries"
         );
-        return None;
+        return FailureRetryDisposition::Exhausted;
     }
 
-    let delay = calculate_backoff(attempt, max_backoff_ms);
+    let backoff_attempt = match semantics {
+        FailureRetrySemantics::PipelineCycle => attempt.saturating_sub(1),
+        FailureRetrySemantics::LegacyManual => attempt,
+    };
+    let delay = calculate_backoff(backoff_attempt, max_backoff_ms);
     let due_at_ms = current_time_ms() + delay;
 
     let entry = RetryEntry {
@@ -119,8 +362,34 @@ pub fn schedule_failure_retry(
         "scheduling failure retry"
     );
 
-    state.add_retry(entry);
-    Some(due_at_ms)
+    state.add_retry(entry.clone());
+    FailureRetryDisposition::Scheduled(entry)
+}
+
+/// Defer scheduler work for a retry without consuming another pipeline cycle.
+pub fn defer_retry(
+    state: &mut OrchestratorState,
+    retry_entry: &RetryEntry,
+    max_backoff_ms: u64,
+    reason: &str,
+) -> RetryEntry {
+    let delay = calculate_backoff(retry_entry.attempt.saturating_sub(1), max_backoff_ms);
+    let mut deferred = retry_entry.clone();
+    deferred.due_at_ms = current_time_ms() + delay;
+    deferred.error = Some(reason.to_string());
+
+    info!(
+        event = ISSUE_RETRY_SCHEDULED,
+        issue_id = %deferred.issue_id,
+        identifier = %deferred.identifier,
+        attempt = deferred.attempt,
+        delay_ms = delay,
+        reason = normalize_reason(reason),
+        "deferring retry scheduler work"
+    );
+
+    state.add_retry(deferred.clone());
+    deferred
 }
 
 /// Identify deterministic agent/runtime configuration failures that another
@@ -131,9 +400,10 @@ pub fn is_non_retryable_failure(reason: &str) -> bool {
 }
 
 /// Determine the next attempt number from a running entry.
-/// If the entry had a retry_attempt, increment it; otherwise start at 1.
+/// If the entry had a retry attempt, increment it; otherwise advance from the
+/// initial pipeline cycle to cycle 2.
 pub fn next_attempt(current: Option<u32>) -> u32 {
-    current.map(|a| a + 1).unwrap_or(1)
+    current.unwrap_or(1) + 1
 }
 
 fn normalize_reason(reason: &str) -> &str {
@@ -180,7 +450,194 @@ pub fn next_retry_time(state: &OrchestratorState) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ensemble::ConcurrencyConfig;
+    use crate::config::ensemble::{ConcurrencyConfig, OnFailure, StepConfig, StepKind};
+    use crate::interaction::model::InteractionKind;
+    use crate::orchestrator::state::WaitingOnHumanEntry;
+    use crate::pipeline::dag::build_dag;
+    use crate::pipeline::engine::PipelineRun;
+    use crate::tracker::model::Issue;
+
+    fn manual_retry_state() -> Arc<RwLock<OrchestratorState>> {
+        let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
+        let issue = Issue {
+            id: "issue-1".to_string(),
+            identifier: "repo#1".to_string(),
+            title: "Retry me".to_string(),
+            description: None,
+            priority: None,
+            state: "In Progress".to_string(),
+            branch_name: None,
+            url: None,
+            labels: Vec::new(),
+            blocked_by: Vec::new(),
+            created_at: None,
+            updated_at: None,
+        };
+        state.add_waiting_on_human(WaitingOnHumanEntry {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            interaction_request_id: "halted:issue-1:build".to_string(),
+            step_name: "build".to_string(),
+            kind: InteractionKind::Handoff,
+            prompt: "manual repair needed".to_string(),
+            agent_name: "builder".to_string(),
+            retry_attempt: Some(1),
+            started_at: Some(chrono::Utc::now()),
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: chrono::Utc::now(),
+            run_id: Some("run-1".to_string()),
+            issue: Some(issue),
+        });
+        let dag = build_dag(&[StepConfig {
+            name: "build".to_string(),
+            kind: StepKind::Agent,
+            agent: "builder".to_string(),
+            depends: None,
+            tracker_state: None,
+            timeout_ms: None,
+            approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
+        }])
+        .unwrap();
+        state.pipeline_runs.insert(
+            "issue-1".to_string(),
+            PipelineRun::new("issue-1".to_string(), 1, dag),
+        );
+        Arc::new(RwLock::new(state))
+    }
+
+    #[tokio::test]
+    async fn concurrent_manual_retries_commit_in_owner_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let ready = Arc::new(tokio::sync::Barrier::new(2));
+        let release = Arc::new(tokio::sync::Barrier::new(2));
+        let mut journal = PipelineRunJournal::new(dir.path());
+        journal.transaction_append_test_barriers = Some((Arc::clone(&ready), Arc::clone(&release)));
+        let state = manual_retry_state();
+
+        let first = tokio::spawn({
+            let state = Arc::clone(&state);
+            let journal = journal.clone();
+            async move {
+                queue_manual_step_retry(
+                    &state,
+                    &journal,
+                    ManualStepRetryRequest {
+                        issue_id: "issue-1",
+                        identifier: "repo#1",
+                        step_name: "build",
+                        max_backoff_ms: 300_000,
+                        max_cycles: 5,
+                    },
+                )
+                .await
+            }
+        });
+        ready.wait().await;
+
+        let mut second = tokio::spawn({
+            let state = Arc::clone(&state);
+            let mut journal = PipelineRunJournal::new(dir.path());
+            journal.transaction_append_test_barriers = None;
+            async move {
+                queue_manual_step_retry(
+                    &state,
+                    &journal,
+                    ManualStepRetryRequest {
+                        issue_id: "issue-1",
+                        identifier: "repo#1",
+                        step_name: "build",
+                        max_backoff_ms: 300_000,
+                        max_cycles: 5,
+                    },
+                )
+                .await
+            }
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut second)
+                .await
+                .is_err(),
+            "the second retry must not mutate state before the first transition is durable"
+        );
+        assert_eq!(
+            state
+                .read()
+                .await
+                .retry_attempts
+                .get("issue-1")
+                .map(|entry| entry.attempt),
+            Some(2)
+        );
+
+        release.wait().await;
+        assert_eq!(first.await.unwrap().unwrap().attempt, 2);
+        assert_eq!(second.await.unwrap().unwrap().attempt, 3);
+
+        let records = journal.read_records_for_issue("issue-1").await.unwrap();
+        let attempts: Vec<_> = records
+            .iter()
+            .filter_map(|record| record.retry.as_ref().map(|entry| entry.attempt))
+            .collect();
+        assert_eq!(attempts, vec![2, 3]);
+        let latest = journal
+            .latest_live_record_for_issue("issue-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(latest.retry.map(|entry| entry.attempt), Some(3));
+        assert_eq!(
+            state
+                .read()
+                .await
+                .retry_attempts
+                .get("issue-1")
+                .map(|entry| entry.attempt),
+            Some(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn late_append_error_keeps_the_exact_restart_visible_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = PipelineRunJournal::new(dir.path());
+        journal.transaction_append_late_error = true;
+        let state = manual_retry_state();
+
+        let scheduled = queue_manual_step_retry(
+            &state,
+            &journal,
+            ManualStepRetryRequest {
+                issue_id: "issue-1",
+                identifier: "repo#1",
+                step_name: "build",
+                max_backoff_ms: 300_000,
+                max_cycles: 5,
+            },
+        )
+        .await
+        .expect("a visible exact record makes the semantic append successful");
+
+        assert_eq!(scheduled.attempt, 2);
+        assert_eq!(
+            state
+                .read()
+                .await
+                .retry_attempts
+                .get("issue-1")
+                .map(|entry| entry.attempt),
+            Some(2)
+        );
+        let latest = journal
+            .latest_live_record_for_issue("issue-1")
+            .await
+            .unwrap()
+            .expect("the retry remains recoverable after restart");
+        assert_eq!(latest.retry, Some(scheduled));
+    }
 
     #[test]
     fn retry_reason_is_non_empty() {
@@ -260,8 +717,9 @@ mod tests {
     #[test]
     fn test_schedule_failure_retry() {
         let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
+        let before = current_time_ms();
 
-        let due = schedule_failure_retry(
+        let disposition = schedule_failure_retry(
             &mut state,
             FailureRetryRequest {
                 issue_id: "issue-1",
@@ -275,26 +733,50 @@ mod tests {
             },
         );
 
-        assert!(due.is_some());
+        let FailureRetryDisposition::Scheduled(scheduled) = disposition else {
+            panic!("retry should be scheduled");
+        };
         assert!(state.retry_attempts.contains_key("issue-1"));
 
         let entry = state.retry_attempts.get("issue-1").unwrap();
+        assert_eq!(scheduled.due_at_ms, entry.due_at_ms);
         assert_eq!(entry.attempt, 2);
         assert_eq!(entry.error.as_deref(), Some("agent crashed"));
         assert_eq!(entry.retry_from_step, None);
         assert!(!entry.with_fixup);
+        assert!(entry.due_at_ms >= before + 10_000);
+        assert!(entry.due_at_ms <= current_time_ms() + 10_000);
     }
 
     #[test]
     fn test_schedule_failure_retry_respects_max_cycles() {
         let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
 
-        // attempt 3, max_cycles 3 → should NOT schedule
-        let due = schedule_failure_retry(
+        // attempt 4, max_cycles 3 → should NOT schedule
+        let disposition = schedule_failure_retry(
             &mut state,
             FailureRetryRequest {
                 issue_id: "issue-1",
                 identifier: "repo#1",
+                attempt: 4,
+                max_backoff_ms: 300_000,
+                max_cycles: 3,
+                error: "agent crashed",
+                retry_from_step: None,
+                with_fixup: false,
+            },
+        );
+        let FailureRetryDisposition::Exhausted = disposition else {
+            panic!("retry should be exhausted");
+        };
+        assert!(!state.retry_attempts.contains_key("issue-1"));
+
+        // attempt 3, max_cycles 3 → should schedule
+        let disposition = schedule_failure_retry(
+            &mut state,
+            FailureRetryRequest {
+                issue_id: "issue-2",
+                identifier: "repo#2",
                 attempt: 3,
                 max_backoff_ms: 300_000,
                 max_cycles: 3,
@@ -303,30 +785,95 @@ mod tests {
                 with_fixup: false,
             },
         );
-        assert!(due.is_none());
-        assert!(!state.retry_attempts.contains_key("issue-1"));
-
-        // attempt 2, max_cycles 3 → should schedule
-        let due = schedule_failure_retry(
-            &mut state,
-            FailureRetryRequest {
-                issue_id: "issue-2",
-                identifier: "repo#2",
-                attempt: 2,
-                max_backoff_ms: 300_000,
-                max_cycles: 3,
-                error: "agent crashed",
-                retry_from_step: None,
-                with_fixup: false,
-            },
-        );
-        assert!(due.is_some());
+        assert!(matches!(disposition, FailureRetryDisposition::Scheduled(_)));
         assert!(state.retry_attempts.contains_key("issue-2"));
     }
 
     #[test]
+    fn manual_failure_retry_preserves_legacy_boundary_and_backoff() {
+        let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
+        let before = current_time_ms();
+
+        let disposition = schedule_manual_failure_retry(
+            &mut state,
+            FailureRetryRequest {
+                issue_id: "issue-1",
+                identifier: "repo#1",
+                attempt: 2,
+                max_backoff_ms: 300_000,
+                max_cycles: 3,
+                error: "manual step-level retry",
+                retry_from_step: Some("review".to_string()),
+                with_fixup: false,
+            },
+        );
+
+        let FailureRetryDisposition::Scheduled(entry) = disposition else {
+            panic!("manual retry below max_cycles should be scheduled");
+        };
+        assert_eq!(entry.attempt, 2);
+        assert!(entry.due_at_ms >= before + 20_000);
+        assert!(entry.due_at_ms <= current_time_ms() + 20_000);
+
+        let disposition = schedule_manual_failure_retry(
+            &mut state,
+            FailureRetryRequest {
+                issue_id: "issue-2",
+                identifier: "repo#2",
+                attempt: 3,
+                max_backoff_ms: 300_000,
+                max_cycles: 3,
+                error: "manual step-level retry",
+                retry_from_step: Some("review".to_string()),
+                with_fixup: false,
+            },
+        );
+        assert_eq!(disposition, FailureRetryDisposition::Exhausted);
+        assert!(!state.retry_attempts.contains_key("issue-2"));
+    }
+
+    #[test]
+    fn retry_deferral_preserves_the_pipeline_cycle_and_payload() {
+        let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
+        let entry = RetryEntry {
+            issue_id: "issue-1".to_string(),
+            identifier: "repo#1".to_string(),
+            attempt: 3,
+            due_at_ms: 0,
+            error: Some("agent crashed".to_string()),
+            retry_from_step: Some("review".to_string()),
+            with_fixup: true,
+        };
+
+        let deferred = defer_retry(
+            &mut state,
+            &entry,
+            300_000,
+            "no available orchestrator slots",
+        );
+
+        assert_eq!(deferred.issue_id, entry.issue_id);
+        assert_eq!(deferred.identifier, entry.identifier);
+        assert_eq!(deferred.attempt, entry.attempt);
+        assert_eq!(
+            deferred.error.as_deref(),
+            Some("no available orchestrator slots")
+        );
+        assert_eq!(deferred.retry_from_step, entry.retry_from_step);
+        assert_eq!(deferred.with_fixup, entry.with_fixup);
+        assert!(deferred.due_at_ms > entry.due_at_ms);
+        assert_eq!(
+            state
+                .retry_attempts
+                .get(&entry.issue_id)
+                .map(|scheduled| scheduled.due_at_ms),
+            Some(deferred.due_at_ms)
+        );
+    }
+
+    #[test]
     fn test_next_attempt() {
-        assert_eq!(next_attempt(None), 1);
+        assert_eq!(next_attempt(None), 2);
         assert_eq!(next_attempt(Some(1)), 2);
         assert_eq!(next_attempt(Some(5)), 6);
     }

--- a/crates/ensemble-core/src/tracker/model.rs
+++ b/crates/ensemble-core/src/tracker/model.rs
@@ -68,7 +68,7 @@ pub struct RunningEntry {
     pub started_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RetryEntry {
     pub issue_id: String,
     pub identifier: String,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -211,7 +211,7 @@ Parsed `config.yaml` payload:
 - `concurrency` (ConcurrencyConfig)
   - `max_concurrent_agents` (global cap) and `max_step_parallelism` (per-issue cap).
 - `max_cycles` (integer, default 3)
-  - Maximum times an issue can re-enter the pipeline.
+  - Maximum pipeline cycle number an issue can enter. Scheduler deferrals do not consume cycles.
 
 #### 4.1.3 Agent Config
 
@@ -304,6 +304,16 @@ Pipeline run recovery:
 - Dispatch-time restore never creates new candidates; it only applies to issues already returned by
   the tracker as dispatch-eligible candidates.
 - Restored retry and waiting records stay parked until their normal resume or retry path.
+- A retry entry's `attempt` is the next pipeline cycle to dispatch. Tracker polling failures,
+  capacity pressure, and shutdown quiescence defer the exact same retry entry while preserving its
+  claim, attempt, step/fixup scope, and failure context.
+- Automated failures that exhaust `max_cycles` transfer ownership to the same durable pending
+  terminal transition used by normal terminal outcomes; they are never represented by an absent
+  retry alone.
+- Reconciliation keeps the exact cancelled worker drain-owned until it has fully drained and the
+  post-drain retry disposition is committed. A scheduled disposition transfers ownership to its
+  retry entry; an exhausted disposition persists the pending terminal transition before clearing
+  the superseded running worker and drain handle.
 - Once pipeline execution and required finalization produce a terminal outcome, Ensemble appends a
   pending terminal transition containing the configured target tracker state, outcome, retry
   metadata, completion history, and pipeline snapshot before finalization returns control to the
@@ -395,7 +405,7 @@ Fields:
 
 - `issue_id`
 - `identifier` (best-effort human ID for status surfaces/logs)
-- `attempt` (integer, 1-based for retry queue)
+- `attempt` (integer, 1-based next pipeline cycle to dispatch)
 - `due_at_ms` (monotonic clock timestamp)
 - `timer_handle` (runtime-specific timer reference)
 - `error` (string or null)

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -167,6 +167,14 @@ max_cycles: 3  # default
 - After cycle 3: Issue moves to `on_failure` state
 
 Retries use exponential backoff: 10s, 20s, 40s, ... capped at `agent.max_retry_backoff_ms` (default 5 minutes).
+The queued retry's `attempt` is the next pipeline cycle to dispatch. Scheduler work such as fetching
+tracker candidates, waiting for agent capacity, or entering shutdown quiescence can defer that same
+queued entry, but does not consume another pipeline cycle or release its claim.
+
+When an automated failure reaches `max_cycles`, Ensemble durably records the configured
+`on_failure` transition before attempting the tracker write. The issue remains claimed with its
+pipeline snapshot and completion history until terminal reconciliation succeeds. A restart restores
+that pending transition instead of rerunning the pipeline or silently dropping the exhausted retry.
 
 The workspace persists across retries, so agents can see previous work and build on it. The `attempt` variable is available in prompt templates for retry-aware prompts.
 


### PR DESCRIPTION
Closes #317

## Summary
- preserve retry and claim ownership through deferral, exhaustion, and automated discard paths
- serialize manual retry ownership through an orchestrator-owned per-issue command transaction
- harden retry journal append, tail repair, and restart recovery against partial or ambiguous writes

## Validation
- focused retry, journal, controls, and bootstrap suites
- cargo test --workspace --exclude ensemble-desktop
- product E2E with web-ui
- web-ui feature check
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check
- review-and-simplify, ponytail, standards, and plan/SPEC reviews clean