### PR TITLE
Make issue workspace keys collision-resistant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,6 +1309,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "shell-words",
  "shellexpand",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tokio-util = "0.7.19"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serde_yaml = "0.9.34"
+sha2 = "0.10.9"
 liquid = "0.26.11"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["json", "env-filter"] }

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -11,6 +11,7 @@ tokio-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+sha2 = { workspace = true }
 liquid = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -10,7 +10,7 @@ use crate::observability::snapshot::{
     RepoFinalizeSnapshot, RetryRow, RunningDetail, RuntimeSnapshot, StepDetailSnapshot,
     WorkflowStepInfo, WorkspaceInfo,
 };
-use crate::tracker::model::sanitize_workspace_key;
+use crate::workspace::key::issue_workspace_key;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -182,7 +182,6 @@ async fn build_issue_snapshot_from_history(
     Ok(issue_snapshot_from_history_record(
         &record,
         workspace_root,
-        identifier,
         step_kinds,
     ))
 }
@@ -207,7 +206,6 @@ async fn latest_history_record(
 fn issue_snapshot_from_history_record(
     record: &HistoryRecord,
     workspace_root: &str,
-    identifier: &str,
     step_kinds: HashMap<String, StepKind>,
 ) -> Option<IssueDetailSnapshot> {
     let status = match record.outcome.as_str() {
@@ -218,8 +216,7 @@ fn issue_snapshot_from_history_record(
     };
 
     let workspace_path = if record.workspace_path.is_empty() {
-        let key = sanitize_workspace_key(identifier);
-        let key = key?;
+        let key = issue_workspace_key(&record.issue_id, &record.issue_identifier);
         format!("{}/{}", workspace_root, key)
     } else {
         record.workspace_path.clone()
@@ -803,7 +800,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_issue_detail_history_fallback_rejects_unsafe_workspace_key() {
+    async fn workspace_identity_path_history_fallback_uses_record_identity() {
         let mut app_state = build_empty_state();
         let tmp = NamedTempFile::new().unwrap();
         let history_path = tmp.path().to_path_buf();
@@ -838,7 +835,13 @@ mod tests {
             .await
             .into_response();
 
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let path = json["workspace"]["path"].as_str().unwrap();
+        assert!(path.ends_with(&issue_workspace_key("dot", ".")));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -216,7 +216,7 @@ fn issue_snapshot_from_history_record(
     };
 
     let workspace_path = if record.workspace_path.is_empty() {
-        let key = issue_workspace_key(&record.issue_id, &record.issue_identifier);
+        let key = issue_workspace_key(&record.issue_id);
         format!("{}/{}", workspace_root, key)
     } else {
         record.workspace_path.clone()
@@ -841,7 +841,7 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let path = json["workspace"]["path"].as_str().unwrap();
-        assert!(path.ends_with(&issue_workspace_key("dot", ".")));
+        assert!(path.ends_with(&issue_workspace_key("dot")));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -56,6 +56,18 @@ pub enum ConfigError {
 pub enum WorkspaceError {
     #[error("workspace creation failed: {reason}")]
     CreationFailed { reason: String },
+    #[error("workspace metadata is unavailable at {path}: {reason}")]
+    MetadataUnavailable { path: String, reason: String },
+    #[error(
+        "workspace ownership mismatch at {path}: expected {expected_issue_id} ({expected_identifier}), found {actual_issue_id} ({actual_identifier})"
+    )]
+    OwnershipMismatch {
+        path: String,
+        expected_issue_id: String,
+        expected_identifier: String,
+        actual_issue_id: String,
+        actual_identifier: String,
+    },
     #[error("hook failed: {hook} — {reason}")]
     HookFailed { hook: String, reason: String },
     #[error("hook timed out: {hook} after {timeout_ms}ms")]

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -59,14 +59,12 @@ pub enum WorkspaceError {
     #[error("workspace metadata is unavailable at {path}: {reason}")]
     MetadataUnavailable { path: String, reason: String },
     #[error(
-        "workspace ownership mismatch at {path}: expected {expected_issue_id} ({expected_identifier}), found {actual_issue_id} ({actual_identifier})"
+        "workspace ownership mismatch at {path}: expected issue ID {expected_issue_id}, found {actual_issue_id}"
     )]
     OwnershipMismatch {
         path: String,
         expected_issue_id: String,
-        expected_identifier: String,
         actual_issue_id: String,
-        actual_identifier: String,
     },
     #[error("hook failed: {hook} — {reason}")]
     HookFailed { hook: String, reason: String },

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -531,7 +531,7 @@ pub async fn build_issue_snapshot(
         (entry.issue_id.clone(), entry.identifier.clone())
     };
 
-    let workspace_key = issue_workspace_key(&issue_id, &issue_identifier);
+    let workspace_key = issue_workspace_key(&issue_id);
     let workspace_path = format!("{}/{}", workspace_root, workspace_key);
 
     let status = if running_entry.is_some() {
@@ -1177,7 +1177,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn workspace_identity_path_running_snapshot_uses_identity_pair() {
+    async fn workspace_identity_path_running_snapshot_uses_immutable_issue_id() {
         let state = build_test_state();
         let detail = build_issue_snapshot(&state, "my-repo#42", "/tmp/workspaces", None).await;
 
@@ -1188,10 +1188,7 @@ mod tests {
         assert_eq!(detail.status, "running");
         assert_eq!(
             detail.workspace.path,
-            format!(
-                "/tmp/workspaces/{}",
-                issue_workspace_key("NODE_123", "my-repo#42")
-            )
+            format!("/tmp/workspaces/{}", issue_workspace_key("NODE_123"))
         );
         assert!(detail.running.is_some());
         assert!(detail.retry.is_none());
@@ -1202,7 +1199,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn workspace_identity_path_retry_snapshot_uses_identity_pair() {
+    async fn workspace_identity_path_retry_snapshot_uses_immutable_issue_id() {
         let state = build_test_state();
         let detail = build_issue_snapshot(&state, "my-repo#99", "/tmp/workspaces", None).await;
 
@@ -1213,10 +1210,7 @@ mod tests {
         assert_eq!(detail.status, "retrying");
         assert_eq!(
             detail.workspace.path,
-            format!(
-                "/tmp/workspaces/{}",
-                issue_workspace_key("NODE_456", "my-repo#99")
-            )
+            format!("/tmp/workspaces/{}", issue_workspace_key("NODE_456"))
         );
         assert!(detail.running.is_none());
         assert!(detail.retry.is_some());
@@ -1234,7 +1228,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn workspace_identity_path_waiting_snapshot_uses_identity_pair() {
+    async fn workspace_identity_path_waiting_snapshot_uses_immutable_issue_id() {
         let state = build_test_state();
         let detail = build_issue_snapshot(&state, "my-repo#77", "/tmp/workspaces", None)
             .await
@@ -1243,10 +1237,7 @@ mod tests {
         assert_eq!(detail.status, "waiting_on_human");
         assert_eq!(
             detail.workspace.path,
-            format!(
-                "/tmp/workspaces/{}",
-                issue_workspace_key("NODE_789", "my-repo#77")
-            )
+            format!("/tmp/workspaces/{}", issue_workspace_key("NODE_789"))
         );
         let interaction = detail.current_interaction.unwrap();
         assert_eq!(interaction.interaction_request_id, "interaction-1");
@@ -1254,7 +1245,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn workspace_identity_path_finalizing_snapshot_uses_identity_pair() {
+    async fn workspace_identity_path_finalizing_snapshot_uses_immutable_issue_id() {
         let mut state = build_test_state();
         state.set_finalize_state(
             "NODE_FINAL",
@@ -1271,10 +1262,7 @@ mod tests {
 
         assert_eq!(
             detail.workspace.path,
-            format!(
-                "/tmp/workspaces/{}",
-                issue_workspace_key("NODE_FINAL", "my-repo#final")
-            )
+            format!("/tmp/workspaces/{}", issue_workspace_key("NODE_FINAL"))
         );
     }
 
@@ -1409,10 +1397,7 @@ mod tests {
         assert_eq!(detail.workflow_steps[1].state, "running");
         assert_eq!(
             detail.workspace.path,
-            format!(
-                "/tmp/workspaces/{}",
-                issue_workspace_key("NODE_123", "my-repo#42")
-            )
+            format!("/tmp/workspaces/{}", issue_workspace_key("NODE_123"))
         );
     }
 

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -3,6 +3,7 @@ use crate::interaction::store::InteractionStore;
 use crate::orchestrator::state::{FinalizeStatus, OrchestratorState, RateLimitSnapshot};
 use crate::pipeline::engine::{PipelineRun, StepState};
 use crate::tracker::model::{RetryEntry, RunningEntry};
+use crate::workspace::key::issue_workspace_key;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use std::collections::HashMap;
@@ -530,7 +531,7 @@ pub async fn build_issue_snapshot(
         (entry.issue_id.clone(), entry.identifier.clone())
     };
 
-    let workspace_key = crate::tracker::model::sanitize_workspace_key(identifier)?;
+    let workspace_key = issue_workspace_key(&issue_id, &issue_identifier);
     let workspace_path = format!("{}/{}", workspace_root, workspace_key);
 
     let status = if running_entry.is_some() {
@@ -1176,7 +1177,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_build_issue_snapshot_found_running() {
+    async fn workspace_identity_path_running_snapshot_uses_identity_pair() {
         let state = build_test_state();
         let detail = build_issue_snapshot(&state, "my-repo#42", "/tmp/workspaces", None).await;
 
@@ -1185,7 +1186,13 @@ mod tests {
         assert_eq!(detail.issue_identifier, "my-repo#42");
         assert_eq!(detail.issue_id, "NODE_123");
         assert_eq!(detail.status, "running");
-        assert_eq!(detail.workspace.path, "/tmp/workspaces/my-repo_42");
+        assert_eq!(
+            detail.workspace.path,
+            format!(
+                "/tmp/workspaces/{}",
+                issue_workspace_key("NODE_123", "my-repo#42")
+            )
+        );
         assert!(detail.running.is_some());
         assert!(detail.retry.is_none());
 
@@ -1195,7 +1202,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_build_issue_snapshot_found_retrying() {
+    async fn workspace_identity_path_retry_snapshot_uses_identity_pair() {
         let state = build_test_state();
         let detail = build_issue_snapshot(&state, "my-repo#99", "/tmp/workspaces", None).await;
 
@@ -1204,6 +1211,13 @@ mod tests {
         assert_eq!(detail.issue_identifier, "my-repo#99");
         assert_eq!(detail.issue_id, "NODE_456");
         assert_eq!(detail.status, "retrying");
+        assert_eq!(
+            detail.workspace.path,
+            format!(
+                "/tmp/workspaces/{}",
+                issue_workspace_key("NODE_456", "my-repo#99")
+            )
+        );
         assert!(detail.running.is_none());
         assert!(detail.retry.is_some());
         assert_eq!(
@@ -1220,16 +1234,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn issue_detail_snapshot_includes_current_interaction_summary() {
+    async fn workspace_identity_path_waiting_snapshot_uses_identity_pair() {
         let state = build_test_state();
         let detail = build_issue_snapshot(&state, "my-repo#77", "/tmp/workspaces", None)
             .await
             .unwrap();
 
         assert_eq!(detail.status, "waiting_on_human");
+        assert_eq!(
+            detail.workspace.path,
+            format!(
+                "/tmp/workspaces/{}",
+                issue_workspace_key("NODE_789", "my-repo#77")
+            )
+        );
         let interaction = detail.current_interaction.unwrap();
         assert_eq!(interaction.interaction_request_id, "interaction-1");
         assert_eq!(interaction.step_name, "review");
+    }
+
+    #[tokio::test]
+    async fn workspace_identity_path_finalizing_snapshot_uses_identity_pair() {
+        let mut state = build_test_state();
+        state.set_finalize_state(
+            "NODE_FINAL",
+            crate::orchestrator::state::IssueFinalizeState {
+                issue_identifier: "my-repo#final".to_string(),
+                status: FinalizeStatus::InProgress,
+                repos: Vec::new(),
+            },
+        );
+
+        let detail = build_issue_snapshot(&state, "my-repo#final", "/tmp/workspaces", None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            detail.workspace.path,
+            format!(
+                "/tmp/workspaces/{}",
+                issue_workspace_key("NODE_FINAL", "my-repo#final")
+            )
+        );
     }
 
     #[tokio::test]
@@ -1342,7 +1388,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completed_issue_snapshot_retains_issue_and_workflow_details() {
+    async fn workspace_identity_path_completed_snapshot_retains_identity_and_workflow() {
         let mut state = build_test_state();
         attach_pipeline_state(&mut state, "NODE_123");
         state.complete_issue("NODE_123", Some("completed_succeeded".to_string()), None);
@@ -1361,6 +1407,13 @@ mod tests {
         assert_eq!(detail.workflow_steps[0].state, "passed");
         assert_eq!(detail.workflow_steps[1].name, "review");
         assert_eq!(detail.workflow_steps[1].state, "running");
+        assert_eq!(
+            detail.workspace.path,
+            format!(
+                "/tmp/workspaces/{}",
+                issue_workspace_key("NODE_123", "my-repo#42")
+            )
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1891,11 +1891,7 @@ impl Orchestrator {
                 };
                 remove_drained_workers(&self.cancellation_registry, &drained.handles);
                 self.cancel_open_interaction(result.1).await;
-                if let Err(error) = self
-                    .workspace_mgr
-                    .remove_workspace(issue_id, &result.0)
-                    .await
-                {
+                if let Err(error) = self.workspace_mgr.remove_workspace(issue_id).await {
                     warn!(
                         identifier = %result.0,
                         error = %error,
@@ -5555,10 +5551,7 @@ impl Orchestrator {
 
         let workspace_path = self
             .workspace_mgr
-            .workspace_path(
-                &input.running_entry.issue_id,
-                &input.running_entry.identifier,
-            )
+            .workspace_path(&input.running_entry.issue_id)
             .display()
             .to_string();
 
@@ -5599,10 +5592,7 @@ impl Orchestrator {
             .max(0) as u64;
         let workspace_path = self
             .workspace_mgr
-            .workspace_path(
-                &input.waiting_entry.issue_id,
-                &input.waiting_entry.identifier,
-            )
+            .workspace_path(&input.waiting_entry.issue_id)
             .display()
             .to_string();
 
@@ -8071,13 +8061,10 @@ agent:
         assert_eq!(
             orchestrator
                 .workspace_mgr
-                .workspace_path(&restored_retry.issue_id, &restored_retry.identifier),
+                .workspace_path(&restored_retry.issue_id),
             temp.path()
                 .join("workspaces")
-                .join(crate::workspace::key::issue_workspace_key(
-                    &issue.id,
-                    &issue.identifier
-                ))
+                .join(crate::workspace::key::issue_workspace_key(&issue.id))
         );
     }
 
@@ -9889,7 +9876,7 @@ agent:
             state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
         }
 
-        let workspace = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
+        let workspace = orchestrator.workspace_mgr.workspace_path("1");
         tokio::fs::create_dir_all(workspace.join(".ensemble"))
             .await
             .unwrap();
@@ -9963,7 +9950,7 @@ agent:
                 state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
             }
 
-            let workspace = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
+            let workspace = orchestrator.workspace_mgr.workspace_path("1");
             tokio::fs::create_dir_all(workspace.join(".ensemble"))
                 .await
                 .unwrap();
@@ -14061,7 +14048,7 @@ agent:
             .prepare_workspace("1", "repo#1")
             .await
             .unwrap();
-        let workspace_path = workspace_mgr.workspace_path("1", "repo#1");
+        let workspace_path = workspace_mgr.workspace_path("1");
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator = Orchestrator::new(
@@ -14124,7 +14111,7 @@ agent:
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
-        let workspace_path = workspace_mgr.workspace_path("1", "repo#1");
+        let workspace_path = workspace_mgr.workspace_path("1");
         std::fs::create_dir_all(&workspace_path).unwrap();
         std::fs::write(
             workspace_path.join(".ensemble-workspace.json"),
@@ -14315,7 +14302,7 @@ agent:
         );
         let workspace_path = orchestrator
             .workspace_mgr
-            .workspace_path("1", "repo#1")
+            .workspace_path("1")
             .display()
             .to_string();
 
@@ -14720,7 +14707,7 @@ agent:
             .prepare_workspace("1", "repo#1")
             .await
             .unwrap();
-        let workspace_path = workspace_mgr.workspace_path("1", "repo#1");
+        let workspace_path = workspace_mgr.workspace_path("1");
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator = Orchestrator::new(
@@ -16290,7 +16277,7 @@ agent:
     async fn reconciliation_drain_terminal_waits_before_release_and_cleanup() {
         let (orchestrator, dir, issues, cancelled, release) =
             blocking_drain_test_orchestrator().await;
-        let workspace_path = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
+        let workspace_path = orchestrator.workspace_mgr.workspace_path("1");
         assert!(workspace_path.exists());
         issues.write().await[0].state = "Done".to_string();
 
@@ -16337,7 +16324,7 @@ agent:
     async fn reconciliation_drain_inactive_waits_before_release_without_cleanup() {
         let (orchestrator, dir, issues, cancelled, release) =
             blocking_drain_test_orchestrator().await;
-        let workspace_path = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
+        let workspace_path = orchestrator.workspace_mgr.workspace_path("1");
         issues.write().await[0].state = "Backlog".to_string();
 
         let tick = tokio::spawn({
@@ -16467,7 +16454,7 @@ agent:
     async fn reconciliation_drain_stalled_timeout_retains_owner_then_retries_once() {
         let (orchestrator, _dir, _issues, cancelled, release) =
             blocking_drain_test_orchestrator().await;
-        let workspace_path = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
+        let workspace_path = orchestrator.workspace_mgr.workspace_path("1");
         orchestrator.config.write().await.agent.stall_timeout_ms = 1;
         let identity = {
             let mut state = orchestrator.state.write().await;

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -304,7 +304,6 @@ pub struct OrchestratorRuntimeParts {
 }
 
 struct RunningHistoryRecordInput<'a> {
-    issue_id: &'a str,
     outcome: &'a str,
     last_error: Option<String>,
     running_entry: &'a crate::tracker::model::RunningEntry,
@@ -314,7 +313,6 @@ struct RunningHistoryRecordInput<'a> {
 }
 
 struct WaitingHistoryRecordInput<'a> {
-    issue_id: &'a str,
     outcome: &'a str,
     last_error: Option<String>,
     waiting_entry: &'a WaitingOnHumanEntry,
@@ -1072,7 +1070,6 @@ impl Orchestrator {
                                 .zip(state.get_pipeline_run(&issue.id))
                                 .map(|(entry, run)| {
                                     self.build_history_record(RunningHistoryRecordInput {
-                                        issue_id: &issue.id,
                                         outcome: HISTORY_OUTCOME_SUCCEEDED,
                                         last_error: None,
                                         running_entry: entry,
@@ -1324,7 +1321,7 @@ impl Orchestrator {
     ) -> Result<std::path::PathBuf, EnsembleError> {
         let workspace = self
             .workspace_mgr
-            .prepare_workspace(&issue.identifier)
+            .prepare_workspace(&issue.id, &issue.identifier)
             .await?;
 
         if workspace.created_now {
@@ -1864,7 +1861,6 @@ impl Orchestrator {
                     let history_record = running_entry.as_ref().and_then(|entry| {
                         state.get_pipeline_run(issue_id).map(|run| {
                             self.build_history_record(RunningHistoryRecordInput {
-                                issue_id,
                                 outcome: HISTORY_OUTCOME_STOPPED,
                                 last_error: None,
                                 running_entry: entry,
@@ -1895,7 +1891,11 @@ impl Orchestrator {
                 };
                 remove_drained_workers(&self.cancellation_registry, &drained.handles);
                 self.cancel_open_interaction(result.1).await;
-                if let Err(error) = self.workspace_mgr.remove_workspace(&result.0).await {
+                if let Err(error) = self
+                    .workspace_mgr
+                    .remove_workspace(issue_id, &result.0)
+                    .await
+                {
                     warn!(
                         identifier = %result.0,
                         error = %error,
@@ -1924,7 +1924,6 @@ impl Orchestrator {
                     let history_record = running_entry.as_ref().and_then(|entry| {
                         state.get_pipeline_run(issue_id).map(|run| {
                             self.build_history_record(RunningHistoryRecordInput {
-                                issue_id,
                                 outcome: HISTORY_OUTCOME_STOPPED,
                                 last_error: None,
                                 running_entry: entry,
@@ -2379,7 +2378,6 @@ impl Orchestrator {
                                     .zip(state.get_pipeline_run(issue_id))
                                     .map(|(entry, run)| {
                                         self.build_history_record(RunningHistoryRecordInput {
-                                            issue_id,
                                             outcome: HISTORY_OUTCOME_SUCCEEDED,
                                             last_error: None,
                                             running_entry: entry,
@@ -2493,7 +2491,6 @@ impl Orchestrator {
                                                         );
                                                     self.build_history_record(
                                                         RunningHistoryRecordInput {
-                                                            issue_id,
                                                             outcome: HISTORY_OUTCOME_FAILED,
                                                             last_error: Some(reason.clone()),
                                                             running_entry: &entry,
@@ -2576,7 +2573,6 @@ impl Orchestrator {
                                                         );
                                                     self.build_history_record(
                                                         RunningHistoryRecordInput {
-                                                            issue_id,
                                                             outcome: HISTORY_OUTCOME_FAILED,
                                                             last_error: Some(reason.clone()),
                                                             running_entry: &entry,
@@ -2683,7 +2679,6 @@ impl Orchestrator {
                                                         );
                                                     self.build_history_record(
                                                         RunningHistoryRecordInput {
-                                                            issue_id,
                                                             outcome: HISTORY_OUTCOME_FAILED,
                                                             last_error: Some(reason.clone()),
                                                             running_entry: &entry,
@@ -2893,7 +2888,6 @@ impl Orchestrator {
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             self.build_history_record(RunningHistoryRecordInput {
-                                issue_id,
                                 outcome: HISTORY_OUTCOME_FAILED,
                                 last_error: Some(error.clone()),
                                 running_entry: &entry,
@@ -2992,7 +2986,6 @@ impl Orchestrator {
                 state.running.insert(issue_id.clone(), entry.clone());
                 let history_record = state.get_pipeline_run(&issue_id).map(|run| {
                     self.build_history_record(RunningHistoryRecordInput {
-                        issue_id: &issue_id,
                         outcome: HISTORY_OUTCOME_FAILED,
                         last_error: Some(error.to_string()),
                         running_entry: &entry,
@@ -3122,7 +3115,6 @@ impl Orchestrator {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             rejection_comment = Self::rejection_comment_for_step(run, step);
                             self.build_history_record(RunningHistoryRecordInput {
-                                issue_id,
                                 outcome: HISTORY_OUTCOME_FAILED,
                                 last_error: Some(reason.clone()),
                                 running_entry: &entry,
@@ -3194,7 +3186,6 @@ impl Orchestrator {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             rejection_comment = Self::rejection_comment_for_step(run, step);
                             self.build_history_record(RunningHistoryRecordInput {
-                                issue_id,
                                 outcome: HISTORY_OUTCOME_FAILED,
                                 last_error: Some(reason.clone()),
                                 running_entry: &entry,
@@ -3290,7 +3281,6 @@ impl Orchestrator {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             rejection_comment = Self::rejection_comment_for_step(run, step);
                             self.build_history_record(RunningHistoryRecordInput {
-                                issue_id,
                                 outcome: HISTORY_OUTCOME_FAILED,
                                 last_error: Some(reason.clone()),
                                 running_entry: &entry,
@@ -4919,7 +4909,6 @@ impl Orchestrator {
                     .get(issue_id)
                     .map(|entry| {
                         self.build_history_record(RunningHistoryRecordInput {
-                            issue_id,
                             outcome: match outcome {
                                 TerminalOutcome::Succeeded => HISTORY_OUTCOME_SUCCEEDED,
                                 TerminalOutcome::Failed => HISTORY_OUTCOME_FAILED,
@@ -4934,7 +4923,6 @@ impl Orchestrator {
                     .or_else(|| {
                         state.waiting_on_human.get(issue_id).map(|entry| {
                             self.build_history_record_from_waiting(WaitingHistoryRecordInput {
-                                issue_id,
                                 outcome: match outcome {
                                     TerminalOutcome::Succeeded => HISTORY_OUTCOME_SUCCEEDED,
                                     TerminalOutcome::Failed => HISTORY_OUTCOME_FAILED,
@@ -4979,7 +4967,11 @@ impl Orchestrator {
             .any(|repo| repo.finalize.enabled && !matches!(repo.finalize.mode, FinalizeMode::None));
 
         let prepared_workspace = if requires_workspace {
-            match self.workspace_mgr.prepare_workspace(issue_identifier).await {
+            match self
+                .workspace_mgr
+                .prepare_workspace(issue_id, issue_identifier)
+                .await
+            {
                 Ok(workspace) => Some(workspace),
                 Err(error) => {
                     return IssueFinalizeState {
@@ -5168,7 +5160,11 @@ impl Orchestrator {
             return;
         }
 
-        let workspace = match self.workspace_mgr.prepare_workspace(issue_identifier).await {
+        let workspace = match self
+            .workspace_mgr
+            .prepare_workspace(issue_id, issue_identifier)
+            .await
+        {
             Ok(workspace) => workspace,
             Err(error) => {
                 {
@@ -5559,13 +5555,16 @@ impl Orchestrator {
 
         let workspace_path = self
             .workspace_mgr
-            .workspace_path(&input.running_entry.identifier)
-            .map(|path| path.display().to_string())
-            .unwrap_or_default();
+            .workspace_path(
+                &input.running_entry.issue_id,
+                &input.running_entry.identifier,
+            )
+            .display()
+            .to_string();
 
         HistoryRecord {
             issue_identifier: input.running_entry.identifier.clone(),
-            issue_id: input.issue_id.to_string(),
+            issue_id: input.running_entry.issue_id.clone(),
             outcome: input.outcome.to_string(),
             steps_traversed,
             attempts: input.running_entry.retry_attempt.unwrap_or(1),
@@ -5600,13 +5599,16 @@ impl Orchestrator {
             .max(0) as u64;
         let workspace_path = self
             .workspace_mgr
-            .workspace_path(&input.waiting_entry.identifier)
-            .map(|path| path.display().to_string())
-            .unwrap_or_default();
+            .workspace_path(
+                &input.waiting_entry.issue_id,
+                &input.waiting_entry.identifier,
+            )
+            .display()
+            .to_string();
 
         HistoryRecord {
             issue_identifier: input.waiting_entry.identifier.clone(),
-            issue_id: input.issue_id.to_string(),
+            issue_id: input.waiting_entry.issue_id.clone(),
             outcome: input.outcome.to_string(),
             steps_traversed,
             attempts: input.waiting_entry.retry_attempt.unwrap_or(1),
@@ -6154,7 +6156,6 @@ impl Orchestrator {
                                     state.get_pipeline_run(&issue.id).map(|run| {
                                         self.build_history_record_from_waiting(
                                             WaitingHistoryRecordInput {
-                                                issue_id: &issue.id,
                                                 outcome: HISTORY_OUTCOME_SUCCEEDED,
                                                 last_error: None,
                                                 waiting_entry: entry,
@@ -6213,7 +6214,6 @@ impl Orchestrator {
                                 state.get_pipeline_run(&issue.id).map(|run| {
                                     self.build_history_record_from_waiting(
                                         WaitingHistoryRecordInput {
-                                            issue_id: &issue.id,
                                             outcome: HISTORY_OUTCOME_FAILED,
                                             last_error: Some(reason.clone()),
                                             waiting_entry: entry,
@@ -7989,7 +7989,7 @@ agent:
     }
 
     #[tokio::test]
-    async fn restore_pipeline_runs_from_journal_restores_step_retry_entry() {
+    async fn workspace_identity_lifecycle_retry_journal_restoration_uses_same_path() {
         let temp = tempfile::tempdir().unwrap();
         let cfg = make_retry_step_config();
         let issue = test_issue("1", "Todo");
@@ -8066,6 +8066,18 @@ agent:
                 .get(&issue.id)
                 .and_then(|entry| entry.retry_from_step.as_deref()),
             Some("build")
+        );
+        let restored_retry = lock.retry_attempts.get(&issue.id).unwrap();
+        assert_eq!(
+            orchestrator
+                .workspace_mgr
+                .workspace_path(&restored_retry.issue_id, &restored_retry.identifier),
+            temp.path()
+                .join("workspaces")
+                .join(crate::workspace::key::issue_workspace_key(
+                    &issue.id,
+                    &issue.identifier
+                ))
         );
     }
 
@@ -9877,10 +9889,7 @@ agent:
             state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
         }
 
-        let workspace = orchestrator
-            .workspace_mgr
-            .workspace_path("repo#1")
-            .expect("workspace path");
+        let workspace = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
         tokio::fs::create_dir_all(workspace.join(".ensemble"))
             .await
             .unwrap();
@@ -9954,10 +9963,7 @@ agent:
                 state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
             }
 
-            let workspace = orchestrator
-                .workspace_mgr
-                .workspace_path("repo#1")
-                .expect("workspace path");
+            let workspace = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
             tokio::fs::create_dir_all(workspace.join(".ensemble"))
                 .await
                 .unwrap();
@@ -14051,7 +14057,11 @@ agent:
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
-        workspace_mgr.prepare_workspace("repo#1").await.unwrap();
+        workspace_mgr
+            .prepare_workspace("1", "repo#1")
+            .await
+            .unwrap();
+        let workspace_path = workspace_mgr.workspace_path("1", "repo#1");
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator = Orchestrator::new(
@@ -14098,7 +14108,76 @@ agent:
         assert!(!state.is_claimed("1"));
         assert!(!state.is_waiting_on_human("1"));
         assert!(state.get_pipeline_run("1").is_none());
-        assert!(!dir.path().join("repo_1").exists());
+        assert!(!workspace_path.exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_identity_lifecycle_active_cleanup_refuses_mismatched_owner() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let issues = Arc::new(RwLock::new(vec![test_issue("1", "Done")]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let workspace_path = workspace_mgr.workspace_path("1", "repo#1");
+        std::fs::create_dir_all(&workspace_path).unwrap();
+        std::fs::write(
+            workspace_path.join(".ensemble-workspace.json"),
+            r#"{"issue_id":"other","issue_identifier":"other#7","branch_date":"2024-01-01"}"#,
+        )
+        .unwrap();
+        let sentinel = workspace_path.join("sentinel");
+        std::fs::write(&sentinel, "untouched").unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut pipeline_run = PipelineRun::new("1".to_string(), 1, dag);
+            pipeline_run.start();
+            pipeline_run.step_blocked_on_human("build", "interaction-1".to_string());
+            let mut state = orchestrator.state.write().await;
+            state.insert_pipeline_run("1", pipeline_run, Arc::new(cfg.clone()));
+            state.add_claimed("1");
+            state.add_waiting_on_human(crate::orchestrator::state::WaitingOnHumanEntry {
+                issue_id: "1".to_string(),
+                identifier: "repo#1".to_string(),
+                interaction_request_id: "interaction-1".to_string(),
+                step_name: "build".to_string(),
+                kind: crate::interaction::model::InteractionKind::BrainstormPrompt,
+                prompt: "Need input".to_string(),
+                agent_name: "builder".to_string(),
+                retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: Utc::now(),
+                run_id: None,
+                issue: None,
+            });
+        }
+
+        orchestrator.handle_tick().await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.is_claimed("1"));
+        assert!(!state.is_waiting_on_human("1"));
+        assert!(state.get_pipeline_run("1").is_none());
+        assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
     }
 
     #[tokio::test]
@@ -14197,7 +14276,6 @@ agent:
         drop(state);
 
         let record = orchestrator.build_history_record(RunningHistoryRecordInput {
-            issue_id: "1",
             outcome: "succeeded",
             last_error: None,
             running_entry: &entry,
@@ -14213,7 +14291,7 @@ agent:
     }
 
     #[tokio::test]
-    async fn build_history_record_preserves_run_artifacts() {
+    async fn workspace_identity_path_history_and_artifacts_use_canonical_owner() {
         let config = Arc::new(RwLock::new(make_config()));
         let issues = Arc::new(RwLock::new(vec![]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
@@ -14235,6 +14313,11 @@ agent:
             dir.path(),
             shutdown_rx,
         );
+        let workspace_path = orchestrator
+            .workspace_mgr
+            .workspace_path("1", "repo#1")
+            .display()
+            .to_string();
 
         let cfg = config.read().await;
         let dag = build_dag(&cfg.steps).unwrap();
@@ -14245,7 +14328,7 @@ agent:
         );
         let artifacts = RunArtifacts {
             run_id: "run-1".to_string(),
-            workspace_path: dir.path().display().to_string(),
+            workspace_path: workspace_path.clone(),
             repos: Vec::new(),
             transcripts: vec![crate::history::artifacts::StepTranscriptArtifact {
                 step_name: "build".to_string(),
@@ -14259,7 +14342,6 @@ agent:
         drop(state);
 
         let record = orchestrator.build_history_record(RunningHistoryRecordInput {
-            issue_id: "1",
             outcome: "succeeded",
             last_error: None,
             running_entry: &entry,
@@ -14268,6 +14350,7 @@ agent:
             artifacts: Some(artifacts.clone()),
         });
 
+        assert_eq!(record.workspace_path, workspace_path);
         assert_eq!(record.artifacts, Some(artifacts));
     }
 
@@ -14633,7 +14716,11 @@ agent:
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
-        workspace_mgr.prepare_workspace("repo#1").await.unwrap();
+        workspace_mgr
+            .prepare_workspace("1", "repo#1")
+            .await
+            .unwrap();
+        let workspace_path = workspace_mgr.workspace_path("1", "repo#1");
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator = Orchestrator::new(
@@ -14680,7 +14767,7 @@ agent:
         assert!(!state.is_claimed("1"));
         assert!(!state.is_waiting_on_human("1"));
         assert!(state.get_pipeline_run("1").is_none());
-        assert!(dir.path().join("repo_1").exists());
+        assert!(workspace_path.exists());
     }
 
     #[tokio::test]
@@ -16203,7 +16290,7 @@ agent:
     async fn reconciliation_drain_terminal_waits_before_release_and_cleanup() {
         let (orchestrator, dir, issues, cancelled, release) =
             blocking_drain_test_orchestrator().await;
-        let workspace_path = orchestrator.workspace_mgr.workspace_path("repo#1").unwrap();
+        let workspace_path = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
         assert!(workspace_path.exists());
         issues.write().await[0].state = "Done".to_string();
 
@@ -16250,7 +16337,7 @@ agent:
     async fn reconciliation_drain_inactive_waits_before_release_without_cleanup() {
         let (orchestrator, dir, issues, cancelled, release) =
             blocking_drain_test_orchestrator().await;
-        let workspace_path = orchestrator.workspace_mgr.workspace_path("repo#1").unwrap();
+        let workspace_path = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
         issues.write().await[0].state = "Backlog".to_string();
 
         let tick = tokio::spawn({
@@ -16380,7 +16467,7 @@ agent:
     async fn reconciliation_drain_stalled_timeout_retains_owner_then_retries_once() {
         let (orchestrator, _dir, _issues, cancelled, release) =
             blocking_drain_test_orchestrator().await;
-        let workspace_path = orchestrator.workspace_mgr.workspace_path("repo#1").unwrap();
+        let workspace_path = orchestrator.workspace_mgr.workspace_path("1", "repo#1");
         orchestrator.config.write().await.agent.stall_timeout_ms = 1;
         let identity = {
             let mut state = orchestrator.state.write().await;

--- a/crates/ensemble-core/src/orchestrator/reconciler.rs
+++ b/crates/ensemble-core/src/orchestrator/reconciler.rs
@@ -223,10 +223,7 @@ pub async fn startup_terminal_cleanup(
                 .filter(|issue| !excluded_issue_ids.contains(&issue.id))
                 .collect::<Vec<_>>();
             for issue in &cleanup_issues {
-                match workspace_mgr
-                    .remove_workspace(&issue.id, &issue.identifier)
-                    .await
-                {
+                match workspace_mgr.remove_workspace(&issue.id).await {
                     Ok(()) => {
                         debug!(
                             identifier = %issue.identifier,
@@ -522,7 +519,7 @@ mod tests {
             .prepare_workspace("42", "repo#42")
             .await
             .unwrap();
-        let workspace_path = workspace_mgr.workspace_path("42", "repo#42");
+        let workspace_path = workspace_mgr.workspace_path("42");
         assert!(workspace_path.exists());
 
         let tracker = MockTrackerForReconcile {
@@ -563,14 +560,14 @@ mod tests {
         )
         .await;
 
-        assert!(workspace_mgr.workspace_path("42", "repo#42").exists());
+        assert!(workspace_mgr.workspace_path("42").exists());
     }
 
     #[tokio::test]
     async fn workspace_identity_lifecycle_startup_cleanup_refuses_mismatched_owner() {
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
-        let workspace_path = workspace_mgr.workspace_path("42", "repo#42");
+        let workspace_path = workspace_mgr.workspace_path("42");
         std::fs::create_dir_all(&workspace_path).unwrap();
         std::fs::write(
             workspace_path.join(".ensemble-workspace.json"),

--- a/crates/ensemble-core/src/orchestrator/reconciler.rs
+++ b/crates/ensemble-core/src/orchestrator/reconciler.rs
@@ -223,7 +223,10 @@ pub async fn startup_terminal_cleanup(
                 .filter(|issue| !excluded_issue_ids.contains(&issue.id))
                 .collect::<Vec<_>>();
             for issue in &cleanup_issues {
-                match workspace_mgr.remove_workspace(&issue.identifier).await {
+                match workspace_mgr
+                    .remove_workspace(&issue.id, &issue.identifier)
+                    .await
+                {
                     Ok(()) => {
                         debug!(
                             identifier = %issue.identifier,
@@ -515,8 +518,12 @@ mod tests {
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
 
         // Create a workspace
-        workspace_mgr.prepare_workspace("repo#42").await.unwrap();
-        assert!(dir.path().join("repo_42").exists());
+        workspace_mgr
+            .prepare_workspace("42", "repo#42")
+            .await
+            .unwrap();
+        let workspace_path = workspace_mgr.workspace_path("42", "repo#42");
+        assert!(workspace_path.exists());
 
         let tracker = MockTrackerForReconcile {
             issues: vec![test_issue("42", "Done")],
@@ -532,14 +539,17 @@ mod tests {
         .await;
 
         // Workspace should be cleaned up
-        assert!(!dir.path().join("repo_42").exists());
+        assert!(!workspace_path.exists());
     }
 
     #[tokio::test]
     async fn startup_terminal_cleanup_retains_pending_reconciliation_workspace() {
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
-        workspace_mgr.prepare_workspace("repo#42").await.unwrap();
+        workspace_mgr
+            .prepare_workspace("42", "repo#42")
+            .await
+            .unwrap();
 
         let tracker = MockTrackerForReconcile {
             issues: vec![test_issue("42", "Done")],
@@ -553,7 +563,36 @@ mod tests {
         )
         .await;
 
-        assert!(dir.path().join("repo_42").exists());
+        assert!(workspace_mgr.workspace_path("42", "repo#42").exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_identity_lifecycle_startup_cleanup_refuses_mismatched_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let workspace_path = workspace_mgr.workspace_path("42", "repo#42");
+        std::fs::create_dir_all(&workspace_path).unwrap();
+        std::fs::write(
+            workspace_path.join(".ensemble-workspace.json"),
+            r#"{"issue_id":"other","issue_identifier":"other#7","branch_date":"2024-01-01"}"#,
+        )
+        .unwrap();
+        let sentinel = workspace_path.join("sentinel");
+        std::fs::write(&sentinel, "untouched").unwrap();
+
+        let tracker = MockTrackerForReconcile {
+            issues: vec![test_issue("42", "Done")],
+            should_fail: false,
+        };
+        startup_terminal_cleanup(
+            &tracker,
+            &default_terminal(),
+            &workspace_mgr,
+            &HashSet::new(),
+        )
+        .await;
+
+        assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/tracker/model.rs
+++ b/crates/ensemble-core/src/tracker/model.rs
@@ -106,86 +106,9 @@ pub struct TrackerComment {
     pub updated_at: Option<DateTime<Utc>>,
 }
 
-/// Sanitize an issue identifier for use as a workspace directory name.
-/// Only [A-Za-z0-9._-] are allowed; all other characters become '_'.
-/// Returns None if the result would be unsafe (empty, ".", or "..").
-pub fn sanitize_workspace_key(identifier: &str) -> Option<String> {
-    let key: String = identifier
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-
-    if key.is_empty() || key == "." || key == ".." {
-        None
-    } else {
-        Some(key)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_sanitize_simple_identifier() {
-        assert_eq!(
-            sanitize_workspace_key("my-repo_42"),
-            Some("my-repo_42".to_string())
-        );
-    }
-
-    #[test]
-    fn test_sanitize_hash_in_identifier() {
-        assert_eq!(
-            sanitize_workspace_key("my-repo#42"),
-            Some("my-repo_42".to_string())
-        );
-    }
-
-    #[test]
-    fn test_sanitize_slashes_and_spaces() {
-        assert_eq!(
-            sanitize_workspace_key("acme/repo 123"),
-            Some("acme_repo_123".to_string())
-        );
-    }
-
-    #[test]
-    fn test_sanitize_preserves_dots() {
-        assert_eq!(
-            sanitize_workspace_key("v1.2.3-rc1"),
-            Some("v1.2.3-rc1".to_string())
-        );
-    }
-
-    #[test]
-    fn test_sanitize_all_special_chars() {
-        assert_eq!(
-            sanitize_workspace_key("a@b!c$d%e"),
-            Some("a_b_c_d_e".to_string())
-        );
-    }
-
-    #[test]
-    fn test_sanitize_rejects_dot() {
-        assert_eq!(sanitize_workspace_key("."), None);
-    }
-
-    #[test]
-    fn test_sanitize_rejects_dotdot() {
-        assert_eq!(sanitize_workspace_key(".."), None);
-    }
-
-    #[test]
-    fn test_sanitize_rejects_empty() {
-        assert_eq!(sanitize_workspace_key(""), None);
-    }
 
     #[test]
     fn test_issue_serialization_roundtrip() {

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -1,5 +1,6 @@
 use crate::config::ensemble::RepoConfig;
 use crate::error::WorktreeError;
+use crate::workspace::key::issue_workspace_key;
 use crate::workspace::worktree::{
     attach_worktree, branch_exists, create_worktree, delete_branch_if_exists, pull_worktree,
     remove_orphaned_worktree, remove_worktree, sanitize_branch_name, worktree_exists,
@@ -243,7 +244,7 @@ impl WorktreeCoordinator {
     }
 
     fn format_branch_name(&self, issue_id: &str) -> String {
-        let sanitized = sanitize_branch_name(issue_id);
+        let sanitized = sanitize_branch_name(&issue_workspace_key(issue_id));
         format!("ensemble-{}-{}", self.base_date, sanitized)
     }
 
@@ -283,6 +284,9 @@ mod tests {
         );
 
         let branch = coordinator.format_branch_name("my-repo#42");
-        assert_eq!(branch, "ensemble-2026-03-30-my-repo-42");
+        assert_eq!(
+            branch,
+            "ensemble-2026-03-30-my-repo-42-cd63d98cfaa29e655eee811690c95794e4c23c8abc06242fc0b41f72e8687ef5"
+        );
     }
 }

--- a/crates/ensemble-core/src/workspace/key.rs
+++ b/crates/ensemble-core/src/workspace/key.rs
@@ -1,0 +1,82 @@
+use sha2::{Digest, Sha256};
+
+const READABLE_PREFIX_MAX_BYTES: usize = 80;
+
+/// Returns one deterministic, path-safe workspace key for an immutable issue identity.
+///
+/// The readable identifier prefix is only diagnostic. The full SHA-256 suffix,
+/// computed from a length-framed identity pair, is the ownership-bearing part.
+pub fn issue_workspace_key(issue_id: &str, identifier: &str) -> String {
+    let mut prefix: String = identifier
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .take(READABLE_PREFIX_MAX_BYTES)
+        .collect();
+    if prefix.is_empty() || prefix == "." || prefix == ".." {
+        prefix = "issue".to_string();
+    }
+
+    let mut digest = Sha256::new();
+    for component in [issue_id.as_bytes(), identifier.as_bytes()] {
+        digest.update((component.len() as u64).to_be_bytes());
+        digest.update(component);
+    }
+
+    format!("{prefix}--{:x}", digest.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::issue_workspace_key;
+
+    #[test]
+    fn workspace_key_distinguishes_former_punctuation_collisions() {
+        assert_ne!(
+            issue_workspace_key("issue-a", "a#b"),
+            issue_workspace_key("issue-b", "a_b")
+        );
+    }
+
+    #[test]
+    fn workspace_key_is_deterministic_and_uses_immutable_identity() {
+        assert_eq!(
+            issue_workspace_key("NODE_123", "repo#42"),
+            issue_workspace_key("NODE_123", "repo#42")
+        );
+        assert_ne!(
+            issue_workspace_key("NODE_123", "repo#42"),
+            issue_workspace_key("NODE_456", "repo#42")
+        );
+    }
+
+    #[test]
+    fn workspace_key_is_a_bounded_safe_path_segment() {
+        let key = issue_workspace_key(
+            "../NODE/💥",
+            &format!("{}../nested/💥", "very-long-identifier".repeat(20)),
+        );
+
+        assert!(key.len() <= 146);
+        assert!(!key.is_empty());
+        assert_ne!(key, ".");
+        assert_ne!(key, "..");
+        assert!(key
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"._-".contains(&byte)));
+        assert!(!key.contains('/'));
+    }
+
+    #[test]
+    fn workspace_key_digest_matches_length_framed_fixed_vector() {
+        assert_eq!(
+            issue_workspace_key("NODE_ABC", "test-repo#7"),
+            "test-repo_7--97cce6aedbaacd2ef8fe4118ccad1dc1895f549d08dce5ef24069e3111c1c1bb"
+        );
+    }
+}

--- a/crates/ensemble-core/src/workspace/key.rs
+++ b/crates/ensemble-core/src/workspace/key.rs
@@ -4,10 +4,10 @@ const READABLE_PREFIX_MAX_BYTES: usize = 80;
 
 /// Returns one deterministic, path-safe workspace key for an immutable issue identity.
 ///
-/// The readable identifier prefix is only diagnostic. The full SHA-256 suffix,
-/// computed from a length-framed identity pair, is the ownership-bearing part.
-pub fn issue_workspace_key(issue_id: &str, identifier: &str) -> String {
-    let mut prefix: String = identifier
+/// The readable issue-ID prefix is only diagnostic. The full SHA-256 suffix,
+/// computed from the length-framed immutable issue ID, is the ownership-bearing part.
+pub fn issue_workspace_key(issue_id: &str) -> String {
+    let mut prefix: String = issue_id
         .chars()
         .map(|character| {
             if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
@@ -23,10 +23,8 @@ pub fn issue_workspace_key(issue_id: &str, identifier: &str) -> String {
     }
 
     let mut digest = Sha256::new();
-    for component in [issue_id.as_bytes(), identifier.as_bytes()] {
-        digest.update((component.len() as u64).to_be_bytes());
-        digest.update(component);
-    }
+    digest.update((issue_id.len() as u64).to_be_bytes());
+    digest.update(issue_id.as_bytes());
 
     format!("{prefix}--{:x}", digest.finalize())
 }
@@ -37,30 +35,27 @@ mod tests {
 
     #[test]
     fn workspace_key_distinguishes_former_punctuation_collisions() {
-        assert_ne!(
-            issue_workspace_key("issue-a", "a#b"),
-            issue_workspace_key("issue-b", "a_b")
-        );
+        assert_ne!(issue_workspace_key("a#b"), issue_workspace_key("a_b"));
     }
 
     #[test]
     fn workspace_key_is_deterministic_and_uses_immutable_identity() {
         assert_eq!(
-            issue_workspace_key("NODE_123", "repo#42"),
-            issue_workspace_key("NODE_123", "repo#42")
+            issue_workspace_key("NODE_123"),
+            issue_workspace_key("NODE_123")
         );
         assert_ne!(
-            issue_workspace_key("NODE_123", "repo#42"),
-            issue_workspace_key("NODE_456", "repo#42")
+            issue_workspace_key("NODE_123"),
+            issue_workspace_key("NODE_456")
         );
     }
 
     #[test]
     fn workspace_key_is_a_bounded_safe_path_segment() {
-        let key = issue_workspace_key(
-            "../NODE/💥",
-            &format!("{}../nested/💥", "very-long-identifier".repeat(20)),
-        );
+        let key = issue_workspace_key(&format!(
+            "{}../NODE/nested/💥",
+            "very-long-issue-id".repeat(20)
+        ));
 
         assert!(key.len() <= 146);
         assert!(!key.is_empty());
@@ -75,8 +70,8 @@ mod tests {
     #[test]
     fn workspace_key_digest_matches_length_framed_fixed_vector() {
         assert_eq!(
-            issue_workspace_key("NODE_ABC", "test-repo#7"),
-            "test-repo_7--97cce6aedbaacd2ef8fe4118ccad1dc1895f549d08dce5ef24069e3111c1c1bb"
+            issue_workspace_key("NODE_ABC"),
+            "NODE_ABC--da02292e1c3dea3ff44b5e49011f57890f5d02eb400295469ecec963c7079932"
         );
     }
 }

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -3,8 +3,8 @@ use crate::error::WorkspaceError;
 use crate::observability::events_contract::{
     elapsed_ms, WORKSPACE_PREPARE_FAILED, WORKSPACE_PREPARE_FINISHED, WORKSPACE_PREPARE_STARTED,
 };
-use crate::tracker::model::sanitize_workspace_key;
 use crate::workspace::coordinator::{WorktreeCoordinator, WorktreeInfo};
+use crate::workspace::key::issue_workspace_key;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::fs;
@@ -14,6 +14,8 @@ const WORKSPACE_METADATA_FILE: &str = ".ensemble-workspace.json";
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct WorkspaceMetadata {
+    issue_id: String,
+    issue_identifier: String,
     branch_date: String,
 }
 
@@ -24,12 +26,13 @@ pub struct WorkspaceManager {
 }
 
 /// Result of preparing a workspace for an issue.
+#[derive(Debug)]
 pub struct WorkspaceResult {
     /// Absolute path to the base workspace directory (logs, artifacts).
     pub base_path: PathBuf,
     /// Map of repo name to worktree info (if repos configured).
     pub worktrees: HashMap<String, WorktreeInfo>,
-    /// The sanitized workspace key used as the directory name.
+    /// The collision-resistant workspace key used as the directory name.
     pub workspace_key: String,
     /// True if the directory was newly created (not reused).
     pub created_now: bool,
@@ -83,51 +86,39 @@ impl WorkspaceManager {
         &self.repos
     }
 
-    /// Get the workspace path for a given identifier without creating it.
-    /// Returns None if the identifier cannot be sanitized.
-    pub fn workspace_path(&self, identifier: &str) -> Option<PathBuf> {
-        sanitize_workspace_key(identifier).map(|key| self.root.join(key))
+    /// Get the workspace path for an immutable issue identity without creating it.
+    pub fn workspace_path(&self, issue_id: &str, identifier: &str) -> PathBuf {
+        self.root.join(issue_workspace_key(issue_id, identifier))
     }
 
     fn metadata_path(base_path: &Path) -> PathBuf {
         base_path.join(WORKSPACE_METADATA_FILE)
     }
 
-    async fn load_branch_date(&self, base_path: &Path) -> Option<String> {
+    async fn load_metadata(&self, base_path: &Path) -> Result<WorkspaceMetadata, WorkspaceError> {
         let metadata_path = Self::metadata_path(base_path);
-        if !metadata_path.exists() {
-            return None;
-        }
-
-        let content = match fs::read_to_string(&metadata_path).await {
-            Ok(content) => content,
-            Err(error) => {
-                warn!(
-                    path = %metadata_path.display(),
-                    error = %error,
-                    "failed to read workspace metadata; ignoring persisted branch date"
-                );
-                return None;
+        let content = fs::read_to_string(&metadata_path).await.map_err(|error| {
+            WorkspaceError::MetadataUnavailable {
+                path: metadata_path.display().to_string(),
+                reason: error.to_string(),
             }
-        };
-
-        let metadata: WorkspaceMetadata = match serde_json::from_str(&content) {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                warn!(
-                    path = %metadata_path.display(),
-                    error = %error,
-                    "failed to parse workspace metadata; ignoring persisted branch date"
-                );
-                return None;
-            }
-        };
-
-        Some(metadata.branch_date)
+        })?;
+        serde_json::from_str(&content).map_err(|error| WorkspaceError::MetadataUnavailable {
+            path: metadata_path.display().to_string(),
+            reason: error.to_string(),
+        })
     }
 
-    async fn save_branch_date(&self, base_path: &Path, date: &str) -> Result<(), WorkspaceError> {
+    async fn save_metadata(
+        &self,
+        base_path: &Path,
+        issue_id: &str,
+        identifier: &str,
+        date: &str,
+    ) -> Result<(), WorkspaceError> {
         let metadata = WorkspaceMetadata {
+            issue_id: issue_id.to_string(),
+            issue_identifier: identifier.to_string(),
             branch_date: date.to_string(),
         };
         let content =
@@ -142,9 +133,28 @@ impl WorkspaceManager {
             })
     }
 
-    /// Prepare (create or reuse) a workspace for the given issue identifier.
+    fn verify_ownership(
+        base_path: &Path,
+        metadata: &WorkspaceMetadata,
+        issue_id: &str,
+        identifier: &str,
+    ) -> Result<(), WorkspaceError> {
+        if metadata.issue_id == issue_id && metadata.issue_identifier == identifier {
+            return Ok(());
+        }
+        Err(WorkspaceError::OwnershipMismatch {
+            path: base_path.display().to_string(),
+            expected_issue_id: issue_id.to_string(),
+            expected_identifier: identifier.to_string(),
+            actual_issue_id: metadata.issue_id.clone(),
+            actual_identifier: metadata.issue_identifier.clone(),
+        })
+    }
+
+    /// Prepare (create or reuse) a workspace for the given immutable issue identity.
     pub async fn prepare_workspace(
         &self,
+        issue_id: &str,
         identifier: &str,
     ) -> Result<WorkspaceResult, WorkspaceError> {
         let prepare_started_at = std::time::Instant::now();
@@ -153,16 +163,13 @@ impl WorkspaceManager {
             issue_identifier = identifier,
             "preparing workspace"
         );
-        let workspace_key =
-            sanitize_workspace_key(identifier).ok_or_else(|| WorkspaceError::CreationFailed {
-                reason: format!("unsafe workspace key from identifier: {identifier:?}"),
-            })?;
+        let workspace_key = issue_workspace_key(issue_id, identifier);
         let base_path = self.root.join(&workspace_key);
 
         // Safety: ensure workspace path is inside root
         self.validate_path_inside_root(&base_path)?;
 
-        let base_created = if base_path.exists() {
+        let (base_created, metadata) = if base_path.exists() {
             if !base_path.is_dir() {
                 return Err(WorkspaceError::CreationFailed {
                     reason: format!(
@@ -171,32 +178,44 @@ impl WorkspaceManager {
                     ),
                 });
             }
-            false
+            let metadata = self.load_metadata(&base_path).await?;
+            Self::verify_ownership(&base_path, &metadata, issue_id, identifier)?;
+            (false, metadata)
         } else {
             std::fs::create_dir_all(&base_path).map_err(|e| WorkspaceError::CreationFailed {
                 reason: format!("mkdir failed: {e}"),
             })?;
-            true
+            let branch_date = chrono::Local::now().format("%Y-%m-%d").to_string();
+            if let Err(error) = self
+                .save_metadata(&base_path, issue_id, identifier, &branch_date)
+                .await
+            {
+                if let Err(cleanup_error) = std::fs::remove_dir_all(&base_path) {
+                    warn!(
+                        workspace = %base_path.display(),
+                        error = %cleanup_error,
+                        "failed to remove workspace after metadata persistence failed"
+                    );
+                }
+                return Err(error);
+            }
+            (
+                true,
+                WorkspaceMetadata {
+                    issue_id: issue_id.to_string(),
+                    issue_identifier: identifier.to_string(),
+                    branch_date,
+                },
+            )
         };
 
         // Prepare worktrees if repos configured
         let worktrees = if !self.repos.is_empty() {
-            let branch_date = if base_created {
-                let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-                self.save_branch_date(&base_path, &today).await?;
-                today
-            } else {
-                match self.load_branch_date(&base_path).await {
-                    Some(date) => date,
-                    None => {
-                        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-                        self.save_branch_date(&base_path, &today).await?;
-                        today
-                    }
-                }
-            };
-            let coordinator =
-                WorktreeCoordinator::new(self.repos.clone(), branch_date, base_path.clone());
+            let coordinator = WorktreeCoordinator::new(
+                self.repos.clone(),
+                metadata.branch_date,
+                base_path.clone(),
+            );
             info!(workspace = %base_path.display(), "preparing worktrees inside workspace");
             match coordinator.prepare_worktrees(identifier).await {
                 Ok(worktrees) => worktrees,
@@ -237,30 +256,29 @@ impl WorkspaceManager {
         Ok(result)
     }
 
-    /// Remove a workspace directory and its worktrees for the given issue identifier.
-    pub async fn remove_workspace(&self, identifier: &str) -> Result<(), WorkspaceError> {
-        let workspace_key =
-            sanitize_workspace_key(identifier).ok_or_else(|| WorkspaceError::CreationFailed {
-                reason: format!("unsafe workspace key from identifier: {identifier:?}"),
-            })?;
+    /// Remove a workspace directory and its worktrees for the given immutable issue identity.
+    pub async fn remove_workspace(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+    ) -> Result<(), WorkspaceError> {
+        let workspace_key = issue_workspace_key(issue_id, identifier);
         let base_path = self.root.join(&workspace_key);
 
         self.validate_path_inside_root(&base_path)?;
+        if !base_path.exists() {
+            return Ok(());
+        }
+        let metadata = self.load_metadata(&base_path).await?;
+        Self::verify_ownership(&base_path, &metadata, issue_id, identifier)?;
 
         // Clean up worktrees first - use persisted branch date to avoid date drift
         if !self.repos.is_empty() {
-            let branch_date = match self.load_branch_date(&base_path).await {
-                Some(date) => date,
-                None => {
-                    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-                    if base_path.exists() {
-                        self.save_branch_date(&base_path, &today).await?;
-                    }
-                    today
-                }
-            };
-            let coordinator =
-                WorktreeCoordinator::new(self.repos.clone(), branch_date, base_path.clone());
+            let coordinator = WorktreeCoordinator::new(
+                self.repos.clone(),
+                metadata.branch_date,
+                base_path.clone(),
+            );
             warn!(workspace = %base_path.display(), "cleaning up worktrees");
             coordinator
                 .cleanup_worktrees(identifier)
@@ -375,21 +393,116 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn workspace_ownership_new_workspace_persists_identity_without_repositories() {
+        let (_dir, mgr) = setup();
+
+        let result = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        let metadata: WorkspaceMetadata = serde_json::from_str(
+            &std::fs::read_to_string(WorkspaceManager::metadata_path(&result.base_path)).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(metadata.issue_id, "NODE_42");
+        assert_eq!(metadata.issue_identifier, "my-repo#42");
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_mismatch_blocks_reuse_without_modifying_workspace() {
+        let (_dir, mgr) = setup();
+        let base_path = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap()
+            .base_path;
+        mgr.save_metadata(&base_path, "NODE_OTHER", "other#7", "2024-01-01")
+            .await
+            .unwrap();
+        let sentinel = base_path.join("sentinel");
+        std::fs::write(&sentinel, "untouched").unwrap();
+
+        let error = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, WorkspaceError::OwnershipMismatch { .. }));
+        assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_mismatch_blocks_removal_without_modifying_workspace() {
+        let (_dir, mgr) = setup();
+        let base_path = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap()
+            .base_path;
+        mgr.save_metadata(&base_path, "NODE_OTHER", "other#7", "2024-01-01")
+            .await
+            .unwrap();
+        let sentinel = base_path.join("sentinel");
+        std::fs::write(&sentinel, "untouched").unwrap();
+
+        let error = mgr
+            .remove_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, WorkspaceError::OwnershipMismatch { .. }));
+        assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_malformed_metadata_blocks_reuse_and_removal() {
+        let (_dir, mgr) = setup();
+        let base_path = mgr.workspace_path("NODE_42", "my-repo#42");
+        std::fs::create_dir_all(&base_path).unwrap();
+        std::fs::write(WorkspaceManager::metadata_path(&base_path), "{not-json").unwrap();
+        let sentinel = base_path.join("sentinel");
+        std::fs::write(&sentinel, "untouched").unwrap();
+
+        assert!(matches!(
+            mgr.prepare_workspace("NODE_42", "my-repo#42").await,
+            Err(WorkspaceError::MetadataUnavailable { .. })
+        ));
+        assert!(matches!(
+            mgr.remove_workspace("NODE_42", "my-repo#42").await,
+            Err(WorkspaceError::MetadataUnavailable { .. })
+        ));
+        assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
+    }
+
+    #[tokio::test]
     async fn test_prepare_creates_new_workspace() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace("my-repo#42").await.unwrap();
+        let result = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
         assert!(result.created_now);
-        assert_eq!(result.workspace_key, "my-repo_42");
+        assert_eq!(
+            result.workspace_key,
+            issue_workspace_key("NODE_42", "my-repo#42")
+        );
         assert!(result.base_path.is_dir());
     }
 
     #[tokio::test]
-    async fn test_prepare_reuses_existing_workspace() {
+    async fn workspace_ownership_reuses_existing_workspace_for_exact_owner() {
         let (_dir, mgr) = setup();
-        let first = mgr.prepare_workspace("my-repo#42").await.unwrap();
+        let first = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
         assert!(first.created_now);
 
-        let second = mgr.prepare_workspace("my-repo#42").await.unwrap();
+        let second = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
         assert!(!second.created_now);
         assert_eq!(first.base_path, second.base_path);
     }
@@ -397,66 +510,83 @@ mod tests {
     #[tokio::test]
     async fn test_prepare_sanitizes_identifier() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace("acme/repo 123!@#").await.unwrap();
-        assert_eq!(result.workspace_key, "acme_repo_123___");
+        let result = mgr
+            .prepare_workspace("NODE_123", "acme/repo 123!@#")
+            .await
+            .unwrap();
+        assert_eq!(
+            result.workspace_key,
+            issue_workspace_key("NODE_123", "acme/repo 123!@#")
+        );
         assert!(result.base_path.is_dir());
     }
 
     #[tokio::test]
     async fn test_prepare_deterministic_path() {
         let (_dir, mgr) = setup();
-        let r1 = mgr.prepare_workspace("test-issue").await.unwrap();
-        let r2 = mgr.prepare_workspace("test-issue").await.unwrap();
+        let r1 = mgr
+            .prepare_workspace("NODE_TEST", "test-issue")
+            .await
+            .unwrap();
+        let r2 = mgr
+            .prepare_workspace("NODE_TEST", "test-issue")
+            .await
+            .unwrap();
         assert_eq!(r1.base_path, r2.base_path);
     }
 
     #[tokio::test]
     async fn test_remove_workspace() {
         let (_dir, mgr) = setup();
-        mgr.prepare_workspace("my-repo#42").await.unwrap();
+        mgr.prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
 
-        let ws_path = mgr.root().join("my-repo_42");
+        let ws_path = mgr.workspace_path("NODE_42", "my-repo#42");
         assert!(ws_path.exists());
 
-        mgr.remove_workspace("my-repo#42").await.unwrap();
+        mgr.remove_workspace("NODE_42", "my-repo#42").await.unwrap();
         assert!(!ws_path.exists());
     }
 
     #[tokio::test]
     async fn test_remove_nonexistent_is_ok() {
         let (_dir, mgr) = setup();
-        assert!(mgr.remove_workspace("nonexistent").await.is_ok());
+        assert!(mgr
+            .remove_workspace("NODE_MISSING", "nonexistent")
+            .await
+            .is_ok());
     }
 
     #[tokio::test]
     async fn test_path_inside_root_validation() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace("normal-issue").await;
+        let result = mgr.prepare_workspace("NODE_NORMAL", "normal-issue").await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn test_file_at_workspace_path_errors() {
-        let (dir, mgr) = setup();
-        let file_path = dir.path().join("my-repo_42");
+        let (_dir, mgr) = setup();
+        let file_path = mgr.workspace_path("NODE_42", "my-repo#42");
         std::fs::write(&file_path, "not a directory").unwrap();
 
-        let result = mgr.prepare_workspace("my-repo#42").await;
+        let result = mgr.prepare_workspace("NODE_42", "my-repo#42").await;
         assert!(matches!(result, Err(WorkspaceError::CreationFailed { .. })));
     }
 
     #[tokio::test]
-    async fn test_dot_identifier_rejected() {
+    async fn test_dot_identifier_uses_safe_workspace_key() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace(".").await;
-        assert!(matches!(result, Err(WorkspaceError::CreationFailed { .. })));
+        let result = mgr.prepare_workspace("NODE_DOT", ".").await.unwrap();
+        assert!(result.base_path.is_dir());
     }
 
     #[tokio::test]
-    async fn test_dotdot_identifier_rejected() {
+    async fn test_dotdot_identifier_uses_safe_workspace_key() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace("..").await;
-        assert!(matches!(result, Err(WorkspaceError::CreationFailed { .. })));
+        let result = mgr.prepare_workspace("NODE_DOTDOT", "..").await.unwrap();
+        assert!(result.base_path.is_dir());
     }
 
     #[tokio::test]
@@ -473,12 +603,12 @@ mod tests {
         let test_path = dir.path().join("test-workspace");
         std::fs::create_dir_all(&test_path).unwrap();
 
-        mgr.save_branch_date(&test_path, "2024-06-15")
+        mgr.save_metadata(&test_path, "NODE_TEST", "test-workspace", "2024-06-15")
             .await
             .unwrap();
 
-        let loaded = mgr.load_branch_date(&test_path).await;
-        assert_eq!(loaded, Some("2024-06-15".to_string()));
+        let loaded = mgr.load_metadata(&test_path).await.unwrap();
+        assert_eq!(loaded.branch_date, "2024-06-15");
     }
 
     #[tokio::test]
@@ -486,12 +616,17 @@ mod tests {
         let dir = TempDir::new().unwrap();
 
         let identifier = "test-issue";
-        let workspace_key = sanitize_workspace_key(identifier).unwrap();
+        let issue_id = "NODE_TEST";
+        let workspace_key = issue_workspace_key(issue_id, identifier);
         let test_path = dir.path().join(&workspace_key);
         std::fs::create_dir_all(&test_path).unwrap();
 
         let metadata_path = test_path.join(".ensemble-workspace.json");
-        std::fs::write(&metadata_path, r#"{"branch_date":"2020-01-01"}"#).unwrap();
+        std::fs::write(
+            &metadata_path,
+            r#"{"issue_id":"NODE_TEST","issue_identifier":"test-issue","branch_date":"2020-01-01"}"#,
+        )
+        .unwrap();
 
         let repos = vec![RepoConfig {
             path: "/nonexistent/path".to_string(),
@@ -501,7 +636,7 @@ mod tests {
         }];
         let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
 
-        let result = mgr.remove_workspace(identifier).await;
+        let result = mgr.remove_workspace(issue_id, identifier).await;
         assert!(result.is_err());
         assert!(test_path.exists());
     }
@@ -517,12 +652,16 @@ mod tests {
         }];
         let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
 
-        let ws_path = dir.path().join("cleanup-test");
+        let ws_path = mgr.workspace_path("NODE_CLEANUP", "cleanup-test");
         std::fs::create_dir_all(&ws_path).unwrap();
         let metadata_path = ws_path.join(".ensemble-workspace.json");
-        std::fs::write(&metadata_path, r#"{"branch_date":"2020-01-01"}"#).unwrap();
+        std::fs::write(
+            &metadata_path,
+            r#"{"issue_id":"NODE_CLEANUP","issue_identifier":"cleanup-test","branch_date":"2020-01-01"}"#,
+        )
+        .unwrap();
 
-        let remove_result = mgr.remove_workspace("cleanup-test").await;
+        let remove_result = mgr.remove_workspace("NODE_CLEANUP", "cleanup-test").await;
         assert!(remove_result.is_err());
 
         assert!(
@@ -532,20 +671,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_prepare_persists_branch_date_for_legacy_workspace() {
+    async fn workspace_ownership_missing_metadata_workspace_fails_closed() {
         let root = TempDir::new().unwrap();
         let (_repo_dir, repo) = setup_repo("repo1");
         let mgr = WorkspaceManager::new(root.path(), Some(vec![repo])).unwrap();
 
         let identifier = "legacy#42";
-        let workspace_key = sanitize_workspace_key(identifier).unwrap();
+        let issue_id = "NODE_LEGACY";
+        let workspace_key = issue_workspace_key(issue_id, identifier);
         let base_path = root.path().join(workspace_key);
         std::fs::create_dir_all(&base_path).unwrap();
 
         assert!(!WorkspaceManager::metadata_path(&base_path).exists());
 
-        let result = mgr.prepare_workspace(identifier).await;
-        assert!(result.is_ok());
-        assert!(WorkspaceManager::metadata_path(&base_path).exists());
+        let sentinel = base_path.join("sentinel");
+        std::fs::write(&sentinel, "untouched").unwrap();
+        let result = mgr.prepare_workspace(issue_id, identifier).await;
+        assert!(matches!(
+            result,
+            Err(WorkspaceError::MetadataUnavailable { .. })
+        ));
+        assert!(matches!(
+            mgr.remove_workspace(issue_id, identifier).await,
+            Err(WorkspaceError::MetadataUnavailable { .. })
+        ));
+        assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_ownerless_legacy_metadata_fails_closed() {
+        let root = TempDir::new().unwrap();
+        let (_repo_dir, repo) = setup_repo("repo1");
+        let mgr = WorkspaceManager::new(root.path(), Some(vec![repo])).unwrap();
+
+        let identifier = "legacy#43";
+        let issue_id = "NODE_LEGACY_METADATA";
+        let workspace_key = issue_workspace_key(issue_id, identifier);
+        let base_path = root.path().join(workspace_key);
+        std::fs::create_dir_all(&base_path).unwrap();
+        std::fs::write(
+            WorkspaceManager::metadata_path(&base_path),
+            r#"{"branch_date":"2020-01-01"}"#,
+        )
+        .unwrap();
+
+        let sentinel = base_path.join("sentinel");
+        std::fs::write(&sentinel, "untouched").unwrap();
+        assert!(matches!(
+            mgr.prepare_workspace(issue_id, identifier).await,
+            Err(WorkspaceError::MetadataUnavailable { .. })
+        ));
+        assert!(matches!(
+            mgr.remove_workspace(issue_id, identifier).await,
+            Err(WorkspaceError::MetadataUnavailable { .. })
+        ));
+        assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
     }
 }

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -6,11 +6,15 @@ use crate::observability::events_contract::{
 use crate::workspace::coordinator::{WorktreeCoordinator, WorktreeInfo};
 use crate::workspace::key::issue_workspace_key;
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use tokio::fs;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 use tracing::{info, warn};
 
-const WORKSPACE_METADATA_FILE: &str = ".ensemble-workspace.json";
+const WORKSPACE_METADATA_DIR: &str = ".ensemble-workspace-metadata";
+type WorkspaceLifecycleLock = tokio::sync::Mutex<()>;
+type WorkspaceLifecycleLockRegistry = Mutex<HashMap<PathBuf, Weak<WorkspaceLifecycleLock>>>;
+static WORKSPACE_LIFECYCLE_LOCKS: OnceLock<WorkspaceLifecycleLockRegistry> = OnceLock::new();
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct WorkspaceMetadata {
@@ -23,6 +27,10 @@ struct WorkspaceMetadata {
 pub struct WorkspaceManager {
     root: PathBuf,
     repos: HashMap<String, RepoConfig>,
+    #[cfg(test)]
+    preparation_test_barriers: Option<(Arc<tokio::sync::Barrier>, Arc<tokio::sync::Barrier>)>,
+    #[cfg(test)]
+    removal_test_barriers: Option<(Arc<tokio::sync::Barrier>, Arc<tokio::sync::Barrier>)>,
 }
 
 /// Result of preparing a workspace for an issue.
@@ -73,6 +81,10 @@ impl WorkspaceManager {
         Ok(Self {
             root,
             repos: repos_map,
+            #[cfg(test)]
+            preparation_test_barriers: None,
+            #[cfg(test)]
+            removal_test_barriers: None,
         })
     }
 
@@ -91,13 +103,53 @@ impl WorkspaceManager {
         self.root.join(issue_workspace_key(issue_id))
     }
 
-    fn metadata_path(base_path: &Path) -> PathBuf {
-        base_path.join(WORKSPACE_METADATA_FILE)
+    fn metadata_dir(&self) -> PathBuf {
+        self.root.join(WORKSPACE_METADATA_DIR)
     }
 
-    async fn load_metadata(&self, base_path: &Path) -> Result<WorkspaceMetadata, WorkspaceError> {
-        let metadata_path = Self::metadata_path(base_path);
-        let content = fs::read_to_string(&metadata_path).await.map_err(|error| {
+    fn metadata_path(&self, issue_id: &str) -> PathBuf {
+        self.metadata_dir()
+            .join(format!("{}.json", issue_workspace_key(issue_id)))
+    }
+
+    fn lifecycle_lock(&self, workspace_key: &str) -> Arc<WorkspaceLifecycleLock> {
+        let canonical_root = Self::canonicalize_allow_missing(&self.root);
+        let path = canonical_root.join(workspace_key);
+        let mut locks = WORKSPACE_LIFECYCLE_LOCKS
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(&path).and_then(Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(WorkspaceLifecycleLock::new(()));
+        locks.insert(path, Arc::downgrade(&lock));
+        lock
+    }
+
+    #[cfg(test)]
+    fn set_preparation_test_barriers(
+        &mut self,
+        after_lock: Arc<tokio::sync::Barrier>,
+        resume_preparation: Arc<tokio::sync::Barrier>,
+    ) {
+        self.preparation_test_barriers = Some((after_lock, resume_preparation));
+    }
+
+    #[cfg(test)]
+    fn set_removal_test_barriers(
+        &mut self,
+        after_verification: Arc<tokio::sync::Barrier>,
+        resume_removal: Arc<tokio::sync::Barrier>,
+    ) {
+        self.removal_test_barriers = Some((after_verification, resume_removal));
+    }
+
+    fn load_metadata(&self, issue_id: &str) -> Result<WorkspaceMetadata, WorkspaceError> {
+        let metadata_path = self.metadata_path(issue_id);
+        self.validate_path_inside_root(&self.metadata_dir())?;
+        let content = std::fs::read_to_string(&metadata_path).map_err(|error| {
             WorkspaceError::MetadataUnavailable {
                 path: metadata_path.display().to_string(),
                 reason: error.to_string(),
@@ -109,32 +161,77 @@ impl WorkspaceManager {
         })
     }
 
-    async fn save_metadata(
+    fn serialize_metadata(
+        issue_id: &str,
+        identifier: &str,
+        date: &str,
+    ) -> Result<Vec<u8>, WorkspaceError> {
+        serde_json::to_vec(&WorkspaceMetadata {
+            issue_id: issue_id.to_string(),
+            issue_identifier: identifier.to_string(),
+            branch_date: date.to_string(),
+        })
+        .map_err(|error| WorkspaceError::CreationFailed {
+            reason: format!("failed to serialize workspace metadata: {error}"),
+        })
+    }
+
+    fn write_metadata_temp(
         &self,
-        base_path: &Path,
+        content: &[u8],
+    ) -> Result<tempfile::NamedTempFile, WorkspaceError> {
+        let metadata_dir = self.metadata_dir();
+        let mut file = tempfile::NamedTempFile::new_in(&metadata_dir).map_err(|error| {
+            WorkspaceError::CreationFailed {
+                reason: format!("failed to create temporary workspace metadata: {error}"),
+            }
+        })?;
+        file.write_all(content)
+            .and_then(|()| file.as_file().sync_all())
+            .map_err(|error| WorkspaceError::CreationFailed {
+                reason: format!("failed to persist temporary workspace metadata: {error}"),
+            })?;
+        Ok(file)
+    }
+
+    fn create_metadata(
+        &self,
         issue_id: &str,
         identifier: &str,
         date: &str,
     ) -> Result<(), WorkspaceError> {
-        let metadata = WorkspaceMetadata {
-            issue_id: issue_id.to_string(),
-            issue_identifier: identifier.to_string(),
-            branch_date: date.to_string(),
-        };
-        let content =
-            serde_json::to_string(&metadata).map_err(|e| WorkspaceError::CreationFailed {
-                reason: format!("failed to serialize workspace metadata: {e}"),
+        let metadata_dir = self.metadata_dir();
+        std::fs::create_dir_all(&metadata_dir).map_err(|error| WorkspaceError::CreationFailed {
+            reason: format!("failed to create workspace metadata directory: {error}"),
+        })?;
+        self.validate_path_inside_root(&metadata_dir)?;
+
+        let content = Self::serialize_metadata(issue_id, identifier, date)?;
+        self.write_metadata_temp(&content)?
+            .persist_noclobber(self.metadata_path(issue_id))
+            .map_err(|error| WorkspaceError::CreationFailed {
+                reason: format!("failed to create workspace metadata: {}", error.error),
             })?;
-        let metadata_path = Self::metadata_path(base_path);
-        fs::write(&metadata_path, content)
-            .await
-            .map_err(|e| WorkspaceError::CreationFailed {
-                reason: format!("failed to write workspace metadata: {e}"),
-            })
+        Ok(())
+    }
+
+    fn refresh_metadata(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+        date: &str,
+    ) -> Result<(), WorkspaceError> {
+        let content = Self::serialize_metadata(issue_id, identifier, date)?;
+        self.write_metadata_temp(&content)?
+            .persist(self.metadata_path(issue_id))
+            .map_err(|error| WorkspaceError::CreationFailed {
+                reason: format!("failed to refresh workspace metadata: {}", error.error),
+            })?;
+        Ok(())
     }
 
     fn verify_ownership(
-        base_path: &Path,
+        metadata_path: &Path,
         metadata: &WorkspaceMetadata,
         issue_id: &str,
     ) -> Result<(), WorkspaceError> {
@@ -142,7 +239,7 @@ impl WorkspaceManager {
             return Ok(());
         }
         Err(WorkspaceError::OwnershipMismatch {
-            path: base_path.display().to_string(),
+            path: metadata_path.display().to_string(),
             expected_issue_id: issue_id.to_string(),
             actual_issue_id: metadata.issue_id.clone(),
         })
@@ -161,6 +258,12 @@ impl WorkspaceManager {
             "preparing workspace"
         );
         let workspace_key = issue_workspace_key(issue_id);
+        let _lifecycle_guard = self.lifecycle_lock(&workspace_key).lock_owned().await;
+        #[cfg(test)]
+        if let Some((after_lock, resume_preparation)) = &self.preparation_test_barriers {
+            after_lock.wait().await;
+            resume_preparation.wait().await;
+        }
         let base_path = self.root.join(&workspace_key);
 
         // Safety: ensure workspace path is inside root
@@ -175,23 +278,60 @@ impl WorkspaceManager {
                     ),
                 });
             }
-            let mut metadata = self.load_metadata(&base_path).await?;
-            Self::verify_ownership(&base_path, &metadata, issue_id)?;
+            let mut metadata = self.load_metadata(issue_id)?;
+            Self::verify_ownership(&self.metadata_path(issue_id), &metadata, issue_id)?;
             if metadata.issue_identifier != identifier {
-                self.save_metadata(&base_path, issue_id, identifier, &metadata.branch_date)
-                    .await?;
+                self.refresh_metadata(issue_id, identifier, &metadata.branch_date)?;
                 metadata.issue_identifier = identifier.to_string();
             }
             (false, metadata)
         } else {
-            std::fs::create_dir_all(&base_path).map_err(|e| WorkspaceError::CreationFailed {
+            std::fs::create_dir_all(&self.root).map_err(|e| WorkspaceError::CreationFailed {
+                reason: format!("workspace root mkdir failed: {e}"),
+            })?;
+            std::fs::create_dir(&base_path).map_err(|e| WorkspaceError::CreationFailed {
                 reason: format!("mkdir failed: {e}"),
             })?;
             let branch_date = chrono::Local::now().format("%Y-%m-%d").to_string();
-            if let Err(error) = self
-                .save_metadata(&base_path, issue_id, identifier, &branch_date)
-                .await
-            {
+            let metadata = match self.create_metadata(issue_id, identifier, &branch_date) {
+                Ok(()) => WorkspaceMetadata {
+                    issue_id: issue_id.to_string(),
+                    issue_identifier: identifier.to_string(),
+                    branch_date,
+                },
+                Err(create_error) => match self.load_metadata(issue_id) {
+                    Ok(mut existing) => {
+                        if let Err(error) = Self::verify_ownership(
+                            &self.metadata_path(issue_id),
+                            &existing,
+                            issue_id,
+                        ) {
+                            let _ = std::fs::remove_dir(&base_path);
+                            return Err(error);
+                        }
+                        if existing.issue_identifier != identifier {
+                            if let Err(error) =
+                                self.refresh_metadata(issue_id, identifier, &existing.branch_date)
+                            {
+                                let _ = std::fs::remove_dir(&base_path);
+                                return Err(error);
+                            }
+                            existing.issue_identifier = identifier.to_string();
+                        }
+                        existing
+                    }
+                    Err(load_error) => {
+                        let metadata_exists = self.metadata_path(issue_id).exists();
+                        let _ = std::fs::remove_dir(&base_path);
+                        return Err(if metadata_exists {
+                            load_error
+                        } else {
+                            create_error
+                        });
+                    }
+                },
+            };
+            if !base_path.is_dir() {
                 if let Err(cleanup_error) = std::fs::remove_dir_all(&base_path) {
                     warn!(
                         workspace = %base_path.display(),
@@ -199,16 +339,11 @@ impl WorkspaceManager {
                         "failed to remove workspace after metadata persistence failed"
                     );
                 }
-                return Err(error);
+                return Err(WorkspaceError::CreationFailed {
+                    reason: format!("workspace path is not a directory: {}", base_path.display()),
+                });
             }
-            (
-                true,
-                WorkspaceMetadata {
-                    issue_id: issue_id.to_string(),
-                    issue_identifier: identifier.to_string(),
-                    branch_date,
-                },
-            )
+            (true, metadata)
         };
 
         // Prepare worktrees if repos configured
@@ -261,14 +396,32 @@ impl WorkspaceManager {
     /// Remove a workspace directory and its worktrees for the given immutable issue identity.
     pub async fn remove_workspace(&self, issue_id: &str) -> Result<(), WorkspaceError> {
         let workspace_key = issue_workspace_key(issue_id);
+        let _lifecycle_guard = self.lifecycle_lock(&workspace_key).lock_owned().await;
         let base_path = self.root.join(&workspace_key);
 
         self.validate_path_inside_root(&base_path)?;
         if !base_path.exists() {
+            let metadata_path = self.metadata_path(issue_id);
+            if !metadata_path.exists() {
+                return Ok(());
+            }
+            let metadata = self.load_metadata(issue_id)?;
+            Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
+            std::fs::remove_file(&metadata_path).map_err(|error| {
+                WorkspaceError::CreationFailed {
+                    reason: format!("failed to remove workspace metadata: {error}"),
+                }
+            })?;
             return Ok(());
         }
-        let metadata = self.load_metadata(&base_path).await?;
-        Self::verify_ownership(&base_path, &metadata, issue_id)?;
+        let metadata_path = self.metadata_path(issue_id);
+        let metadata = self.load_metadata(issue_id)?;
+        Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
+        #[cfg(test)]
+        if let Some((after_verification, resume_removal)) = &self.removal_test_barriers {
+            after_verification.wait().await;
+            resume_removal.wait().await;
+        }
 
         // Clean up worktrees first - use persisted branch date to avoid date drift
         if !self.repos.is_empty() {
@@ -291,6 +444,9 @@ impl WorkspaceManager {
                 reason: format!("remove failed: {e}"),
             })?;
         }
+        std::fs::remove_file(&metadata_path).map_err(|error| WorkspaceError::CreationFailed {
+            reason: format!("failed to remove workspace metadata: {error}"),
+        })?;
         Ok(())
     }
 
@@ -300,24 +456,11 @@ impl WorkspaceManager {
     /// so that the `starts_with` check is reliable on platforms such as macOS where
     /// `/var/folders/...` is a symlink to `/private/var/folders/...`.
     ///
-    /// When `path` does not yet exist (pre-creation), its parent is canonicalized
-    /// and the final component is re-appended, preserving the intended semantics.
+    /// When `path` does not yet exist (pre-creation), its nearest existing ancestor
+    /// is canonicalized and the missing components are re-appended.
     fn validate_path_inside_root(&self, path: &Path) -> Result<(), WorkspaceError> {
-        let canonical_root = self
-            .root
-            .canonicalize()
-            .unwrap_or_else(|_| self.root.clone());
-
-        let canonical_path = if path.exists() {
-            path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
-        } else if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
-            parent
-                .canonicalize()
-                .unwrap_or_else(|_| parent.to_path_buf())
-                .join(file_name)
-        } else {
-            path.to_path_buf()
-        };
+        let canonical_root = Self::canonicalize_allow_missing(&self.root);
+        let canonical_path = Self::canonicalize_allow_missing(path);
 
         if !canonical_path.starts_with(&canonical_root) {
             return Err(WorkspaceError::PathOutsideRoot {
@@ -325,6 +468,26 @@ impl WorkspaceManager {
             });
         }
         Ok(())
+    }
+
+    fn canonicalize_allow_missing(path: &Path) -> PathBuf {
+        let mut existing = path;
+        let mut missing = Vec::new();
+        while !existing.exists() {
+            let (Some(parent), Some(file_name)) = (existing.parent(), existing.file_name()) else {
+                return path.to_path_buf();
+            };
+            missing.push(file_name.to_os_string());
+            existing = parent;
+        }
+
+        let mut canonical = existing
+            .canonicalize()
+            .unwrap_or_else(|_| existing.to_path_buf());
+        for component in missing.into_iter().rev() {
+            canonical.push(component);
+        }
+        canonical
     }
 }
 
@@ -397,13 +560,13 @@ mod tests {
             .prepare_workspace("NODE_42", "my-repo#42")
             .await
             .unwrap();
-        let metadata: WorkspaceMetadata = serde_json::from_str(
-            &std::fs::read_to_string(WorkspaceManager::metadata_path(&result.base_path)).unwrap(),
-        )
-        .unwrap();
+        let metadata: WorkspaceMetadata =
+            serde_json::from_str(&std::fs::read_to_string(mgr.metadata_path("NODE_42")).unwrap())
+                .unwrap();
 
         assert_eq!(metadata.issue_id, "NODE_42");
         assert_eq!(metadata.issue_identifier, "my-repo#42");
+        assert!(!result.base_path.join(".ensemble-workspace.json").exists());
     }
 
     #[tokio::test]
@@ -414,9 +577,11 @@ mod tests {
             .await
             .unwrap()
             .base_path;
-        mgr.save_metadata(&base_path, "NODE_OTHER", "other#7", "2024-01-01")
-            .await
-            .unwrap();
+        std::fs::write(
+            mgr.metadata_path("NODE_42"),
+            r#"{"issue_id":"NODE_OTHER","issue_identifier":"other#7","branch_date":"2024-01-01"}"#,
+        )
+        .unwrap();
         let sentinel = base_path.join("sentinel");
         std::fs::write(&sentinel, "untouched").unwrap();
 
@@ -437,9 +602,11 @@ mod tests {
             .await
             .unwrap()
             .base_path;
-        mgr.save_metadata(&base_path, "NODE_OTHER", "other#7", "2024-01-01")
-            .await
-            .unwrap();
+        std::fs::write(
+            mgr.metadata_path("NODE_42"),
+            r#"{"issue_id":"NODE_OTHER","issue_identifier":"other#7","branch_date":"2024-01-01"}"#,
+        )
+        .unwrap();
         let sentinel = base_path.join("sentinel");
         std::fs::write(&sentinel, "untouched").unwrap();
 
@@ -454,7 +621,8 @@ mod tests {
         let (_dir, mgr) = setup();
         let base_path = mgr.workspace_path("NODE_42");
         std::fs::create_dir_all(&base_path).unwrap();
-        std::fs::write(WorkspaceManager::metadata_path(&base_path), "{not-json").unwrap();
+        std::fs::create_dir_all(mgr.metadata_dir()).unwrap();
+        std::fs::write(mgr.metadata_path("NODE_42"), "{not-json").unwrap();
         let sentinel = base_path.join("sentinel");
         std::fs::write(&sentinel, "untouched").unwrap();
 
@@ -519,7 +687,7 @@ mod tests {
         let second_worktree = second.worktrees.values().next().unwrap();
         assert_eq!(first_worktree.path, second_worktree.path);
         assert_eq!(first_worktree.branch, second_worktree.branch);
-        let metadata = mgr.load_metadata(&second.base_path).await.unwrap();
+        let metadata = mgr.load_metadata("NODE_42").unwrap();
         assert_eq!(metadata.issue_id, "NODE_42");
         assert_eq!(metadata.issue_identifier, "renamed-repo#42");
 
@@ -548,6 +716,275 @@ mod tests {
         mgr.remove_workspace("a_b").await.unwrap();
         assert!(!first.base_path.exists());
         assert!(!second.base_path.exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_agent_workspace_metadata_tampering_cannot_change_authority() {
+        let root = TempDir::new().unwrap();
+        let (_repo_dir, repo) = setup_repo("repo1");
+        let mgr = WorkspaceManager::new(root.path(), Some(vec![repo])).unwrap();
+
+        let first = mgr
+            .prepare_workspace("NODE_42", "old-repo#42")
+            .await
+            .unwrap();
+        let workspace_metadata = first.base_path.join(".ensemble-workspace.json");
+        std::fs::write(
+            &workspace_metadata,
+            r#"{"issue_id":"NODE_OTHER","issue_identifier":"other#7","branch_date":"2024-01-01"}"#,
+        )
+        .unwrap();
+
+        let reused = mgr
+            .prepare_workspace("NODE_42", "renamed-repo#42")
+            .await
+            .unwrap();
+        assert_eq!(first.base_path, reused.base_path);
+        assert!(!reused.created_now);
+
+        std::fs::write(&workspace_metadata, "{not-json").unwrap();
+        mgr.prepare_workspace("NODE_42", "renamed-again#42")
+            .await
+            .unwrap();
+        std::fs::remove_file(workspace_metadata).unwrap();
+
+        mgr.remove_workspace("NODE_42").await.unwrap();
+        assert!(!first.base_path.exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_sidecar_create_never_clobbers_an_existing_owner() {
+        let (_dir, mgr) = setup();
+        let metadata_path = mgr.metadata_path("NODE_42");
+        std::fs::create_dir_all(mgr.metadata_dir()).unwrap();
+        let original =
+            r#"{"issue_id":"NODE_OTHER","issue_identifier":"other#7","branch_date":"2024-01-01"}"#;
+        std::fs::write(&metadata_path, original).unwrap();
+
+        let error = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, WorkspaceError::OwnershipMismatch { .. }));
+        assert_eq!(std::fs::read_to_string(metadata_path).unwrap(), original);
+        assert!(!mgr.workspace_path("NODE_42").exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_corrupt_leftover_sidecar_fails_closed() {
+        let (_dir, mgr) = setup();
+        let metadata_path = mgr.metadata_path("NODE_42");
+        std::fs::create_dir_all(mgr.metadata_dir()).unwrap();
+        std::fs::write(&metadata_path, "{not-json").unwrap();
+
+        let error = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, WorkspaceError::MetadataUnavailable { .. }));
+        assert_eq!(std::fs::read_to_string(metadata_path).unwrap(), "{not-json");
+        assert!(!mgr.workspace_path("NODE_42").exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_removal_cleans_the_authoritative_sidecar() {
+        let (_dir, mgr) = setup();
+        let workspace = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        let metadata_path = mgr.metadata_path("NODE_42");
+        assert!(metadata_path.exists());
+
+        mgr.remove_workspace("NODE_42").await.unwrap();
+
+        assert!(!workspace.base_path.exists());
+        assert!(!metadata_path.exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_absent_workspace_finishes_valid_sidecar_cleanup() {
+        let (_dir, mgr) = setup();
+        let workspace = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        let metadata_path = mgr.metadata_path("NODE_42");
+        std::fs::remove_dir_all(workspace.base_path).unwrap();
+
+        mgr.remove_workspace("NODE_42").await.unwrap();
+
+        assert!(!metadata_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_ownership_identifier_refresh_failure_preserves_valid_sidecar() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_dir, mgr) = setup();
+        let workspace = mgr
+            .prepare_workspace("NODE_42", "old-repo#42")
+            .await
+            .unwrap();
+        let metadata_path = mgr.metadata_path("NODE_42");
+        let original = std::fs::read_to_string(&metadata_path).unwrap();
+        let metadata_dir = mgr.metadata_dir();
+        std::fs::set_permissions(&metadata_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let result = mgr.prepare_workspace("NODE_42", "renamed-repo#42").await;
+
+        std::fs::set_permissions(&metadata_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(matches!(result, Err(WorkspaceError::CreationFailed { .. })));
+        assert_eq!(std::fs::read_to_string(metadata_path).unwrap(), original);
+        assert!(workspace.base_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_ownership_sidecar_create_failure_removes_new_workspace() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_dir, mgr) = setup();
+        let metadata_dir = mgr.metadata_dir();
+        std::fs::create_dir(&metadata_dir).unwrap();
+        std::fs::set_permissions(&metadata_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let result = mgr.prepare_workspace("NODE_42", "my-repo#42").await;
+
+        std::fs::set_permissions(&metadata_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(matches!(result, Err(WorkspaceError::CreationFailed { .. })));
+        assert!(!mgr.workspace_path("NODE_42").exists());
+        assert!(!mgr.metadata_path("NODE_42").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_ownership_interrupted_sidecar_cleanup_is_retryable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_dir, mgr) = setup();
+        let workspace = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        let metadata_path = mgr.metadata_path("NODE_42");
+        let metadata_dir = mgr.metadata_dir();
+        std::fs::set_permissions(&metadata_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let first_removal = mgr.remove_workspace("NODE_42").await;
+
+        std::fs::set_permissions(&metadata_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(matches!(
+            first_removal,
+            Err(WorkspaceError::CreationFailed { .. })
+        ));
+        assert!(!workspace.base_path.exists());
+        assert!(metadata_path.exists());
+
+        mgr.remove_workspace("NODE_42").await.unwrap();
+        assert!(!metadata_path.exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_prepare_waits_for_same_issue_removal_transaction() {
+        let root = TempDir::new().unwrap();
+        let mut removing_mgr = WorkspaceManager::new(root.path(), None).unwrap();
+        removing_mgr
+            .prepare_workspace("NODE_42", "old-repo#42")
+            .await
+            .unwrap();
+        let after_verification = Arc::new(tokio::sync::Barrier::new(2));
+        let resume_removal = Arc::new(tokio::sync::Barrier::new(2));
+        removing_mgr.set_removal_test_barriers(
+            Arc::clone(&after_verification),
+            Arc::clone(&resume_removal),
+        );
+        let removing_mgr = Arc::new(removing_mgr);
+        let preparing_mgr = Arc::new(WorkspaceManager::new(root.path(), None).unwrap());
+
+        let removal = {
+            let mgr = Arc::clone(&removing_mgr);
+            tokio::spawn(async move { mgr.remove_workspace("NODE_42").await })
+        };
+        after_verification.wait().await;
+        let mut preparation = {
+            let mgr = Arc::clone(&preparing_mgr);
+            tokio::spawn(async move { mgr.prepare_workspace("NODE_42", "renamed-repo#42").await })
+        };
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), &mut preparation)
+                .await
+                .is_err(),
+            "prepare must wait while removal owns the issue lifecycle transaction"
+        );
+
+        resume_removal.wait().await;
+        removal.await.unwrap().unwrap();
+        let prepared = preparation.await.unwrap().unwrap();
+        let metadata = preparing_mgr.load_metadata("NODE_42").unwrap();
+        assert!(prepared.base_path.exists());
+        assert_eq!(metadata.issue_id, "NODE_42");
+        assert_eq!(metadata.issue_identifier, "renamed-repo#42");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_ownership_missing_root_aliases_share_one_lifecycle_transaction() {
+        use std::os::unix::fs::symlink;
+
+        let physical_parent = TempDir::new().unwrap();
+        let alias_parent = TempDir::new().unwrap();
+        let alias = alias_parent.path().join("workspace-parent");
+        symlink(physical_parent.path(), &alias).unwrap();
+        let physical_root = physical_parent.path().join("missing-root");
+        let alias_root = alias.join("missing-root");
+        let after_lock = Arc::new(tokio::sync::Barrier::new(2));
+        let resume_preparation = Arc::new(tokio::sync::Barrier::new(2));
+
+        let mut first_mgr = WorkspaceManager::new(&alias_root, None).unwrap();
+        first_mgr.set_preparation_test_barriers(
+            Arc::clone(&after_lock),
+            Arc::clone(&resume_preparation),
+        );
+        let first_mgr = Arc::new(first_mgr);
+        let second_mgr = Arc::new(WorkspaceManager::new(&physical_root, None).unwrap());
+
+        let first_preparation = {
+            let mgr = Arc::clone(&first_mgr);
+            tokio::spawn(async move { mgr.prepare_workspace("NODE_42", "my-repo#42").await })
+        };
+        after_lock.wait().await;
+        let mut second_preparation = {
+            let mgr = Arc::clone(&second_mgr);
+            tokio::spawn(async move { mgr.prepare_workspace("NODE_42", "my-repo#42").await })
+        };
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                &mut second_preparation
+            )
+            .await
+            .is_err(),
+            "canonical and symlinked missing roots must share one lifecycle lock"
+        );
+
+        resume_preparation.wait().await;
+        let first = first_preparation.await.unwrap().unwrap();
+        let second = second_preparation.await.unwrap().unwrap();
+        assert_eq!(
+            first.base_path.canonicalize().unwrap(),
+            second.base_path.canonicalize().unwrap()
+        );
+        assert!(second.base_path.exists());
+        assert_eq!(
+            second_mgr.load_metadata("NODE_42").unwrap().issue_id,
+            "NODE_42"
+        );
     }
 
     #[tokio::test]
@@ -643,11 +1080,10 @@ mod tests {
         let test_path = dir.path().join("test-workspace");
         std::fs::create_dir_all(&test_path).unwrap();
 
-        mgr.save_metadata(&test_path, "NODE_TEST", "test-workspace", "2024-06-15")
-            .await
+        mgr.create_metadata("NODE_TEST", "test-workspace", "2024-06-15")
             .unwrap();
 
-        let loaded = mgr.load_metadata(&test_path).await.unwrap();
+        let loaded = mgr.load_metadata("NODE_TEST").unwrap();
         assert_eq!(loaded.branch_date, "2024-06-15");
     }
 
@@ -660,13 +1096,6 @@ mod tests {
         let test_path = dir.path().join(&workspace_key);
         std::fs::create_dir_all(&test_path).unwrap();
 
-        let metadata_path = test_path.join(".ensemble-workspace.json");
-        std::fs::write(
-            &metadata_path,
-            r#"{"issue_id":"NODE_TEST","issue_identifier":"test-issue","branch_date":"2020-01-01"}"#,
-        )
-        .unwrap();
-
         let repos = vec![RepoConfig {
             path: "/nonexistent/path".to_string(),
             branch: "main".to_string(),
@@ -674,6 +1103,8 @@ mod tests {
             finalize: Default::default(),
         }];
         let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
+        mgr.create_metadata(issue_id, "test-issue", "2020-01-01")
+            .unwrap();
 
         let result = mgr.remove_workspace(issue_id).await;
         assert!(result.is_err());
@@ -693,12 +1124,8 @@ mod tests {
 
         let ws_path = mgr.workspace_path("NODE_CLEANUP");
         std::fs::create_dir_all(&ws_path).unwrap();
-        let metadata_path = ws_path.join(".ensemble-workspace.json");
-        std::fs::write(
-            &metadata_path,
-            r#"{"issue_id":"NODE_CLEANUP","issue_identifier":"cleanup-test","branch_date":"2020-01-01"}"#,
-        )
-        .unwrap();
+        mgr.create_metadata("NODE_CLEANUP", "cleanup-test", "2020-01-01")
+            .unwrap();
 
         let remove_result = mgr.remove_workspace("NODE_CLEANUP").await;
         assert!(remove_result.is_err());
@@ -721,7 +1148,7 @@ mod tests {
         let base_path = root.path().join(workspace_key);
         std::fs::create_dir_all(&base_path).unwrap();
 
-        assert!(!WorkspaceManager::metadata_path(&base_path).exists());
+        assert!(!mgr.metadata_path(issue_id).exists());
 
         let sentinel = base_path.join("sentinel");
         std::fs::write(&sentinel, "untouched").unwrap();
@@ -749,7 +1176,7 @@ mod tests {
         let base_path = root.path().join(workspace_key);
         std::fs::create_dir_all(&base_path).unwrap();
         std::fs::write(
-            WorkspaceManager::metadata_path(&base_path),
+            base_path.join(".ensemble-workspace.json"),
             r#"{"branch_date":"2020-01-01"}"#,
         )
         .unwrap();

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -87,8 +87,8 @@ impl WorkspaceManager {
     }
 
     /// Get the workspace path for an immutable issue identity without creating it.
-    pub fn workspace_path(&self, issue_id: &str, identifier: &str) -> PathBuf {
-        self.root.join(issue_workspace_key(issue_id, identifier))
+    pub fn workspace_path(&self, issue_id: &str) -> PathBuf {
+        self.root.join(issue_workspace_key(issue_id))
     }
 
     fn metadata_path(base_path: &Path) -> PathBuf {
@@ -137,17 +137,14 @@ impl WorkspaceManager {
         base_path: &Path,
         metadata: &WorkspaceMetadata,
         issue_id: &str,
-        identifier: &str,
     ) -> Result<(), WorkspaceError> {
-        if metadata.issue_id == issue_id && metadata.issue_identifier == identifier {
+        if metadata.issue_id == issue_id {
             return Ok(());
         }
         Err(WorkspaceError::OwnershipMismatch {
             path: base_path.display().to_string(),
             expected_issue_id: issue_id.to_string(),
-            expected_identifier: identifier.to_string(),
             actual_issue_id: metadata.issue_id.clone(),
-            actual_identifier: metadata.issue_identifier.clone(),
         })
     }
 
@@ -163,7 +160,7 @@ impl WorkspaceManager {
             issue_identifier = identifier,
             "preparing workspace"
         );
-        let workspace_key = issue_workspace_key(issue_id, identifier);
+        let workspace_key = issue_workspace_key(issue_id);
         let base_path = self.root.join(&workspace_key);
 
         // Safety: ensure workspace path is inside root
@@ -178,8 +175,13 @@ impl WorkspaceManager {
                     ),
                 });
             }
-            let metadata = self.load_metadata(&base_path).await?;
-            Self::verify_ownership(&base_path, &metadata, issue_id, identifier)?;
+            let mut metadata = self.load_metadata(&base_path).await?;
+            Self::verify_ownership(&base_path, &metadata, issue_id)?;
+            if metadata.issue_identifier != identifier {
+                self.save_metadata(&base_path, issue_id, identifier, &metadata.branch_date)
+                    .await?;
+                metadata.issue_identifier = identifier.to_string();
+            }
             (false, metadata)
         } else {
             std::fs::create_dir_all(&base_path).map_err(|e| WorkspaceError::CreationFailed {
@@ -217,7 +219,7 @@ impl WorkspaceManager {
                 base_path.clone(),
             );
             info!(workspace = %base_path.display(), "preparing worktrees inside workspace");
-            match coordinator.prepare_worktrees(identifier).await {
+            match coordinator.prepare_worktrees(issue_id).await {
                 Ok(worktrees) => worktrees,
                 Err(e) => {
                     warn!(
@@ -257,12 +259,8 @@ impl WorkspaceManager {
     }
 
     /// Remove a workspace directory and its worktrees for the given immutable issue identity.
-    pub async fn remove_workspace(
-        &self,
-        issue_id: &str,
-        identifier: &str,
-    ) -> Result<(), WorkspaceError> {
-        let workspace_key = issue_workspace_key(issue_id, identifier);
+    pub async fn remove_workspace(&self, issue_id: &str) -> Result<(), WorkspaceError> {
+        let workspace_key = issue_workspace_key(issue_id);
         let base_path = self.root.join(&workspace_key);
 
         self.validate_path_inside_root(&base_path)?;
@@ -270,7 +268,7 @@ impl WorkspaceManager {
             return Ok(());
         }
         let metadata = self.load_metadata(&base_path).await?;
-        Self::verify_ownership(&base_path, &metadata, issue_id, identifier)?;
+        Self::verify_ownership(&base_path, &metadata, issue_id)?;
 
         // Clean up worktrees first - use persisted branch date to avoid date drift
         if !self.repos.is_empty() {
@@ -280,12 +278,11 @@ impl WorkspaceManager {
                 base_path.clone(),
             );
             warn!(workspace = %base_path.display(), "cleaning up worktrees");
-            coordinator
-                .cleanup_worktrees(identifier)
-                .await
-                .map_err(|e| WorkspaceError::CreationFailed {
+            coordinator.cleanup_worktrees(issue_id).await.map_err(|e| {
+                WorkspaceError::CreationFailed {
                     reason: format!("worktree cleanup failed: {e}"),
-                })?;
+                }
+            })?;
         }
 
         // Remove base workspace
@@ -446,10 +443,7 @@ mod tests {
         let sentinel = base_path.join("sentinel");
         std::fs::write(&sentinel, "untouched").unwrap();
 
-        let error = mgr
-            .remove_workspace("NODE_42", "my-repo#42")
-            .await
-            .unwrap_err();
+        let error = mgr.remove_workspace("NODE_42").await.unwrap_err();
 
         assert!(matches!(error, WorkspaceError::OwnershipMismatch { .. }));
         assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
@@ -458,7 +452,7 @@ mod tests {
     #[tokio::test]
     async fn workspace_ownership_malformed_metadata_blocks_reuse_and_removal() {
         let (_dir, mgr) = setup();
-        let base_path = mgr.workspace_path("NODE_42", "my-repo#42");
+        let base_path = mgr.workspace_path("NODE_42");
         std::fs::create_dir_all(&base_path).unwrap();
         std::fs::write(WorkspaceManager::metadata_path(&base_path), "{not-json").unwrap();
         let sentinel = base_path.join("sentinel");
@@ -469,7 +463,7 @@ mod tests {
             Err(WorkspaceError::MetadataUnavailable { .. })
         ));
         assert!(matches!(
-            mgr.remove_workspace("NODE_42", "my-repo#42").await,
+            mgr.remove_workspace("NODE_42").await,
             Err(WorkspaceError::MetadataUnavailable { .. })
         ));
         assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
@@ -483,10 +477,7 @@ mod tests {
             .await
             .unwrap();
         assert!(result.created_now);
-        assert_eq!(
-            result.workspace_key,
-            issue_workspace_key("NODE_42", "my-repo#42")
-        );
+        assert_eq!(result.workspace_key, issue_workspace_key("NODE_42"));
         assert!(result.base_path.is_dir());
     }
 
@@ -508,15 +499,67 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_prepare_sanitizes_identifier() {
+    async fn workspace_ownership_reuses_and_removes_workspace_after_identifier_changes() {
+        let root = TempDir::new().unwrap();
+        let (_repo_dir, repo) = setup_repo("repo1");
+        let mgr = WorkspaceManager::new(root.path(), Some(vec![repo])).unwrap();
+
+        let first = mgr
+            .prepare_workspace("NODE_42", "old-repo#42")
+            .await
+            .unwrap();
+        let second = mgr
+            .prepare_workspace("NODE_42", "renamed-repo#42")
+            .await
+            .unwrap();
+
+        assert_eq!(first.base_path, second.base_path);
+        assert!(!second.created_now);
+        let first_worktree = first.worktrees.values().next().unwrap();
+        let second_worktree = second.worktrees.values().next().unwrap();
+        assert_eq!(first_worktree.path, second_worktree.path);
+        assert_eq!(first_worktree.branch, second_worktree.branch);
+        let metadata = mgr.load_metadata(&second.base_path).await.unwrap();
+        assert_eq!(metadata.issue_id, "NODE_42");
+        assert_eq!(metadata.issue_identifier, "renamed-repo#42");
+
+        mgr.remove_workspace("NODE_42").await.unwrap();
+        assert!(!first.base_path.exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_distinct_ids_with_colliding_readable_forms_isolate_worktrees() {
+        let root = TempDir::new().unwrap();
+        let (_repo_dir, repo) = setup_repo("repo1");
+        let mgr = WorkspaceManager::new(root.path(), Some(vec![repo])).unwrap();
+
+        let first = mgr.prepare_workspace("a#b", "repo#1").await.unwrap();
+        let second = mgr.prepare_workspace("a_b", "repo#2").await.unwrap();
+        let first_worktree = first.worktrees.values().next().unwrap();
+        let second_worktree = second.worktrees.values().next().unwrap();
+
+        assert_ne!(first.base_path, second.base_path);
+        assert_ne!(first_worktree.path, second_worktree.path);
+        assert_ne!(first_worktree.branch, second_worktree.branch);
+        assert!(first_worktree.path.exists());
+        assert!(second_worktree.path.exists());
+
+        mgr.remove_workspace("a#b").await.unwrap();
+        mgr.remove_workspace("a_b").await.unwrap();
+        assert!(!first.base_path.exists());
+        assert!(!second.base_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_prepare_sanitizes_issue_id() {
         let (_dir, mgr) = setup();
         let result = mgr
-            .prepare_workspace("NODE_123", "acme/repo 123!@#")
+            .prepare_workspace("acme/NODE 123!@#", "acme/repo#123")
             .await
             .unwrap();
         assert_eq!(
             result.workspace_key,
-            issue_workspace_key("NODE_123", "acme/repo 123!@#")
+            issue_workspace_key("acme/NODE 123!@#")
         );
         assert!(result.base_path.is_dir());
     }
@@ -542,20 +585,17 @@ mod tests {
             .await
             .unwrap();
 
-        let ws_path = mgr.workspace_path("NODE_42", "my-repo#42");
+        let ws_path = mgr.workspace_path("NODE_42");
         assert!(ws_path.exists());
 
-        mgr.remove_workspace("NODE_42", "my-repo#42").await.unwrap();
+        mgr.remove_workspace("NODE_42").await.unwrap();
         assert!(!ws_path.exists());
     }
 
     #[tokio::test]
     async fn test_remove_nonexistent_is_ok() {
         let (_dir, mgr) = setup();
-        assert!(mgr
-            .remove_workspace("NODE_MISSING", "nonexistent")
-            .await
-            .is_ok());
+        assert!(mgr.remove_workspace("NODE_MISSING").await.is_ok());
     }
 
     #[tokio::test]
@@ -568,7 +608,7 @@ mod tests {
     #[tokio::test]
     async fn test_file_at_workspace_path_errors() {
         let (_dir, mgr) = setup();
-        let file_path = mgr.workspace_path("NODE_42", "my-repo#42");
+        let file_path = mgr.workspace_path("NODE_42");
         std::fs::write(&file_path, "not a directory").unwrap();
 
         let result = mgr.prepare_workspace("NODE_42", "my-repo#42").await;
@@ -576,16 +616,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dot_identifier_uses_safe_workspace_key() {
+    async fn test_dot_issue_id_uses_safe_workspace_key() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace("NODE_DOT", ".").await.unwrap();
+        let result = mgr.prepare_workspace(".", "repo#dot").await.unwrap();
         assert!(result.base_path.is_dir());
     }
 
     #[tokio::test]
-    async fn test_dotdot_identifier_uses_safe_workspace_key() {
+    async fn test_dotdot_issue_id_uses_safe_workspace_key() {
         let (_dir, mgr) = setup();
-        let result = mgr.prepare_workspace("NODE_DOTDOT", "..").await.unwrap();
+        let result = mgr.prepare_workspace("..", "repo#dotdot").await.unwrap();
         assert!(result.base_path.is_dir());
     }
 
@@ -615,9 +655,8 @@ mod tests {
     async fn test_remove_workspace_uses_persisted_branch_date() {
         let dir = TempDir::new().unwrap();
 
-        let identifier = "test-issue";
         let issue_id = "NODE_TEST";
-        let workspace_key = issue_workspace_key(issue_id, identifier);
+        let workspace_key = issue_workspace_key(issue_id);
         let test_path = dir.path().join(&workspace_key);
         std::fs::create_dir_all(&test_path).unwrap();
 
@@ -636,7 +675,7 @@ mod tests {
         }];
         let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
 
-        let result = mgr.remove_workspace(issue_id, identifier).await;
+        let result = mgr.remove_workspace(issue_id).await;
         assert!(result.is_err());
         assert!(test_path.exists());
     }
@@ -652,7 +691,7 @@ mod tests {
         }];
         let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
 
-        let ws_path = mgr.workspace_path("NODE_CLEANUP", "cleanup-test");
+        let ws_path = mgr.workspace_path("NODE_CLEANUP");
         std::fs::create_dir_all(&ws_path).unwrap();
         let metadata_path = ws_path.join(".ensemble-workspace.json");
         std::fs::write(
@@ -661,7 +700,7 @@ mod tests {
         )
         .unwrap();
 
-        let remove_result = mgr.remove_workspace("NODE_CLEANUP", "cleanup-test").await;
+        let remove_result = mgr.remove_workspace("NODE_CLEANUP").await;
         assert!(remove_result.is_err());
 
         assert!(
@@ -678,7 +717,7 @@ mod tests {
 
         let identifier = "legacy#42";
         let issue_id = "NODE_LEGACY";
-        let workspace_key = issue_workspace_key(issue_id, identifier);
+        let workspace_key = issue_workspace_key(issue_id);
         let base_path = root.path().join(workspace_key);
         std::fs::create_dir_all(&base_path).unwrap();
 
@@ -692,7 +731,7 @@ mod tests {
             Err(WorkspaceError::MetadataUnavailable { .. })
         ));
         assert!(matches!(
-            mgr.remove_workspace(issue_id, identifier).await,
+            mgr.remove_workspace(issue_id).await,
             Err(WorkspaceError::MetadataUnavailable { .. })
         ));
         assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");
@@ -706,7 +745,7 @@ mod tests {
 
         let identifier = "legacy#43";
         let issue_id = "NODE_LEGACY_METADATA";
-        let workspace_key = issue_workspace_key(issue_id, identifier);
+        let workspace_key = issue_workspace_key(issue_id);
         let base_path = root.path().join(workspace_key);
         std::fs::create_dir_all(&base_path).unwrap();
         std::fs::write(
@@ -722,7 +761,7 @@ mod tests {
             Err(WorkspaceError::MetadataUnavailable { .. })
         ));
         assert!(matches!(
-            mgr.remove_workspace(issue_id, identifier).await,
+            mgr.remove_workspace(issue_id).await,
             Err(WorkspaceError::MetadataUnavailable { .. })
         ));
         assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "untouched");

--- a/crates/ensemble-core/src/workspace/mod.rs
+++ b/crates/ensemble-core/src/workspace/mod.rs
@@ -1,5 +1,6 @@
 pub mod coordinator;
 pub mod finalize;
 pub mod hooks;
+pub mod key;
 pub mod manager;
 pub mod worktree;

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -16,6 +16,7 @@ use ensemble_core::observability::events::EventBus;
 use ensemble_core::orchestrator::state::{OrchestratorState, WaitingOnHumanEntry};
 use ensemble_core::tracker::model::{Issue, RetryEntry, RunningEntry};
 use ensemble_core::transcript::events::TranscriptEventBus;
+use ensemble_core::workspace::key::issue_workspace_key;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -293,7 +294,10 @@ async fn test_get_issue_detail_running() {
     // Verify workspace info
     let workspace = json.get("workspace").unwrap();
     assert!(workspace.get("path").is_some());
-    assert!(workspace["path"].as_str().unwrap().contains("my-repo_42"));
+    assert!(workspace["path"]
+        .as_str()
+        .unwrap()
+        .ends_with(&issue_workspace_key("NODE_123")));
 
     // Verify attempts info
     let attempts = json.get("attempts").unwrap();

--- a/crates/ensemble-core/tests/workflow_to_workspace.rs
+++ b/crates/ensemble-core/tests/workflow_to_workspace.rs
@@ -2,8 +2,9 @@
 
 use ensemble_core::config::ensemble::{parse_config, EnsembleConfig, RepoConfig};
 use ensemble_core::config::template::render_prompt;
-use ensemble_core::tracker::model::{sanitize_workspace_key, Issue};
+use ensemble_core::tracker::model::Issue;
 use ensemble_core::workspace::hooks::run_hook;
+use ensemble_core::workspace::key::issue_workspace_key;
 use ensemble_core::workspace::manager::WorkspaceManager;
 use tempfile::TempDir;
 
@@ -85,21 +86,29 @@ async fn test_full_config_flow() {
 
     // 3. Create workspace
     let mgr = WorkspaceManager::new(&ws_root, None).unwrap();
-    let ws = mgr.prepare_workspace(&issue.identifier).await.unwrap();
+    let ws = mgr
+        .prepare_workspace(&issue.id, &issue.identifier)
+        .await
+        .unwrap();
     assert!(ws.created_now);
     assert!(ws.base_path.is_dir());
     assert_eq!(
         ws.workspace_key,
-        sanitize_workspace_key(&issue.identifier).unwrap()
+        issue_workspace_key(&issue.id, &issue.identifier)
     );
 
     // 4. Reuse workspace
-    let ws2 = mgr.prepare_workspace(&issue.identifier).await.unwrap();
+    let ws2 = mgr
+        .prepare_workspace(&issue.id, &issue.identifier)
+        .await
+        .unwrap();
     assert!(!ws2.created_now);
     assert_eq!(ws.base_path, ws2.base_path);
 
     // 5. Cleanup
-    mgr.remove_workspace(&issue.identifier).await.unwrap();
+    mgr.remove_workspace(&issue.id, &issue.identifier)
+        .await
+        .unwrap();
     assert!(!ws.base_path.exists());
 }
 
@@ -107,7 +116,10 @@ async fn test_full_config_flow() {
 async fn test_hook_in_workspace() {
     let dir = TempDir::new().unwrap();
     let mgr = WorkspaceManager::new(dir.path(), None).unwrap();
-    let ws = mgr.prepare_workspace("hook-test#1").await.unwrap();
+    let ws = mgr
+        .prepare_workspace("NODE_HOOK", "hook-test#1")
+        .await
+        .unwrap();
 
     // Run a hook that creates a file
     run_hook(
@@ -166,7 +178,10 @@ async fn test_workflow_with_worktrees() {
     let issue = sample_issue();
 
     // Create workspace with worktrees
-    let ws = mgr.prepare_workspace(&issue.identifier).await.unwrap();
+    let ws = mgr
+        .prepare_workspace(&issue.id, &issue.identifier)
+        .await
+        .unwrap();
     assert!(ws.created_now);
     assert!(ws.base_path.is_dir());
     assert!(!ws.worktrees.is_empty());
@@ -178,7 +193,10 @@ async fn test_workflow_with_worktrees() {
     assert!(worktree_info.path.join("README.md").exists());
 
     // Reuse workspace
-    let ws2 = mgr.prepare_workspace(&issue.identifier).await.unwrap();
+    let ws2 = mgr
+        .prepare_workspace(&issue.id, &issue.identifier)
+        .await
+        .unwrap();
     assert!(!ws2.created_now);
     let worktree_info2 = ws2.worktrees.get(repo_key).unwrap();
     assert!(!worktree_info2.created_now);
@@ -186,7 +204,49 @@ async fn test_workflow_with_worktrees() {
 
     // Cleanup
     let wt_path = worktree_info.path.clone();
-    mgr.remove_workspace(&issue.identifier).await.unwrap();
+    mgr.remove_workspace(&issue.id, &issue.identifier)
+        .await
+        .unwrap();
     assert!(!ws.base_path.exists());
     assert!(!wt_path.exists());
+}
+
+#[tokio::test]
+async fn collision_resistant_issue_workspace_lifecycle() {
+    let root = TempDir::new().unwrap();
+    let manager = WorkspaceManager::new(root.path(), None).unwrap();
+    let first = Issue {
+        id: "NODE_A".to_string(),
+        identifier: "a#b".to_string(),
+        ..sample_issue()
+    };
+    let second = Issue {
+        id: "NODE_B".to_string(),
+        identifier: "a_b".to_string(),
+        ..sample_issue()
+    };
+
+    let first_workspace = manager
+        .prepare_workspace(&first.id, &first.identifier)
+        .await
+        .unwrap();
+    let second_workspace = manager
+        .prepare_workspace(&second.id, &second.identifier)
+        .await
+        .unwrap();
+    assert_ne!(first_workspace.base_path, second_workspace.base_path);
+
+    let reused = manager
+        .prepare_workspace(&first.id, &first.identifier)
+        .await
+        .unwrap();
+    assert_eq!(reused.base_path, first_workspace.base_path);
+    assert!(!reused.created_now);
+
+    manager
+        .remove_workspace(&first.id, &first.identifier)
+        .await
+        .unwrap();
+    assert!(!first_workspace.base_path.exists());
+    assert!(second_workspace.base_path.exists());
 }

--- a/crates/ensemble-core/tests/workflow_to_workspace.rs
+++ b/crates/ensemble-core/tests/workflow_to_workspace.rs
@@ -92,10 +92,7 @@ async fn test_full_config_flow() {
         .unwrap();
     assert!(ws.created_now);
     assert!(ws.base_path.is_dir());
-    assert_eq!(
-        ws.workspace_key,
-        issue_workspace_key(&issue.id, &issue.identifier)
-    );
+    assert_eq!(ws.workspace_key, issue_workspace_key(&issue.id));
 
     // 4. Reuse workspace
     let ws2 = mgr
@@ -106,9 +103,7 @@ async fn test_full_config_flow() {
     assert_eq!(ws.base_path, ws2.base_path);
 
     // 5. Cleanup
-    mgr.remove_workspace(&issue.id, &issue.identifier)
-        .await
-        .unwrap();
+    mgr.remove_workspace(&issue.id).await.unwrap();
     assert!(!ws.base_path.exists());
 }
 
@@ -204,9 +199,7 @@ async fn test_workflow_with_worktrees() {
 
     // Cleanup
     let wt_path = worktree_info.path.clone();
-    mgr.remove_workspace(&issue.id, &issue.identifier)
-        .await
-        .unwrap();
+    mgr.remove_workspace(&issue.id).await.unwrap();
     assert!(!ws.base_path.exists());
     assert!(!wt_path.exists());
 }
@@ -243,10 +236,7 @@ async fn collision_resistant_issue_workspace_lifecycle() {
     assert_eq!(reused.base_path, first_workspace.base_path);
     assert!(!reused.created_now);
 
-    manager
-        .remove_workspace(&first.id, &first.identifier)
-        .await
-        .unwrap();
+    manager.remove_workspace(&first.id).await.unwrap();
     assert!(!first_workspace.base_path.exists());
     assert!(second_workspace.base_path.exists());
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -255,13 +255,14 @@ Pipeline step definition:
 
 #### 4.1.5 Workspace
 
-Filesystem workspace assigned to one issue identifier.
+Filesystem workspace assigned to one immutable issue identity.
 
 Fields (logical):
 
 - `path` (workspace path; current runtime typically uses absolute paths, but relative roots are
   possible if configured without path separators)
-- `workspace_key` (sanitized issue identifier)
+- `workspace_key` (bounded readable identifier prefix plus a stable identity digest)
+- `issue_id` and `issue_identifier` (persisted owner identity)
 - `created_now` (boolean, used to gate `after_create` hook)
 
 #### 4.1.6 Pipeline Run
@@ -1303,7 +1304,8 @@ Part B: Tracker state refresh
 - Fetch current issue states for all running issue IDs.
 - For each running issue:
   - If tracker state is terminal: drain and revalidate the worker, then release state and clean the
-    workspace.
+    workspace using both the immutable issue ID and identifier. Cleanup fails closed if persisted
+    workspace ownership does not match.
   - If tracker state is still active: update the in-memory issue snapshot.
   - If tracker state is neither active nor terminal: drain and revalidate the worker, then release
     state without workspace cleanup.
@@ -1327,10 +1329,12 @@ confirmed `Released` without waiting for an in-memory worker.
 When the service starts:
 
 1. Query tracker for issues in terminal states.
-2. For each returned issue identifier, remove the corresponding workspace directory.
+2. For each returned issue identity, resolve the workspace from both its immutable ID and
+   identifier, verify its persisted owner metadata, and remove the corresponding directory.
 3. If the terminal-issues fetch fails, log a warning and continue startup.
 
-This prevents stale terminal workspaces from accumulating after restarts.
+An absent canonical workspace is already clean. A workspace with missing, malformed, ownerless, or
+mismatched metadata is left untouched and reported as a cleanup failure; startup continues.
 
 ## 9. Workspace Management and Safety
 
@@ -1343,25 +1347,41 @@ Workspace root:
 
 Per-issue workspace path:
 
-- `<workspace.root>/<sanitized_issue_identifier>`
+- `<workspace.root>/<readable_identifier_prefix>--<identity_sha256>`
+
+The readable prefix contains only `[A-Za-z0-9._-]`, is capped at 80 bytes, and falls back to
+`issue` when the sanitized result would be empty, `.` or `..`. The lowercase SHA-256 suffix hashes
+the length-framed UTF-8 bytes of `(issue.id, issue.identifier)`, so punctuation collisions and
+identical readable identifiers with different immutable IDs remain distinct. The resulting path
+component is at most 146 bytes.
 
 Workspace persistence:
 
-- Workspaces are reused across runs for the same issue.
+- Workspaces are reused across runs for the same exact issue identity.
 - Successful runs do not auto-delete workspaces.
+- `.ensemble-workspace.json` stores `issue_id`, `issue_identifier`, and the branch date used for
+  repository worktrees.
 
 ### 9.2 Workspace Creation and Reuse
 
-Input: `issue.identifier`
+Input: `issue.id` and `issue.identifier`
 
 Algorithm summary:
 
-1. Sanitize identifier to `workspace_key`.
+1. Derive the bounded readable-plus-digest `workspace_key` from both identity fields.
 2. Compute workspace path under workspace root.
-3. Ensure the workspace path exists as a directory.
-4. Mark `created_now=true` only if the directory was created during this call; otherwise
+3. For a new directory, persist exact owner metadata before hooks or repository worktree
+   preparation.
+4. For an existing directory, load owner metadata and require both fields to match before reuse,
+   metadata changes, hooks, or repository worktree preparation.
+5. Mark `created_now=true` only if the directory was created during this call; otherwise
    `created_now=false`.
-5. If `created_now=true`, run `after_create` hook if configured.
+6. If `created_now=true`, run `after_create` hook if configured.
+
+Missing, malformed, ownerless legacy, or mismatched metadata is not repaired or adopted. Reuse and
+removal fail before any workspace side effect. Removing an absent canonical workspace remains
+idempotent. Implementations do not scan, migrate, rename, or remove legacy identifier-only
+directories as part of normal workspace lifecycle.
 
 Notes:
 
@@ -1424,10 +1444,17 @@ Invariant 2: Workspace path must stay inside workspace root.
 - Require `workspace_path` to have `workspace_root` as a prefix directory.
 - Reject any path outside the workspace root.
 
-Invariant 3: Workspace key is sanitized.
+Invariant 3: Workspace key is safe and collision-resistant.
 
 - Only `[A-Za-z0-9._-]` allowed in workspace directory names.
-- Replace all other characters with `_`.
+- Bound the readable prefix and append the full stable identity digest.
+
+Invariant 4: Existing workspace ownership is proven before reuse or deletion.
+
+- Require readable, valid owner metadata containing both `issue.id` and `issue.identifier`.
+- Require both persisted fields to exactly equal the requested identity.
+- Treat missing, malformed, ownerless, or mismatched metadata as a fail-closed error before hooks,
+  repository worktree operations, metadata repair, or recursive deletion.
 
 ## 10. Agent Runner Protocol (ACP Integration)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1330,11 +1330,14 @@ When the service starts:
 
 1. Query tracker for issues in terminal states.
 2. For each returned issue identity, resolve the workspace from its immutable ID, verify its
-   persisted owner metadata, and remove the corresponding directory.
+   manager-owned sidecar metadata, and remove the corresponding directory and sidecar.
 3. If the terminal-issues fetch fails, log a warning and continue startup.
 
-An absent canonical workspace is already clean. A workspace with missing, malformed, ownerless, or
-mismatched metadata is left untouched and reported as a cleanup failure; startup continues.
+An absent canonical workspace with no sidecar is already clean. When the workspace is absent but a
+valid matching sidecar remains from interrupted cleanup, cleanup removes the sidecar and succeeds.
+A present workspace with missing, malformed, ownerless, or mismatched sidecar metadata is left
+untouched and reported as a cleanup failure; startup continues. Corrupt or mismatched leftover
+sidecars also fail closed.
 
 ## 9. Workspace Management and Safety
 
@@ -1360,8 +1363,10 @@ Workspace persistence:
 - Workspaces are reused across runs for the same immutable issue ID, including when the display
   identifier changes.
 - Successful runs do not auto-delete workspaces.
-- `.ensemble-workspace.json` stores `issue_id`, `issue_identifier`, and the branch date used for
-  repository worktrees.
+- `<workspace.root>/.ensemble-workspace-metadata/<workspace_key>.json` stores `issue_id`,
+  `issue_identifier`, and the branch date used for repository worktrees. This manager-owned
+  sidecar, outside the agent workspace, is the ownership authority. Files inside an agent
+  workspace, including a forged `.ensemble-workspace.json`, have no lifecycle authority.
 - Built-in coordinated repository worktrees derive their branch identity from the same
   collision-resistant immutable-ID key. Display-identifier changes therefore reuse the same branch,
   while distinct issue IDs remain isolated even when lossy branch sanitization would otherwise
@@ -1373,21 +1378,29 @@ Input: `issue.id` and `issue.identifier`
 
 Algorithm summary:
 
-1. Derive the bounded readable-plus-digest `workspace_key` from `issue.id`.
-2. Compute workspace path under workspace root.
-3. For a new directory, persist owner metadata before hooks or repository worktree
-   preparation.
-4. For an existing directory, load owner metadata and require `issue_id` to match before reuse,
-   hooks, or repository worktree preparation. `issue_identifier` is informational display metadata
-   and may be refreshed when the same issue ID is observed under a different identifier.
+1. Derive the bounded readable-plus-digest `workspace_key` from `issue.id` and acquire the
+   process-wide lifecycle transaction for that workspace root and key. Preparation and removal
+   hold the same per-issue transaction through metadata checks, repository worktree operations,
+   and workspace and sidecar mutation.
+2. Compute the workspace path under the workspace root.
+3. For a new directory, atomically create manager-owned owner metadata without replacing an
+   existing sidecar, before hooks or repository worktree preparation. If metadata creation fails,
+   remove the newly created empty directory.
+4. For an existing directory, load sidecar metadata and require `issue_id` to match before reuse,
+   hooks, repository worktree preparation, or any metadata write. `issue_identifier` is
+   informational display metadata and may be refreshed after immutable-ID verification using an
+   atomic replacement, so a failed refresh leaves the previous valid sidecar intact.
 5. Mark `created_now=true` only if the directory was created during this call; otherwise
    `created_now=false`.
 6. If `created_now=true`, run `after_create` hook if configured.
 
-Missing, malformed, ownerless legacy, or mismatched metadata is not repaired or adopted. Reuse and
-removal fail before any workspace side effect. Removing an absent canonical workspace remains
-idempotent. Implementations do not scan, migrate, rename, or remove legacy identifier-only
-directories as part of normal workspace lifecycle.
+Missing, malformed, ownerless legacy, or mismatched sidecar metadata is not repaired or adopted.
+Reuse and removal fail before any workspace side effect. Removing an absent canonical workspace
+with no sidecar remains idempotent; removing one with a valid matching leftover sidecar completes
+the interrupted cleanup. Cleanup removes repository worktrees exhaustively, then the agent
+workspace, then the sidecar. A sidecar-removal failure is retryable because the valid sidecar
+remains authoritative. Implementations do not scan, migrate, rename, or remove legacy
+identifier-only directories, and do not migrate or adopt in-workspace metadata.
 
 Notes:
 
@@ -1455,13 +1468,16 @@ Invariant 3: Workspace key is safe and collision-resistant.
 - Only `[A-Za-z0-9._-]` allowed in workspace directory names.
 - Bound the readable prefix and append the full stable identity digest.
 
-Invariant 4: Existing workspace ownership is proven before reuse or deletion.
+Invariant 4: Existing workspace ownership is proven from manager-owned state before reuse or
+deletion.
 
-- Require readable, valid owner metadata containing both `issue.id` and `issue.identifier`.
+- Require a readable, valid sidecar under `.ensemble-workspace-metadata` containing both `issue.id`
+  and `issue.identifier`.
 - Require persisted `issue.id` to exactly equal the requested immutable ID; do not treat a changed
   display identifier as a different owner.
-- Treat missing, malformed, ownerless, or mismatched metadata as a fail-closed error before hooks,
-  repository worktree operations, metadata repair, or recursive deletion.
+- Treat missing, malformed, ownerless, or mismatched sidecar metadata as a fail-closed error before
+  hooks, repository worktree operations, metadata repair, or recursive deletion.
+- Do not use metadata inside the agent-writable workspace as ownership authority.
 
 ## 10. Agent Runner Protocol (ACP Integration)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -261,8 +261,8 @@ Fields (logical):
 
 - `path` (workspace path; current runtime typically uses absolute paths, but relative roots are
   possible if configured without path separators)
-- `workspace_key` (bounded readable identifier prefix plus a stable identity digest)
-- `issue_id` and `issue_identifier` (persisted owner identity)
+- `workspace_key` (bounded readable issue-ID prefix plus a stable identity digest)
+- `issue_id` (persisted ownership authority) and `issue_identifier` (persisted display metadata)
 - `created_now` (boolean, used to gate `after_create` hook)
 
 #### 4.1.6 Pipeline Run
@@ -1304,8 +1304,8 @@ Part B: Tracker state refresh
 - Fetch current issue states for all running issue IDs.
 - For each running issue:
   - If tracker state is terminal: drain and revalidate the worker, then release state and clean the
-    workspace using both the immutable issue ID and identifier. Cleanup fails closed if persisted
-    workspace ownership does not match.
+    workspace using the immutable issue ID. Cleanup fails closed if persisted workspace ownership
+    does not match.
   - If tracker state is still active: update the in-memory issue snapshot.
   - If tracker state is neither active nor terminal: drain and revalidate the worker, then release
     state without workspace cleanup.
@@ -1329,8 +1329,8 @@ confirmed `Released` without waiting for an in-memory worker.
 When the service starts:
 
 1. Query tracker for issues in terminal states.
-2. For each returned issue identity, resolve the workspace from both its immutable ID and
-   identifier, verify its persisted owner metadata, and remove the corresponding directory.
+2. For each returned issue identity, resolve the workspace from its immutable ID, verify its
+   persisted owner metadata, and remove the corresponding directory.
 3. If the terminal-issues fetch fails, log a warning and continue startup.
 
 An absent canonical workspace is already clean. A workspace with missing, malformed, ownerless, or
@@ -1347,20 +1347,25 @@ Workspace root:
 
 Per-issue workspace path:
 
-- `<workspace.root>/<readable_identifier_prefix>--<identity_sha256>`
+- `<workspace.root>/<readable_issue_id_prefix>--<identity_sha256>`
 
 The readable prefix contains only `[A-Za-z0-9._-]`, is capped at 80 bytes, and falls back to
 `issue` when the sanitized result would be empty, `.` or `..`. The lowercase SHA-256 suffix hashes
-the length-framed UTF-8 bytes of `(issue.id, issue.identifier)`, so punctuation collisions and
-identical readable identifiers with different immutable IDs remain distinct. The resulting path
-component is at most 146 bytes.
+the length-framed UTF-8 bytes of `issue.id`, so display-identifier changes preserve the path while
+distinct immutable IDs remain distinct even when their readable prefixes collide. The resulting
+path component is at most 146 bytes.
 
 Workspace persistence:
 
-- Workspaces are reused across runs for the same exact issue identity.
+- Workspaces are reused across runs for the same immutable issue ID, including when the display
+  identifier changes.
 - Successful runs do not auto-delete workspaces.
 - `.ensemble-workspace.json` stores `issue_id`, `issue_identifier`, and the branch date used for
   repository worktrees.
+- Built-in coordinated repository worktrees derive their branch identity from the same
+  collision-resistant immutable-ID key. Display-identifier changes therefore reuse the same branch,
+  while distinct issue IDs remain isolated even when lossy branch sanitization would otherwise
+  collide.
 
 ### 9.2 Workspace Creation and Reuse
 
@@ -1368,12 +1373,13 @@ Input: `issue.id` and `issue.identifier`
 
 Algorithm summary:
 
-1. Derive the bounded readable-plus-digest `workspace_key` from both identity fields.
+1. Derive the bounded readable-plus-digest `workspace_key` from `issue.id`.
 2. Compute workspace path under workspace root.
-3. For a new directory, persist exact owner metadata before hooks or repository worktree
+3. For a new directory, persist owner metadata before hooks or repository worktree
    preparation.
-4. For an existing directory, load owner metadata and require both fields to match before reuse,
-   metadata changes, hooks, or repository worktree preparation.
+4. For an existing directory, load owner metadata and require `issue_id` to match before reuse,
+   hooks, or repository worktree preparation. `issue_identifier` is informational display metadata
+   and may be refreshed when the same issue ID is observed under a different identifier.
 5. Mark `created_now=true` only if the directory was created during this call; otherwise
    `created_now=false`.
 6. If `created_now=true`, run `after_create` hook if configured.
@@ -1452,7 +1458,8 @@ Invariant 3: Workspace key is safe and collision-resistant.
 Invariant 4: Existing workspace ownership is proven before reuse or deletion.
 
 - Require readable, valid owner metadata containing both `issue.id` and `issue.identifier`.
-- Require both persisted fields to exactly equal the requested identity.
+- Require persisted `issue.id` to exactly equal the requested immutable ID; do not treat a changed
+  display identifier as a different owner.
 - Treat missing, malformed, ownerless, or mismatched metadata as a fail-closed error before hooks,
   repository worktree operations, metadata repair, or recursive deletion.
 


### PR DESCRIPTION
Closes #321

## Summary
- derive bounded readable workspace keys from immutable issue identity plus a full SHA-256 suffix
- persist and verify exact workspace ownership before reuse or removal
- route lifecycle, reconciliation, snapshot, history, and artifact-facing paths through the canonical identity-aware key
- document the fail-closed workspace ownership contract

## Validation
- focused key, ownership, collision lifecycle, cleanup, projection, retry-restoration, and artifact-path suites
- cargo test --workspace --exclude ensemble-desktop
- product E2E with web-ui
- web-ui feature check
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check
- review-and-simplify, ponytail, standards, and plan/SPEC reviews clean