### PR TITLE
Make config reload transactional

### DIFF
--- a/crates/ensemble-cli/src/commands/run.rs
+++ b/crates/ensemble-cli/src/commands/run.rs
@@ -5,7 +5,7 @@ use tracing::{error, info, warn};
 use ensemble_core::api::bootstrap::{
     build_app_state, clear_registered_orchestrator, start_or_replace_registered_orchestrator,
 };
-use ensemble_core::config::draft::load_config_document_or_missing;
+use ensemble_core::config::draft::recover_and_load_config_state;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
 use ensemble_core::config_watcher::start_config_watcher;
 use ensemble_core::observability::events::EventBus;
@@ -46,7 +46,14 @@ pub async fn execute(args: RunArgs) -> ExitCode {
         "starting ensemble in headless mode"
     );
 
-    let document_state = load_config_document_or_missing(&resolved.config_path);
+    let document_state = match recover_and_load_config_state(&resolved.config_path) {
+        Ok(state) => state,
+        Err(error) => {
+            error!(error = %error, "failed to recover or load config");
+            eprintln!("error: failed to recover or load config: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
     let prepared = build_app_state(
         resolved.config_path.clone(),
         document_state,

--- a/crates/ensemble-cli/src/commands/web.rs
+++ b/crates/ensemble-cli/src/commands/web.rs
@@ -7,7 +7,7 @@ use ensemble_core::api::bootstrap::{
     build_app_state, clear_registered_orchestrator, start_or_replace_registered_orchestrator,
 };
 use ensemble_core::api::router::create_api_router;
-use ensemble_core::config::draft::load_config_document_or_missing;
+use ensemble_core::config::draft::recover_and_load_config_state;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
 use ensemble_core::config_watcher::start_config_watcher;
 use ensemble_core::observability::events::EventBus;
@@ -73,7 +73,14 @@ pub async fn execute(args: WebArgs) -> ExitCode {
         "starting ensemble in web mode"
     );
 
-    let document_state = load_config_document_or_missing(&resolved.config_path);
+    let document_state = match recover_and_load_config_state(&resolved.config_path) {
+        Ok(state) => state,
+        Err(error) => {
+            error!(error = %error, "failed to recover or load config");
+            eprintln!("error: failed to recover or load config: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
     let prepared = build_app_state(
         resolved.config_path.clone(),
         document_state,

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -389,30 +389,66 @@ pub async fn start_or_replace_registered_orchestrator(
         candidate,
         file_mtime,
         ORCHESTRATOR_RESTART_TIMEOUT,
+        || Ok(()),
     )
     .await
 }
 
-pub(crate) async fn apply_prepared_config_candidate(
+pub(crate) async fn apply_prepared_config_candidate_with_hooks<Commit, AfterCommit>(
     app_state: &AppState,
     candidate: ConfigDocumentState,
     file_mtime: Option<SystemTime>,
-) -> Result<bool, EnsembleError> {
-    apply_prepared_config_candidate_with_timeout(
+    before_commit: Commit,
+    after_commit: AfterCommit,
+) -> Result<bool, EnsembleError>
+where
+    Commit: FnOnce() -> Result<(), EnsembleError>,
+    AfterCommit: FnOnce(),
+{
+    apply_prepared_config_candidate_with_timeout_and_hooks(
         app_state,
         candidate,
         file_mtime,
         ORCHESTRATOR_RESTART_TIMEOUT,
+        before_commit,
+        after_commit,
     )
     .await
 }
 
-async fn apply_prepared_config_candidate_with_timeout(
+async fn apply_prepared_config_candidate_with_timeout<Commit>(
     app_state: &AppState,
     candidate: ConfigDocumentState,
     file_mtime: Option<SystemTime>,
     restart_timeout: Duration,
-) -> Result<bool, EnsembleError> {
+    before_commit: Commit,
+) -> Result<bool, EnsembleError>
+where
+    Commit: FnOnce() -> Result<(), EnsembleError>,
+{
+    apply_prepared_config_candidate_with_timeout_and_hooks(
+        app_state,
+        candidate,
+        file_mtime,
+        restart_timeout,
+        before_commit,
+        || {},
+    )
+    .await
+}
+
+async fn apply_prepared_config_candidate_with_timeout_and_hooks<Commit, AfterCommit>(
+    app_state: &AppState,
+    candidate: ConfigDocumentState,
+    file_mtime: Option<SystemTime>,
+    restart_timeout: Duration,
+    before_commit: Commit,
+    after_commit: AfterCommit,
+) -> Result<bool, EnsembleError>
+where
+    Commit: FnOnce() -> Result<(), EnsembleError>,
+    AfterCommit: FnOnce(),
+{
     let (active_raw_yaml, active_repos) = {
         let active = app_state.config_runtime.document_state.read().await;
         (
@@ -457,9 +493,10 @@ async fn apply_prepared_config_candidate_with_timeout(
         }
     }
 
-    let current_file_matches_candidate =
-        std::fs::read_to_string(&app_state.config_runtime.config_path).ok() == candidate.raw_yaml;
     if let Some(expected_mtime) = file_mtime {
+        let current_file_matches_candidate =
+            std::fs::read_to_string(&app_state.config_runtime.config_path).ok()
+                == candidate.raw_yaml;
         let current_mtime = std::fs::metadata(&app_state.config_runtime.config_path)
             .and_then(|metadata| metadata.modified())
             .ok();
@@ -492,6 +529,21 @@ async fn apply_prepared_config_candidate_with_timeout(
         _ => return Err(EnsembleError::RuntimeBusy),
     }
 
+    before_commit()?;
+    if let Some(expected_mtime) = file_mtime {
+        let current_file_matches_candidate =
+            std::fs::read_to_string(&app_state.config_runtime.config_path).ok()
+                == candidate.raw_yaml;
+        let current_mtime = std::fs::metadata(&app_state.config_runtime.config_path)
+            .and_then(|metadata| metadata.modified())
+            .ok();
+        if candidate.raw_yaml.is_some()
+            && (!current_file_matches_candidate || current_mtime != Some(expected_mtime))
+        {
+            return Err(EnsembleError::RuntimeBusy);
+        }
+    }
+
     let retired = registered.take();
     let (replacement, start_tx) = match prepared {
         Some(prepared) => {
@@ -521,6 +573,7 @@ async fn apply_prepared_config_candidate_with_timeout(
     drop(orchestrator_state);
     drop(last_loaded_mtime);
     drop(document_state);
+    after_commit();
     if let Some(start_tx) = start_tx {
         let _ = start_tx.send(());
     }
@@ -529,7 +582,7 @@ async fn apply_prepared_config_candidate_with_timeout(
 }
 
 #[cfg(test)]
-async fn start_or_replace_registered_orchestrator_with_timeout(
+pub(crate) async fn start_or_replace_registered_orchestrator_with_timeout(
     app_state: &AppState,
     restart_timeout: Duration,
 ) -> Result<bool, EnsembleError> {
@@ -537,8 +590,14 @@ async fn start_or_replace_registered_orchestrator_with_timeout(
     let file_mtime = std::fs::metadata(&app_state.config_runtime.config_path)
         .and_then(|metadata| metadata.modified())
         .ok();
-    apply_prepared_config_candidate_with_timeout(app_state, candidate, file_mtime, restart_timeout)
-        .await
+    apply_prepared_config_candidate_with_timeout(
+        app_state,
+        candidate,
+        file_mtime,
+        restart_timeout,
+        || Ok(()),
+    )
+    .await
 }
 
 async fn wait_for_registered_runtime_completion(
@@ -931,6 +990,7 @@ mod tests {
                     candidate,
                     None,
                     Duration::from_secs(2),
+                    || Ok(()),
                 )
                 .await
             }
@@ -1103,6 +1163,7 @@ mod tests {
             candidate.clone(),
             None,
             Duration::from_millis(20),
+            || Ok(()),
         )
         .await;
         assert!(matches!(first, Err(EnsembleError::RuntimeBusy)));
@@ -1134,6 +1195,7 @@ mod tests {
             candidate.clone(),
             None,
             Duration::from_millis(20),
+            || Ok(()),
         )
         .await;
         assert!(matches!(concurrent, Err(EnsembleError::RuntimeBusy)));
@@ -1157,6 +1219,7 @@ mod tests {
                     candidate.clone(),
                     None,
                     Duration::from_millis(20),
+                    || Ok(()),
                 )
                 .await,
                 Err(EnsembleError::RuntimeBusy)
@@ -1180,6 +1243,7 @@ mod tests {
             candidate,
             None,
             Duration::from_secs(1),
+            || Ok(()),
         )
         .await
         .unwrap());

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -21,8 +21,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::MutexGuard;
-use std::time::Duration;
-use tokio::sync::{mpsc, watch, RwLock};
+use std::time::{Duration, SystemTime};
+use tokio::sync::{mpsc, oneshot, watch, RwLock};
 use tokio::task::JoinHandle;
 use tracing::warn;
 
@@ -124,7 +124,7 @@ impl RegisteredOrchestrator {
     }
 }
 
-struct PreparedOrchestratorRuntime {
+pub(crate) struct PreparedOrchestratorRuntime {
     orchestrator: Orchestrator,
     shutdown_tx: mpsc::Sender<()>,
 }
@@ -216,6 +216,7 @@ pub fn build_app_state(
         config_runtime: ConfigRuntime {
             config_path,
             document_state: Arc::new(RwLock::new(document_state)),
+            reload_coordinator: Arc::new(tokio::sync::Mutex::new(())),
             last_loaded_mtime: Arc::new(RwLock::new(None)),
         },
         cancellation_registry: new_cancellation_registry(),
@@ -245,20 +246,11 @@ fn registered_orchestrator_guard(
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
-async fn prepare_orchestrator_runtime(
+pub(crate) async fn prepare_orchestrator_runtime(
     app_state: &AppState,
+    candidate: &ConfigDocumentState,
 ) -> Result<Option<PreparedOrchestratorRuntime>, EnsembleError> {
-    let active_config = {
-        app_state
-            .config_runtime
-            .document_state
-            .read()
-            .await
-            .active_config
-            .clone()
-    };
-
-    let Some(config) = active_config else {
+    let Some(config) = candidate.active_config.clone() else {
         return Ok(None);
     };
 
@@ -276,7 +268,7 @@ async fn prepare_orchestrator_runtime(
     )?;
     let config_dir = config_dir_for_path(&app_state.config_runtime.config_path)?;
     let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
-    let orchestrator = Orchestrator::new_with_state(
+    let orchestrator = Orchestrator::new_with_state_and_history(
         OrchestratorRuntimeParts {
             state: Arc::clone(&app_state.orchestrator_state),
             config,
@@ -291,6 +283,7 @@ async fn prepare_orchestrator_runtime(
         },
         &config_dir,
         shutdown_rx,
+        app_state.history_store.clone(),
     );
 
     Ok(Some(PreparedOrchestratorRuntime {
@@ -299,7 +292,9 @@ async fn prepare_orchestrator_runtime(
     }))
 }
 
-fn launch_orchestrator_runtime(prepared: PreparedOrchestratorRuntime) -> OrchestratorRuntime {
+fn launch_orchestrator_runtime_gated(
+    prepared: PreparedOrchestratorRuntime,
+) -> (OrchestratorRuntime, oneshot::Sender<()>) {
     let PreparedOrchestratorRuntime {
         mut orchestrator,
         shutdown_tx,
@@ -308,28 +303,42 @@ fn launch_orchestrator_runtime(prepared: PreparedOrchestratorRuntime) -> Orchest
     let quiescing = orchestrator.quiescing_latch_owner();
     let command_tx = orchestrator.command_sender_owner();
     let (completion_tx, completion) = watch::channel(false);
+    let (start_tx, start_rx) = oneshot::channel();
     let task = tokio::spawn(async move {
+        if start_rx.await.is_err() {
+            return;
+        }
         let quiesced = orchestrator.run().await;
         if quiesced {
             let _ = completion_tx.send(true);
         }
     });
 
-    OrchestratorRuntime {
-        id: NEXT_RUNTIME_ID.fetch_add(1, Ordering::Relaxed),
-        shutdown_tx,
-        completion,
-        quiescing,
-        command_tx,
-        _worker_event_receiver: worker_event_receiver,
-        task,
-    }
+    (
+        OrchestratorRuntime {
+            id: NEXT_RUNTIME_ID.fetch_add(1, Ordering::Relaxed),
+            shutdown_tx,
+            completion,
+            quiescing,
+            command_tx,
+            _worker_event_receiver: worker_event_receiver,
+            task,
+        },
+        start_tx,
+    )
+}
+
+fn launch_orchestrator_runtime(prepared: PreparedOrchestratorRuntime) -> OrchestratorRuntime {
+    let (runtime, start_tx) = launch_orchestrator_runtime_gated(prepared);
+    let _ = start_tx.send(());
+    runtime
 }
 
 pub async fn start_orchestrator_for_app(
     app_state: &AppState,
 ) -> Result<Option<OrchestratorRuntime>, EnsembleError> {
-    Ok(prepare_orchestrator_runtime(app_state)
+    let candidate = app_state.config_runtime.document_state.read().await.clone();
+    Ok(prepare_orchestrator_runtime(app_state, &candidate)
         .await?
         .map(launch_orchestrator_runtime))
 }
@@ -370,64 +379,166 @@ pub async fn clear_registered_orchestrator(app_state: &AppState) {
 pub async fn start_or_replace_registered_orchestrator(
     app_state: &AppState,
 ) -> Result<bool, EnsembleError> {
-    start_or_replace_registered_orchestrator_with_timeout(app_state, ORCHESTRATOR_RESTART_TIMEOUT)
-        .await
+    let _reload = app_state.config_runtime.reload_coordinator.lock().await;
+    let candidate = app_state.config_runtime.document_state.read().await.clone();
+    let file_mtime = std::fs::metadata(&app_state.config_runtime.config_path)
+        .and_then(|metadata| metadata.modified())
+        .ok();
+    apply_prepared_config_candidate_with_timeout(
+        app_state,
+        candidate,
+        file_mtime,
+        ORCHESTRATOR_RESTART_TIMEOUT,
+    )
+    .await
 }
 
+pub(crate) async fn apply_prepared_config_candidate(
+    app_state: &AppState,
+    candidate: ConfigDocumentState,
+    file_mtime: Option<SystemTime>,
+) -> Result<bool, EnsembleError> {
+    apply_prepared_config_candidate_with_timeout(
+        app_state,
+        candidate,
+        file_mtime,
+        ORCHESTRATOR_RESTART_TIMEOUT,
+    )
+    .await
+}
+
+async fn apply_prepared_config_candidate_with_timeout(
+    app_state: &AppState,
+    candidate: ConfigDocumentState,
+    file_mtime: Option<SystemTime>,
+    restart_timeout: Duration,
+) -> Result<bool, EnsembleError> {
+    let (active_raw_yaml, active_repos) = {
+        let active = app_state.config_runtime.document_state.read().await;
+        (
+            active.raw_yaml.clone(),
+            active
+                .active_config
+                .as_ref()
+                .map(|config| config.repos.clone()),
+        )
+    };
+    let prepared = prepare_orchestrator_runtime(app_state, &candidate).await?;
+    let started = prepared.is_some();
+
+    let prior_runtime = {
+        let mut registered = registered_orchestrator_guard(app_state);
+        if let Some(existing) = registered.as_mut() {
+            match existing.phase {
+                RuntimePhase::QuiescingForShutdown => return Err(EnsembleError::RuntimeBusy),
+                RuntimePhase::QuiescingForReplacement if !existing.runtime.is_complete() => {
+                    return Err(EnsembleError::RuntimeBusy);
+                }
+                RuntimePhase::Running | RuntimePhase::QuiescingForReplacement => {}
+            }
+            existing.phase = RuntimePhase::QuiescingForReplacement;
+            existing.runtime.request_shutdown();
+            Some((existing.runtime.id, existing.runtime.completion.clone()))
+        } else {
+            None
+        }
+    };
+
+    if let Some((runtime_id, completion)) = prior_runtime.as_ref() {
+        if !wait_for_registered_runtime_completion(
+            app_state,
+            *runtime_id,
+            completion.clone(),
+            restart_timeout,
+        )
+        .await
+        {
+            return Err(EnsembleError::RuntimeBusy);
+        }
+    }
+
+    let current_file_matches_candidate =
+        std::fs::read_to_string(&app_state.config_runtime.config_path).ok() == candidate.raw_yaml;
+    if let Some(expected_mtime) = file_mtime {
+        let current_mtime = std::fs::metadata(&app_state.config_runtime.config_path)
+            .and_then(|metadata| metadata.modified())
+            .ok();
+        if candidate.raw_yaml.is_some()
+            && (!current_file_matches_candidate || current_mtime != Some(expected_mtime))
+        {
+            return Err(EnsembleError::RuntimeBusy);
+        }
+    }
+
+    let mut document_state = app_state.config_runtime.document_state.write().await;
+    let mut last_loaded_mtime = app_state.config_runtime.last_loaded_mtime.write().await;
+    let mut orchestrator_state = app_state.orchestrator_state.write().await;
+    let mut registered = registered_orchestrator_guard(app_state);
+
+    let current_repos = document_state
+        .active_config
+        .as_ref()
+        .map(|config| config.repos.clone());
+    if document_state.raw_yaml != active_raw_yaml || current_repos != active_repos {
+        return Err(EnsembleError::RuntimeBusy);
+    }
+
+    match (registered.as_ref(), prior_runtime.as_ref()) {
+        (None, None) => {}
+        (Some(existing), Some((runtime_id, _)))
+            if existing.phase == RuntimePhase::QuiescingForReplacement
+                && existing.runtime.id == *runtime_id
+                && existing.runtime.is_complete() => {}
+        _ => return Err(EnsembleError::RuntimeBusy),
+    }
+
+    let retired = registered.take();
+    let (replacement, start_tx) = match prepared {
+        Some(prepared) => {
+            let (runtime, start_tx) = launch_orchestrator_runtime_gated(prepared);
+            (
+                Some(RegisteredRuntime {
+                    phase: RuntimePhase::Running,
+                    runtime,
+                }),
+                Some(start_tx),
+            )
+        }
+        None => (None, None),
+    };
+    *registered = replacement;
+
+    if let Some(config) = candidate.active_config.as_ref() {
+        orchestrator_state.poll_interval_ms = config.polling.interval_ms;
+        orchestrator_state.max_concurrent_agents = config.concurrency.max_concurrent_agents;
+        orchestrator_state.completed_expiry_secs = config.concurrency.completed_expiry_secs;
+        orchestrator_state.init_state_lists(config);
+    }
+    *document_state = candidate;
+    *last_loaded_mtime = file_mtime;
+
+    drop(registered);
+    drop(orchestrator_state);
+    drop(last_loaded_mtime);
+    drop(document_state);
+    if let Some(start_tx) = start_tx {
+        let _ = start_tx.send(());
+    }
+    drop(retired);
+    Ok(started)
+}
+
+#[cfg(test)]
 async fn start_or_replace_registered_orchestrator_with_timeout(
     app_state: &AppState,
     restart_timeout: Duration,
 ) -> Result<bool, EnsembleError> {
-    let prepared = prepare_orchestrator_runtime(app_state).await?;
-    let started = prepared.is_some();
-
-    let (runtime_id, completion) = {
-        let mut registered = registered_orchestrator_guard(app_state);
-        let Some(existing) = registered.as_mut() else {
-            *registered = prepared.map(|prepared| RegisteredRuntime {
-                phase: RuntimePhase::Running,
-                runtime: launch_orchestrator_runtime(prepared),
-            });
-            return Ok(started);
-        };
-
-        match existing.phase {
-            RuntimePhase::QuiescingForShutdown => return Err(EnsembleError::RuntimeBusy),
-            RuntimePhase::QuiescingForReplacement if !existing.runtime.is_complete() => {
-                return Err(EnsembleError::RuntimeBusy);
-            }
-            RuntimePhase::Running | RuntimePhase::QuiescingForReplacement => {}
-        }
-        existing.phase = RuntimePhase::QuiescingForReplacement;
-        existing.runtime.request_shutdown();
-        (existing.runtime.id, existing.runtime.completion.clone())
-    };
-
-    if !wait_for_registered_runtime_completion(app_state, runtime_id, completion, restart_timeout)
+    let candidate = app_state.config_runtime.document_state.read().await.clone();
+    let file_mtime = std::fs::metadata(&app_state.config_runtime.config_path)
+        .and_then(|metadata| metadata.modified())
+        .ok();
+    apply_prepared_config_candidate_with_timeout(app_state, candidate, file_mtime, restart_timeout)
         .await
-    {
-        return Err(EnsembleError::RuntimeBusy);
-    }
-
-    let retired = {
-        let mut registered = registered_orchestrator_guard(app_state);
-        let replaceable = registered.as_ref().is_some_and(|existing| {
-            existing.phase == RuntimePhase::QuiescingForReplacement
-                && existing.runtime.id == runtime_id
-                && existing.runtime.is_complete()
-        });
-        if !replaceable {
-            return Err(EnsembleError::RuntimeBusy);
-        }
-        let retired = registered.take();
-        *registered = prepared.map(|prepared| RegisteredRuntime {
-            phase: RuntimePhase::Running,
-            runtime: launch_orchestrator_runtime(prepared),
-        });
-        retired
-    };
-    drop(retired);
-    Ok(started)
 }
 
 async fn wait_for_registered_runtime_completion(
@@ -474,6 +585,17 @@ mod tests {
     use super::*;
     use crate::config::draft::{missing_config_state, parse_raw_yaml};
     use crate::observability::events::EventBus;
+    use crate::timeline::model::TimelineEventRecord;
+    use crate::timeline::TimelineQuery;
+    use crate::transcript::model::{
+        TranscriptRecord, TranscriptRecordKind, TRANSCRIPT_SCHEMA_VERSION,
+    };
+    use crate::transcript::persistence::TranscriptPersistRequest;
+    use crate::transcript::reader::read_transcript_page;
+    use crate::transcript::writer::TranscriptWriter;
+    use chrono::Utc;
+    use rusqlite::TransactionBehavior;
+    use std::os::fd::AsRawFd;
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
     fn valid_config_yaml(workspace_root: Option<&str>) -> String {
@@ -715,7 +837,207 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_replacement_timeout_retains_quiescing_owner_until_later_retry() {
+    async fn transactional_reload_durable_resources_flush_before_replacement_commit() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join("config.yaml");
+        let initial_yaml = valid_config_yaml(Some(temp_dir.path().to_str().unwrap()));
+        let document_state = parse_raw_yaml(config_path.clone(), initial_yaml);
+        let built = build_app_state(config_path.clone(), document_state.clone(), EventBus::new());
+        let candidate = parse_raw_yaml(
+            config_path,
+            valid_config_yaml(Some(temp_dir.path().to_str().unwrap()))
+                .replace("interval_ms: 1234", "interval_ms: 4321"),
+        );
+
+        let writer = TranscriptWriter::new(temp_dir.path().to_path_buf());
+        writer
+            .append(&TranscriptRecord {
+                schema_version: TRANSCRIPT_SCHEMA_VERSION,
+                run_id: "run-durable".to_string(),
+                issue_identifier: "repo#durable".to_string(),
+                step_name: "build".to_string(),
+                attempt: 1,
+                sequence: 1,
+                timestamp: Utc::now(),
+                kind: TranscriptRecordKind::ToolCall,
+                payload: serde_json::json!({"name": "first"}),
+                truncated: None,
+            })
+            .await
+            .unwrap();
+        let transcript_path = writer.transcript_path("run-durable", "build").unwrap();
+        let transcript_lock = std::fs::OpenOptions::new()
+            .append(true)
+            .open(transcript_path)
+            .unwrap();
+        assert_eq!(
+            unsafe { libc::flock(transcript_lock.as_raw_fd(), libc::LOCK_EX) },
+            0
+        );
+
+        let mut history_connection =
+            rusqlite::Connection::open(&built.app_state.history_db_path).unwrap();
+        let history_transaction = history_connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .unwrap();
+
+        let prepared = prepare_orchestrator_runtime(&built.app_state, &document_state)
+            .await
+            .unwrap()
+            .unwrap();
+        prepared
+            .orchestrator
+            .persist_timeline_for_test(TimelineEventRecord {
+                run_id: "run-durable".to_string(),
+                issue_identifier: "repo#durable".to_string(),
+                sequence: 7,
+                timestamp: Utc::now(),
+                event_type: "step_completed".to_string(),
+                step_name: Some("build".to_string()),
+                attempt: 1,
+                detail: "old runtime completed persistence".to_string(),
+                verdict: Some("succeeded".to_string()),
+                tool_name: None,
+            });
+        prepared
+            .orchestrator
+            .persist_transcript_for_test(TranscriptPersistRequest {
+                run_id: "run-durable".to_string(),
+                issue_identifier: "repo#durable".to_string(),
+                step_name: "build".to_string(),
+                attempt: 1,
+                timestamp: Utc::now(),
+                kind: TranscriptRecordKind::ToolResult,
+                payload: serde_json::json!({"text": "second"}),
+                truncated: None,
+            });
+        built
+            .app_state
+            .orchestrator_state
+            .write()
+            .await
+            .timeline_sequences
+            .insert("run-durable".to_string(), 7);
+        *registered_orchestrator_guard(&built.app_state) = Some(RegisteredRuntime {
+            phase: RuntimePhase::Running,
+            runtime: launch_orchestrator_runtime(prepared),
+        });
+
+        let mut reload = tokio::spawn({
+            let app_state = built.app_state.clone();
+            async move {
+                apply_prepared_config_candidate_with_timeout(
+                    &app_state,
+                    candidate,
+                    None,
+                    Duration::from_secs(2),
+                )
+                .await
+            }
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut reload)
+                .await
+                .is_err(),
+            "SQLite persistence must finish before replacement commits"
+        );
+
+        drop(history_transaction);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if built
+                    .app_state
+                    .history_store
+                    .as_ref()
+                    .unwrap()
+                    .max_timeline_sequence("run-durable")
+                    .await
+                    .unwrap()
+                    == Some(7)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("old timeline persistence should flush after its lock is released");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            !reload.is_finished(),
+            "transcript persistence must finish before replacement commits"
+        );
+        assert_eq!(
+            unsafe { libc::flock(transcript_lock.as_raw_fd(), libc::LOCK_UN) },
+            0
+        );
+
+        assert!(reload.await.unwrap().unwrap());
+        let timeline = built
+            .app_state
+            .history_store
+            .as_ref()
+            .unwrap()
+            .read_timeline(
+                &TimelineQuery {
+                    run_id: "run-durable".to_string(),
+                    cursor: None,
+                    limit: None,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            timeline
+                .events
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            vec![7]
+        );
+        let transcript = read_transcript_page(temp_dir.path(), "run-durable", "build", None, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            transcript
+                .records
+                .iter()
+                .map(|record| record.sequence)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(
+            built
+                .app_state
+                .orchestrator_state
+                .read()
+                .await
+                .timeline_sequences
+                .get("run-durable"),
+            Some(&7)
+        );
+        assert_eq!(
+            built
+                .app_state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            4321
+        );
+
+        clear_registered_orchestrator(&built.app_state).await;
+    }
+
+    #[tokio::test]
+    async fn transactional_reload_handover_runtime_replacement_timeout_retains_old_generation_until_retry(
+    ) {
         let temp_dir = tempfile::tempdir().unwrap();
         let config_path = temp_dir.path().join("config.yaml");
         let document_state = parse_raw_yaml(config_path, valid_config_yaml(None));
@@ -723,6 +1045,10 @@ mod tests {
             temp_dir.path().join("config.yaml"),
             document_state,
             EventBus::new(),
+        );
+        let candidate = parse_raw_yaml(
+            temp_dir.path().join("config.yaml"),
+            valid_config_yaml(None).replace("interval_ms: 1234", "interval_ms: 4321"),
         );
 
         let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
@@ -750,9 +1076,32 @@ mod tests {
             phase: RuntimePhase::Running,
             runtime: old_runtime,
         });
+        {
+            let mut state = built.app_state.orchestrator_state.write().await;
+            state.timeline_sequences.insert("run-live".to_string(), 41);
+            state.pending_terminal_transitions.insert(
+                "issue-terminal".to_string(),
+                crate::orchestrator::state::PendingTerminalEntry {
+                    identifier: "repo#terminal".to_string(),
+                    run_id: Some("run-terminal".to_string()),
+                    issue: None,
+                    transition: crate::orchestrator::pipeline_journal::PendingTerminalTransition {
+                        target_state: "Failed".to_string(),
+                        outcome: crate::orchestrator::pipeline_journal::TerminalOutcome::Failed,
+                        attempt: 1,
+                        last_error: Some("persist me".to_string()),
+                        last_attempted_at: None,
+                        tracker_write_confirmed: false,
+                        history_record: None,
+                    },
+                },
+            );
+        }
 
-        let first = start_or_replace_registered_orchestrator_with_timeout(
+        let first = apply_prepared_config_candidate_with_timeout(
             &built.app_state,
+            candidate.clone(),
+            None,
             Duration::from_millis(20),
         )
         .await;
@@ -764,9 +1113,26 @@ mod tests {
             assert_eq!(retained.runtime.id, old_id);
             assert!(!retained.runtime.task.is_finished());
         }
+        assert_eq!(
+            built
+                .app_state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            1234,
+            "a busy handover must keep the candidate invisible"
+        );
 
-        let concurrent = start_or_replace_registered_orchestrator_with_timeout(
+        let concurrent = apply_prepared_config_candidate_with_timeout(
             &built.app_state,
+            candidate.clone(),
+            None,
             Duration::from_millis(20),
         )
         .await;
@@ -786,8 +1152,10 @@ mod tests {
         assert!(*old_completion.borrow());
         assert!(
             matches!(
-                start_or_replace_registered_orchestrator_with_timeout(
+                apply_prepared_config_candidate_with_timeout(
                     &built.app_state,
+                    candidate.clone(),
+                    None,
                     Duration::from_millis(20),
                 )
                 .await,
@@ -807,8 +1175,10 @@ mod tests {
             "old runtime should become quiescent"
         );
 
-        assert!(start_or_replace_registered_orchestrator_with_timeout(
+        assert!(apply_prepared_config_candidate_with_timeout(
             &built.app_state,
+            candidate,
+            None,
             Duration::from_secs(1),
         )
         .await
@@ -819,6 +1189,38 @@ mod tests {
             assert_eq!(replacement.phase, RuntimePhase::Running);
             assert_ne!(replacement.runtime.id, old_id);
         }
+        assert_eq!(
+            built
+                .app_state
+                .orchestrator_state
+                .read()
+                .await
+                .poll_interval_ms,
+            4321
+        );
+        let state = built.app_state.orchestrator_state.read().await;
+        assert_eq!(state.timeline_sequences.get("run-live"), Some(&41));
+        assert!(
+            state
+                .pending_terminal_transitions
+                .contains_key("issue-terminal"),
+            "runtime replacement must preserve pending terminal ownership"
+        );
+        drop(state);
+        assert_eq!(
+            built
+                .app_state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            4321
+        );
 
         if let Some(runtime) = take_registered_orchestrator(&built.app_state) {
             runtime.shutdown().await;

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -1,18 +1,16 @@
-use crate::api::bootstrap::start_or_replace_registered_orchestrator;
 use crate::api::router::AppState;
 use crate::config::draft::{
     parse_raw_yaml, save_raw_yaml_atomically, ConfigDocumentState, ConfigStateKind, ValidationIssue,
 };
 use crate::config::ensemble::EnsembleConfig;
 use crate::config::secrets::{merge_redacted_yaml, redact_yaml_secrets, SecretDisplay};
-use crate::config_watcher::record_self_write;
+use crate::config_watcher::{apply_config_from_disk_locked, ReloadOutcome};
 use crate::error::ConfigError;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
-use std::path::Path;
 use std::time::Duration;
 use tracing::warn;
 
@@ -116,32 +114,55 @@ fn config_error_json(
     Json(build_error_response(current, error))
 }
 
-fn replace_document_state(
-    doc_state: &mut ConfigDocumentState,
-    load_state: impl FnOnce() -> Result<ConfigDocumentState, ConfigError>,
-) -> Result<ConfigStateResponse, ConfigError> {
-    let new_state = load_state()?;
-    *doc_state = new_state.clone();
-    Ok(ConfigStateResponse::from_state(&new_state))
+async fn finish_saved_config_transaction(
+    state: &AppState,
+) -> (StatusCode, Json<ConfigStateResponse>) {
+    let outcome = apply_config_from_disk_locked(state, false).await;
+    let current = state.config_runtime.document_state.read().await;
+    match outcome {
+        Ok(ReloadOutcome::Applied | ReloadOutcome::Unchanged) => {
+            (StatusCode::OK, config_state_json(&current))
+        }
+        Ok(ReloadOutcome::RestartRequired) => (
+            StatusCode::CONFLICT,
+            current_error_json(
+                &current,
+                "runtime",
+                "Saved config changes workspace or repository resources; restart Ensemble to apply it"
+                    .to_string(),
+            ),
+        ),
+        Ok(ReloadOutcome::Rejected) => (
+            StatusCode::BAD_REQUEST,
+            current_error_json(
+                &current,
+                "save",
+                "Saved config could not be activated; the last known good config is still running"
+                    .to_string(),
+            ),
+        ),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            current_error_json(
+                &current,
+                "runtime",
+                "Saved config could not replace the active runtime; retry the save".to_string(),
+            ),
+        ),
+    }
 }
 
-fn replace_document_state_from_yaml(
-    doc_state: &mut ConfigDocumentState,
-    config_path: &Path,
+async fn save_config_yaml_and_finish_transaction(
+    state: &AppState,
     raw_yaml: &str,
-) -> Result<ConfigStateResponse, ConfigError> {
-    replace_document_state(doc_state, || {
-        save_raw_yaml_atomically(config_path, raw_yaml)
-    })
-}
-
-fn reload_document_state(
-    doc_state: &mut ConfigDocumentState,
-    config_path: &Path,
-) -> Result<ConfigStateResponse, ConfigError> {
-    replace_document_state(doc_state, || {
-        crate::config::draft::load_config_state(config_path)
-    })
+) -> (StatusCode, Json<ConfigStateResponse>) {
+    match save_raw_yaml_atomically(&state.config_runtime.config_path, raw_yaml) {
+        Ok(_) => finish_saved_config_transaction(state).await,
+        Err(error) => {
+            let current = state.config_runtime.document_state.read().await;
+            (StatusCode::BAD_REQUEST, config_error_json(&current, &error))
+        }
+    }
 }
 
 fn apply_guided_form_to_current(
@@ -202,6 +223,7 @@ pub struct SaveYamlRequest {
     responses(
         (status = 200, description = "Save result", body = ConfigStateResponse),
         (status = 400, description = "Invalid YAML or validation failed"),
+        (status = 409, description = "Saved config requires a process restart", body = ConfigStateResponse),
         (status = 500, description = "Config saved but orchestrator restart failed", body = ConfigStateResponse)
     ),
     tag = "config"
@@ -210,7 +232,8 @@ pub async fn save_yaml(
     State(state): State<AppState>,
     Json(request): Json<SaveYamlRequest>,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
-    let mut doc_state = state.config_runtime.document_state.write().await;
+    let _reload = state.config_runtime.reload_coordinator.lock().await;
+    let doc_state = state.config_runtime.document_state.read().await;
     let merged_yaml = match merge_redacted_yaml(doc_state.raw_yaml.as_deref(), &request.raw_yaml) {
         Ok(merged_yaml) => merged_yaml,
         Err(error) => {
@@ -221,31 +244,8 @@ pub async fn save_yaml(
         }
     };
 
-    match replace_document_state_from_yaml(
-        &mut doc_state,
-        &state.config_runtime.config_path,
-        &merged_yaml,
-    ) {
-        Ok(response) => {
-            drop(doc_state);
-            record_self_write(&state).await;
-            match start_or_replace_registered_orchestrator(&state).await {
-                Ok(_) => (StatusCode::OK, Json(response)),
-                Err(error) => {
-                    let doc_state = state.config_runtime.document_state.read().await;
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        current_error_json(
-                            &doc_state,
-                            "runtime",
-                            format!("saved config but failed to restart orchestrator: {error}"),
-                        ),
-                    )
-                }
-            }
-        }
-        Err(e) => (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
-    }
+    drop(doc_state);
+    save_config_yaml_and_finish_transaction(&state, &merged_yaml).await
 }
 
 /// Response containing setup defaults.
@@ -512,6 +512,7 @@ pub struct SaveSetupRequest {
     responses(
         (status = 200, description = "Save result", body = ConfigStateResponse),
         (status = 400, description = "Setup validation failed"),
+        (status = 409, description = "Saved config requires a process restart", body = ConfigStateResponse),
         (status = 500, description = "Config saved but orchestrator restart failed", body = ConfigStateResponse)
     ),
     tag = "config"
@@ -544,7 +545,8 @@ where
         );
     }
 
-    let mut doc_state = state.config_runtime.document_state.write().await;
+    let _reload = state.config_runtime.reload_coordinator.lock().await;
+    let doc_state = state.config_runtime.document_state.read().await;
     let artifacts = match crate::config::setup::merge_setup_request(
         doc_state.raw_yaml.as_deref(),
         &request.setup,
@@ -560,27 +562,10 @@ where
         .unwrap_or_else(|| std::path::Path::new("."));
 
     match crate::config::setup::write_setup_artifacts(root, &request.setup, &artifacts) {
-        Ok(()) => match reload_document_state(&mut doc_state, &state.config_runtime.config_path) {
-            Ok(response) => {
-                drop(doc_state);
-                record_self_write(&state).await;
-                match start_or_replace_registered_orchestrator(&state).await {
-                    Ok(_) => (StatusCode::OK, Json(response)),
-                    Err(error) => {
-                        let doc_state = state.config_runtime.document_state.read().await;
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            current_error_json(
-                                &doc_state,
-                                "runtime",
-                                format!("saved config but failed to restart orchestrator: {error}"),
-                            ),
-                        )
-                    }
-                }
-            }
-            Err(e) => (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
-        },
+        Ok(()) => {
+            drop(doc_state);
+            finish_saved_config_transaction(&state).await
+        }
         Err(e) => (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
     }
 }
@@ -757,6 +742,7 @@ pub struct SaveGuidedFormRequest {
     responses(
         (status = 200, description = "Save result", body = ConfigStateResponse),
         (status = 400, description = "Merge or save failed"),
+        (status = 409, description = "Saved config requires a process restart", body = ConfigStateResponse),
         (status = 500, description = "Config saved but orchestrator restart failed", body = ConfigStateResponse)
     ),
     tag = "config"
@@ -765,7 +751,8 @@ pub async fn save_guided_form(
     State(state): State<AppState>,
     Json(request): Json<SaveGuidedFormRequest>,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
-    let mut doc_state = state.config_runtime.document_state.write().await;
+    let _reload = state.config_runtime.reload_coordinator.lock().await;
+    let doc_state = state.config_runtime.document_state.read().await;
 
     // First, merge the guided form with the base YAML
     let merged_yaml =
@@ -780,31 +767,8 @@ pub async fn save_guided_form(
         };
 
     // Now save the merged YAML using the same path as save_yaml
-    match replace_document_state_from_yaml(
-        &mut doc_state,
-        &state.config_runtime.config_path,
-        &merged_yaml,
-    ) {
-        Ok(response) => {
-            drop(doc_state);
-            record_self_write(&state).await;
-            match start_or_replace_registered_orchestrator(&state).await {
-                Ok(_) => (StatusCode::OK, Json(response)),
-                Err(error) => {
-                    let doc_state = state.config_runtime.document_state.read().await;
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        current_error_json(
-                            &doc_state,
-                            "runtime",
-                            format!("saved config but failed to restart orchestrator: {error}"),
-                        ),
-                    )
-                }
-            }
-        }
-        Err(e) => (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
-    }
+    drop(doc_state);
+    save_config_yaml_and_finish_transaction(&state, &merged_yaml).await
 }
 
 #[cfg(test)]
@@ -888,7 +852,7 @@ mod tests {
     fn test_app_state() -> (AppState, TempDir) {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("config.yaml");
-        let workspace_root = temp_dir.path().join("workspaces").display().to_string();
+        let workspace_root = crate::config::ensemble::default_workspace_root();
         let mut app_state = app_state_with_missing_config(config_path, &workspace_root);
         app_state.history_path = temp_dir.path().join("history.jsonl");
         (app_state, temp_dir)
@@ -1714,37 +1678,6 @@ on_failure: Failed
     }
 
     #[tokio::test]
-    async fn test_replace_document_state_from_yaml_updates_doc_state_for_valid_yaml() {
-        let (state, _temp_dir) = test_app_state();
-        let mut doc_state = state.config_runtime.document_state.write().await;
-        let raw_yaml = r#"
-tracker:
-  kind: todo_file
-  path: TODO.md
-agents:
-  builder:
-    acpx_agent: claude
-    prompt: "Build it."
-steps:
-  - name: build
-    agent: builder
-on_success: Done
-on_failure: Failed
-"#;
-
-        let response = replace_document_state_from_yaml(
-            &mut doc_state,
-            &state.config_runtime.config_path,
-            raw_yaml,
-        )
-        .unwrap();
-
-        assert_eq!(response.state, "parsed");
-        assert_eq!(doc_state.kind, ConfigStateKind::Parsed);
-        assert_eq!(doc_state.raw_yaml.as_deref(), Some(raw_yaml));
-    }
-
-    #[tokio::test]
     async fn save_guided_form_preserves_form_section_for_merge_failures() {
         let (state, _temp_dir) = test_app_state();
         let current_yaml = r#"
@@ -2192,6 +2125,70 @@ on_failure: Failed
         })
         .await
         .expect("orchestrator should start after saving a valid config");
+    }
+
+    #[tokio::test]
+    async fn config_save_reload_transaction_restart_required_is_redacted_and_retryable() {
+        let (state, temp_dir) = test_app_state();
+        let todo_path = temp_dir.path().join("TODO.md");
+        std::fs::write(&todo_path, "## Todo\n").unwrap();
+        let config_yaml = |interval_ms: u64, workspace_root: Option<&str>| {
+            let workspace = workspace_root
+                .map(|root| format!("workspace:\n  root: {root}\n"))
+                .unwrap_or_default();
+            format!(
+                "tracker:\n  kind: todo_file\n  path: {}\npolling:\n  interval_ms: {interval_ms}\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n{workspace}",
+                todo_path.display()
+            )
+        };
+        let (status, _) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: config_yaml(1000, None),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let committed_mtime = *state.config_runtime.last_loaded_mtime.read().await;
+
+        let restart_root = "/tmp/private-restart-root";
+        let (status, Json(response)) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: config_yaml(2000, Some(restart_root)),
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(
+            state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            1000
+        );
+        assert_eq!(
+            *state.config_runtime.last_loaded_mtime.read().await,
+            committed_mtime,
+            "restart-required save must leave the candidate mtime unconsumed"
+        );
+        assert!(
+            !serde_json::to_string(&response)
+                .unwrap()
+                .contains(restart_root),
+            "restart diagnostics must not echo candidate values"
+        );
+
+        if let Some(runtime) = take_registered_orchestrator(&state) {
+            runtime.shutdown().await;
+        }
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -1,10 +1,11 @@
 use crate::api::router::AppState;
 use crate::config::draft::{
-    parse_raw_yaml, save_raw_yaml_atomically, ConfigDocumentState, ConfigStateKind, ValidationIssue,
+    load_config_state, parse_raw_yaml, save_raw_yaml_atomically, ConfigDocumentState,
+    ConfigStateKind, ValidationIssue,
 };
 use crate::config::ensemble::EnsembleConfig;
 use crate::config::secrets::{merge_redacted_yaml, redact_yaml_secrets, SecretDisplay};
-use crate::config_watcher::{apply_config_from_disk_locked, ReloadOutcome};
+use crate::config_watcher::{apply_config_candidate_locked_with_hooks, ReloadOutcome};
 use crate::error::ConfigError;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -116,39 +117,135 @@ fn config_error_json(
 
 async fn finish_saved_config_transaction(
     state: &AppState,
+    mut candidate: ConfigDocumentState,
+    accept_unchanged: bool,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
-    let outcome = apply_config_from_disk_locked(state, false).await;
-    let current = state.config_runtime.document_state.read().await;
-    match outcome {
+    let file_mtime = std::fs::metadata(&state.config_runtime.config_path)
+        .and_then(|metadata| metadata.modified())
+        .ok();
+    let initial_candidate = candidate.clone();
+    let had_pending_setup = match crate::config::setup_transaction::has_pending_setup_generation(
+        &state.config_runtime.config_path,
+    ) {
+        Ok(pending) => pending,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                config_error_json(&initial_candidate, &error),
+            )
+        }
+    };
+    let setup_generation = match candidate.raw_yaml.as_deref() {
+        Some(raw_yaml) => match crate::config::setup_transaction::matching_setup_generation(
+            &state.config_runtime.config_path,
+            raw_yaml,
+        ) {
+            Ok(generation) => generation,
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    config_error_json(&initial_candidate, &error),
+                )
+            }
+        },
+        None => None,
+    };
+    if had_pending_setup && setup_generation.is_none() {
+        candidate = match persisted_config_state(state) {
+            Ok(reloaded) => reloaded,
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    config_error_json(&initial_candidate, &error),
+                )
+            }
+        };
+    }
+    let candidate = match (&setup_generation, candidate.raw_yaml.as_deref()) {
+        (Some(generation), Some(raw_yaml)) => match generation.prepare_candidate(raw_yaml) {
+            Ok(candidate) => candidate,
+            Err(error) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    config_error_json(&candidate, &error),
+                )
+            }
+        },
+        _ => candidate,
+    };
+    let response_candidate = candidate.clone();
+    let raw_yaml = candidate.raw_yaml.clone();
+    let generation_for_publish = setup_generation.clone();
+    let generation_for_finish = setup_generation;
+    let config_path = state.config_runtime.config_path.clone();
+    let (status, section, message) = match apply_config_candidate_locked_with_hooks(
+        state,
+        candidate,
+        file_mtime,
+        accept_unchanged,
+        move || {
+            if let (Some(generation), Some(raw_yaml)) =
+                (generation_for_publish, raw_yaml.as_deref())
+            {
+                generation.publish(raw_yaml)?;
+            }
+            Ok(())
+        },
+        move || {
+            if let Some(generation) = generation_for_finish {
+                if let Err(error) = generation.finish_activation() {
+                    warn!(
+                        error = %error,
+                        path = %config_path.display(),
+                        "setup generation activated but journal cleanup remains pending"
+                    );
+                }
+            }
+        },
+    )
+    .await
+    {
         Ok(ReloadOutcome::Applied | ReloadOutcome::Unchanged) => {
-            (StatusCode::OK, config_state_json(&current))
+            let current = state.config_runtime.document_state.read().await;
+            return (StatusCode::OK, config_state_json(&current));
         }
         Ok(ReloadOutcome::RestartRequired) => (
             StatusCode::CONFLICT,
-            current_error_json(
-                &current,
-                "runtime",
-                "Saved config changes workspace or repository resources; restart Ensemble to apply it"
-                    .to_string(),
-            ),
+            "runtime",
+            "Saved config changes workspace or repository resources; restart Ensemble to apply it",
         ),
         Ok(ReloadOutcome::Rejected) => (
             StatusCode::BAD_REQUEST,
-            current_error_json(
-                &current,
-                "save",
-                "Saved config could not be activated; the last known good config is still running"
-                    .to_string(),
-            ),
+            "save",
+            "Saved config could not be activated; the last known good config is still running",
         ),
         Err(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            current_error_json(
-                &current,
-                "runtime",
-                "Saved config could not replace the active runtime; retry the save".to_string(),
-            ),
+            "runtime",
+            "Saved config could not replace the active runtime; retry the save",
         ),
+    };
+    (
+        status,
+        current_error_json(&response_candidate, section, message.to_string()),
+    )
+}
+
+fn persisted_config_state(state: &AppState) -> Result<ConfigDocumentState, ConfigError> {
+    load_config_state(&state.config_runtime.config_path)
+}
+
+async fn persisted_or_current_config_state(state: &AppState) -> ConfigDocumentState {
+    match persisted_config_state(state) {
+        Ok(persisted) => persisted,
+        Err(error) => {
+            warn!(
+                error = %error,
+                path = %state.config_runtime.config_path.display(),
+                "failed to load persisted config state; using active document for response"
+            );
+            state.config_runtime.document_state.read().await.clone()
+        }
     }
 }
 
@@ -157,20 +254,23 @@ async fn save_config_yaml_and_finish_transaction(
     raw_yaml: &str,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
     match save_raw_yaml_atomically(&state.config_runtime.config_path, raw_yaml) {
-        Ok(_) => finish_saved_config_transaction(state).await,
+        Ok(candidate) => finish_saved_config_transaction(state, candidate, true).await,
         Err(error) => {
-            let current = state.config_runtime.document_state.read().await;
-            (StatusCode::BAD_REQUEST, config_error_json(&current, &error))
+            let response_state = persisted_or_current_config_state(state).await;
+            (
+                StatusCode::BAD_REQUEST,
+                config_error_json(&response_state, &error),
+            )
         }
     }
 }
 
-fn apply_guided_form_to_current(
-    current: &ConfigDocumentState,
+fn apply_guided_form_to_document(
+    document: &ConfigDocumentState,
     base_raw_yaml: &str,
     form: &crate::config::form::GuidedConfigForm,
 ) -> Result<String, ConfigError> {
-    let base_yaml = merge_redacted_yaml(current.raw_yaml.as_deref(), base_raw_yaml)?;
+    let base_yaml = merge_redacted_yaml(document.raw_yaml.as_deref(), base_raw_yaml)?;
     crate::config::form::apply_guided_form(&base_yaml, form)
 }
 
@@ -191,8 +291,9 @@ pub async fn validate_yaml(
     State(state): State<AppState>,
     Json(request): Json<ValidateYamlRequest>,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
-    let current = state.config_runtime.document_state.read().await;
-    match merge_redacted_yaml(current.raw_yaml.as_deref(), &request.raw_yaml) {
+    let _reload = state.config_runtime.reload_coordinator.lock().await;
+    let authoritative = persisted_or_current_config_state(&state).await;
+    match merge_redacted_yaml(authoritative.raw_yaml.as_deref(), &request.raw_yaml) {
         Ok(merged_yaml) => {
             let draft = parse_raw_yaml(state.config_runtime.config_path.clone(), merged_yaml);
             (StatusCode::OK, config_state_json(&draft))
@@ -233,18 +334,23 @@ pub async fn save_yaml(
     Json(request): Json<SaveYamlRequest>,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
     let _reload = state.config_runtime.reload_coordinator.lock().await;
-    let doc_state = state.config_runtime.document_state.read().await;
-    let merged_yaml = match merge_redacted_yaml(doc_state.raw_yaml.as_deref(), &request.raw_yaml) {
+    let persisted = match persisted_config_state(&state) {
+        Ok(persisted) => persisted,
+        Err(error) => {
+            let current = state.config_runtime.document_state.read().await;
+            return (StatusCode::BAD_REQUEST, config_error_json(&current, &error));
+        }
+    };
+    let merged_yaml = match merge_redacted_yaml(persisted.raw_yaml.as_deref(), &request.raw_yaml) {
         Ok(merged_yaml) => merged_yaml,
         Err(error) => {
             return (
                 StatusCode::BAD_REQUEST,
-                current_error_json(&doc_state, "yaml", error.to_string()),
+                current_error_json(&persisted, "yaml", error.to_string()),
             )
         }
     };
 
-    drop(doc_state);
     save_config_yaml_and_finish_transaction(&state, &merged_yaml).await
 }
 
@@ -496,7 +602,7 @@ pub async fn validate_setup(
 }
 
 /// Request to save a setup configuration.
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct SaveSetupRequest {
     pub setup: crate::config::setup::SetupRequest,
 }
@@ -538,36 +644,70 @@ where
 {
     let checks = run_checks(request.setup.clone()).await;
     if !crate::config::setup::setup_can_save(&checks) {
-        let doc_state = state.config_runtime.document_state.read().await;
+        let _reload = state.config_runtime.reload_coordinator.lock().await;
+        let response_state = persisted_or_current_config_state(&state).await;
         return (
             StatusCode::BAD_REQUEST,
-            current_error_json(&doc_state, "setup", "Setup validation failed".to_string()),
+            current_error_json(
+                &response_state,
+                "setup",
+                "Setup validation failed".to_string(),
+            ),
         );
     }
 
     let _reload = state.config_runtime.reload_coordinator.lock().await;
-    let doc_state = state.config_runtime.document_state.read().await;
+    let persisted = match persisted_config_state(&state) {
+        Ok(persisted) => persisted,
+        Err(error) => {
+            let current = state.config_runtime.document_state.read().await;
+            return (StatusCode::BAD_REQUEST, config_error_json(&current, &error));
+        }
+    };
     let artifacts = match crate::config::setup::merge_setup_request(
-        doc_state.raw_yaml.as_deref(),
+        persisted.raw_yaml.as_deref(),
         &request.setup,
     ) {
         Ok(artifacts) => artifacts,
-        Err(e) => return (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
+        Err(e) => return (StatusCode::BAD_REQUEST, config_error_json(&persisted, &e)),
     };
 
-    let root = state
-        .config_runtime
-        .config_path
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("."));
-
-    match crate::config::setup::write_setup_artifacts(root, &request.setup, &artifacts) {
-        Ok(()) => {
-            drop(doc_state);
-            finish_saved_config_transaction(&state).await
+    let generation = match crate::config::setup_transaction::stage_setup_generation(
+        &state.config_runtime.config_path,
+        &request.setup,
+        &artifacts,
+    ) {
+        Ok(generation) => generation,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                config_error_json(&persisted, &error),
+            )
         }
-        Err(e) => (StatusCode::BAD_REQUEST, config_error_json(&doc_state, &e)),
+    };
+    if let Err(error) = crate::config::draft::persist_config_atomically(
+        &state.config_runtime.config_path,
+        &artifacts.raw_yaml,
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            config_error_json(&persisted, &error),
+        );
     }
+    let candidate = match generation.prepare_candidate(&artifacts.raw_yaml) {
+        Ok(candidate) => candidate,
+        Err(error) => {
+            let candidate = parse_raw_yaml(
+                state.config_runtime.config_path.clone(),
+                artifacts.raw_yaml.clone(),
+            );
+            return (
+                StatusCode::BAD_REQUEST,
+                config_error_json(&candidate, &error),
+            );
+        }
+    };
+    finish_saved_config_transaction(&state, candidate, false).await
 }
 
 fn default_setup_defaults() -> serde_json::Value {
@@ -688,8 +828,9 @@ pub async fn validate_guided_form(
     State(state): State<AppState>,
     Json(request): Json<ValidateGuidedFormRequest>,
 ) -> (StatusCode, Json<ValidateGuidedFormResponse>) {
-    let current = state.config_runtime.document_state.read().await;
-    match apply_guided_form_to_current(&current, &request.base_raw_yaml, &request.form) {
+    let _reload = state.config_runtime.reload_coordinator.lock().await;
+    let authoritative = persisted_or_current_config_state(&state).await;
+    match apply_guided_form_to_document(&authoritative, &request.base_raw_yaml, &request.form) {
         Ok(merged_yaml) => {
             // Parse and validate the merged YAML
             let draft = crate::config::draft::parse_raw_yaml(
@@ -752,40 +893,54 @@ pub async fn save_guided_form(
     Json(request): Json<SaveGuidedFormRequest>,
 ) -> (StatusCode, Json<ConfigStateResponse>) {
     let _reload = state.config_runtime.reload_coordinator.lock().await;
-    let doc_state = state.config_runtime.document_state.read().await;
+    let persisted = match persisted_config_state(&state) {
+        Ok(persisted) => persisted,
+        Err(error) => {
+            let current = state.config_runtime.document_state.read().await;
+            return (StatusCode::BAD_REQUEST, config_error_json(&current, &error));
+        }
+    };
 
     // First, merge the guided form with the base YAML
     let merged_yaml =
-        match apply_guided_form_to_current(&doc_state, &request.base_raw_yaml, &request.form) {
+        match apply_guided_form_to_document(&persisted, &request.base_raw_yaml, &request.form) {
             Ok(yaml) => yaml,
             Err(e) => {
                 return (
                     StatusCode::BAD_REQUEST,
-                    current_error_json(&doc_state, "form", format!("Form merge failed: {}", e)),
+                    current_error_json(&persisted, "form", format!("Form merge failed: {}", e)),
                 )
             }
         };
 
     // Now save the merged YAML using the same path as save_yaml
-    drop(doc_state);
     save_config_yaml_and_finish_transaction(&state, &merged_yaml).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::bootstrap::take_registered_orchestrator;
+    use crate::agent::cancellation::register_worker;
+    use crate::agent::events::WorkerIdentity;
+    use crate::api::bootstrap::{
+        start_or_replace_registered_orchestrator_with_timeout, take_registered_orchestrator,
+    };
     use crate::api::test_helpers::app_state_with_missing_config;
     use crate::config::draft::{ConfigStateKind, DraftValidationReport};
     use crate::config::secrets::{SecretEdit, REDACTED_SECRET};
     use axum::body::Body;
     use axum::response::IntoResponse;
+    use chrono::Utc;
     use futures_util::StreamExt;
     use std::io::Write;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::sync::Mutex;
     use tempfile::TempDir;
+    use tokio::sync::watch;
+    use tokio_util::sync::CancellationToken;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -856,6 +1011,121 @@ mod tests {
         let mut app_state = app_state_with_missing_config(config_path, &workspace_root);
         app_state.history_path = temp_dir.path().join("history.jsonl");
         (app_state, temp_dir)
+    }
+
+    fn retryable_secret_yaml(
+        todo_path: &std::path::Path,
+        interval_ms: u64,
+        secret: &str,
+        workspace_root: Option<&str>,
+        step_agent: &str,
+    ) -> String {
+        let workspace = workspace_root
+            .map(|root| format!("workspace:\n  root: {root}\n"))
+            .unwrap_or_default();
+        format!(
+            "tracker:\n  kind: todo_file\n  path: {}\n  api_key: {secret}\npolling:\n  interval_ms: {interval_ms}\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: {step_agent}\non_success: Done\non_failure: Failed\n{workspace}",
+            todo_path.display()
+        )
+    }
+
+    async fn active_retry_secret_state() -> (AppState, TempDir, PathBuf) {
+        let (state, temp_dir) = test_app_state();
+        let todo_path = temp_dir.path().join("TODO.md");
+        std::fs::write(&todo_path, "## Todo\n").unwrap();
+        let (status, _) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: retryable_secret_yaml(
+                    &todo_path,
+                    1000,
+                    "old-literal-secret",
+                    None,
+                    "builder",
+                ),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        (state, temp_dir, todo_path)
+    }
+
+    fn assert_response_hides_secret(response: &ConfigStateResponse, secret: &str) {
+        assert!(!serde_json::to_string(response).unwrap().contains(secret));
+    }
+
+    fn todo_setup_request(todo_path: PathBuf) -> crate::config::setup::SetupRequest {
+        crate::config::setup::SetupRequest {
+            tracker: crate::config::setup::SetupTracker::TodoFile { path: todo_path },
+            repos: vec![],
+            agents: vec![crate::config::setup::SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "codex".to_string(),
+                model: None,
+                reasoning_level: None,
+                permission_mode: None,
+                prompt: None,
+                prompt_file: Some("templates/build.liquid".to_string()),
+            }],
+            steps: vec![crate::config::setup::SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                kind: None,
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn assert_config_is_private(path: &std::path::Path) {
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[cfg(not(unix))]
+    fn assert_config_is_private(_path: &std::path::Path) {}
+
+    #[tokio::test]
+    async fn validate_guided_form_uses_latest_persisted_secret_generation() {
+        let (state, temp_dir) = test_app_state();
+        let todo_path = temp_dir.path().join("TODO.md");
+        std::fs::write(&todo_path, "## Todo\n").unwrap();
+        let active_yaml =
+            retryable_secret_yaml(&todo_path, 1000, "old-literal-secret", None, "builder")
+                .replace("  api_key: old-literal-secret\n", "");
+        *state.config_runtime.document_state.write().await =
+            parse_raw_yaml(state.config_runtime.config_path.clone(), active_yaml);
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            &retryable_secret_yaml(&todo_path, 2000, "new-literal-secret", None, "builder"),
+        )
+        .unwrap();
+        let candidate = load_config_state(&state.config_runtime.config_path).unwrap();
+        let candidate_response = ConfigStateResponse::from_state(&candidate);
+
+        let (status, Json(response)) = validate_guided_form(
+            axum::extract::State(state),
+            Json(ValidateGuidedFormRequest {
+                base_raw_yaml: candidate_response.raw_yaml.unwrap(),
+                form: candidate_response.guided_form.unwrap(),
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "response: {}",
+            serde_json::to_string(&response).unwrap()
+        );
+        assert!(response.valid, "{:?}", response.issues);
+        assert!(response.merged_yaml.contains(REDACTED_SECRET));
+        assert!(!response.merged_yaml.contains("new-literal-secret"));
     }
 
     #[tokio::test]
@@ -1502,7 +1772,12 @@ custom_root:
         let (status, Json(response)) =
             save_setup(axum::extract::State(state.clone()), Json(request)).await;
 
-        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "response: {}",
+            serde_json::to_string(&response).unwrap()
+        );
         assert_eq!(response.state, "parsed");
         assert!(state.config_runtime.config_path.exists());
         assert!(temp_dir.path().join("templates/build.liquid").exists());
@@ -1706,6 +1981,11 @@ on_failure: Failed
             state.config_runtime.config_path.clone(),
             current_yaml.to_string(),
         );
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            current_yaml,
+        )
+        .unwrap();
 
         let form = crate::config::form::GuidedConfigForm {
             tracker: crate::config::form::GuidedTrackerForm {
@@ -1860,6 +2140,11 @@ on_failure: Failed
             state.config_runtime.config_path.clone(),
             current_yaml.to_string(),
         );
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            current_yaml,
+        )
+        .unwrap();
 
         let (yaml_status, Json(yaml_response)) = save_yaml(
             axum::extract::State(state.clone()),
@@ -2129,33 +2414,20 @@ on_failure: Failed
 
     #[tokio::test]
     async fn config_save_reload_transaction_restart_required_is_redacted_and_retryable() {
-        let (state, temp_dir) = test_app_state();
-        let todo_path = temp_dir.path().join("TODO.md");
-        std::fs::write(&todo_path, "## Todo\n").unwrap();
-        let config_yaml = |interval_ms: u64, workspace_root: Option<&str>| {
-            let workspace = workspace_root
-                .map(|root| format!("workspace:\n  root: {root}\n"))
-                .unwrap_or_default();
-            format!(
-                "tracker:\n  kind: todo_file\n  path: {}\npolling:\n  interval_ms: {interval_ms}\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n{workspace}",
-                todo_path.display()
-            )
-        };
-        let (status, _) = save_yaml(
-            axum::extract::State(state.clone()),
-            Json(SaveYamlRequest {
-                raw_yaml: config_yaml(1000, None),
-            }),
-        )
-        .await;
-        assert_eq!(status, StatusCode::OK);
+        let (state, _temp_dir, todo_path) = active_retry_secret_state().await;
         let committed_mtime = *state.config_runtime.last_loaded_mtime.read().await;
 
         let restart_root = "/tmp/private-restart-root";
         let (status, Json(response)) = save_yaml(
             axum::extract::State(state.clone()),
             Json(SaveYamlRequest {
-                raw_yaml: config_yaml(2000, Some(restart_root)),
+                raw_yaml: retryable_secret_yaml(
+                    &todo_path,
+                    2000,
+                    "new-literal-secret",
+                    Some(restart_root),
+                    "builder",
+                ),
             }),
         )
         .await;
@@ -2179,16 +2451,669 @@ on_failure: Failed
             committed_mtime,
             "restart-required save must leave the candidate mtime unconsumed"
         );
+        let persisted = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
         assert!(
-            !serde_json::to_string(&response)
+            persisted.contains("new-literal-secret"),
+            "persisted candidate: {persisted}"
+        );
+        assert!(!persisted.contains("old-literal-secret"));
+        assert_config_is_private(&state.config_runtime.config_path);
+        let retry_yaml = response
+            .raw_yaml
+            .as_deref()
+            .expect("restart-required response should describe the persisted candidate");
+        assert!(retry_yaml.contains(restart_root));
+        assert!(retry_yaml.contains(REDACTED_SECRET));
+        assert_response_hides_secret(&response, "old-literal-secret");
+        assert_response_hides_secret(&response, "new-literal-secret");
+
+        let retry_yaml = retry_yaml.replace(
+            restart_root,
+            &crate::config::ensemble::default_workspace_root(),
+        );
+        let (status, Json(response)) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: retry_yaml,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let persisted = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
+        assert!(
+            persisted.contains("new-literal-secret"),
+            "persisted candidate: {persisted}"
+        );
+        assert!(!persisted.contains("old-literal-secret"));
+        assert!(!persisted.contains(REDACTED_SECRET));
+        assert_response_hides_secret(&response, "new-literal-secret");
+
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
+    }
+
+    #[tokio::test]
+    async fn guided_retry_preserves_restart_required_candidate_secret_generation() {
+        let (state, _temp_dir, todo_path) = active_retry_secret_state().await;
+
+        let (status, Json(response)) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: retryable_secret_yaml(
+                    &todo_path,
+                    2000,
+                    "new-literal-secret",
+                    Some("/tmp/guided-restart-root"),
+                    "builder",
+                ),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+
+        let mut form = response
+            .guided_form
+            .expect("restart-required response should include the candidate form");
+        assert_eq!(form.tracker.api_key, SecretDisplay::Redacted);
+        form.runtime.workspace.root = None;
+        let (status, Json(response)) = save_guided_form(
+            axum::extract::State(state.clone()),
+            Json(SaveGuidedFormRequest {
+                base_raw_yaml: response
+                    .raw_yaml
+                    .expect("restart-required response should include candidate YAML"),
+                form,
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let persisted = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
+        assert!(persisted.contains("new-literal-secret"));
+        assert!(!persisted.contains("old-literal-secret"));
+        assert!(!persisted.contains(REDACTED_SECRET));
+        assert_response_hides_secret(&response, "new-literal-secret");
+
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
+    }
+
+    #[tokio::test]
+    async fn config_save_rejected_retry_preserves_new_literal_secret_generation() {
+        let (state, _temp_dir, todo_path) = active_retry_secret_state().await;
+
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            &retryable_secret_yaml(
+                &todo_path,
+                2000,
+                "new-literal-secret",
+                None,
+                "missing-agent",
+            ),
+        )
+        .unwrap();
+        let _reload = state.config_runtime.reload_coordinator.lock().await;
+        let candidate = persisted_config_state(&state).unwrap();
+        let (status, Json(response)) =
+            finish_saved_config_transaction(&state, candidate, true).await;
+        drop(_reload);
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "response: {}",
+            serde_json::to_string(&response).unwrap()
+        );
+        assert_eq!(
+            state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
                 .unwrap()
-                .contains(restart_root),
-            "restart diagnostics must not echo candidate values"
+                .polling
+                .interval_ms,
+            1000
+        );
+        let persisted = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
+        assert!(
+            persisted.contains("new-literal-secret"),
+            "persisted candidate: {persisted}"
+        );
+        assert!(!persisted.contains("old-literal-secret"));
+        let retry_yaml = response
+            .raw_yaml
+            .as_deref()
+            .expect("rejected response should describe the persisted candidate");
+        assert!(retry_yaml.contains("agent: missing-agent"));
+        assert!(retry_yaml.contains(REDACTED_SECRET));
+        assert_response_hides_secret(&response, "new-literal-secret");
+
+        let (status, Json(response)) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: retry_yaml.to_string(),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let retry_yaml = response
+            .raw_yaml
+            .as_deref()
+            .expect("validation failure should retain the persisted candidate");
+        assert!(retry_yaml.contains("agent: missing-agent"));
+        assert!(retry_yaml.contains(REDACTED_SECRET));
+        assert_response_hides_secret(&response, "new-literal-secret");
+
+        let (status, Json(response)) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: retry_yaml.replace("agent: missing-agent", "agent: builder"),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let persisted = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
+        assert!(persisted.contains("new-literal-secret"));
+        assert!(!persisted.contains(REDACTED_SECRET));
+        assert_config_is_private(&state.config_runtime.config_path);
+        assert_response_hides_secret(&response, "new-literal-secret");
+
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
+    }
+
+    #[tokio::test]
+    async fn failed_save_response_uses_the_evaluated_candidate_snapshot() {
+        let (state, _temp_dir, todo_path) = active_retry_secret_state().await;
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            &retryable_secret_yaml(&todo_path, 2000, "evaluated-secret", None, "builder"),
+        )
+        .unwrap();
+        let evaluated = persisted_config_state(&state).unwrap();
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            &retryable_secret_yaml(&todo_path, 3000, "later-secret", None, "builder"),
+        )
+        .unwrap();
+
+        let _reload = state.config_runtime.reload_coordinator.lock().await;
+        let (status, Json(response)) =
+            finish_saved_config_transaction(&state, evaluated, true).await;
+        drop(_reload);
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        let response_yaml = response.raw_yaml.as_deref().unwrap();
+        assert!(response_yaml.contains("interval_ms: 2000"));
+        assert!(!response_yaml.contains("interval_ms: 3000"));
+        assert!(response_yaml.contains(REDACTED_SECRET));
+        assert_response_hides_secret(&response, "evaluated-secret");
+        assert_response_hides_secret(&response, "later-secret");
+        assert_eq!(
+            state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            1000
         );
 
-        if let Some(runtime) = take_registered_orchestrator(&state) {
-            runtime.shutdown().await;
-        }
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
+    }
+
+    #[tokio::test]
+    async fn missing_persisted_generation_metadata_blocks_candidate_commit() {
+        let (state, _temp_dir, todo_path) = active_retry_secret_state().await;
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            &retryable_secret_yaml(&todo_path, 2000, "uncommitted-secret", None, "builder"),
+        )
+        .unwrap();
+        let candidate = persisted_config_state(&state).unwrap();
+        std::fs::remove_file(&state.config_runtime.config_path).unwrap();
+
+        let _reload = state.config_runtime.reload_coordinator.lock().await;
+        let (status, Json(response)) =
+            finish_saved_config_transaction(&state, candidate, true).await;
+        drop(_reload);
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_response_hides_secret(&response, "uncommitted-secret");
+        assert_eq!(
+            state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            1000
+        );
+
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
+    }
+
+    #[tokio::test]
+    async fn transactional_setup_activation_external_edit_prevents_companion_publication() {
+        let (state, temp_dir, todo_path) = active_retry_secret_state().await;
+        let setup_todo_path = temp_dir.path().join("setup/TODO.md");
+        let request = todo_setup_request(setup_todo_path.clone());
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = crate::config::setup_transaction::stage_setup_generation(
+            &state.config_runtime.config_path,
+            &request,
+            &artifacts,
+        )
+        .unwrap();
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            &artifacts.raw_yaml,
+        )
+        .unwrap();
+        let candidate = generation.prepare_candidate(&artifacts.raw_yaml).unwrap();
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            &retryable_secret_yaml(&todo_path, 3000, "external-secret", None, "builder"),
+        )
+        .unwrap();
+
+        let _reload = state.config_runtime.reload_coordinator.lock().await;
+        let (status, Json(response)) =
+            finish_saved_config_transaction(&state, candidate, false).await;
+        drop(_reload);
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!setup_todo_path.exists());
+        assert!(!temp_dir.path().join("templates/build.liquid").exists());
+        assert_response_hides_secret(&response, "external-secret");
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
+    }
+
+    #[tokio::test]
+    async fn setup_preserve_uses_latest_persisted_secret_generation() {
+        let (state, _temp_dir) = test_app_state();
+        let config_yaml = |secret: &str| {
+            format!(
+                "tracker:\n  kind: github\n  repository: acme/repo\n  project_number: 9\n  api_key: {secret}\n  active_states:\n    - Todo\n    - In Progress\n  terminal_states:\n    - Done\nagents:\n  builder:\n    acpx_agent: claude\n    prompt: Build it.\nsteps:\n  - name: build\n    agent: builder\non_success: Done\non_failure: Failed\n"
+            )
+        };
+        let old_yaml = config_yaml("old-literal-secret");
+        let new_yaml = config_yaml("new-literal-secret");
+        *state.config_runtime.document_state.write().await =
+            parse_raw_yaml(state.config_runtime.config_path.clone(), old_yaml);
+        crate::config::draft::persist_config_atomically(
+            &state.config_runtime.config_path,
+            &new_yaml,
+        )
+        .unwrap();
+
+        let request = SaveSetupRequest {
+            setup: crate::config::setup::SetupRequest {
+                tracker: crate::config::setup::SetupTracker::GitHub {
+                    repository: "acme/repo".to_string(),
+                    project_number: Some(9),
+                    api_key: SecretDisplay::Redacted,
+                    api_key_edit: SecretEdit::Preserve,
+                    api_token: None,
+                    active_states: vec!["Todo".to_string(), "In Progress".to_string()],
+                    terminal_states: vec!["Done".to_string()],
+                },
+                repos: vec![],
+                agents: vec![crate::config::setup::SetupAgent {
+                    role: "builder".to_string(),
+                    acpx_agent: "claude".to_string(),
+                    model: None,
+                    reasoning_level: None,
+                    permission_mode: None,
+                    prompt: Some("Build it.".to_string()),
+                    prompt_file: None,
+                }],
+                steps: vec![crate::config::setup::SetupStep {
+                    name: "build".to_string(),
+                    agent_role: "builder".to_string(),
+                    kind: None,
+                    depends: vec![],
+                    tracker_state: None,
+                }],
+                on_success: "Done".to_string(),
+                on_failure: "Failed".to_string(),
+            },
+        };
+        let (status, Json(response)) = save_setup_with_checks(state.clone(), request, |_| async {
+            vec![crate::config::setup::SetupCheck {
+                kind: crate::config::setup::SetupCheckKind::Config,
+                label: "stub".to_string(),
+                passed: true,
+                detail: "valid".to_string(),
+            }]
+        })
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let persisted = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
+        assert!(persisted.contains("new-literal-secret"));
+        assert!(!persisted.contains("old-literal-secret"));
+        assert!(!persisted.contains(REDACTED_SECRET));
+        assert_config_is_private(&state.config_runtime.config_path);
+        assert_response_hides_secret(&response, "new-literal-secret");
+        assert_eq!(
+            state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .and_then(|config| config.tracker.api_key.as_deref()),
+            Some("new-literal-secret")
+        );
+
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
+    }
+
+    #[tokio::test]
+    async fn transactional_setup_activation_runtime_busy_defers_secret_companions_until_commit() {
+        let _env = EnvGuard::lock(&["ENSEMBLE_SETUP_RETRY_TOKEN"]);
+        let (state, _temp_dir, _todo_path) = active_retry_secret_state().await;
+        let cancellation = CancellationToken::new();
+        let (completion_tx, completion_rx) = watch::channel(false);
+        register_worker(
+            &state.cancellation_registry,
+            WorkerIdentity {
+                issue_id: "setup-busy-issue".to_string(),
+                run_id: "setup-busy-run".to_string(),
+                cycle: 1,
+                step_name: "build".to_string(),
+                started_at: Utc::now(),
+            },
+            cancellation,
+            completion_rx,
+        );
+        assert!(matches!(
+            start_or_replace_registered_orchestrator_with_timeout(
+                &state,
+                Duration::from_millis(20),
+            )
+            .await,
+            Err(crate::error::EnsembleError::RuntimeBusy)
+        ));
+
+        let request = SaveSetupRequest {
+            setup: crate::config::setup::SetupRequest {
+                tracker: crate::config::setup::SetupTracker::GitHub {
+                    repository: "acme/repo".to_string(),
+                    project_number: Some(9),
+                    api_key: SecretDisplay::Environment {
+                        variable: "ENSEMBLE_SETUP_RETRY_TOKEN".to_string(),
+                    },
+                    api_key_edit: SecretEdit::SetEnvironment {
+                        variable: "ENSEMBLE_SETUP_RETRY_TOKEN".to_string(),
+                    },
+                    api_token: Some(crate::config::secrets::SecretValue::new(
+                        "setup-candidate-secret",
+                    )),
+                    active_states: vec!["Todo".to_string(), "In Progress".to_string()],
+                    terminal_states: vec!["Done".to_string()],
+                },
+                repos: vec![],
+                agents: vec![crate::config::setup::SetupAgent {
+                    role: "builder".to_string(),
+                    acpx_agent: "claude".to_string(),
+                    model: None,
+                    reasoning_level: None,
+                    permission_mode: None,
+                    prompt: Some("Build it.".to_string()),
+                    prompt_file: None,
+                }],
+                steps: vec![crate::config::setup::SetupStep {
+                    name: "build".to_string(),
+                    agent_role: "builder".to_string(),
+                    kind: None,
+                    depends: vec![],
+                    tracker_state: None,
+                }],
+                on_success: "Done".to_string(),
+                on_failure: "Failed".to_string(),
+            },
+        };
+        let checks = |_| async {
+            vec![crate::config::setup::SetupCheck {
+                kind: crate::config::setup::SetupCheckKind::Config,
+                label: "stub".to_string(),
+                passed: true,
+                detail: "valid".to_string(),
+            }]
+        };
+        let (status, Json(mut response)) =
+            save_setup_with_checks(state.clone(), request.clone(), checks).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!state
+            .config_runtime
+            .config_path
+            .parent()
+            .unwrap()
+            .join(".env")
+            .exists());
+        assert_response_hides_secret(&response, "setup-candidate-secret");
+
+        completion_tx.send(true).unwrap();
+        response = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let (status, Json(next_response)) =
+                    save_setup_with_checks(state.clone(), request.clone(), checks).await;
+                if status == StatusCode::OK {
+                    break next_response;
+                }
+                assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("quiescing runtime should become replaceable");
+
+        let env_path = state
+            .config_runtime
+            .config_path
+            .parent()
+            .unwrap()
+            .join(".env");
+        assert_eq!(
+            std::fs::read_to_string(&env_path).unwrap(),
+            "ENSEMBLE_SETUP_RETRY_TOKEN=setup-candidate-secret\n"
+        );
+        assert_config_is_private(&env_path);
+        assert_eq!(
+            state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .and_then(|config| config.tracker.api_key.as_deref()),
+            Some("setup-candidate-secret")
+        );
+        assert_response_hides_secret(&response, "setup-candidate-secret");
+
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
+    }
+
+    #[tokio::test]
+    async fn config_save_restart_required_retry_preserves_new_environment_secret_generation() {
+        let _env = EnvGuard::lock(&["ENSEMBLE_RETRY_TOKEN"]);
+        std::env::set_var("ENSEMBLE_RETRY_TOKEN", "new-environment-secret");
+        let (state, _temp_dir, todo_path) = active_retry_secret_state().await;
+
+        let restart_root = "/tmp/private-environment-restart-root";
+        let (status, Json(response)) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: retryable_secret_yaml(
+                    &todo_path,
+                    2000,
+                    "$ENSEMBLE_RETRY_TOKEN",
+                    Some(restart_root),
+                    "builder",
+                ),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        let response_json = serde_json::to_string(&response).unwrap();
+        assert!(response_json.contains("$ENSEMBLE_RETRY_TOKEN"));
+        assert!(!response_json.contains("new-environment-secret"));
+        let retry_yaml = response.raw_yaml.as_deref().unwrap().replace(
+            restart_root,
+            &crate::config::ensemble::default_workspace_root(),
+        );
+
+        let (status, Json(response)) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: retry_yaml,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let persisted = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
+        assert!(persisted.contains("$ENSEMBLE_RETRY_TOKEN"));
+        assert!(!persisted.contains("new-environment-secret"));
+        assert_eq!(
+            state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .tracker
+                .api_key
+                .as_deref(),
+            Some("new-environment-secret")
+        );
+        assert_config_is_private(&state.config_runtime.config_path);
+        assert_response_hides_secret(&response, "new-environment-secret");
+
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
+    }
+
+    #[tokio::test]
+    async fn config_save_runtime_busy_retry_preserves_new_environment_secret_generation() {
+        let _env = EnvGuard::lock(&["ENSEMBLE_BUSY_RETRY_TOKEN"]);
+        std::env::set_var("ENSEMBLE_BUSY_RETRY_TOKEN", "busy-environment-secret");
+        let (state, _temp_dir, todo_path) = active_retry_secret_state().await;
+
+        let cancellation = CancellationToken::new();
+        let (completion_tx, completion_rx) = watch::channel(false);
+        register_worker(
+            &state.cancellation_registry,
+            WorkerIdentity {
+                issue_id: "busy-issue".to_string(),
+                run_id: "busy-run".to_string(),
+                cycle: 1,
+                step_name: "build".to_string(),
+                started_at: Utc::now(),
+            },
+            cancellation.clone(),
+            completion_rx,
+        );
+        assert!(matches!(
+            start_or_replace_registered_orchestrator_with_timeout(
+                &state,
+                Duration::from_millis(20),
+            )
+            .await,
+            Err(crate::error::EnsembleError::RuntimeBusy)
+        ));
+        assert!(cancellation.is_cancelled());
+
+        let (status, Json(mut response)) = save_yaml(
+            axum::extract::State(state.clone()),
+            Json(SaveYamlRequest {
+                raw_yaml: retryable_secret_yaml(
+                    &todo_path,
+                    2000,
+                    "$ENSEMBLE_BUSY_RETRY_TOKEN",
+                    None,
+                    "builder",
+                ),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            1000
+        );
+        let persisted = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
+        assert!(persisted.contains("$ENSEMBLE_BUSY_RETRY_TOKEN"));
+        assert!(!persisted.contains("old-literal-secret"));
+        assert_response_hides_secret(&response, "busy-environment-secret");
+
+        completion_tx.send(true).unwrap();
+        let response = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let retry_yaml = response
+                    .raw_yaml
+                    .clone()
+                    .expect("busy response should describe the persisted candidate");
+                let (status, Json(next_response)) = save_yaml(
+                    axum::extract::State(state.clone()),
+                    Json(SaveYamlRequest {
+                        raw_yaml: retry_yaml,
+                    }),
+                )
+                .await;
+                response = next_response;
+                if status == StatusCode::OK {
+                    break response;
+                }
+                assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("quiescing runtime should become replaceable");
+        let persisted = std::fs::read_to_string(&state.config_runtime.config_path).unwrap();
+        assert!(persisted.contains("$ENSEMBLE_BUSY_RETRY_TOKEN"));
+        assert!(!persisted.contains("busy-environment-secret"));
+        assert_eq!(
+            state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .tracker
+                .api_key
+                .as_deref(),
+            Some("busy-environment-secret")
+        );
+        assert_config_is_private(&state.config_runtime.config_path);
+        assert_response_hides_secret(&response, "busy-environment-secret");
+
+        crate::api::bootstrap::clear_registered_orchestrator(&state).await;
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -24,6 +24,9 @@ use utoipa::OpenApi;
 pub struct ConfigRuntime {
     pub config_path: PathBuf,
     pub document_state: Arc<RwLock<ConfigDocumentState>>,
+    /// Serializes candidate acquisition, safe file writes, runtime handover,
+    /// and generation commit so watcher and API reloads cannot interleave.
+    pub reload_coordinator: Arc<tokio::sync::Mutex<()>>,
     /// mtime of the last config file content we have already applied.
     /// The watcher uses this to skip filesystem events whose mtime matches
     /// the content we already loaded, which prevents the watcher from

--- a/crates/ensemble-core/src/api/test_helpers.rs
+++ b/crates/ensemble-core/src/api/test_helpers.rs
@@ -45,6 +45,7 @@ pub(crate) fn app_state_with_document_state(document_state: ConfigDocumentState)
         config_runtime: ConfigRuntime {
             config_path: document_state.path.clone(),
             document_state: Arc::new(RwLock::new(document_state)),
+            reload_coordinator: Arc::new(tokio::sync::Mutex::new(())),
             last_loaded_mtime: Arc::new(RwLock::new(None)),
         },
         cancellation_registry: new_cancellation_registry(),
@@ -71,6 +72,7 @@ pub(crate) fn app_state_with_missing_config(
         config_runtime: ConfigRuntime {
             config_path: config_path.clone(),
             document_state: Arc::new(RwLock::new(missing_config_state(config_path))),
+            reload_coordinator: Arc::new(tokio::sync::Mutex::new(())),
             last_loaded_mtime: Arc::new(RwLock::new(None)),
         },
         cancellation_registry: new_cancellation_registry(),

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -72,6 +72,15 @@ pub fn load_config_state(path: &Path) -> Result<ConfigDocumentState, ConfigError
     Ok(parse_raw_yaml(path.to_path_buf(), raw_yaml))
 }
 
+/// Recover any private setup transaction before parsing public configuration.
+///
+/// Hosts must use this entry point before constructing root-scoped runtime
+/// resources so a mixed setup generation fails closed.
+pub fn recover_and_load_config_state(path: &Path) -> Result<ConfigDocumentState, ConfigError> {
+    crate::config::setup_transaction::recover_setup_before_load(path)?;
+    load_config_state(path)
+}
+
 pub fn load_config_document_or_missing(path: &Path) -> ConfigDocumentState {
     match load_config_state(path) {
         Ok(state) => state,
@@ -83,9 +92,18 @@ pub fn load_config_document_or_missing(path: &Path) -> ConfigDocumentState {
 }
 
 pub fn parse_raw_yaml(path: PathBuf, raw_yaml: String) -> ConfigDocumentState {
-    let parsed: Result<serde_yaml::Value, _> = serde_yaml::from_str(&raw_yaml);
     let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
     let dotenv_map = read_dotenv(&config_dir.join(".env"));
+    parse_raw_yaml_with_dotenv(path, raw_yaml, &dotenv_map)
+}
+
+pub(crate) fn parse_raw_yaml_with_dotenv(
+    path: PathBuf,
+    raw_yaml: String,
+    dotenv_map: &std::collections::HashMap<String, String>,
+) -> ConfigDocumentState {
+    let parsed: Result<serde_yaml::Value, _> = serde_yaml::from_str(&raw_yaml);
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
 
     match parsed {
         Ok(document) => {
@@ -94,7 +112,7 @@ pub fn parse_raw_yaml(path: PathBuf, raw_yaml: String) -> ConfigDocumentState {
                 Ok(mut config) => {
                     let mut report = validate_document(&document);
                     let mut config_valid = true;
-                    if let Err(e) = config.resolve_env_from(config_dir, &dotenv_map) {
+                    if let Err(e) = config.resolve_env_from(config_dir, dotenv_map) {
                         report.issues.push(config_error_to_validation_issue(e));
                         config_valid = false;
                     }

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -68,7 +68,7 @@ pub enum HumanResumeMode {
 }
 
 /// A repository to be managed by the workspace (path + branch).
-#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
 pub struct RepoConfig {
     pub path: String,
     pub branch: String,

--- a/crates/ensemble-core/src/config/mod.rs
+++ b/crates/ensemble-core/src/config/mod.rs
@@ -4,6 +4,7 @@ pub mod form;
 pub mod location;
 pub mod secrets;
 pub mod setup;
+pub mod setup_transaction;
 pub mod template;
 
 pub use crate::workspace::finalize::{FinalizeMode, RepoFinalizeConfig};

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -199,74 +199,17 @@ pub fn write_setup_artifacts(
     request: &SetupRequest,
     artifacts: &SetupArtifacts,
 ) -> Result<(), ConfigError> {
+    let config_path = root.join("config.yaml");
     validate_setup_secret_edit(request)?;
-
-    // Create config directory if it doesn't exist
     std::fs::create_dir_all(root).map_err(|e| ConfigError::PathExpansionError {
         path: root.display().to_string(),
         reason: e.to_string(),
     })?;
-
-    // Write templates before config.yaml so a companion write failure does not
-    // leave a newly-activated config pointing at missing artifacts.
-    let templates_dir = root.join("templates");
-    if !artifacts.templates.is_empty() {
-        std::fs::create_dir_all(&templates_dir).map_err(|e| ConfigError::ConfigWriteFailed {
-            reason: format!("failed to create templates directory: {}", e),
-        })?;
-    }
-
-    for (template_path, content) in &artifacts.templates {
-        let path = root.join(template_path);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| ConfigError::ConfigWriteFailed {
-                reason: format!(
-                    "failed to create template parent directory '{}': {}",
-                    parent.display(),
-                    e
-                ),
-            })?;
-        }
-        std::fs::write(&path, content).map_err(|e| ConfigError::ConfigWriteFailed {
-            reason: format!("failed to write template '{}': {}", path.display(), e),
-        })?;
-    }
-
-    if let Some(ref todo_content) = artifacts.todo_md {
-        if let SetupTracker::TodoFile { path } = &request.tracker {
-            let resolved_path = resolve_tracker_output_path(path, root)?;
-            if let Some(parent) = resolved_path.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| ConfigError::ConfigWriteFailed {
-                    reason: format!("failed to create TODO.md parent directory: {}", e),
-                })?;
-            }
-            std::fs::write(&resolved_path, todo_content).map_err(|e| {
-                ConfigError::ConfigWriteFailed {
-                    reason: format!("failed to write TODO.md: {}", e),
-                }
-            })?;
-        }
-    }
-
-    if let Some(ref env_content) = artifacts.env_file {
-        let env_path = root.join(".env");
-        std::fs::write(&env_path, env_content).map_err(|e| ConfigError::ConfigWriteFailed {
-            reason: format!("failed to write .env: {}", e),
-        })?;
-
-        // Set restrictive permissions (user read/write only) on Unix
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o600);
-            let _ = std::fs::set_permissions(&env_path, perms);
-        }
-    }
-
-    let config_path = root.join("config.yaml");
+    let generation =
+        crate::config::setup_transaction::stage_setup_generation(&config_path, request, artifacts)?;
     crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml)?;
-
-    Ok(())
+    generation.publish(&artifacts.raw_yaml)?;
+    generation.finish_activation()
 }
 
 /// Run setup checks and return the results.
@@ -2471,7 +2414,10 @@ on_failure: Failed
             on_failure: "Failed".to_string(),
         };
         let artifacts = SetupArtifacts {
-            raw_yaml: "tracker:\n  kind: todo_file\n".to_string(),
+            raw_yaml: format!(
+                "tracker:\n  kind: todo_file\n  path: {}\n",
+                todo_path.display()
+            ),
             templates: {
                 let mut map = BTreeMap::new();
                 map.insert(
@@ -2531,7 +2477,7 @@ on_failure: Failed
             on_failure: "Failed".to_string(),
         };
         let artifacts = SetupArtifacts {
-            raw_yaml: "tracker:\n  kind: todo_file\n".to_string(),
+            raw_yaml: "tracker:\n  kind: todo_file\n  path: ~/ensemble/TODO.md\n".to_string(),
             templates: BTreeMap::new(),
             todo_md: Some("## Todo\n".to_string()),
             env_file: None,
@@ -2563,7 +2509,7 @@ on_failure: Failed
             on_failure: "Failed".to_string(),
         };
         let artifacts = SetupArtifacts {
-            raw_yaml: "tracker:\n  kind: todo_file\n".to_string(),
+            raw_yaml: "tracker:\n  kind: todo_file\n  path: nested/TODO.md\n".to_string(),
             templates: BTreeMap::new(),
             todo_md: Some("## Todo\n".to_string()),
             env_file: None,
@@ -2597,7 +2543,7 @@ on_failure: Failed
             on_failure: "Failed".to_string(),
         };
         let artifacts = SetupArtifacts {
-            raw_yaml: "tracker:\n  kind: todo_file\n".to_string(),
+            raw_yaml: "tracker:\n  kind: todo_file\n  path: $ENSEMBLE_TODO_PATH\n".to_string(),
             templates: BTreeMap::new(),
             todo_md: Some("## Todo\n".to_string()),
             env_file: None,

--- a/crates/ensemble-core/src/config/setup_transaction.rs
+++ b/crates/ensemble-core/src/config/setup_transaction.rs
@@ -1,0 +1,1303 @@
+use crate::config::draft::{parse_raw_yaml_with_dotenv, ConfigDocumentState};
+use crate::config::setup::{
+    resolve_tracker_output_path, SetupArtifacts, SetupRequest, SetupTracker,
+};
+use crate::error::ConfigError;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+
+const JOURNAL_VERSION: u8 = 1;
+const STATE_DIR: &str = ".ensemble-state";
+const PENDING_DIR: &str = "pending-setup";
+const MANIFEST_FILE: &str = "manifest.json";
+const RAW_CONFIG_FILE: &str = "config.raw";
+
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Phase {
+    Staged,
+    Publishing,
+    Published,
+    Activated,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum OperationKind {
+    Template,
+    Todo,
+    Dotenv,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Operation {
+    kind: OperationKind,
+    destination: PathBuf,
+    payload: String,
+    payload_digest: String,
+    before: Option<String>,
+    before_digest: Option<String>,
+    before_mode: Option<u32>,
+    required_mode: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Manifest {
+    version: u8,
+    raw_digest: String,
+    phase: Phase,
+    published_operations: usize,
+    operations_digest: String,
+    operations: Vec<Operation>,
+}
+
+/// Handle to the one private setup generation owned by a config directory.
+///
+/// It intentionally exposes no `Debug` implementation because its payload may
+/// contain a resolved tracker secret.
+#[derive(Clone)]
+pub struct PendingSetupGeneration {
+    config_path: PathBuf,
+    journal_dir: PathBuf,
+    raw_digest: String,
+}
+
+impl PendingSetupGeneration {
+    pub fn prepare_candidate(&self, raw_yaml: &str) -> Result<ConfigDocumentState, ConfigError> {
+        self.require_digest(raw_yaml)?;
+        let manifest = self.load_manifest()?;
+        let dotenv = self.staged_dotenv(&manifest)?;
+        Ok(parse_raw_yaml_with_dotenv(
+            self.config_path.clone(),
+            raw_yaml.to_string(),
+            &dotenv,
+        ))
+    }
+
+    pub fn publish(&self, raw_yaml: &str) -> Result<(), ConfigError> {
+        self.require_current_config(raw_yaml)?;
+        let mut manifest = self.load_manifest()?;
+        if manifest.raw_digest != self.raw_digest {
+            return Err(transaction_error("pending setup generation changed"));
+        }
+        match manifest.phase {
+            Phase::Activated => return Ok(()),
+            Phase::Published => return self.verify_published(&manifest),
+            Phase::Staged => {
+                manifest.phase = Phase::Publishing;
+                self.write_manifest(&manifest)?;
+            }
+            Phase::Publishing => {}
+        }
+
+        for index in manifest.published_operations..manifest.operations.len() {
+            let operation = &manifest.operations[index];
+            validate_operation_parent(&config_dir(&self.config_path)?, operation)?;
+            let payload = read_private_payload(&self.journal_dir, &operation.payload)?;
+            write_file_atomically(
+                &operation.destination,
+                &payload,
+                operation.required_mode,
+                "setup companion",
+            )?;
+            manifest.published_operations = index + 1;
+            self.write_manifest(&manifest)?;
+        }
+        manifest.phase = Phase::Published;
+        self.write_manifest(&manifest)?;
+        self.verify_published(&manifest)
+    }
+
+    pub fn finish_activation(&self) -> Result<(), ConfigError> {
+        let mut manifest = self.load_manifest()?;
+        if manifest.phase != Phase::Published && manifest.phase != Phase::Activated {
+            return Err(transaction_error(
+                "pending setup generation is not fully published",
+            ));
+        }
+        if manifest.phase == Phase::Published {
+            manifest.phase = Phase::Activated;
+            self.write_manifest(&manifest)?;
+        }
+        remove_journal_dir(&self.journal_dir)
+    }
+
+    fn staged_dotenv(&self, manifest: &Manifest) -> Result<HashMap<String, String>, ConfigError> {
+        let mut dotenv = crate::config::ensemble::read_dotenv(
+            &self
+                .config_path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join(".env"),
+        );
+        let Some(operation) = manifest
+            .operations
+            .iter()
+            .find(|operation| operation.kind == OperationKind::Dotenv)
+        else {
+            return Ok(dotenv);
+        };
+        let payload = read_private_payload(&self.journal_dir, &operation.payload)?;
+        for item in dotenvy::from_read_iter(payload.as_slice()) {
+            let (name, value) = item
+                .map_err(|_| transaction_error("pending setup environment payload is malformed"))?;
+            dotenv.insert(name, value);
+        }
+        Ok(dotenv)
+    }
+
+    fn verify_published(&self, manifest: &Manifest) -> Result<(), ConfigError> {
+        for operation in &manifest.operations {
+            let expected = read_private_payload(&self.journal_dir, &operation.payload)?;
+            let actual = std::fs::read(&operation.destination).map_err(|error| {
+                transaction_error(format!(
+                    "failed to verify setup companion '{}': {error}",
+                    operation.destination.display()
+                ))
+            })?;
+            if actual != expected {
+                return Err(transaction_error(format!(
+                    "setup companion '{}' does not match the pending generation",
+                    operation.destination.display()
+                )));
+            }
+            verify_mode(&operation.destination, operation.required_mode)?;
+        }
+        Ok(())
+    }
+
+    fn require_current_config(&self, raw_yaml: &str) -> Result<(), ConfigError> {
+        self.require_digest(raw_yaml)?;
+        let actual = std::fs::read(&self.config_path).map_err(|error| {
+            transaction_error(format!(
+                "failed to re-read config generation '{}': {error}",
+                self.config_path.display()
+            ))
+        })?;
+        if digest_bytes(&actual) != self.raw_digest {
+            return Err(transaction_error(
+                "config generation changed before setup publication",
+            ));
+        }
+        Ok(())
+    }
+
+    fn require_digest(&self, raw_yaml: &str) -> Result<(), ConfigError> {
+        if digest_bytes(raw_yaml.as_bytes()) != self.raw_digest {
+            return Err(transaction_error(
+                "setup candidate does not match the pending generation",
+            ));
+        }
+        Ok(())
+    }
+
+    fn load_manifest(&self) -> Result<Manifest, ConfigError> {
+        load_manifest(&self.journal_dir, &self.config_path)
+    }
+
+    fn write_manifest(&self, manifest: &Manifest) -> Result<(), ConfigError> {
+        write_manifest(&self.journal_dir, manifest)
+    }
+}
+
+/// Stage a setup generation before `config.yaml` is persisted.
+pub fn stage_setup_generation(
+    config_path: &Path,
+    request: &SetupRequest,
+    artifacts: &SetupArtifacts,
+) -> Result<PendingSetupGeneration, ConfigError> {
+    let config_dir = config_dir(config_path)?;
+    let state_dir = state_dir(&config_dir);
+    ensure_private_dir(&state_dir)?;
+    cleanup_orphan_staging_dirs(&state_dir)?;
+    let pending_dir = pending_dir(&config_dir);
+    let raw_digest = digest_bytes(artifacts.raw_yaml.as_bytes());
+
+    if pending_dir.exists() {
+        let existing = load_manifest(&pending_dir, config_path)?;
+        if existing.raw_digest == raw_digest
+            && pending_payload_matches(&pending_dir, &existing, artifacts)?
+        {
+            return Ok(PendingSetupGeneration {
+                config_path: config_path.to_path_buf(),
+                journal_dir: pending_dir,
+                raw_digest,
+            });
+        }
+        if existing.phase == Phase::Published || existing.phase == Phase::Activated {
+            remove_journal_dir(&pending_dir)?;
+        } else {
+            recover_mismatched_generation(config_path, &pending_dir, &existing)?;
+        }
+    }
+
+    let staging = tempfile::Builder::new()
+        .prefix(".setup-stage-")
+        .tempdir_in(&state_dir)
+        .map_err(|error| {
+            transaction_error(format!("failed to create setup staging area: {error}"))
+        })?;
+    set_mode(staging.path(), 0o700, "setup staging directory")?;
+
+    let operations = build_operations(config_path, request, artifacts, staging.path())?;
+    preflight_destination_directories(&config_dir, &operations)?;
+    write_file_atomically(
+        &staging.path().join(RAW_CONFIG_FILE),
+        artifacts.raw_yaml.as_bytes(),
+        0o600,
+        "setup raw config payload",
+    )?;
+    let manifest = Manifest {
+        version: JOURNAL_VERSION,
+        raw_digest: raw_digest.clone(),
+        phase: Phase::Staged,
+        published_operations: 0,
+        operations_digest: digest_operations(&operations)?,
+        operations,
+    };
+    write_manifest(staging.path(), &manifest)?;
+    sync_directory(staging.path())?;
+    let staging_path = staging.keep();
+    std::fs::rename(&staging_path, &pending_dir)
+        .map_err(|error| transaction_error(format!("failed to publish setup journal: {error}")))?;
+    sync_directory(&state_dir)?;
+
+    Ok(PendingSetupGeneration {
+        config_path: config_path.to_path_buf(),
+        journal_dir: pending_dir,
+        raw_digest,
+    })
+}
+
+fn pending_payload_matches(
+    journal_dir: &Path,
+    manifest: &Manifest,
+    artifacts: &SetupArtifacts,
+) -> Result<bool, ConfigError> {
+    let Some(expected_dotenv) = artifacts.env_file.as_deref() else {
+        // Preserve edits intentionally reuse the resolved secret payload from
+        // the persisted pending generation.
+        return Ok(true);
+    };
+    let Some(operation) = manifest
+        .operations
+        .iter()
+        .find(|operation| operation.kind == OperationKind::Dotenv)
+    else {
+        return Ok(false);
+    };
+    Ok(read_private_payload(journal_dir, &operation.payload)? == expected_dotenv.as_bytes())
+}
+
+fn preflight_destination_directories(
+    config_dir: &Path,
+    operations: &[Operation],
+) -> Result<(), ConfigError> {
+    for operation in operations {
+        validate_operation_parent(config_dir, operation)?;
+        let Some(parent) = operation.destination.parent() else {
+            continue;
+        };
+        std::fs::create_dir_all(parent).map_err(|error| {
+            transaction_error(format!(
+                "failed to prepare setup destination directory '{}': {error}",
+                parent.display()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+/// Return the pending generation only when it owns these exact raw config bytes.
+pub fn matching_setup_generation(
+    config_path: &Path,
+    raw_yaml: &str,
+) -> Result<Option<PendingSetupGeneration>, ConfigError> {
+    let config_dir = config_dir(config_path)?;
+    let journal_dir = pending_dir(&config_dir);
+    if !journal_dir.exists() {
+        return Ok(None);
+    }
+    let manifest = load_manifest(&journal_dir, config_path)?;
+    let raw_digest = digest_bytes(raw_yaml.as_bytes());
+    if manifest.raw_digest != raw_digest {
+        recover_mismatched_generation(config_path, &journal_dir, &manifest)?;
+        return Ok(None);
+    }
+    Ok(Some(PendingSetupGeneration {
+        config_path: config_path.to_path_buf(),
+        journal_dir,
+        raw_digest,
+    }))
+}
+
+pub fn has_pending_setup_generation(config_path: &Path) -> Result<bool, ConfigError> {
+    let config_dir = config_dir(config_path)?;
+    Ok(pending_dir(&config_dir).exists())
+}
+
+/// Recover setup filesystem state before any host parses config or opens root resources.
+pub fn recover_setup_before_load(config_path: &Path) -> Result<(), ConfigError> {
+    let config_dir = config_dir(config_path)?;
+    let state_dir = state_dir(&config_dir);
+    if state_dir.exists() {
+        verify_private_directory(&state_dir)?;
+        cleanup_orphan_staging_dirs(&state_dir)?;
+    }
+    let journal_dir = pending_dir(&config_dir);
+    if !journal_dir.exists() {
+        return Ok(());
+    }
+    let manifest = load_manifest(&journal_dir, config_path)?;
+    let current = std::fs::read(config_path).ok();
+    let matches = current
+        .as_deref()
+        .is_some_and(|raw| digest_bytes(raw) == manifest.raw_digest);
+    if matches {
+        let raw = String::from_utf8(current.unwrap())
+            .map_err(|_| transaction_error("config generation is not valid UTF-8"))?;
+        let generation = PendingSetupGeneration {
+            config_path: config_path.to_path_buf(),
+            journal_dir,
+            raw_digest: manifest.raw_digest,
+        };
+        generation.publish(&raw)?;
+        generation.finish_activation()
+    } else {
+        recover_mismatched_generation(config_path, &journal_dir, &manifest)
+    }
+}
+
+fn cleanup_orphan_staging_dirs(state_dir: &Path) -> Result<(), ConfigError> {
+    let entries = std::fs::read_dir(state_dir)
+        .map_err(|error| transaction_error(format!("failed to inspect setup state: {error}")))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            transaction_error(format!("failed to inspect setup state: {error}"))
+        })?;
+        let name = entry.file_name();
+        if !name.to_string_lossy().starts_with(".setup-stage-") {
+            continue;
+        }
+        let path = entry.path();
+        verify_private_directory(&path)?;
+        std::fs::remove_dir_all(&path).map_err(|error| {
+            transaction_error(format!(
+                "failed to remove abandoned setup staging area: {error}"
+            ))
+        })?;
+    }
+    sync_directory(state_dir)
+}
+
+fn recover_mismatched_generation(
+    config_path: &Path,
+    journal_dir: &Path,
+    manifest: &Manifest,
+) -> Result<(), ConfigError> {
+    match manifest.phase {
+        Phase::Staged | Phase::Activated => remove_journal_dir(journal_dir),
+        Phase::Publishing | Phase::Published => {
+            let root = config_dir(config_path)?;
+            let errors = manifest
+                .operations
+                .iter()
+                .rev()
+                .filter_map(|operation| restore_operation(&root, journal_dir, operation).err())
+                .map(|error| error.to_string())
+                .collect::<Vec<_>>();
+            if !errors.is_empty() {
+                return Err(transaction_error(format!(
+                    "setup rollback failed for {} destination(s): {}",
+                    errors.len(),
+                    errors.join("; ")
+                )));
+            }
+            remove_journal_dir(journal_dir)
+        }
+    }
+    .map_err(|error| {
+        transaction_error(format!(
+            "failed to recover setup transaction for '{}': {error}",
+            config_path.display()
+        ))
+    })
+}
+
+fn build_operations(
+    config_path: &Path,
+    request: &SetupRequest,
+    artifacts: &SetupArtifacts,
+    staging_dir: &Path,
+) -> Result<Vec<Operation>, ConfigError> {
+    let root = config_dir(config_path)?;
+    let mut sources = artifacts
+        .templates
+        .iter()
+        .map(|(relative, contents)| {
+            let destination = normalize_absolute(&root.join(relative))?;
+            if !destination.starts_with(normalize_absolute(&root.join("templates"))?) {
+                return Err(transaction_error(
+                    "template destination escapes the setup template directory",
+                ));
+            }
+            Ok((
+                OperationKind::Template,
+                destination,
+                contents.as_bytes(),
+                0o644,
+            ))
+        })
+        .collect::<Result<Vec<_>, ConfigError>>()?;
+
+    if let (Some(contents), SetupTracker::TodoFile { path }) =
+        (artifacts.todo_md.as_deref(), &request.tracker)
+    {
+        sources.push((
+            OperationKind::Todo,
+            normalize_absolute(&resolve_tracker_output_path(path, &root)?)?,
+            contents.as_bytes(),
+            0o644,
+        ));
+    }
+    if let Some(contents) = artifacts.env_file.as_deref() {
+        sources.push((
+            OperationKind::Dotenv,
+            normalize_absolute(&root.join(".env"))?,
+            contents.as_bytes(),
+            0o600,
+        ));
+    }
+
+    sources
+        .into_iter()
+        .enumerate()
+        .map(|(index, (kind, destination, contents, default_mode))| {
+            let payload = format!("payload-{index}");
+            write_file_atomically(
+                &staging_dir.join(&payload),
+                contents,
+                0o600,
+                "setup payload",
+            )?;
+            let (before, before_digest, before_mode, required_mode) =
+                match std::fs::read(&destination) {
+                    Ok(contents) => {
+                        let before = format!("before-{index}");
+                        write_file_atomically(
+                            &staging_dir.join(&before),
+                            &contents,
+                            0o600,
+                            "setup before-image",
+                        )?;
+                        let mode = file_mode(&destination)?;
+                        (
+                            Some(before),
+                            Some(digest_bytes(&contents)),
+                            Some(mode),
+                            if kind == OperationKind::Dotenv {
+                                0o600
+                            } else {
+                                mode
+                            },
+                        )
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        (None, None, None, default_mode)
+                    }
+                    Err(error) => {
+                        return Err(transaction_error(format!(
+                            "failed to capture setup destination '{}': {error}",
+                            destination.display()
+                        )))
+                    }
+                };
+            Ok(Operation {
+                kind,
+                destination,
+                payload,
+                payload_digest: digest_bytes(contents),
+                before,
+                before_digest,
+                before_mode,
+                required_mode,
+            })
+        })
+        .collect()
+}
+
+fn restore_operation(
+    config_dir: &Path,
+    journal_dir: &Path,
+    operation: &Operation,
+) -> Result<(), ConfigError> {
+    validate_operation_parent(config_dir, operation)?;
+    match &operation.before {
+        Some(before) => {
+            let contents = read_private_payload(journal_dir, before)?;
+            write_file_atomically(
+                &operation.destination,
+                &contents,
+                operation.before_mode.unwrap_or(0o600),
+                "setup before-image",
+            )
+        }
+        None => match std::fs::remove_file(&operation.destination) {
+            Ok(()) => {
+                sync_parent(&operation.destination)?;
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(transaction_error(format!(
+                "failed to remove setup destination '{}': {error}",
+                operation.destination.display()
+            ))),
+        },
+    }
+}
+
+fn load_manifest(journal_dir: &Path, config_path: &Path) -> Result<Manifest, ConfigError> {
+    let parent = journal_dir
+        .parent()
+        .ok_or_else(|| transaction_error("setup journal has no state directory"))?;
+    verify_private_directory(parent)?;
+    verify_private_directory(journal_dir)?;
+    let manifest_path = journal_dir.join(MANIFEST_FILE);
+    verify_private_file(&manifest_path)?;
+    let raw = std::fs::read(manifest_path)
+        .map_err(|error| transaction_error(format!("failed to read setup journal: {error}")))?;
+    let manifest: Manifest = serde_json::from_slice(&raw)
+        .map_err(|_| transaction_error("setup journal manifest is malformed"))?;
+    if manifest.version != JOURNAL_VERSION {
+        return Err(transaction_error("setup journal version is unsupported"));
+    }
+    if manifest.published_operations > manifest.operations.len() {
+        return Err(transaction_error("setup journal progress is invalid"));
+    }
+    if digest_operations(&manifest.operations)? != manifest.operations_digest {
+        return Err(transaction_error("setup journal operation set is invalid"));
+    }
+    let root = config_dir(config_path)?;
+    let template_root = normalize_absolute(&root.join("templates"))?;
+    let staged_raw = read_private_payload(journal_dir, RAW_CONFIG_FILE)?;
+    if digest_bytes(&staged_raw) != manifest.raw_digest {
+        return Err(transaction_error(
+            "setup journal raw config digest is invalid",
+        ));
+    }
+    let expected_todo = staged_todo_destination(&staged_raw, &root)?;
+    let mut destinations = HashSet::new();
+    for (index, operation) in manifest.operations.iter().enumerate() {
+        if operation.payload != format!("payload-{index}")
+            || operation
+                .before
+                .as_deref()
+                .is_some_and(|name| name != format!("before-{index}"))
+            || !operation.destination.is_absolute()
+            || normalize_absolute(&operation.destination)? != operation.destination
+        {
+            return Err(transaction_error("setup journal operation is invalid"));
+        }
+        if !destinations.insert(operation.destination.clone())
+            || operation.before.is_some() != operation.before_mode.is_some()
+            || operation.before.is_some() != operation.before_digest.is_some()
+        {
+            return Err(transaction_error("setup journal operation is invalid"));
+        }
+        let expected_mode = if operation.kind == OperationKind::Dotenv {
+            0o600
+        } else {
+            operation.before_mode.unwrap_or(0o644)
+        };
+        if operation.required_mode != expected_mode {
+            return Err(transaction_error("setup journal file mode is invalid"));
+        }
+        match operation.kind {
+            OperationKind::Template if !operation.destination.starts_with(&template_root) => {
+                return Err(transaction_error(
+                    "setup journal template destination is invalid",
+                ))
+            }
+            OperationKind::Dotenv if operation.destination != root.join(".env") => {
+                return Err(transaction_error(
+                    "setup journal environment destination is invalid",
+                ))
+            }
+            OperationKind::Todo if expected_todo.as_ref() != Some(&operation.destination) => {
+                return Err(transaction_error(
+                    "setup journal TODO destination is invalid",
+                ))
+            }
+            _ => {}
+        }
+        validate_operation_parent(&root, operation)?;
+        let payload = read_private_payload(journal_dir, &operation.payload)?;
+        if digest_bytes(&payload) != operation.payload_digest {
+            return Err(transaction_error("setup journal payload digest is invalid"));
+        }
+        if let Some(before) = &operation.before {
+            let before_payload = read_private_payload(journal_dir, before)?;
+            if operation.before_digest.as_deref() != Some(digest_bytes(&before_payload).as_str()) {
+                return Err(transaction_error(
+                    "setup journal before-image digest is invalid",
+                ));
+            }
+        }
+    }
+    Ok(manifest)
+}
+
+fn validate_operation_parent(root: &Path, operation: &Operation) -> Result<(), ConfigError> {
+    if operation.kind != OperationKind::Template {
+        return Ok(());
+    }
+    let parent = operation
+        .destination
+        .parent()
+        .ok_or_else(|| transaction_error("setup template destination has no parent"))?;
+    let relative = parent
+        .strip_prefix(root)
+        .map_err(|_| transaction_error("setup template destination escapes config directory"))?;
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(transaction_error(
+                    "setup template destination contains a symbolic link",
+                ))
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                return Err(transaction_error(
+                    "setup template destination parent is not a directory",
+                ))
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) => {
+                return Err(transaction_error(format!(
+                    "failed to inspect setup template destination: {error}"
+                )))
+            }
+        }
+    }
+    Ok(())
+}
+
+fn staged_todo_destination(raw_yaml: &[u8], root: &Path) -> Result<Option<PathBuf>, ConfigError> {
+    let document: serde_yaml::Value = serde_yaml::from_slice(raw_yaml)
+        .map_err(|_| transaction_error("setup journal raw config is malformed"))?;
+    let tracker = document.get("tracker");
+    if tracker
+        .and_then(|value| value.get("kind"))
+        .and_then(serde_yaml::Value::as_str)
+        != Some("todo_file")
+    {
+        return Ok(None);
+    }
+    let path = tracker
+        .and_then(|value| value.get("path"))
+        .and_then(serde_yaml::Value::as_str)
+        .ok_or_else(|| transaction_error("setup journal TODO config path is missing"))?;
+    resolve_tracker_output_path(Path::new(path), root)
+        .and_then(|path| normalize_absolute(&path))
+        .map(Some)
+}
+
+fn write_manifest(journal_dir: &Path, manifest: &Manifest) -> Result<(), ConfigError> {
+    let bytes = serde_json::to_vec(manifest)
+        .map_err(|_| transaction_error("failed to encode setup journal"))?;
+    write_file_atomically(
+        &journal_dir.join(MANIFEST_FILE),
+        &bytes,
+        0o600,
+        "setup journal",
+    )
+}
+
+fn read_private_payload(journal_dir: &Path, name: &str) -> Result<Vec<u8>, ConfigError> {
+    let path = journal_dir.join(name);
+    verify_private_file(&path)?;
+    std::fs::read(&path).map_err(|error| {
+        transaction_error(format!("failed to read private setup payload: {error}"))
+    })
+}
+
+fn write_file_atomically(
+    path: &Path,
+    contents: &[u8],
+    mode: u32,
+    label: &str,
+) -> Result<(), ConfigError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).map_err(|error| {
+        transaction_error(format!("failed to create {label} directory: {error}"))
+    })?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|error| transaction_error(format!("failed to stage {label}: {error}")))?;
+    set_mode(temporary.path(), mode, label)?;
+    temporary
+        .write_all(contents)
+        .and_then(|_| temporary.as_file().sync_all())
+        .map_err(|error| transaction_error(format!("failed to write {label}: {error}")))?;
+    temporary.persist(path).map_err(|error| {
+        transaction_error(format!("failed to replace {label}: {}", error.error))
+    })?;
+    verify_mode(path, mode)?;
+    sync_parent(path)
+}
+
+fn ensure_private_dir(path: &Path) -> Result<(), ConfigError> {
+    if path.exists() {
+        return verify_private_directory(path);
+    }
+    std::fs::create_dir_all(path).map_err(|error| {
+        transaction_error(format!("failed to create setup state directory: {error}"))
+    })?;
+    set_mode(path, 0o700, "setup state directory")
+}
+
+fn remove_journal_dir(path: &Path) -> Result<(), ConfigError> {
+    std::fs::remove_dir_all(path)
+        .map_err(|error| transaction_error(format!("failed to remove setup journal: {error}")))?;
+    sync_parent(path)
+}
+
+fn state_dir(config_dir: &Path) -> PathBuf {
+    config_dir.join(STATE_DIR)
+}
+
+fn pending_dir(config_dir: &Path) -> PathBuf {
+    state_dir(config_dir).join(PENDING_DIR)
+}
+
+fn config_dir(config_path: &Path) -> Result<PathBuf, ConfigError> {
+    let parent = config_path
+        .parent()
+        .ok_or(ConfigError::ConfigDirUnavailable)?;
+    normalize_absolute(parent)
+}
+
+fn normalize_absolute(path: &Path) -> Result<PathBuf, ConfigError> {
+    let absolute = std::path::absolute(path)
+        .map_err(|error| transaction_error(format!("failed to normalize setup path: {error}")))?;
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str())
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(transaction_error("setup path escapes the filesystem root"));
+                }
+            }
+        }
+    }
+    Ok(normalized)
+}
+
+fn digest_bytes(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn digest_operations(operations: &[Operation]) -> Result<String, ConfigError> {
+    let encoded = serde_json::to_vec(operations)
+        .map_err(|_| transaction_error("failed to encode setup journal operations"))?;
+    Ok(digest_bytes(&encoded))
+}
+
+fn transaction_error(reason: impl Into<String>) -> ConfigError {
+    ConfigError::ConfigWriteFailed {
+        reason: reason.into(),
+    }
+}
+
+#[cfg(unix)]
+fn file_mode(path: &Path) -> Result<u32, ConfigError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|metadata| metadata.permissions().mode() & 0o777)
+        .map_err(|error| transaction_error(format!("failed to inspect setup file mode: {error}")))
+}
+
+#[cfg(not(unix))]
+fn file_mode(_path: &Path) -> Result<u32, ConfigError> {
+    Ok(0o600)
+}
+
+#[cfg(unix)]
+fn set_mode(path: &Path, mode: u32, label: &str) -> Result<(), ConfigError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .map_err(|error| transaction_error(format!("failed to secure {label}: {error}")))
+}
+
+#[cfg(not(unix))]
+fn set_mode(_path: &Path, _mode: u32, _label: &str) -> Result<(), ConfigError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn verify_mode(path: &Path, required: u32) -> Result<(), ConfigError> {
+    let actual = file_mode(path)?;
+    if actual != required {
+        return Err(transaction_error(format!(
+            "private setup state has unsafe permissions at '{}'",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn verify_private_file(path: &Path) -> Result<(), ConfigError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        transaction_error(format!("failed to inspect private setup state: {error}"))
+    })?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Err(transaction_error(
+            "private setup state is not a regular file",
+        ));
+    }
+    verify_mode(path, 0o600)
+}
+
+fn verify_private_directory(path: &Path) -> Result<(), ConfigError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        transaction_error(format!("failed to inspect private setup state: {error}"))
+    })?;
+    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+        return Err(transaction_error("private setup state is not a directory"));
+    }
+    verify_mode(path, 0o700)
+}
+
+#[cfg(not(unix))]
+fn verify_mode(_path: &Path, _required: u32) -> Result<(), ConfigError> {
+    Ok(())
+}
+
+fn sync_parent(path: &Path) -> Result<(), ConfigError> {
+    if let Some(parent) = path.parent() {
+        sync_directory(parent)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> Result<(), ConfigError> {
+    std::fs::File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| transaction_error(format!("failed to flush setup directory: {error}")))
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> Result<(), ConfigError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::secrets::{SecretDisplay, SecretEdit, SecretValue};
+    use crate::config::setup::{SetupAgent, SetupStep};
+
+    fn github_request(token: &str) -> SetupRequest {
+        SetupRequest {
+            tracker: SetupTracker::GitHub {
+                repository: "owner/repo".to_string(),
+                project_number: Some(1),
+                api_key: SecretDisplay::Unset,
+                api_key_edit: SecretEdit::SetEnvironment {
+                    variable: "GITHUB_TOKEN".to_string(),
+                },
+                api_token: Some(SecretValue::new(token)),
+                active_states: vec!["Ready".to_string()],
+                terminal_states: vec!["Done".to_string()],
+            },
+            repos: vec![],
+            agents: vec![SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "codex".to_string(),
+                model: None,
+                reasoning_level: None,
+                permission_mode: None,
+                prompt: None,
+                prompt_file: Some("templates/build.liquid".to_string()),
+            }],
+            steps: vec![SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                kind: None,
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        }
+    }
+
+    fn todo_request(root: &Path) -> SetupRequest {
+        SetupRequest {
+            tracker: SetupTracker::TodoFile {
+                path: root.join("nested/TODO.md"),
+            },
+            repos: vec![],
+            agents: vec![SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "codex".to_string(),
+                model: None,
+                reasoning_level: None,
+                permission_mode: None,
+                prompt: None,
+                prompt_file: Some("templates/build.liquid".to_string()),
+            }],
+            steps: vec![SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                kind: None,
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        }
+    }
+
+    #[test]
+    fn pending_setup_generation_is_private_and_prepares_staged_dotenv() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = github_request("secret-value");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+
+        #[cfg(unix)]
+        {
+            assert_eq!(file_mode(&generation.journal_dir).unwrap(), 0o700);
+            let manifest = generation.load_manifest().unwrap();
+            assert!(manifest.operations.iter().all(|operation| {
+                file_mode(&generation.journal_dir.join(&operation.payload)).unwrap() == 0o600
+            }));
+        }
+        let candidate = generation.prepare_candidate(&artifacts.raw_yaml).unwrap();
+        let config = candidate.active_config.unwrap();
+        assert_eq!(config.tracker.api_key.as_deref(), Some("secret-value"));
+        assert!(config
+            .agents
+            .get("builder")
+            .unwrap()
+            .prompt_template
+            .as_ref()
+            .unwrap()
+            .ends_with("templates/build.liquid"));
+        assert!(
+            !format!("{}", generation.load_manifest().unwrap().version).contains("secret-value")
+        );
+    }
+
+    #[test]
+    fn pending_setup_generation_recovers_published_generation_forward() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = github_request("secret-value");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml).unwrap();
+        generation.publish(&artifacts.raw_yaml).unwrap();
+
+        recover_setup_before_load(&config_path).unwrap();
+
+        assert!(!generation.journal_dir.exists());
+        assert_eq!(
+            std::fs::read_to_string(root.path().join(".env")).unwrap(),
+            "GITHUB_TOKEN=secret-value\n"
+        );
+    }
+
+    #[test]
+    fn setup_generation_entrypoint_startup_recovers_before_config_parse() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = github_request("secret-value");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml).unwrap();
+
+        let document = crate::config::draft::recover_and_load_config_state(&config_path).unwrap();
+
+        assert_eq!(
+            document
+                .active_config
+                .as_ref()
+                .unwrap()
+                .tracker
+                .api_key
+                .as_deref(),
+            Some("secret-value")
+        );
+        assert!(!generation.journal_dir.exists());
+    }
+
+    #[test]
+    fn pending_setup_generation_rolls_back_mismatched_published_generation() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        std::fs::write(root.path().join(".env"), "GITHUB_TOKEN=old\n").unwrap();
+        set_mode(&root.path().join(".env"), 0o600, "test dotenv").unwrap();
+        let request = github_request("secret-value");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml).unwrap();
+        generation.publish(&artifacts.raw_yaml).unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, "tracker: invalid\n")
+            .unwrap();
+
+        recover_setup_before_load(&config_path).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join(".env")).unwrap(),
+            "GITHUB_TOKEN=old\n"
+        );
+        assert!(!generation.journal_dir.exists());
+    }
+
+    #[test]
+    fn pending_setup_generation_mismatch_restores_environment_before_reparse() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        std::fs::write(root.path().join(".env"), "GITHUB_TOKEN=old\n").unwrap();
+        set_mode(&root.path().join(".env"), 0o600, "test dotenv").unwrap();
+        let request = github_request("candidate");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml).unwrap();
+        generation.publish(&artifacts.raw_yaml).unwrap();
+        let external_raw = format!("{}\n", artifacts.raw_yaml);
+        crate::config::draft::persist_config_atomically(&config_path, &external_raw).unwrap();
+
+        assert!(matching_setup_generation(&config_path, &external_raw)
+            .unwrap()
+            .is_none());
+        let reparsed = crate::config::draft::load_config_state(&config_path).unwrap();
+
+        assert_eq!(
+            reparsed
+                .active_config
+                .as_ref()
+                .unwrap()
+                .tracker
+                .api_key
+                .as_deref(),
+            Some("old")
+        );
+    }
+
+    #[test]
+    fn pending_setup_generation_rejects_digest_mismatch_without_secret_diagnostic() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = github_request("do-not-leak");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+
+        let error = generation.prepare_candidate("different").unwrap_err();
+
+        assert!(!error.to_string().contains("do-not-leak"));
+    }
+
+    #[test]
+    fn pending_setup_preparation_keeps_final_todo_and_template_paths() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = todo_request(root.path());
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+
+        let candidate = generation.prepare_candidate(&artifacts.raw_yaml).unwrap();
+        let config = candidate.active_config.unwrap();
+
+        assert_eq!(
+            config.tracker.path.as_deref(),
+            Some(root.path().join("nested/TODO.md").as_path())
+        );
+        assert!(config
+            .agents
+            .get("builder")
+            .unwrap()
+            .prompt_template
+            .as_ref()
+            .unwrap()
+            .ends_with("templates/build.liquid"));
+        assert!(root.path().join("nested").is_dir());
+        assert!(!root.path().join("nested/TODO.md").exists());
+    }
+
+    #[test]
+    fn pending_setup_generation_recovers_forward_after_each_replacement() {
+        for interrupted_after in 0..=2 {
+            let root = tempfile::tempdir().unwrap();
+            let config_path = root.path().join("config.yaml");
+            let request = todo_request(root.path());
+            let artifacts = crate::config::setup::build_setup_artifacts(&request);
+            let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+            crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml)
+                .unwrap();
+            let mut manifest = generation.load_manifest().unwrap();
+            manifest.phase = Phase::Publishing;
+            for (index, operation) in manifest
+                .operations
+                .iter()
+                .take(interrupted_after)
+                .enumerate()
+            {
+                let payload =
+                    read_private_payload(&generation.journal_dir, &operation.payload).unwrap();
+                write_file_atomically(
+                    &operation.destination,
+                    &payload,
+                    operation.required_mode,
+                    "test companion",
+                )
+                .unwrap();
+                manifest.published_operations = index + 1;
+            }
+            generation.write_manifest(&manifest).unwrap();
+
+            recover_setup_before_load(&config_path).unwrap();
+
+            assert!(!generation.journal_dir.exists());
+            assert!(root.path().join("templates/build.liquid").exists());
+            assert!(root.path().join("nested/TODO.md").exists());
+        }
+    }
+
+    #[test]
+    fn pending_setup_generation_rejects_unknown_and_malformed_manifests() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = github_request("do-not-leak");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        let mut manifest = generation.load_manifest().unwrap();
+        manifest.version = JOURNAL_VERSION + 1;
+        generation.write_manifest(&manifest).unwrap();
+
+        let error = recover_setup_before_load(&config_path).unwrap_err();
+        assert!(error.to_string().contains("unsupported"));
+        assert!(!error.to_string().contains("do-not-leak"));
+
+        write_file_atomically(
+            &generation.journal_dir.join(MANIFEST_FILE),
+            b"{not-json",
+            0o600,
+            "test manifest",
+        )
+        .unwrap();
+        let error = recover_setup_before_load(&config_path).unwrap_err();
+        assert!(error.to_string().contains("malformed"));
+        assert!(!error.to_string().contains("do-not-leak"));
+    }
+
+    #[test]
+    fn pending_setup_generation_rejects_untrusted_destination_changes() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = todo_request(root.path());
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        let mut manifest = generation.load_manifest().unwrap();
+        manifest.operations[0].destination = config_path.clone();
+        generation.write_manifest(&manifest).unwrap();
+
+        let error = generation
+            .prepare_candidate(&artifacts.raw_yaml)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("operation set"));
+        assert!(!config_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_setup_generation_rejects_symlinked_template_parent() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), root.path().join("templates")).unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = todo_request(root.path());
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+
+        let error = match stage_setup_generation(&config_path, &request, &artifacts) {
+            Ok(_) => panic!("symlinked template parent should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("symbolic link"));
+        assert!(!outside.path().join("build.liquid").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_setup_generation_fails_closed_on_unsafe_payload_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = github_request("do-not-leak");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        let manifest = generation.load_manifest().unwrap();
+        let payload = generation.journal_dir.join(&manifest.operations[0].payload);
+        std::fs::set_permissions(&payload, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let error = generation
+            .prepare_candidate(&artifacts.raw_yaml)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("unsafe permissions"));
+        assert!(!error.to_string().contains("do-not-leak"));
+    }
+
+    #[test]
+    fn pending_setup_generation_rejects_payload_mutation_and_operation_omission() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let request = github_request("do-not-leak");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        let manifest = generation.load_manifest().unwrap();
+        write_file_atomically(
+            &generation.journal_dir.join(&manifest.operations[0].payload),
+            b"mutated",
+            0o600,
+            "test payload",
+        )
+        .unwrap();
+
+        let error = generation
+            .prepare_candidate(&artifacts.raw_yaml)
+            .unwrap_err();
+        assert!(error.to_string().contains("payload digest"));
+
+        let generation = {
+            remove_journal_dir(&generation.journal_dir).unwrap();
+            stage_setup_generation(&config_path, &request, &artifacts).unwrap()
+        };
+        let mut manifest = generation.load_manifest().unwrap();
+        manifest.operations.pop();
+        generation.write_manifest(&manifest).unwrap();
+
+        let error = generation
+            .prepare_candidate(&artifacts.raw_yaml)
+            .unwrap_err();
+        assert!(error.to_string().contains("operation set"));
+        assert!(!error.to_string().contains("do-not-leak"));
+    }
+}

--- a/crates/ensemble-core/src/config/setup_transaction.rs
+++ b/crates/ensemble-core/src/config/setup_transaction.rs
@@ -535,16 +535,69 @@ fn restore_operation(
     operation: &Operation,
 ) -> Result<(), ConfigError> {
     validate_operation_parent(config_dir, operation)?;
-    match &operation.before {
-        Some(before) => {
-            let contents = read_private_payload(journal_dir, before)?;
-            write_file_atomically(
-                &operation.destination,
-                &contents,
-                operation.before_mode.unwrap_or(0o600),
-                "setup before-image",
-            )
+    let current = match std::fs::symlink_metadata(&operation.destination) {
+        Ok(metadata) if metadata.file_type().is_file() && !metadata.file_type().is_symlink() => {
+            Some((
+                std::fs::read(&operation.destination).map_err(|error| {
+                    transaction_error(format!(
+                        "failed to inspect setup destination '{}': {error}",
+                        operation.destination.display()
+                    ))
+                })?,
+                file_mode(&operation.destination)?,
+            ))
         }
+        Ok(_) => {
+            return Err(transaction_error(format!(
+                "setup destination '{}' changed after publication; refusing to overwrite it during rollback",
+                operation.destination.display()
+            )))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(transaction_error(format!(
+                "failed to inspect setup destination '{}': {error}",
+                operation.destination.display()
+            )))
+        }
+    };
+    let published = read_private_payload(journal_dir, &operation.payload)?;
+    let matches_published = current.as_ref().is_some_and(|(contents, mode)| {
+        contents == &published && mode_matches(*mode, operation.required_mode)
+    });
+
+    let before = operation
+        .before
+        .as_deref()
+        .map(|name| read_private_payload(journal_dir, name))
+        .transpose()?;
+    let matches_before = match (&current, &before) {
+        (None, None) => true,
+        (Some((current, mode)), Some(before)) => {
+            current == before
+                && operation
+                    .before_mode
+                    .is_some_and(|before_mode| mode_matches(*mode, before_mode))
+        }
+        _ => false,
+    };
+    if matches_before {
+        return Ok(());
+    }
+    if !matches_published {
+        return Err(transaction_error(format!(
+            "setup destination '{}' changed after publication; refusing to overwrite it during rollback",
+            operation.destination.display()
+        )));
+    }
+
+    match before {
+        Some(contents) => write_file_atomically(
+            &operation.destination,
+            &contents,
+            operation.before_mode.unwrap_or(0o600),
+            "setup before-image",
+        ),
         None => match std::fs::remove_file(&operation.destination) {
             Ok(()) => {
                 sync_parent(&operation.destination)?;
@@ -818,6 +871,16 @@ fn transaction_error(reason: impl Into<String>) -> ConfigError {
 }
 
 #[cfg(unix)]
+fn mode_matches(actual: u32, expected: u32) -> bool {
+    actual == expected
+}
+
+#[cfg(not(unix))]
+fn mode_matches(_actual: u32, _expected: u32) -> bool {
+    true
+}
+
+#[cfg(unix)]
 fn file_mode(path: &Path) -> Result<u32, ConfigError> {
     use std::os::unix::fs::PermissionsExt;
     std::fs::metadata(path)
@@ -1064,6 +1127,67 @@ mod tests {
             "GITHUB_TOKEN=old\n"
         );
         assert!(!generation.journal_dir.exists());
+    }
+
+    #[test]
+    fn pending_setup_generation_does_not_overwrite_externally_rotated_environment() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let dotenv_path = root.path().join(".env");
+        std::fs::write(&dotenv_path, "GITHUB_TOKEN=old\n").unwrap();
+        set_mode(&dotenv_path, 0o600, "test dotenv").unwrap();
+        let request = github_request("candidate");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml).unwrap();
+        generation.publish(&artifacts.raw_yaml).unwrap();
+        std::fs::write(&dotenv_path, "GITHUB_TOKEN=rotated\n").unwrap();
+        set_mode(&dotenv_path, 0o600, "test dotenv").unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, "tracker: invalid\n")
+            .unwrap();
+
+        let error = recover_setup_before_load(&config_path).unwrap_err();
+
+        assert!(error.to_string().contains("refusing to overwrite"));
+        assert!(!error.to_string().contains("candidate"));
+        assert_eq!(
+            std::fs::read_to_string(&dotenv_path).unwrap(),
+            "GITHUB_TOKEN=rotated\n"
+        );
+        assert!(generation.journal_dir.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_setup_generation_does_not_follow_externally_replaced_environment_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let dotenv_path = root.path().join(".env");
+        let request = github_request("candidate");
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        let generation = stage_setup_generation(&config_path, &request, &artifacts).unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml).unwrap();
+        generation.publish(&artifacts.raw_yaml).unwrap();
+        std::fs::remove_file(&dotenv_path).unwrap();
+        let outside_dotenv = outside.path().join(".env");
+        std::fs::write(&outside_dotenv, artifacts.env_file.as_ref().unwrap()).unwrap();
+        set_mode(&outside_dotenv, 0o600, "test dotenv").unwrap();
+        symlink(&outside_dotenv, &dotenv_path).unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, "tracker: invalid\n")
+            .unwrap();
+
+        let error = recover_setup_before_load(&config_path).unwrap_err();
+
+        assert!(error.to_string().contains("refusing to overwrite"));
+        assert!(dotenv_path.is_symlink());
+        assert_eq!(
+            std::fs::read_to_string(&outside_dotenv).unwrap(),
+            artifacts.env_file.unwrap()
+        );
+        assert!(generation.journal_dir.exists());
     }
 
     #[test]

--- a/crates/ensemble-core/src/config_watcher.rs
+++ b/crates/ensemble-core/src/config_watcher.rs
@@ -1,4 +1,3 @@
-use crate::api::bootstrap::apply_prepared_config_candidate;
 use crate::api::router::AppState;
 use crate::config::draft::{load_config_state, ConfigDocumentState};
 use crate::error::EnsembleError;
@@ -58,16 +57,84 @@ pub(crate) async fn apply_config_from_disk_locked(
         .and_then(|m| m.modified())
         .ok();
 
+    let had_pending_setup = crate::config::setup_transaction::has_pending_setup_generation(
+        &app_state.config_runtime.config_path,
+    )?;
+    let mut loaded = load_config_state(&app_state.config_runtime.config_path)?;
+    let setup_generation = match loaded.raw_yaml.as_deref() {
+        Some(raw_yaml) => crate::config::setup_transaction::matching_setup_generation(
+            &app_state.config_runtime.config_path,
+            raw_yaml,
+        )?,
+        None => None,
+    };
+    if had_pending_setup && setup_generation.is_none() {
+        loaded = load_config_state(&app_state.config_runtime.config_path)?;
+    }
     {
         let last = app_state.config_runtime.last_loaded_mtime.read().await;
-        if skip_matching_mtime && last.is_some() && *last == file_mtime {
+        if setup_generation.is_none()
+            && skip_matching_mtime
+            && last.is_some()
+            && *last == file_mtime
+        {
             return Ok(ReloadOutcome::Unchanged);
         }
     }
+    let candidate = match (&setup_generation, loaded.raw_yaml.as_deref()) {
+        (Some(generation), Some(raw_yaml)) => generation.prepare_candidate(raw_yaml)?,
+        _ => loaded,
+    };
+    let raw_yaml = candidate.raw_yaml.clone();
+    let generation_for_publish = setup_generation.clone();
+    let accept_unchanged = setup_generation.is_none();
+    let generation_for_finish = setup_generation;
+    let config_path = app_state.config_runtime.config_path.clone();
+    apply_config_candidate_locked_with_hooks(
+        app_state,
+        candidate,
+        file_mtime,
+        accept_unchanged,
+        move || {
+            if let (Some(generation), Some(raw_yaml)) =
+                (generation_for_publish, raw_yaml.as_deref())
+            {
+                generation.publish(raw_yaml)?;
+            }
+            Ok(())
+        },
+        move || {
+            if let Some(generation) = generation_for_finish {
+                if let Err(error) = generation.finish_activation() {
+                    warn!(
+                        error = %error,
+                        path = %config_path.display(),
+                        "setup generation activated but journal cleanup remains pending"
+                    );
+                }
+            }
+        },
+    )
+    .await
+}
 
-    let loaded = load_config_state(&app_state.config_runtime.config_path)?;
+pub(crate) async fn apply_config_candidate_locked_with_hooks<Commit, AfterCommit>(
+    app_state: &AppState,
+    candidate: ConfigDocumentState,
+    file_mtime: Option<std::time::SystemTime>,
+    accept_unchanged: bool,
+    before_commit: Commit,
+    after_commit: AfterCommit,
+) -> Result<ReloadOutcome, EnsembleError>
+where
+    Commit: FnOnce() -> Result<(), EnsembleError>,
+    AfterCommit: FnOnce(),
+{
+    if candidate.raw_yaml.is_some() && file_mtime.is_none() {
+        return Err(EnsembleError::RuntimeBusy);
+    }
     let same_document = {
-        loaded.raw_yaml
+        candidate.raw_yaml
             == app_state
                 .config_runtime
                 .document_state
@@ -75,15 +142,15 @@ pub(crate) async fn apply_config_from_disk_locked(
                 .await
                 .raw_yaml
     };
-    if same_document {
+    if same_document && accept_unchanged {
         *app_state.config_runtime.last_loaded_mtime.write().await = file_mtime;
         return Ok(ReloadOutcome::Unchanged);
     }
-    let has_valid_config = loaded.active_config.is_some();
+    let has_valid_config = candidate.active_config.is_some();
 
     if has_valid_config {
         let current = app_state.config_runtime.document_state.read().await;
-        if candidate_requires_restart(app_state, &current, &loaded)? {
+        if candidate_requires_restart(app_state, &current, &candidate)? {
             warn!(
                 path = %app_state.config_runtime.config_path.display(),
                 reason = "workspace_or_repository_generation_changed",
@@ -93,7 +160,14 @@ pub(crate) async fn apply_config_from_disk_locked(
         }
         drop(current);
 
-        apply_prepared_config_candidate(app_state, loaded, file_mtime).await?;
+        crate::api::bootstrap::apply_prepared_config_candidate_with_hooks(
+            app_state,
+            candidate,
+            file_mtime,
+            before_commit,
+            after_commit,
+        )
+        .await?;
         app_state.refresh_requested.notify_one();
         info!(
             path = %app_state.config_runtime.config_path.display(),
@@ -115,7 +189,7 @@ pub(crate) async fn apply_config_from_disk_locked(
     if had_last_good {
         warn!(
             path = %app_state.config_runtime.config_path.display(),
-            issue_count = loaded.validation.issues.len(),
+            issue_count = candidate.validation.issues.len(),
             "config reload rejected; keeping last known good config"
         );
     } else {
@@ -409,6 +483,160 @@ mod tests {
             .await;
         assert!(doc.active_config.is_none());
         assert_eq!(doc.kind, crate::config::draft::ConfigStateKind::Missing);
+    }
+
+    #[tokio::test]
+    async fn setup_generation_entrypoint_watcher_publishes_matching_generation() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        let initial_yaml = valid_yaml(1000);
+        std::fs::write(&config_path, &initial_yaml).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), initial_yaml);
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        start_or_replace_registered_orchestrator(&prepared.app_state)
+            .await
+            .unwrap();
+        let todo_path = temp.path().join("nested/TODO.md");
+        let request = crate::config::setup::SetupRequest {
+            tracker: crate::config::setup::SetupTracker::TodoFile {
+                path: todo_path.clone(),
+            },
+            repos: vec![],
+            agents: vec![crate::config::setup::SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "codex".to_string(),
+                model: None,
+                reasoning_level: None,
+                permission_mode: None,
+                prompt: None,
+                prompt_file: Some("templates/build.liquid".to_string()),
+            }],
+            steps: vec![crate::config::setup::SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                kind: None,
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        };
+        let artifacts = crate::config::setup::build_setup_artifacts(&request);
+        crate::config::setup_transaction::stage_setup_generation(
+            &config_path,
+            &request,
+            &artifacts,
+        )
+        .unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml).unwrap();
+        *prepared
+            .app_state
+            .config_runtime
+            .last_loaded_mtime
+            .write()
+            .await = std::fs::metadata(&config_path)
+            .and_then(|metadata| metadata.modified())
+            .ok();
+        assert!(!todo_path.exists());
+        assert!(!temp.path().join("templates/build.liquid").exists());
+
+        let outcome = reload_config_from_disk(&prepared.app_state).await.unwrap();
+
+        assert_eq!(outcome, ReloadOutcome::Applied);
+        assert!(todo_path.exists());
+        assert!(temp.path().join("templates/build.liquid").exists());
+        assert!(crate::config::setup_transaction::matching_setup_generation(
+            &config_path,
+            &artifacts.raw_yaml,
+        )
+        .unwrap()
+        .is_none());
+        clear_registered_orchestrator(&prepared.app_state).await;
+    }
+
+    #[tokio::test]
+    async fn setup_generation_entrypoint_watcher_accepts_staged_dotenv_candidate() {
+        use crate::config::secrets::{SecretDisplay, SecretEdit, SecretValue};
+
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        let workspace_root = temp.path().join("secret-value");
+        let initial_yaml = format!(
+            "{}workspace:\n  root: {}\n",
+            valid_yaml(1000),
+            workspace_root.display()
+        );
+        std::fs::write(&config_path, &initial_yaml).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), initial_yaml);
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        start_or_replace_registered_orchestrator(&prepared.app_state)
+            .await
+            .unwrap();
+        let request = crate::config::setup::SetupRequest {
+            tracker: crate::config::setup::SetupTracker::GitHub {
+                repository: "owner/repo".to_string(),
+                project_number: Some(1),
+                api_key: SecretDisplay::Unset,
+                api_key_edit: SecretEdit::SetEnvironment {
+                    variable: "NEW_GITHUB_TOKEN".to_string(),
+                },
+                api_token: Some(SecretValue::new("secret-value")),
+                active_states: vec!["Ready".to_string()],
+                terminal_states: vec!["Done".to_string()],
+            },
+            repos: vec![],
+            agents: vec![crate::config::setup::SetupAgent {
+                role: "builder".to_string(),
+                acpx_agent: "codex".to_string(),
+                model: None,
+                reasoning_level: None,
+                permission_mode: None,
+                prompt: None,
+                prompt_file: Some("templates/build.liquid".to_string()),
+            }],
+            steps: vec![crate::config::setup::SetupStep {
+                name: "build".to_string(),
+                agent_role: "builder".to_string(),
+                kind: None,
+                depends: vec![],
+                tracker_state: None,
+            }],
+            on_success: "Done".to_string(),
+            on_failure: "Failed".to_string(),
+        };
+        let mut artifacts = crate::config::setup::build_setup_artifacts(&request);
+        artifacts
+            .raw_yaml
+            .push_str("workspace:\n  root: $NEW_GITHUB_TOKEN\n");
+        crate::config::setup_transaction::stage_setup_generation(
+            &config_path,
+            &request,
+            &artifacts,
+        )
+        .unwrap();
+        crate::config::draft::persist_config_atomically(&config_path, &artifacts.raw_yaml).unwrap();
+
+        let outcome = reload_config_from_disk(&prepared.app_state).await.unwrap();
+
+        assert_eq!(outcome, ReloadOutcome::Applied);
+        let document = prepared
+            .app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await;
+        assert_eq!(
+            document
+                .active_config
+                .as_ref()
+                .unwrap()
+                .tracker
+                .api_key
+                .as_deref(),
+            Some("secret-value")
+        );
+        drop(document);
+        clear_registered_orchestrator(&prepared.app_state).await;
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/config_watcher.rs
+++ b/crates/ensemble-core/src/config_watcher.rs
@@ -1,11 +1,15 @@
-use crate::api::bootstrap::start_or_replace_registered_orchestrator;
+use crate::api::bootstrap::apply_prepared_config_candidate;
 use crate::api::router::AppState;
-use crate::config::draft::load_config_state;
+use crate::config::draft::{load_config_state, ConfigDocumentState};
 use crate::error::EnsembleError;
-use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+#[cfg(test)]
+use notify::PollWatcher as EnsembleWatcher;
+#[cfg(not(test))]
+use notify::RecommendedWatcher as EnsembleWatcher;
+use notify::{Config, EventKind, RecursiveMode, Watcher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -37,32 +41,59 @@ impl Drop for ConfigWatcherHandle {
 pub enum ReloadOutcome {
     Applied,
     Rejected,
+    RestartRequired,
     Unchanged,
 }
 
 pub async fn reload_config_from_disk(app_state: &AppState) -> Result<ReloadOutcome, EnsembleError> {
+    let _reload = app_state.config_runtime.reload_coordinator.lock().await;
+    apply_config_from_disk_locked(app_state, true).await
+}
+
+pub(crate) async fn apply_config_from_disk_locked(
+    app_state: &AppState,
+    skip_matching_mtime: bool,
+) -> Result<ReloadOutcome, EnsembleError> {
     let file_mtime = std::fs::metadata(&app_state.config_runtime.config_path)
         .and_then(|m| m.modified())
         .ok();
 
     {
         let last = app_state.config_runtime.last_loaded_mtime.read().await;
-        if last.is_some() && *last == file_mtime {
+        if skip_matching_mtime && last.is_some() && *last == file_mtime {
             return Ok(ReloadOutcome::Unchanged);
         }
     }
 
     let loaded = load_config_state(&app_state.config_runtime.config_path)?;
+    let same_document = {
+        loaded.raw_yaml
+            == app_state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .raw_yaml
+    };
+    if same_document {
+        *app_state.config_runtime.last_loaded_mtime.write().await = file_mtime;
+        return Ok(ReloadOutcome::Unchanged);
+    }
     let has_valid_config = loaded.active_config.is_some();
 
     if has_valid_config {
-        {
-            let mut current = app_state.config_runtime.document_state.write().await;
-            *current = loaded;
+        let current = app_state.config_runtime.document_state.read().await;
+        if candidate_requires_restart(app_state, &current, &loaded)? {
+            warn!(
+                path = %app_state.config_runtime.config_path.display(),
+                reason = "workspace_or_repository_generation_changed",
+                "config reload requires a process restart; keeping last known good config"
+            );
+            return Ok(ReloadOutcome::RestartRequired);
         }
-        *app_state.config_runtime.last_loaded_mtime.write().await = file_mtime;
+        drop(current);
 
-        start_or_replace_registered_orchestrator(app_state).await?;
+        apply_prepared_config_candidate(app_state, loaded, file_mtime).await?;
         app_state.refresh_requested.notify_one();
         info!(
             path = %app_state.config_runtime.config_path.display(),
@@ -84,13 +115,10 @@ pub async fn reload_config_from_disk(app_state: &AppState) -> Result<ReloadOutco
     if had_last_good {
         warn!(
             path = %app_state.config_runtime.config_path.display(),
-            issues = ?loaded.validation.issues,
+            issue_count = loaded.validation.issues.len(),
             "config reload rejected; keeping last known good config"
         );
     } else {
-        let mut current = app_state.config_runtime.document_state.write().await;
-        *current = loaded;
-        *app_state.config_runtime.last_loaded_mtime.write().await = file_mtime;
         warn!(
             path = %app_state.config_runtime.config_path.display(),
             "config reload rejected; no last known good config is available"
@@ -100,66 +128,79 @@ pub async fn reload_config_from_disk(app_state: &AppState) -> Result<ReloadOutco
     Ok(ReloadOutcome::Rejected)
 }
 
-/// Record that `config_path` was just written by Ensemble itself, so the watcher
-/// will skip the next reload that the write triggers.
-pub async fn record_self_write(app_state: &AppState) {
-    let mtime = std::fs::metadata(&app_state.config_runtime.config_path)
-        .and_then(|m| m.modified())
-        .unwrap_or(SystemTime::now());
-    *app_state.config_runtime.last_loaded_mtime.write().await = Some(mtime);
+fn candidate_requires_restart(
+    app_state: &AppState,
+    current: &ConfigDocumentState,
+    candidate: &ConfigDocumentState,
+) -> Result<bool, EnsembleError> {
+    let Some(candidate_config) = candidate.active_config.as_ref() else {
+        return Ok(false);
+    };
+
+    let current_root =
+        crate::workspace::manager::resolve_workspace_root(Path::new(&app_state.workspace_root))?;
+    let candidate_root = crate::workspace::manager::resolve_workspace_root(Path::new(
+        &crate::api::bootstrap::workspace_root_from_document(candidate),
+    ))?;
+    let current_repos = current
+        .active_config
+        .as_ref()
+        .map(|config| &config.repos)
+        .unwrap_or(&candidate_config.repos);
+    Ok(current_root != candidate_root || current_repos != &candidate_config.repos)
 }
 
 pub fn start_config_watcher(app_state: AppState) -> ConfigWatcherHandle {
-    let task = tokio::spawn(async move {
-        let config_path = std::fs::canonicalize(&app_state.config_runtime.config_path)
-            .unwrap_or_else(|_| app_state.config_runtime.config_path.clone());
-        let watch_dir = config_path
-            .parent()
-            .filter(|path| !path.as_os_str().is_empty())
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| PathBuf::from("."));
+    let config_path = std::fs::canonicalize(&app_state.config_runtime.config_path)
+        .unwrap_or_else(|_| app_state.config_runtime.config_path.clone());
+    let watch_dir = config_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
 
-        if let Ok(initial_mtime) =
-            std::fs::metadata(&app_state.config_runtime.config_path).and_then(|m| m.modified())
-        {
-            *app_state.config_runtime.last_loaded_mtime.write().await = Some(initial_mtime);
-        }
-
-        let (event_tx, mut event_rx) = mpsc::channel(CONFIG_WATCHER_CHANNEL_CAPACITY);
-        let dropped_warned = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let dropped_warned_for_cb = Arc::clone(&dropped_warned);
-        let mut watcher = match RecommendedWatcher::new(
-            move |result| {
-                if event_tx.try_send(result).is_err() {
-                    if !dropped_warned_for_cb.swap(true, std::sync::atomic::Ordering::Relaxed) {
-                        warn!("config watcher event dropped; receiver is unavailable or lagging");
-                    }
-                } else {
-                    dropped_warned_for_cb.store(false, std::sync::atomic::Ordering::Relaxed);
+    let (event_tx, mut event_rx) = mpsc::channel(CONFIG_WATCHER_CHANNEL_CAPACITY);
+    let dropped_warned = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let dropped_warned_for_cb = Arc::clone(&dropped_warned);
+    let watcher_config = Config::default();
+    #[cfg(test)]
+    let watcher_config = watcher_config
+        .with_poll_interval(Duration::from_millis(50))
+        .with_compare_contents(true);
+    let mut watcher = match EnsembleWatcher::new(
+        move |result| {
+            if event_tx.try_send(result).is_err() {
+                if !dropped_warned_for_cb.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                    warn!("config watcher event dropped; receiver is unavailable or lagging");
                 }
-            },
-            Config::default(),
-        ) {
-            Ok(watcher) => watcher,
-            Err(error) => {
-                warn!(
-                    error = %error,
-                    path = %watch_dir.display(),
-                    "failed to create config watcher"
-                );
-                return;
+            } else {
+                dropped_warned_for_cb.store(false, std::sync::atomic::Ordering::Relaxed);
             }
-        };
-
-        if let Err(error) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+        },
+        watcher_config,
+    ) {
+        Ok(watcher) => watcher,
+        Err(error) => {
             warn!(
                 error = %error,
                 path = %watch_dir.display(),
-                "failed to watch config directory"
+                "failed to create config watcher"
             );
-            return;
+            return ConfigWatcherHandle { task: None };
         }
+    };
 
+    if let Err(error) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+        warn!(
+            error = %error,
+            path = %watch_dir.display(),
+            "failed to watch config directory"
+        );
+        return ConfigWatcherHandle { task: None };
+    }
+
+    let task = tokio::spawn(async move {
+        let _watcher = watcher;
         info!(
             config_path = %config_path.display(),
             watch_dir = %watch_dir.display(),
@@ -188,8 +229,13 @@ pub fn start_config_watcher(app_state: AppState) -> ConfigWatcherHandle {
             }
 
             if let Err(error) = reload_config_from_disk(&app_state).await {
+                let reason = if matches!(error, EnsembleError::RuntimeBusy) {
+                    "runtime_busy"
+                } else {
+                    "candidate_prepare_or_commit_failed"
+                };
                 warn!(
-                    error = %error,
+                    reason,
                     path = %config_path.display(),
                     "config reload failed"
                 );
@@ -224,7 +270,10 @@ fn paths_match(event_path: &Path, config_path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::bootstrap::{build_app_state, take_registered_orchestrator};
+    use crate::api::bootstrap::{
+        build_app_state, clear_registered_orchestrator, start_or_replace_registered_orchestrator,
+        take_registered_orchestrator,
+    };
     use crate::config::draft::parse_raw_yaml;
     use crate::observability::events::EventBus;
     use tempfile::TempDir;
@@ -341,7 +390,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn external_reload_records_invalid_document_when_no_last_good_exists() {
+    async fn external_reload_keeps_missing_state_when_invalid_candidate_has_no_last_good() {
         let temp = TempDir::new().unwrap();
         let config_path = temp.path().join("config.yaml");
         let initial = crate::config::draft::missing_config_state(config_path.clone());
@@ -359,7 +408,258 @@ mod tests {
             .read()
             .await;
         assert!(doc.active_config.is_none());
-        assert_eq!(doc.kind, crate::config::draft::ConfigStateKind::SyntaxError);
+        assert_eq!(doc.kind, crate::config::draft::ConfigStateKind::Missing);
+    }
+
+    #[tokio::test]
+    async fn restart_required_reload_workspace_root_keeps_active_generation() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        let initial_root = temp.path().join("workspaces-a");
+        let candidate_root = temp.path().join("workspaces-b");
+        let initial_yaml = format!(
+            "{}workspace:\n  root: {}\n",
+            valid_yaml(1000),
+            initial_root.display()
+        );
+        let candidate_yaml = format!(
+            "{}workspace:\n  root: {}\n",
+            valid_yaml(2500),
+            candidate_root.display()
+        );
+        std::fs::write(&config_path, &initial_yaml).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), initial_yaml);
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        start_or_replace_registered_orchestrator(&prepared.app_state)
+            .await
+            .unwrap();
+        let initial_mtime = *prepared
+            .app_state
+            .config_runtime
+            .last_loaded_mtime
+            .read()
+            .await;
+
+        std::fs::write(&config_path, candidate_yaml).unwrap();
+        let outcome = reload_config_from_disk(&prepared.app_state).await.unwrap();
+
+        assert_eq!(outcome, ReloadOutcome::RestartRequired);
+        let document = prepared
+            .app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await;
+        assert_eq!(
+            document.active_config.as_ref().unwrap().polling.interval_ms,
+            1000
+        );
+        assert_eq!(
+            prepared.app_state.workspace_root,
+            initial_root.display().to_string()
+        );
+        drop(document);
+        assert_eq!(
+            *prepared
+                .app_state
+                .config_runtime
+                .last_loaded_mtime
+                .read()
+                .await,
+            initial_mtime,
+            "restart-required candidates remain retryable"
+        );
+
+        clear_registered_orchestrator(&prepared.app_state).await;
+    }
+
+    #[tokio::test]
+    async fn restart_required_reload_repositories_keeps_active_generation() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        let repo_a = temp.path().join("repo-a");
+        let repo_b = temp.path().join("repo-b");
+        let initial_yaml = format!(
+            "{}repos:\n  - path: {}\n    branch: main\n",
+            valid_yaml(1000),
+            repo_a.display()
+        );
+        let candidate_yaml = format!(
+            "{}repos:\n  - path: {}\n    branch: main\n",
+            valid_yaml(2500),
+            repo_b.display()
+        );
+        std::fs::write(&config_path, &initial_yaml).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), initial_yaml);
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        start_or_replace_registered_orchestrator(&prepared.app_state)
+            .await
+            .unwrap();
+
+        std::fs::write(&config_path, candidate_yaml).unwrap();
+        let outcome = reload_config_from_disk(&prepared.app_state).await.unwrap();
+
+        assert_eq!(outcome, ReloadOutcome::RestartRequired);
+        let document = prepared
+            .app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await;
+        assert_eq!(
+            document.active_config.as_ref().unwrap().repos[0].path,
+            repo_a.display().to_string()
+        );
+        assert_eq!(
+            document.active_config.as_ref().unwrap().polling.interval_ms,
+            1000
+        );
+        drop(document);
+
+        clear_registered_orchestrator(&prepared.app_state).await;
+    }
+
+    #[tokio::test]
+    async fn transactional_reload_preparation_failure_is_retryable_without_rewrite() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        let initial_yaml = valid_yaml(1000);
+        std::fs::write(&config_path, &initial_yaml).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), initial_yaml);
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        start_or_replace_registered_orchestrator(&prepared.app_state)
+            .await
+            .unwrap();
+        let last_good_mtime = *prepared
+            .app_state
+            .config_runtime
+            .last_loaded_mtime
+            .read()
+            .await;
+        let missing_parent = temp.path().join("not-created-yet");
+        let candidate_yaml = valid_yaml(2500).replace(
+            "path: TODO.md",
+            &format!("path: {}/TODO.md", missing_parent.display()),
+        );
+        std::fs::write(&config_path, candidate_yaml).unwrap();
+        let candidate_mtime = std::fs::metadata(&config_path).unwrap().modified().unwrap();
+
+        assert!(reload_config_from_disk(&prepared.app_state).await.is_err());
+        assert_eq!(
+            prepared
+                .app_state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            1000
+        );
+        assert_eq!(
+            prepared
+                .app_state
+                .orchestrator_state
+                .read()
+                .await
+                .poll_interval_ms,
+            1000
+        );
+        assert_eq!(
+            *prepared
+                .app_state
+                .config_runtime
+                .last_loaded_mtime
+                .read()
+                .await,
+            last_good_mtime
+        );
+        assert!(prepared.app_state.orchestrator_runtime.is_registered());
+
+        std::fs::create_dir_all(&missing_parent).unwrap();
+        assert_eq!(
+            std::fs::metadata(&config_path).unwrap().modified().unwrap(),
+            candidate_mtime,
+            "repair must not rewrite the candidate"
+        );
+        assert_eq!(
+            reload_config_from_disk(&prepared.app_state).await.unwrap(),
+            ReloadOutcome::Applied
+        );
+        assert_eq!(
+            prepared
+                .app_state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            2500
+        );
+
+        clear_registered_orchestrator(&prepared.app_state).await;
+    }
+
+    #[tokio::test]
+    async fn serialized_reload_generation_commits_only_the_latest_waiting_candidate() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        let initial_yaml = valid_yaml(1000);
+        std::fs::write(&config_path, &initial_yaml).unwrap();
+        let initial = parse_raw_yaml(config_path.clone(), initial_yaml);
+        let prepared = build_app_state(config_path.clone(), initial, EventBus::new());
+        start_or_replace_registered_orchestrator(&prepared.app_state)
+            .await
+            .unwrap();
+
+        let reload_guard = prepared
+            .app_state
+            .config_runtime
+            .reload_coordinator
+            .lock()
+            .await;
+        std::fs::write(&config_path, valid_yaml(2500)).unwrap();
+        let mut waiting_reload = tokio::spawn({
+            let app_state = prepared.app_state.clone();
+            async move { reload_config_from_disk(&app_state).await }
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut waiting_reload)
+                .await
+                .is_err(),
+            "reload must wait for the active generation transaction"
+        );
+
+        std::fs::write(&config_path, valid_yaml(3500)).unwrap();
+        drop(reload_guard);
+        assert_eq!(
+            waiting_reload.await.unwrap().unwrap(),
+            ReloadOutcome::Applied
+        );
+        assert_eq!(
+            prepared
+                .app_state
+                .config_runtime
+                .document_state
+                .read()
+                .await
+                .active_config
+                .as_ref()
+                .unwrap()
+                .polling
+                .interval_ms,
+            3500,
+            "the superseded candidate must never become observable"
+        );
+
+        clear_registered_orchestrator(&prepared.app_state).await;
     }
 
     #[test]
@@ -391,7 +691,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn watcher_does_not_reload_after_record_self_write() {
+    async fn watcher_skips_generation_already_committed_by_a_reload_transaction() {
         let temp = TempDir::new().unwrap();
         let config_path = temp.path().join("config.yaml");
         std::fs::write(&config_path, valid_yaml(1000)).unwrap();
@@ -404,10 +704,13 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
         std::fs::write(&config_path, valid_yaml(5500)).unwrap();
-        record_self_write(&prepared.app_state).await;
+        assert_eq!(
+            reload_config_from_disk(&prepared.app_state).await.unwrap(),
+            ReloadOutcome::Applied
+        );
 
-        // The watcher will fire after the debounce, but the mtime check should
-        // make it return Unchanged and leave the document state alone.
+        // The watcher will fire after the debounce, but the committed mtime
+        // makes it return Unchanged instead of replacing the runtime twice.
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         let interval = {
             let doc = prepared
@@ -422,8 +725,8 @@ mod tests {
         };
         assert_eq!(
             interval,
-            Some(1000),
-            "watcher should not apply a self-write because record_self_write pins last_loaded_mtime"
+            Some(5500),
+            "watcher must preserve the generation already committed by the transaction"
         );
 
         watcher.abort();
@@ -442,9 +745,9 @@ mod tests {
         let watcher = start_config_watcher(prepared.app_state.clone());
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-        std::fs::write(&config_path, valid_yaml(3500)).unwrap();
+        std::fs::write(&config_path, valid_yaml(35_000)).unwrap();
 
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
         loop {
             let interval = {
                 let doc = prepared
@@ -457,7 +760,7 @@ mod tests {
                     .as_ref()
                     .map(|config| config.polling.interval_ms)
             };
-            if interval == Some(3500) {
+            if interval == Some(35_000) {
                 break;
             }
             assert!(

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -378,8 +378,6 @@ impl Orchestrator {
         config_dir: &Path,
         shutdown_rx: mpsc::Receiver<()>,
     ) -> Self {
-        let (worker_tx, worker_rx) = mpsc::channel(1000);
-        let (command_tx, command_rx) = mpsc::channel(100);
         let history_store = futures::executor::block_on(HistoryStore::new(
             parts.workspace_root.join(".ensemble").join("history.db"),
         ))
@@ -391,6 +389,17 @@ impl Orchestrator {
             error
         })
         .ok();
+        Self::new_with_state_and_history(parts, config_dir, shutdown_rx, history_store)
+    }
+
+    pub(crate) fn new_with_state_and_history(
+        parts: OrchestratorRuntimeParts,
+        config_dir: &Path,
+        shutdown_rx: mpsc::Receiver<()>,
+        history_store: Option<HistoryStore>,
+    ) -> Self {
+        let (worker_tx, worker_rx) = mpsc::channel(1000);
+        let (command_tx, command_rx) = mpsc::channel(100);
         let timeline_persistence = history_store.clone().map(TimelinePersistence::new);
 
         Self {
@@ -459,6 +468,25 @@ impl Orchestrator {
 
     pub(crate) fn command_sender_owner(&self) -> mpsc::Sender<OrchestratorCommand> {
         self.command_tx.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn persist_timeline_for_test(
+        &self,
+        record: crate::timeline::model::TimelineEventRecord,
+    ) {
+        self.timeline_persistence
+            .as_ref()
+            .expect("test orchestrator should have timeline persistence")
+            .send(record);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn persist_transcript_for_test(&self, request: TranscriptPersistRequest) {
+        self.transcript_persistence
+            .as_ref()
+            .expect("test orchestrator should have transcript persistence")
+            .send(request);
     }
 
     async fn handle_command(&self, command: OrchestratorCommand) {

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -46,21 +46,25 @@ pub struct WorkspaceResult {
     pub created_now: bool,
 }
 
+pub(crate) fn resolve_workspace_root(root: &Path) -> Result<PathBuf, WorkspaceError> {
+    if root.is_absolute() {
+        Ok(root.to_path_buf())
+    } else {
+        let current_dir =
+            std::env::current_dir().map_err(|error| WorkspaceError::CreationFailed {
+                reason: format!("cannot resolve relative root: {error}"),
+            })?;
+        Ok(current_dir.join(root))
+    }
+}
+
 impl WorkspaceManager {
     /// Create a new WorkspaceManager with the given workspace root.
     /// The root is normalized to an absolute path.
     /// Pass `repos` to enable worktree-based workspace isolation.
     /// Repo names are derived from path basenames.
     pub fn new(root: &Path, repos: Option<Vec<RepoConfig>>) -> Result<Self, WorkspaceError> {
-        let root = if root.is_absolute() {
-            root.to_path_buf()
-        } else {
-            std::env::current_dir()
-                .map_err(|e| WorkspaceError::CreationFailed {
-                    reason: format!("cannot resolve relative root: {e}"),
-                })?
-                .join(root)
-        };
+        let root = resolve_workspace_root(root)?;
 
         let repos_map = repos
             .filter(|r| !r.is_empty())

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -59,6 +59,7 @@ fn build_app_state(
         config_runtime: ConfigRuntime {
             config_path: document_state.path.clone(),
             document_state: Arc::new(RwLock::new(document_state)),
+            reload_coordinator: Arc::new(tokio::sync::Mutex::new(())),
             last_loaded_mtime: Arc::new(RwLock::new(None)),
         },
         cancellation_registry: new_cancellation_registry(),
@@ -692,7 +693,8 @@ on_failure: Failed
 #[tokio::test]
 async fn test_guided_form_save_round_trips_permission_request_policy() {
     let (state, _temp_dir) = build_app_state_without_config();
-    let raw_yaml = r#"
+    let raw_yaml = format!(
+        r#"
 tracker:
   kind: todo_file
   path: TODO.md
@@ -712,14 +714,18 @@ agent:
     option_id: manual
 on_success: Done
 on_failure: Failed
-"#;
-    std::fs::write(&state.config_runtime.config_path, raw_yaml).unwrap();
+workspace:
+  root: {}
+"#,
+        state.workspace_root
+    );
+    std::fs::write(&state.config_runtime.config_path, &raw_yaml).unwrap();
     *state.config_runtime.document_state.write().await = ConfigDocumentState {
         path: state.config_runtime.config_path.clone(),
         kind: ConfigStateKind::Parsed,
-        raw_yaml: Some(raw_yaml.to_string()),
+        raw_yaml: Some(raw_yaml.clone()),
         document: None,
-        active_config: Some(ensemble_core::config::ensemble::parse_config(raw_yaml).unwrap()),
+        active_config: Some(ensemble_core::config::ensemble::parse_config(&raw_yaml).unwrap()),
         validation: DraftValidationReport::default(),
     };
 
@@ -758,7 +764,8 @@ on_failure: Failed
 #[tokio::test]
 async fn test_guided_form_save_preserves_explicit_agent_runtime() {
     let (state, _temp_dir) = build_app_state_without_config();
-    let raw_yaml = r#"
+    let raw_yaml = format!(
+        r#"
 tracker:
   kind: todo_file
   path: TODO.md
@@ -773,14 +780,18 @@ steps:
     agent: builder
 on_success: Done
 on_failure: Failed
-"#;
-    std::fs::write(&state.config_runtime.config_path, raw_yaml).unwrap();
+workspace:
+  root: {}
+"#,
+        state.workspace_root
+    );
+    std::fs::write(&state.config_runtime.config_path, &raw_yaml).unwrap();
     *state.config_runtime.document_state.write().await = ConfigDocumentState {
         path: state.config_runtime.config_path.clone(),
         kind: ConfigStateKind::Parsed,
-        raw_yaml: Some(raw_yaml.to_string()),
+        raw_yaml: Some(raw_yaml.clone()),
         document: None,
-        active_config: Some(ensemble_core::config::ensemble::parse_config(raw_yaml).unwrap()),
+        active_config: Some(ensemble_core::config::ensemble::parse_config(&raw_yaml).unwrap()),
         validation: DraftValidationReport::default(),
     };
 

--- a/crates/ensemble-desktop/src/server.rs
+++ b/crates/ensemble-desktop/src/server.rs
@@ -16,7 +16,7 @@ use ensemble_core::api::bootstrap::{
 };
 use ensemble_core::api::router::create_api_router;
 use ensemble_core::api::router::AppState;
-use ensemble_core::config::draft::load_config_document_or_missing;
+use ensemble_core::config::draft::recover_and_load_config_state;
 use ensemble_core::config_watcher::{start_config_watcher, ConfigWatcherHandle};
 use ensemble_core::observability::events::EventBus;
 
@@ -70,7 +70,8 @@ pub async fn start_desktop_server(
         "Starting desktop HTTP server"
     );
 
-    let document_state = load_config_document_or_missing(&config_path);
+    let document_state = recover_and_load_config_state(&config_path)
+        .map_err(|error| DesktopError::ConfigLoadFailed(error.to_string()))?;
     let prepared = build_app_state(config_path.clone(), document_state, event_bus);
 
     if prepared.has_runnable_config {

--- a/crates/ensemble-ui/src-ui/src/components/config/RestartRequiredNotice.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/RestartRequiredNotice.tsx
@@ -1,0 +1,34 @@
+import { FetchError } from "@/fetch-client";
+import { AlertCircle } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+
+const DEFAULT_MESSAGE = "Configuration was saved. Restart Ensemble to apply it.";
+
+export function restartRequiredMessage(error: unknown): string | null {
+  if (!(error instanceof FetchError) || error.status !== 409) {
+    return null;
+  }
+
+  return error.message.startsWith("HTTP ") ? DEFAULT_MESSAGE : error.message;
+}
+
+export default function RestartRequiredNotice({ message }: { message: string }) {
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800 dark:bg-yellow-900/30">
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+            <h2 className="text-lg font-semibold text-yellow-800 dark:text-yellow-200">
+              Restart Required
+            </h2>
+          </div>
+          <p className="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
+            Configuration was saved but cannot be activated by the running process.
+          </p>
+          <p className="mt-2 text-sm text-yellow-700 dark:text-yellow-300">{message}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.test.tsx
@@ -4,10 +4,10 @@ import userEvent from "@testing-library/user-event";
 import SetupWizard from "./SetupWizard";
 import { renderWithProviders } from "@/test/render";
 
-function jsonResponse(data: unknown) {
+function jsonResponse(data: unknown, status = 200) {
   return Promise.resolve({
-    ok: true,
-    status: 200,
+    ok: status >= 200 && status < 300,
+    status,
     json: () => Promise.resolve(data),
   } as Response);
 }
@@ -365,6 +365,81 @@ describe("SetupWizard", () => {
       model: "sonnet",
       reasoning_level: "high",
       permission_mode: "approve_reads",
+    });
+  });
+
+  it("completes setup with a restart-required notice when the saved config returns 409", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    const restartMessage = "Configuration saved; restart Ensemble to apply it";
+
+    vi.stubGlobal("fetch", vi.fn((url: string) => {
+      if (url.includes("/api/v1/config/setup/defaults")) {
+        return jsonResponse({
+          has_existing_config: true,
+          defaults: {
+            tracker: { kind: "todo_file", path: "/tmp/TODO.md" },
+            repos: [{ path: "/repo", branch: "main" }],
+            agents: [{ role: "implement", acpx_agent: "builder", model: null }],
+            steps: [
+              {
+                name: "implement",
+                agent_role: "implement",
+                depends: [],
+                tracker_state: null,
+              },
+            ],
+            onSuccess: "Done",
+            onFailure: "Failed",
+          },
+        });
+      }
+      if (url.includes("/api/v1/config/setup/validate")) {
+        return jsonResponse({
+          can_save: true,
+          checks: [{ label: "Configuration", passed: true, detail: "Ready" }],
+        });
+      }
+      if (url.includes("/api/v1/config/setup/save")) {
+        return jsonResponse(
+          {
+            state: "parsed",
+            config_path: "/tmp/config.yaml",
+            raw_yaml: "tracker:\n  kind: todo_file\n",
+            issues: [
+              {
+                kind: "Config",
+                section: "runtime",
+                message: restartMessage,
+                field: null,
+                path: null,
+              },
+            ],
+            guided_form: null,
+          },
+          409,
+        );
+      }
+      return jsonResponse({});
+    }));
+
+    renderWithProviders(
+      <SetupWizard mode="reconfigure" onComplete={onComplete} />,
+      { route: "/config" },
+    );
+
+    expect(await screen.findByText("Reconfigure Ensemble")).toBeInTheDocument();
+    for (let step = 0; step < 4; step += 1) {
+      await user.click(screen.getByRole("button", { name: /next/i }));
+    }
+    await user.click(screen.getByRole("button", { name: /validate/i }));
+    expect(await screen.findByText("Validation Passed")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(await screen.findByText("Restart Required")).toBeInTheDocument();
+    expect(screen.getByText(restartMessage)).toBeInTheDocument();
+    expect(onComplete).toHaveBeenCalledWith({
+      restartRequiredMessage: restartMessage,
     });
   });
 

--- a/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/SetupWizard.tsx
@@ -3,6 +3,7 @@ import { useSetupDefaultsQuery } from "@/hooks";
 import { useValidateSetupMutation, useSaveSetupMutation } from "@/hooks";
 import { useAgentDiscovery } from "@/hooks/useAgentDiscovery";
 import FileBrowser from "./FileBrowser";
+import RestartRequiredNotice, { restartRequiredMessage } from "./RestartRequiredNotice";
 import { secretEditValidationError } from "./secretEditValidation";
 import type {
   SetupTracker,
@@ -55,9 +56,13 @@ interface SetupDraft {
   onFailure: string;
 }
 
+export interface SetupWizardCompletion {
+  restartRequiredMessage?: string;
+}
+
 interface SetupWizardProps {
   mode?: "create" | "reconfigure";
-  onComplete?: () => void;
+  onComplete?: (completion?: SetupWizardCompletion) => void;
 }
 
 const DEFAULT_TODO_TRACKER: SetupTracker = { kind: "todo_file", path: "" };
@@ -131,6 +136,7 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
     canSave: boolean;
     checks: SetupCheck[];
   } | null>(null);
+  const [restartMessage, setRestartMessage] = useState<string | null>(null);
   const [repoPathInput, setRepoPathInput] = useState("");
   const [repoBranchInput, setRepoBranchInput] = useState("main");
   const hasVisitedWorkflow = useRef(false);
@@ -265,19 +271,28 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
       ...agent,
       permission_mode: supportedPermissionMode(agent.permission_mode),
     }));
-    await saveMutation.mutateAsync({
-      data: {
-        setup: {
-          tracker: draft.tracker,
-          repos: draft.repos,
-          agents,
-          steps: draft.steps,
-          on_success: draft.onSuccess,
-          on_failure: draft.onFailure,
+    try {
+      await saveMutation.mutateAsync({
+        data: {
+          setup: {
+            tracker: draft.tracker,
+            repos: draft.repos,
+            agents,
+            steps: draft.steps,
+            on_success: draft.onSuccess,
+            on_failure: draft.onFailure,
+          },
         },
-      },
-    });
-    onComplete?.();
+      });
+      onComplete?.();
+    } catch (error) {
+      const message = restartRequiredMessage(error);
+      if (!message) {
+        throw error;
+      }
+      setRestartMessage(message);
+      onComplete?.({ restartRequiredMessage: message });
+    }
   };
 
   // Generate default workflow steps based on agent count (CLI parity)
@@ -1084,6 +1099,10 @@ export default function SetupWizard({ mode = "create", onComplete }: SetupWizard
         return null;
     }
   };
+
+  if (restartMessage) {
+    return <RestartRequiredNotice message={restartMessage} />;
+  }
 
   if (isLoadingDefaults && mode === "reconfigure") {
     return (

--- a/crates/ensemble-ui/src-ui/src/fetch-client.test.ts
+++ b/crates/ensemble-ui/src-ui/src/fetch-client.test.ts
@@ -29,4 +29,33 @@ describe("customFetch", () => {
     expect(headers.get("Accept")).toBe("application/json");
     expect(headers.get("Authorization")).toBe("Bearer token");
   });
+
+  it("uses config response issues as the error message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            issues: [
+              {
+                section: "runtime",
+                message: "Configuration saved; restart Ensemble to apply it",
+              },
+            ],
+          }),
+          {
+            status: 409,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    );
+
+    const request = customFetch("/api/v1/config/yaml/save", { method: "POST" });
+
+    await expect(request).rejects.toMatchObject({
+      status: 409,
+      message: "Configuration saved; restart Ensemble to apply it",
+    });
+  });
 });

--- a/crates/ensemble-ui/src-ui/src/fetch-client.ts
+++ b/crates/ensemble-ui/src-ui/src/fetch-client.ts
@@ -3,14 +3,39 @@ export class FetchError extends Error {
   body: unknown;
 
   constructor(status: number, body: unknown) {
-    const message =
-      (body as Record<string, Record<string, string>>)?.error?.message ??
-      `HTTP ${status}`;
+    const message = responseMessage(body) ?? `HTTP ${status}`;
     super(message);
     this.name = "FetchError";
     this.status = status;
     this.body = body;
   }
+}
+
+function responseMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") {
+    return undefined;
+  }
+
+  const response = body as Record<string, unknown>;
+  if (response.error && typeof response.error === "object") {
+    const message = (response.error as Record<string, unknown>).message;
+    if (typeof message === "string") {
+      return message;
+    }
+  }
+
+  if (Array.isArray(response.issues)) {
+    for (const issue of response.issues) {
+      if (issue && typeof issue === "object") {
+        const message = (issue as Record<string, unknown>).message;
+        if (typeof message === "string") {
+          return message;
+        }
+      }
+    }
+  }
+
+  return undefined;
 }
 
 export const customFetch = async <T>(

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ValidationIssue } from "@/generated/models";
+import { FetchError } from "@/fetch-client";
 import ConfigPage from "./ConfigPage";
 import { renderWithProviders } from "@/test/render";
 
@@ -11,6 +12,7 @@ const saveGuidedMock = vi.fn();
 const validateYamlMock = vi.fn();
 const saveYamlMock = vi.fn();
 const refetchMock = vi.fn();
+const restartMessage = "Configuration saved; restart Ensemble to apply it";
 
 vi.mock("@/hooks", () => ({
   useConfigStateQuery: () => ({
@@ -34,7 +36,21 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/components/config/SetupWizard", () => ({
-  default: () => <div>Set up Ensemble</div>,
+  default: ({
+    onComplete,
+  }: {
+    onComplete?: (completion?: { restartRequiredMessage?: string }) => void;
+  }) => (
+    <div>
+      <div>Set up Ensemble</div>
+      <button
+        type="button"
+        onClick={() => onComplete?.({ restartRequiredMessage: restartMessage })}
+      >
+        Complete setup with restart required
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/config/GuidedEditor", () => ({
@@ -63,10 +79,21 @@ vi.mock("@/components/config/GuidedEditor", () => ({
 }));
 
 vi.mock("@/components/config/YamlEditor", () => ({
-  default: ({ rawYaml, issues, onValidate }: { rawYaml: string; issues: ValidationIssue[]; onValidate?: (yaml: string) => Promise<ValidationIssue[]> }) => (
+  default: ({
+    rawYaml,
+    issues,
+    onValidate,
+    onSave,
+  }: {
+    rawYaml: string;
+    issues: ValidationIssue[];
+    onValidate?: (yaml: string) => Promise<ValidationIssue[]>;
+    onSave?: (yaml: string) => Promise<void>;
+  }) => (
     <div>
       <div>Raw YAML Editor</div>
       <button type="button" onClick={() => onValidate?.(rawYaml)}>Validate</button>
+      <button type="button" onClick={() => onSave?.(rawYaml)}>Save YAML</button>
       {issues.map((issue, index) => (
         <div key={index}>{issue.message}</div>
       ))}
@@ -262,4 +289,108 @@ describe("ConfigPage", () => {
     expect(savedAgent).not.toHaveProperty("available_modes");
     expect(savedAgent.permission_mode).toBeUndefined();
   });
+
+  it("shows restart-required completion after a guided save persists with 409", async () => {
+    const user = userEvent.setup();
+    mockConfigData = parsedConfigData();
+    saveGuidedMock.mockRejectedValue(restartRequiredError());
+
+    renderWithProviders(<ConfigPage />, { route: "/config" });
+
+    await user.click(await screen.findByRole("button", { name: /save guided/i }));
+
+    expect(await screen.findByText("Restart Required")).toBeInTheDocument();
+    expect(screen.getByText(/restart Ensemble to apply it/i)).toBeInTheDocument();
+    expect(refetchMock).toHaveBeenCalled();
+  });
+
+  it("completes missing-config setup when the persisted save requires restart", async () => {
+    const user = userEvent.setup();
+    mockConfigData = {
+      state: "missing",
+      config_path: "/tmp/ensemble/config.yaml",
+      raw_yaml: null,
+      issues: [],
+      active_config: null,
+      guided_form: null,
+    };
+
+    renderWithProviders(<ConfigPage />, { route: "/config" });
+
+    await user.click(
+      await screen.findByRole("button", { name: /complete setup with restart required/i }),
+    );
+
+    expect(await screen.findByText("Restart Required")).toBeInTheDocument();
+    expect(screen.getByText(restartMessage)).toBeInTheDocument();
+    expect(screen.queryByText("Set up Ensemble")).not.toBeInTheDocument();
+    expect(refetchMock).toHaveBeenCalled();
+  });
+
+  it("shows restart-required completion after a YAML save persists with 409", async () => {
+    const user = userEvent.setup();
+    mockConfigData = parsedConfigData();
+    saveYamlMock.mockRejectedValue(restartRequiredError());
+
+    renderWithProviders(<ConfigPage />, { route: "/config" });
+
+    await user.click(await screen.findByRole("button", { name: /^yaml$/i }));
+    await user.click(screen.getByRole("button", { name: /save yaml/i }));
+
+    expect(await screen.findByText("Restart Required")).toBeInTheDocument();
+    expect(screen.getByText(/restart Ensemble to apply it/i)).toBeInTheDocument();
+    expect(refetchMock).toHaveBeenCalled();
+  });
 });
+
+function parsedConfigData() {
+  return {
+    state: "parsed",
+    config_path: "/tmp/ensemble/config.yaml",
+    raw_yaml: "tracker:\n  kind: todo_file\n",
+    issues: [],
+    active_config: {},
+    guided_form: {
+      tracker: { kind: "todo_file", active_states: [], terminal_states: [], labels_filter: [] },
+      repos: [],
+      agents: [],
+      steps: [],
+      runtime: {
+        max_cycles: 1,
+        concurrency: { max_concurrent_agents: 1, max_step_parallelism: 1 },
+        polling: { interval_ms: 1000 },
+        workspace: {},
+        hooks: { timeout_ms: 1000 },
+        agent: {
+          max_turns: 1,
+          max_retry_backoff_ms: 1,
+          command: "agent",
+          session_mode: "code",
+          permission_request_policy: { mode: "approve_all" },
+          turn_timeout_ms: 1,
+          read_timeout_ms: 1,
+          stall_timeout_ms: 1,
+        },
+      },
+      transitions: { on_success: "Done", on_failure: "Failed" },
+    },
+  };
+}
+
+function restartRequiredError() {
+  return new FetchError(409, {
+    state: "parsed",
+    config_path: "/tmp/ensemble/config.yaml",
+    raw_yaml: "tracker:\n  kind: todo_file\n",
+    issues: [
+      {
+        kind: "Config",
+        section: "runtime",
+        message: restartMessage,
+        field: null,
+        path: null,
+      },
+    ],
+    guided_form: null,
+  });
+}

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -1,7 +1,10 @@
 import { useConfigStateQuery, useValidateGuidedFormMutation, useSaveGuidedFormMutation, useValidateYamlDraftMutation, useSaveYamlDraftMutation } from "@/hooks";
 import type { GuidedConfigForm } from "@/generated/models";
 import type { ValidationIssue } from "@/generated/models";
-import SetupWizard from "@/components/config/SetupWizard";
+import SetupWizard, { type SetupWizardCompletion } from "@/components/config/SetupWizard";
+import RestartRequiredNotice, {
+  restartRequiredMessage,
+} from "@/components/config/RestartRequiredNotice";
 import YamlEditor from "@/components/config/YamlEditor";
 import GuidedEditor, { type GuidedForm } from "@/components/config/GuidedEditor";
 import { useState, useMemo } from "react";
@@ -94,12 +97,22 @@ export default function ConfigPage() {
   const [activeTab, setActiveTab] = useState<"guided" | "yaml">("guided");
   const [comparisonMode, setComparisonMode] = useState(false);
   const [displayedIssues, setDisplayedIssues] = useState<ValidationIssue[]>([]);
+  const [restartMessage, setRestartMessage] = useState<string | null>(null);
   const issues = data?.issues ?? [];
 
   const validateGuidedFormMutation = useValidateGuidedFormMutation();
   const saveGuidedFormMutation = useSaveGuidedFormMutation();
   const validateYamlMutation = useValidateYamlDraftMutation();
   const saveYamlMutation = useSaveYamlDraftMutation();
+
+  const handleRestartRequired = async (error: unknown) => {
+    const message = restartRequiredMessage(error);
+    if (!message) {
+      throw error;
+    }
+    setRestartMessage(message);
+    await refetch();
+  };
 
   const handleValidateGuided = async (form: GuidedForm, baseRawYaml: string): Promise<ValidationIssue[]> => {
     const response = await validateGuidedFormMutation.mutateAsync({
@@ -119,9 +132,13 @@ export default function ConfigPage() {
         kind: step.kind && step.kind !== "agent" ? step.kind : undefined,
       })),
     };
-    await saveGuidedFormMutation.mutateAsync({ baseRawYaml, form: normalizedForm });
-    setDisplayedIssues([]);
-    await refetch();
+    try {
+      await saveGuidedFormMutation.mutateAsync({ baseRawYaml, form: normalizedForm });
+      setDisplayedIssues([]);
+      await refetch();
+    } catch (error) {
+      await handleRestartRequired(error);
+    }
   };
 
   const handleValidateYaml = async (yaml: string): Promise<ValidationIssue[]> => {
@@ -132,9 +149,21 @@ export default function ConfigPage() {
   };
 
   const handleSaveYaml = async (yaml: string) => {
-    await saveYamlMutation.mutateAsync({ data: { raw_yaml: yaml } });
-    setDisplayedIssues([]);
-    await refetch();
+    try {
+      await saveYamlMutation.mutateAsync({ data: { raw_yaml: yaml } });
+      setDisplayedIssues([]);
+      await refetch();
+    } catch (error) {
+      await handleRestartRequired(error);
+    }
+  };
+
+  const handleSetupComplete = (completion?: SetupWizardCompletion) => {
+    setShowSetupWizard(false);
+    if (completion?.restartRequiredMessage) {
+      setRestartMessage(completion.restartRequiredMessage);
+      void refetch();
+    }
   };
 
   const guidedForm = data?.guided_form;
@@ -159,6 +188,15 @@ export default function ConfigPage() {
   const isEditable = state === "parsed";
   const bannerIssues = displayedIssues.length > 0 ? displayedIssues : issues;
 
+  if (restartMessage) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold">Configuration</h1>
+        <RestartRequiredNotice message={restartMessage} />
+      </div>
+    );
+  }
+
   // Missing config - show setup mode
   if (state === "missing" || showSetupWizard) {
     return (
@@ -166,7 +204,7 @@ export default function ConfigPage() {
         <h1 className="text-2xl font-bold">Configuration</h1>
         <SetupWizard 
           mode={state === "missing" ? "create" : "reconfigure"}
-          onComplete={() => setShowSetupWizard(false)}
+          onComplete={handleSetupComplete}
         />
       </div>
     );

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -958,6 +958,21 @@ Dynamic reload is required:
   before dispatch) in case filesystem watch events are missed.
 - Invalid reloads should not crash the service; keep operating with the last known good effective
   configuration and emit an operator-visible error.
+- If an API save persists a candidate that cannot yet activate, return that persisted generation in
+  redacted form and resolve later secret-preserve retries against it; do not roll secret placeholders
+  back to the last-known-good runtime generation.
+- Build a failed save response from the same candidate snapshot used to determine its activation
+  outcome. Setup companion artifacts must publish inside the successful commit boundary, after the
+  prior runtime quiesces. Failures before publication leave last-known-good companions in place;
+  an interrupted partial publication leaves no dispatchable runtime and must recover before retry.
+- Setup saves stage a private versioned journal under the config directory before replacing
+  `config.yaml`. The journal is keyed by the SHA-256 digest of the exact raw config bytes and stores
+  owner-only companion payloads and before-images, never the public setup request. Preparation may
+  resolve dotenv values from the matching staged payload, but runtime template and tracker paths
+  remain their final durable paths.
+- Journal recovery runs before startup opens root-scoped runtime resources. A matching generation
+  resumes publication idempotently; a mismatched partially published generation restores every
+  before-image or fails startup closed. API retry and watcher reload consume the same journal.
 
 ### 6.4 Dispatch Preflight Validation
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2956,6 +2956,19 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Config file changes are detected and trigger re-read/re-apply without restart
 - Invalid config reload keeps last known good effective configuration and emits an
   operator-visible error
+- Watcher reloads and API saves serialize candidate acquisition, secret-safe file writes,
+preparation, exact-runtime quiescence, and commit so config generations cannot interleave
+- A valid reload is prepared without publishing candidate values, drains the exact active runtime
+including workers and timeline/transcript persistence, and atomically commits the document,
+observed mtime, config-derived orchestrator state, and an unlaunched replacement before allowing
+the replacement to execute
+- Invalid candidates, preparation failures, and `RuntimeBusy` retain the complete last-known-good
+generation and do not consume the candidate mtime; the same on-disk candidate remains retryable
+- A timed-out replacement leaves its exact one-way-quiescing runtime registered until positive
+completion is proven; it is never relaunched, detached, or replaced concurrently
+- Effective `workspace.root` or ordered `repos` configuration changes are restart-required and must not
+change live workspace, SQLite history/timeline, transcript, journal, or other root-scoped
+resources; API saves return `409 Conflict` and watcher diagnostics expose no candidate values
 - Missing `<config_dir>/config.yaml` returns typed error
 - Invalid YAML returns typed error
 - Root non-map returns typed error

--- a/docs/adr/0002-treat-the-config-directory-as-a-runtime-boundary.md
+++ b/docs/adr/0002-treat-the-config-directory-as-a-runtime-boundary.md
@@ -5,3 +5,24 @@ status: accepted
 # Treat the config directory as a runtime boundary
 
 An Ensemble installation is configured by a directory containing `config.yaml`; prompt paths and other relative configuration are resolved from that directory rather than the process working directory. The CLI flag, environment override, and platform default select the directory in that order, making desktop startup deterministic and allowing one configuration to coordinate multiple repositories.
+
+The resolved configuration directory also defines one immutable root-resource
+generation for the process. Workspace, SQLite history and timeline, transcript,
+journal, and repository resources are not migrated live. Changes to the
+effective `workspace.root` or ordered repository configuration are persisted but
+reported as restart-required.
+
+Reload is a serialized prepare-quiesce-commit transaction shared by filesystem
+events and all configuration save surfaces. Candidate values remain private
+while preparation runs. The exact active runtime then enters one-way
+quiescence, drains workers and persistence, and must provide positive completion
+proof before the document, observed mtime, config-derived state, and prepared
+runtime cross generations together. The replacement starts only after that
+synchronous commit.
+
+Invalid candidates, preparation failures, and busy or ambiguous handovers keep
+the last-known-good generation and leave the candidate mtime unconsumed. A
+quiescing runtime remains the registered owner and can be replaced by a later
+retry after it finishes; it is never relaunched or detached. Operator
+diagnostics use allowlisted categories rather than candidate values so resolved
+secrets cannot be exposed.

--- a/docs/adr/0002-treat-the-config-directory-as-a-runtime-boundary.md
+++ b/docs/adr/0002-treat-the-config-directory-as-a-runtime-boundary.md
@@ -37,8 +37,9 @@ after exact runtime quiescence and before the retained synchronous commit.
 
 All hosts recover the setup journal before parsing config or constructing
 workspace, history, timeline, transcript, and orchestrator resources. Matching
-staged or partially published generations resume forward. Digest drift restores
-all before-images, and malformed state, unsafe permissions, or incomplete
-rollback fails closed. API saves, watcher reloads, offline CLI setup, and
-startup therefore share one recovery owner rather than separate staging
-semantics.
+staged or partially published generations resume forward. On digest drift,
+rollback restores only destinations that still match the published generation;
+independently changed destinations are preserved and recovery fails closed.
+Malformed state, unsafe permissions, or incomplete rollback also fails closed.
+API saves, watcher reloads, offline CLI setup, and startup therefore share one
+recovery owner rather than separate staging semantics.

--- a/docs/adr/0002-treat-the-config-directory-as-a-runtime-boundary.md
+++ b/docs/adr/0002-treat-the-config-directory-as-a-runtime-boundary.md
@@ -26,3 +26,19 @@ quiescing runtime remains the registered owner and can be replaced by a later
 retry after it finishes; it is never relaunched or detached. Operator
 diagnostics use allowlisted categories rather than candidate values so resolved
 secrets cannot be exposed.
+
+Setup extends this transaction with one private versioned journal inside the
+configuration directory. Before `config.yaml` is persisted, Ensemble records
+the exact raw-byte digest, normalized companion destinations, owner-only
+payloads, and complete before-images. The public config remains the only
+user-editable document. Preparation resolves matching staged dotenv values but
+keeps final template and tracker paths; companion contents become visible only
+after exact runtime quiescence and before the retained synchronous commit.
+
+All hosts recover the setup journal before parsing config or constructing
+workspace, history, timeline, transcript, and orchestrator resources. Matching
+staged or partially published generations resume forward. Digest drift restores
+all before-images, and malformed state, unsafe permissions, or incomplete
+rollback fails closed. API saves, watcher reloads, offline CLI setup, and
+startup therefore share one recovery owner rather than separate staging
+semantics.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,9 @@ start-gated until publication and the active-state commit finish.
 filesystem resources. Changing either while Ensemble is running is saved to
 disk but not activated: API saves return `409 Conflict`, and watcher reloads
 emit a restart-required diagnostic. Restart Ensemble to apply the candidate.
+The web and desktop configuration editors treat this response as a persisted
+save and display the restart-required diagnostic instead of reporting a failed
+save.
 Diagnostics identify only the safe failure category and never include candidate
 values or resolved secrets.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,11 +92,14 @@ API retries, filesystem watcher retries, offline CLI setup, and process startup
 all consume that same pending generation. Startup recovery completes before
 workspace, history, timeline, transcript, or orchestrator resources are opened.
 A matching partial publication resumes forward; an externally replaced config
-causes every published destination to be restored from its before-image. A
-malformed journal, unsafe permissions, or incomplete rollback blocks startup
-rather than launching against mixed config and companion generations. Prepared
-runtimes retain the final configured template and TODO paths and remain
-start-gated until publication and the active-state commit finish.
+causes destinations that still match the published generation to be restored
+from their before-images. If a destination changed independently after
+publication, recovery preserves it and blocks startup rather than overwriting
+the newer contents. A malformed journal, unsafe permissions, or incomplete
+rollback likewise blocks startup rather than launching against mixed config and
+companion generations. Prepared runtimes retain the final configured template
+and TODO paths and remain start-gated until publication and the active-state
+commit finish.
 
 `workspace.root` and the complete ordered `repos` configuration define process-scoped
 filesystem resources. Changing either while Ensemble is running is saved to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,35 @@ another edit. A runtime that timed out while quiescing is not relaunched; it
 remains the registered owner until it finishes, after which a retry may replace
 it.
 
+When an API save persists a candidate but cannot activate it, the error response
+describes the exact evaluated candidate in redacted form. A later external file
+replacement is treated as a separate generation. A subsequent raw YAML,
+guided-form, or setup retry resolves `[REDACTED]` and explicit preserve actions
+against the latest persisted generation, while the running configuration stays
+on the last-known-good generation until activation succeeds.
+
+Setup-generated companion files such as prompt templates, TODO data, and `.env`
+are published only after the prior runtime has quiesced and immediately before
+the candidate config/runtime generation commits. Failed or deferred activation
+before publication leaves the last-known-good companion files unchanged. An
+interrupted partial publication leaves the runtime stopped and is recovered
+before any retry or restart can dispatch work. Ensemble records setup payloads
+and before-images in a private, versioned journal under
+`.ensemble-state/pending-setup`, keyed to the SHA-256 digest of the exact raw
+`config.yaml` bytes. Journal directories use owner-only access and secret-bearing
+files use mode `0600` on Unix. The journal is internal recovery state, not a
+public configuration file or setup workflow.
+
+API retries, filesystem watcher retries, offline CLI setup, and process startup
+all consume that same pending generation. Startup recovery completes before
+workspace, history, timeline, transcript, or orchestrator resources are opened.
+A matching partial publication resumes forward; an externally replaced config
+causes every published destination to be restored from its before-image. A
+malformed journal, unsafe permissions, or incomplete rollback blocks startup
+rather than launching against mixed config and companion generations. Prepared
+runtimes retain the final configured template and TODO paths and remain
+start-gated until publication and the active-state commit finish.
+
 `workspace.root` and the complete ordered `repos` configuration define process-scoped
 filesystem resources. Changing either while Ensemble is running is saved to
 disk but not activated: API saves return `409 Conflict`, and watcher reloads
@@ -233,6 +262,8 @@ credential to a different logical entry. After direct matches are claimed, one u
 identity rename. Multiple unmatched or duplicate identities are rejected. Replacing the placeholder
 with a literal or `$VAR` reference replaces the stored value, and removing the field removes the
 value. Malformed YAML is never returned as raw configuration because it cannot be safely redacted.
+If a persisted candidate has not activated yet, preservation uses that latest on-disk candidate,
+not the older last-known-good runtime generation.
 
 Guided and setup editors use explicit secret actions: keep the current value, replace it with a
 literal, use an environment variable, or remove it. Literal replacement inputs are write-only:
@@ -240,7 +271,9 @@ after save, the UI only reports that a secret is configured. Blank literal and e
 replacements are rejected before configuration persistence, and environment names must match
 `[A-Za-z_][A-Za-z0-9_]*`. New `config.yaml` files created by the editors use owner-only permissions
 (`0600`) on Unix; existing file permissions are retained. Configuration writes replace the file
-atomically from a temporary file in the same directory.
+atomically from a temporary file in the same directory. Setup-generated secret companions and
+private journal payloads use owner-only permissions; permission or rollback failures are reported
+without including resolved values.
 
 **Todo file fields** (when `kind: todo_file`):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,30 @@ All relative paths in `config.yaml` are resolved relative to the configuration d
 
 This makes configurations portable and self-contained.
 
+## Live reload boundary
+
+The file watcher and all web/desktop save paths share one serialized config
+transaction. Ensemble parses and prepares a candidate without publishing it,
+quiesces the exact active orchestrator runtime, waits for its workers and
+timeline/transcript persistence to drain, and then commits the config document,
+observed file mtime, config-derived orchestrator values, and prepared runtime as
+one generation. The replacement runtime cannot start until that commit is
+complete.
+
+Invalid candidates, preparation failures, and a busy runtime leave the complete
+last-known-good generation active. Their file mtime is not consumed, so the same
+on-disk candidate is retried by a later watcher event or save without requiring
+another edit. A runtime that timed out while quiescing is not relaunched; it
+remains the registered owner until it finishes, after which a retry may replace
+it.
+
+`workspace.root` and the complete ordered `repos` configuration define process-scoped
+filesystem resources. Changing either while Ensemble is running is saved to
+disk but not activated: API saves return `409 Conflict`, and watcher reloads
+emit a restart-required diagnostic. Restart Ensemble to apply the candidate.
+Diagnostics identify only the safe failure category and never include candidate
+values or resolved secrets.
+
 ## Minimal example
 
 The smallest working config uses a local TODO file and a single agent:


### PR DESCRIPTION
Closes #326

## Summary
- serialize watcher and API save reloads through one prepare-quiesce-commit transaction
- reject workspace-root and ordered repository changes with redacted restart-required diagnostics
- preserve the exact old runtime through preparation failure or RuntimeBusy and atomically publish document, mtime, state, and replacement runtime
- prove replacement waits for SQLite timeline and transcript persistence before committing
- document the transactional reload and restart boundary

## Validation
- focused reload classification, preparation, handover, save, runtime replacement, watcher, and durable-resource suites
- cargo test --workspace --exclude ensemble-desktop
- product E2E with web-ui
- web-ui feature check
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check
- review-and-simplify, ponytail, standards, security/redaction, and plan/SPEC reviews clean