### PR TITLE
Secure the trusted-local web API boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ The `web` subcommand is available in release builds and source builds installed 
 
 Then open `http://localhost:3000` in your browser.
 
+## Web dashboard security
+
+The web and desktop dashboards control an unauthenticated, single-operator service. `ensemble web`
+therefore binds only to a loopback address by default and rejects every resolved non-loopback address
+before it loads configuration or starts runtime components. There is no `config.yaml` setting or
+environment variable that relaxes this boundary.
+
+For an exceptional local-network or container use case, `ensemble web --host <address>
+--unsafe-allow-remote` permits an unauthenticated remote listener. This mode is unsupported and does
+not add authentication, authorization, TLS, or proxy trust; anyone who can reach the listener can
+operate it. WebSocket upgrades always require matching `Host` and HTTP(S) `Origin` authorities.
+
 ## Configuration location
 
 By default, Ensemble looks for configuration in your system's config directory:

--- a/crates/ensemble-cli/src/commands/web.rs
+++ b/crates/ensemble-cli/src/commands/web.rs
@@ -7,6 +7,7 @@ use ensemble_core::api::bootstrap::{
     build_app_state, clear_registered_orchestrator, start_or_replace_registered_orchestrator,
 };
 use ensemble_core::api::router::create_api_router;
+use ensemble_core::api::security::classify_bind_addr;
 use ensemble_core::config::draft::recover_and_load_config_state;
 use ensemble_core::config::location::resolve_config_dir_for_cli;
 use ensemble_core::config_watcher::start_config_watcher;
@@ -19,6 +20,7 @@ pub struct WebArgs {
     pub config_dir: Option<PathBuf>,
     pub host: String,
     pub port: Option<u16>,
+    pub unsafe_allow_remote: bool,
 }
 
 fn resolve_bind_addr(host: &str, port: u16) -> std::io::Result<SocketAddr> {
@@ -43,6 +45,50 @@ fn bind_addr_display(host: &str, port: u16) -> String {
 /// This now serves the UI and API regardless of config state.
 /// If config is missing or invalid, the UI will show the setup wizard.
 pub async fn execute(args: WebArgs) -> ExitCode {
+    let port = args.port.unwrap_or(0);
+    let bind_addr = match resolve_bind_addr(&args.host, port) {
+        Ok(addr) => addr,
+        Err(e) => {
+            error!(error = %e, host = %args.host, port, "failed to resolve HTTP bind address");
+            eprintln!(
+                "error: failed to resolve HTTP bind address for {}:{}: {}",
+                args.host, port, e
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let exposure = match classify_bind_addr(bind_addr, args.unsafe_allow_remote) {
+        Ok(exposure) => exposure,
+        Err(e) => {
+            error!(error = %e, "refusing non-loopback API listener");
+            eprintln!(
+                "error: {}; pass --unsafe-allow-remote to expose the unauthenticated API",
+                e
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let bind_addr_display = bind_addr.to_string();
+    let listener = match tokio::net::TcpListener::bind(bind_addr).await {
+        Ok(listener) => listener,
+        Err(error) => {
+            error!(error = %error, addr = %bind_addr_display, "failed to bind HTTP server");
+            eprintln!(
+                "error: failed to bind HTTP server on {}: {}",
+                bind_addr_display, error
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let actual_addr = match listener.local_addr() {
+        Ok(addr) => addr,
+        Err(error) => {
+            error!(error = %error, "failed to get local address");
+            eprintln!("error: failed to get local address: {}", error);
+            return ExitCode::FAILURE;
+        }
+    };
+
     let cwd = match std::env::current_dir() {
         Ok(dir) => dir,
         Err(e) => {
@@ -146,61 +192,11 @@ pub async fn execute(args: WebArgs) -> ExitCode {
     }
 
     // Create combined router: API routes + SPA fallback
-    let api_router = create_api_router(app_state.clone());
+    let api_router = create_api_router(app_state.clone(), exposure);
     let spa_router = spa_router();
 
     let router = api_router.merge(spa_router);
 
-    // Warn if binding to a non-loopback address (exposes unauthenticated API)
-    let is_loopback = args.host == "127.0.0.1" || args.host == "::1" || args.host == "localhost";
-    if !is_loopback {
-        warn!(
-            host = %args.host,
-            "binding to a non-loopback address exposes the API without authentication"
-        );
-        eprintln!(
-            "warning: binding to {} exposes the ensemble API to the network without authentication",
-            args.host
-        );
-    }
-
-    // Determine port
-    let port = args.port.unwrap_or(0); // 0 = let OS assign available port
-    let bind_addr = match resolve_bind_addr(&args.host, port) {
-        Ok(addr) => addr,
-        Err(e) => {
-            error!(error = %e, host = %args.host, port, "failed to resolve HTTP bind address");
-            eprintln!(
-                "error: failed to resolve HTTP bind address for {}:{}: {}",
-                args.host, port, e
-            );
-            return ExitCode::FAILURE;
-        }
-    };
-    let bind_addr_display = bind_addr.to_string();
-
-    info!(addr = %bind_addr_display, "starting HTTP server");
-
-    let listener = match tokio::net::TcpListener::bind(bind_addr).await {
-        Ok(l) => l,
-        Err(e) => {
-            error!(error = %e, addr = %bind_addr_display, "failed to bind HTTP server");
-            eprintln!(
-                "error: failed to bind HTTP server on {}: {}",
-                bind_addr_display, e
-            );
-            return ExitCode::FAILURE;
-        }
-    };
-
-    let actual_addr = match listener.local_addr() {
-        Ok(addr) => addr,
-        Err(e) => {
-            error!(error = %e, "failed to get local address");
-            eprintln!("error: failed to get local address: {}", e);
-            return ExitCode::FAILURE;
-        }
-    };
     info!(
         addr = %actual_addr,
         "HTTP server listening. Open http://{} in your browser",
@@ -250,6 +246,7 @@ mod tests {
             config_dir: Some(PathBuf::from("/tmp/test")),
             host: "0.0.0.0".to_string(),
             port: Some(8080),
+            unsafe_allow_remote: false,
         };
         assert_eq!(args.config_dir, Some(PathBuf::from("/tmp/test")));
         assert_eq!(args.host, "0.0.0.0");
@@ -262,6 +259,7 @@ mod tests {
             config_dir: None,
             host: "127.0.0.1".to_string(),
             port: None,
+            unsafe_allow_remote: false,
         };
         assert!(args.config_dir.is_none());
         assert_eq!(args.host, "127.0.0.1");

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -44,6 +44,10 @@ enum Command {
         /// HTTP server port.
         #[arg(long, env = "PORT")]
         port: Option<u16>,
+
+        /// Allow an unauthenticated, unsupported non-loopback HTTP listener.
+        #[arg(long)]
+        unsafe_allow_remote: bool,
     },
     /// Open the ensemble configuration directory in the system file manager.
     OpenConfigDir,
@@ -137,11 +141,16 @@ async fn main() -> ExitCode {
         }
         Some(Command::Run) => commands::run::execute(commands::run::RunArgs { config_dir }).await,
         #[cfg(feature = "web-ui")]
-        Some(Command::Web { host, port }) => {
+        Some(Command::Web {
+            host,
+            port,
+            unsafe_allow_remote,
+        }) => {
             commands::web::execute(commands::web::WebArgs {
                 config_dir,
                 host,
                 port,
+                unsafe_allow_remote,
             })
             .await
         }
@@ -245,10 +254,15 @@ mod tests {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "web"]);
         match cli.command {
-            Some(Command::Web { host: h, port: p }) => {
+            Some(Command::Web {
+                host: h,
+                port: p,
+                unsafe_allow_remote,
+            }) => {
                 assert_eq!(cli.config.config_dir, None);
                 assert_eq!(h, "127.0.0.1");
                 assert_eq!(p, None);
+                assert!(!unsafe_allow_remote);
             }
             other => panic!("expected Web subcommand, got {:?}", other),
         }
@@ -270,11 +284,31 @@ mod tests {
             "8080",
         ]);
         match cli.command {
-            Some(Command::Web { host: h, port: p }) => {
+            Some(Command::Web {
+                host: h,
+                port: p,
+                unsafe_allow_remote,
+            }) => {
                 assert_eq!(cli.config.config_dir, Some(PathBuf::from("/tmp/ensemble")));
                 assert_eq!(h, "0.0.0.0");
                 assert_eq!(p, Some(8080));
+                assert!(!unsafe_allow_remote);
             }
+            other => panic!("expected Web subcommand, got {:?}", other),
+        }
+        restore_env(host, port);
+    }
+
+    #[cfg(feature = "web-ui")]
+    #[test]
+    fn test_cli_parse_web_unsafe_allow_remote() {
+        let (_guard, host, port) = lock_and_clear_env();
+        let cli = Cli::parse_from(["ensemble", "web", "--unsafe-allow-remote"]);
+        match cli.command {
+            Some(Command::Web {
+                unsafe_allow_remote,
+                ..
+            }) => assert!(unsafe_allow_remote),
             other => panic!("expected Web subcommand, got {:?}", other),
         }
         restore_env(host, port);

--- a/crates/ensemble-core/src/api/mod.rs
+++ b/crates/ensemble-core/src/api/mod.rs
@@ -9,6 +9,7 @@ pub mod history_handler;
 pub mod interactions;
 pub mod openapi;
 pub mod router;
+pub mod security;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 pub mod timeline_handler;

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -1,5 +1,6 @@
 use crate::agent::cancellation::CancellationRegistry;
 use crate::api::interactions;
+use crate::api::security::ApiExposure;
 use crate::api::{
     config_edit_handler, config_handler, controls, conversation, fs_handler, handlers,
     history_handler, timeline_handler, ws,
@@ -12,7 +13,7 @@ use crate::transcript::events::TranscriptEventBus;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
-use axum::Router;
+use axum::{Extension, Router};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -79,13 +80,13 @@ pub struct AppState {
 /// - `POST /api/v1/{identifier}/retry` — retry a failed issue
 /// - `GET /ws/events/{identifier}` — WebSocket live event stream
 ///
-/// **Security:** The API is unauthenticated. Bind to `127.0.0.1` by
-/// default. Binding to a non-loopback address exposes this unauthenticated API to the
-/// network — only do so in trusted environments or behind a reverse proxy.
+/// **Security:** The API is unauthenticated. Every host must select an explicit
+/// exposure policy. Trusted-local WebSocket upgrades require same-origin
+/// loopback `Host` and `Origin` authorities.
 ///
 /// Note: This router provides API routes only. UI/SPA serving is handled separately
 /// by the CLI's embedded_ui module.
-pub fn create_api_router(state: AppState) -> Router {
+pub fn create_api_router(state: AppState, exposure: ApiExposure) -> Router {
     // API routes get a JSON 404 fallback
     let api_routes = Router::new()
         .route("/state", get(handlers::get_state))
@@ -198,6 +199,7 @@ pub fn create_api_router(state: AppState) -> Router {
         )
         .nest("/api/v1", api_routes)
         .route("/ws/events/{identifier}", get(ws::ws_events))
+        .layer(Extension(exposure))
         .with_state(state)
 }
 
@@ -212,6 +214,7 @@ async fn api_not_found() -> impl IntoResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::security::ApiExposure;
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
 
     fn test_app_state() -> AppState {
@@ -221,6 +224,6 @@ mod tests {
     #[test]
     fn test_router_creation_does_not_panic() {
         let state = test_app_state();
-        let _router = create_api_router(state);
+        let _router = create_api_router(state, ApiExposure::TrustedLocal);
     }
 }

--- a/crates/ensemble-core/src/api/security.rs
+++ b/crates/ensemble-core/src/api/security.rs
@@ -1,0 +1,318 @@
+use axum::http::uri::Authority;
+use axum::http::{header, HeaderMap, Uri};
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ApiExposure {
+    TrustedLocal,
+    UnsafeRemote,
+}
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+#[error("refusing non-loopback API bind address {addr}")]
+pub struct RemoteBindRejected {
+    pub addr: SocketAddr,
+}
+
+pub fn classify_bind_addr(
+    addr: SocketAddr,
+    unsafe_allow_remote: bool,
+) -> Result<ApiExposure, RemoteBindRejected> {
+    if addr.ip().is_loopback() {
+        Ok(ApiExposure::TrustedLocal)
+    } else if unsafe_allow_remote {
+        Ok(ApiExposure::UnsafeRemote)
+    } else {
+        Err(RemoteBindRejected { addr })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum WebSocketSecurityError {
+    #[error("missing Host header")]
+    MissingHost,
+    #[error("missing Origin header")]
+    MissingOrigin,
+    #[error("malformed Host header")]
+    MalformedHost,
+    #[error("malformed Origin header")]
+    MalformedOrigin,
+    #[error("WebSocket Origin does not match Host")]
+    OriginMismatch,
+    #[error("WebSocket Host is not loopback")]
+    NonLoopbackHost,
+}
+
+pub fn validate_websocket_origin(
+    exposure: ApiExposure,
+    host: Option<&str>,
+    origin: Option<&str>,
+) -> Result<(), WebSocketSecurityError> {
+    let host = host.ok_or(WebSocketSecurityError::MissingHost)?;
+    let host = Authority::from_str(host).map_err(|_| WebSocketSecurityError::MalformedHost)?;
+    if host.as_str().contains('@') {
+        return Err(WebSocketSecurityError::MalformedHost);
+    }
+    let origin = origin.ok_or(WebSocketSecurityError::MissingOrigin)?;
+    let origin = Uri::from_str(origin).map_err(|_| WebSocketSecurityError::MalformedOrigin)?;
+    let valid_scheme = origin
+        .scheme_str()
+        .is_some_and(|scheme| matches!(scheme, "http" | "https"));
+    if !valid_scheme || origin.path() != "/" || origin.query().is_some() {
+        return Err(WebSocketSecurityError::MalformedOrigin);
+    }
+    let origin = origin
+        .authority()
+        .ok_or(WebSocketSecurityError::MalformedOrigin)?;
+    if origin.as_str().contains('@') {
+        return Err(WebSocketSecurityError::MalformedOrigin);
+    }
+
+    if !host.host().eq_ignore_ascii_case(origin.host()) || host.port_u16() != origin.port_u16() {
+        return Err(WebSocketSecurityError::OriginMismatch);
+    }
+
+    if matches!(exposure, ApiExposure::TrustedLocal) && !is_loopback_host(host.host()) {
+        Err(WebSocketSecurityError::NonLoopbackHost)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn validate_websocket_headers(
+    exposure: ApiExposure,
+    headers: &HeaderMap,
+) -> Result<(), WebSocketSecurityError> {
+    let host = match headers
+        .get_all(header::HOST)
+        .iter()
+        .collect::<Vec<_>>()
+        .as_slice()
+    {
+        [] => return Err(WebSocketSecurityError::MissingHost),
+        [host] => host
+            .to_str()
+            .map_err(|_| WebSocketSecurityError::MalformedHost)?,
+        _ => return Err(WebSocketSecurityError::MalformedHost),
+    };
+    let origin = match headers
+        .get_all(header::ORIGIN)
+        .iter()
+        .collect::<Vec<_>>()
+        .as_slice()
+    {
+        [] => return Err(WebSocketSecurityError::MissingOrigin),
+        [origin] => origin
+            .to_str()
+            .map_err(|_| WebSocketSecurityError::MalformedOrigin)?,
+        _ => return Err(WebSocketSecurityError::MalformedOrigin),
+    };
+
+    validate_websocket_origin(exposure, Some(host), Some(origin))
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    host.trim_start_matches('[')
+        .trim_end_matches(']')
+        .parse::<IpAddr>()
+        .is_ok_and(|address| address.is_loopback())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn trusted_local_bind_accepts_ipv4_loopback() {
+        let addr: SocketAddr = "127.0.0.1:3000".parse().unwrap();
+
+        assert_eq!(
+            classify_bind_addr(addr, false).unwrap(),
+            ApiExposure::TrustedLocal
+        );
+    }
+
+    #[test]
+    fn trusted_local_bind_accepts_ipv6_loopback() {
+        let addr: SocketAddr = "[::1]:3000".parse().unwrap();
+
+        assert_eq!(
+            classify_bind_addr(addr, false).unwrap(),
+            ApiExposure::TrustedLocal
+        );
+    }
+
+    #[test]
+    fn trusted_local_bind_rejects_non_loopback_addresses() {
+        for addr in ["0.0.0.0:3000", "192.168.1.20:3000", "[::]:3000"] {
+            let addr: SocketAddr = addr.parse().unwrap();
+            assert_eq!(
+                classify_bind_addr(addr, false),
+                Err(RemoteBindRejected { addr })
+            );
+        }
+    }
+
+    #[test]
+    fn unsafe_remote_bind_requires_explicit_opt_in() {
+        let addr: SocketAddr = "192.168.1.20:3000".parse().unwrap();
+
+        assert_eq!(
+            classify_bind_addr(addr, true),
+            Ok(ApiExposure::UnsafeRemote)
+        );
+    }
+
+    #[test]
+    fn websocket_security_accepts_same_origin_localhost() {
+        assert!(validate_websocket_origin(
+            ApiExposure::TrustedLocal,
+            Some("localhost:3000"),
+            Some("http://localhost:3000"),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn websocket_security_accepts_same_origin_loopback_authorities() {
+        for (host, origin) in [
+            ("localhost", "https://localhost"),
+            ("LOCALHOST:3000", "http://localhost:3000"),
+            ("127.0.0.1:8080", "http://127.0.0.1:8080"),
+            ("[::1]:9090", "https://[::1]:9090"),
+        ] {
+            assert_eq!(
+                validate_websocket_origin(ApiExposure::TrustedLocal, Some(host), Some(origin)),
+                Ok(()),
+                "expected {host} and {origin} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn websocket_security_rejects_missing_or_malformed_headers() {
+        for (host, origin, expected) in [
+            (
+                None,
+                Some("http://localhost:3000"),
+                WebSocketSecurityError::MissingHost,
+            ),
+            (
+                Some("localhost:3000"),
+                None,
+                WebSocketSecurityError::MissingOrigin,
+            ),
+            (
+                Some("http://localhost:3000"),
+                Some("http://localhost:3000"),
+                WebSocketSecurityError::MalformedHost,
+            ),
+            (
+                Some("user@localhost:3000"),
+                Some("http://localhost:3000"),
+                WebSocketSecurityError::MalformedHost,
+            ),
+            (
+                Some("localhost:3000"),
+                Some("null"),
+                WebSocketSecurityError::MalformedOrigin,
+            ),
+            (
+                Some("localhost:3000"),
+                Some("ftp://localhost:3000"),
+                WebSocketSecurityError::MalformedOrigin,
+            ),
+            (
+                Some("localhost:3000"),
+                Some("http://localhost:3000/path"),
+                WebSocketSecurityError::MalformedOrigin,
+            ),
+            (
+                Some("localhost:3000"),
+                Some("http://user@localhost:3000"),
+                WebSocketSecurityError::MalformedOrigin,
+            ),
+        ] {
+            assert_eq!(
+                validate_websocket_origin(ApiExposure::TrustedLocal, host, origin),
+                Err(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn websocket_security_rejects_cross_origin_and_non_loopback_authorities() {
+        for (host, origin, expected) in [
+            (
+                "localhost:3000",
+                "http://localhost:3001",
+                WebSocketSecurityError::OriginMismatch,
+            ),
+            (
+                "localhost:3000",
+                "http://127.0.0.1:3000",
+                WebSocketSecurityError::OriginMismatch,
+            ),
+            (
+                "192.168.1.20:3000",
+                "http://192.168.1.20:3000",
+                WebSocketSecurityError::NonLoopbackHost,
+            ),
+            (
+                "example.test:3000",
+                "https://example.test:3000",
+                WebSocketSecurityError::NonLoopbackHost,
+            ),
+        ] {
+            assert_eq!(
+                validate_websocket_origin(ApiExposure::TrustedLocal, Some(host), Some(origin)),
+                Err(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn unsafe_remote_websocket_still_requires_same_origin() {
+        assert_eq!(
+            validate_websocket_origin(
+                ApiExposure::UnsafeRemote,
+                Some("192.168.1.20:3000"),
+                Some("http://192.168.1.20:3000"),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            validate_websocket_origin(
+                ApiExposure::UnsafeRemote,
+                Some("192.168.1.20:3000"),
+                Some("http://attacker.example:3000"),
+            ),
+            Err(WebSocketSecurityError::OriginMismatch)
+        );
+    }
+
+    #[test]
+    fn websocket_security_rejects_duplicate_origin_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::HOST, HeaderValue::from_static("localhost:3000"));
+        headers.append(
+            header::ORIGIN,
+            HeaderValue::from_static("http://localhost:3000"),
+        );
+        headers.append(
+            header::ORIGIN,
+            HeaderValue::from_static("http://attacker.example"),
+        );
+
+        assert_eq!(
+            validate_websocket_headers(ApiExposure::TrustedLocal, &headers),
+            Err(WebSocketSecurityError::MalformedOrigin)
+        );
+    }
+}

--- a/crates/ensemble-core/src/api/ws.rs
+++ b/crates/ensemble-core/src/api/ws.rs
@@ -1,4 +1,5 @@
 use crate::api::router::AppState;
+use crate::api::security::{validate_websocket_headers, ApiExposure};
 use crate::interaction::store::InteractionStore;
 use crate::observability::events::PipelineEvent;
 use crate::observability::snapshot::{
@@ -7,7 +8,9 @@ use crate::observability::snapshot::{
 use crate::transcript::model::TranscriptRecord;
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::{Path, State, WebSocketUpgrade};
-use axum::response::IntoResponse;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Extension;
 use futures_util::stream::StreamExt;
 use futures_util::SinkExt;
 use serde::Serialize;
@@ -37,8 +40,16 @@ pub async fn ws_events(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,
     Path(identifier): Path<String>,
-) -> impl IntoResponse {
+    Extension(exposure): Extension<ApiExposure>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(error) = validate_websocket_headers(exposure, &headers) {
+        warn!(%error, "rejecting WebSocket upgrade");
+        return (StatusCode::FORBIDDEN, error.to_string()).into_response();
+    }
+
     ws.on_upgrade(move |socket| handle_ws(socket, state, identifier))
+        .into_response()
 }
 
 async fn handle_ws(socket: WebSocket, state: AppState, identifier: String) {

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -17623,7 +17623,10 @@ agent:
             prepared.app_state.history_db_path,
             dir.path().join(".ensemble").join("history.db")
         );
-        let app = crate::api::router::create_api_router(prepared.app_state);
+        let app = crate::api::router::create_api_router(
+            prepared.app_state,
+            crate::api::security::ApiExposure::TrustedLocal,
+        );
         let response = app
             .oneshot(
                 Request::builder()

--- a/crates/ensemble-core/tests/api_endpoints.rs
+++ b/crates/ensemble-core/tests/api_endpoints.rs
@@ -4,6 +4,7 @@
 use chrono::Utc;
 use ensemble_core::agent::cancellation::new_cancellation_registry;
 use ensemble_core::api::router::{create_api_router, AppState, ConfigRuntime};
+use ensemble_core::api::security::ApiExposure;
 use ensemble_core::config::draft::{ConfigDocumentState, ConfigStateKind, DraftValidationReport};
 use ensemble_core::config::ensemble::ConcurrencyConfig;
 use ensemble_core::history_store::store::HistoryStore;
@@ -20,6 +21,7 @@ use ensemble_core::workspace::key::issue_workspace_key;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::RwLock;
 use tokio::time::{timeout, Duration};
 
@@ -188,7 +190,7 @@ async fn create_interaction(app_state: &AppState, interaction: InteractionReques
 
 /// Start an axum test server and return the base URL.
 async fn start_test_server(app_state: AppState) -> String {
-    let router = create_api_router(app_state);
+    let router = create_api_router(app_state, ApiExposure::TrustedLocal);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let base_url = format!("http://{}", addr);
@@ -198,6 +200,66 @@ async fn start_test_server(app_state: AppState) -> String {
     });
 
     base_url
+}
+
+async fn raw_websocket_handshake(
+    base_url: &str,
+    host: &str,
+    origin: &str,
+) -> axum::http::StatusCode {
+    let addr = base_url
+        .strip_prefix("http://")
+        .unwrap()
+        .parse::<std::net::SocketAddr>()
+        .unwrap();
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let request = format!(
+        "GET /ws/events/my-repo%2342 HTTP/1.1\r\n\
+         Host: {host}\r\n\
+         Origin: {origin}\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+         \r\n"
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+
+    let mut response = [0_u8; 1024];
+    let read = timeout(Duration::from_secs(2), stream.read(&mut response))
+        .await
+        .unwrap()
+        .unwrap();
+    let response = String::from_utf8_lossy(&response[..read]);
+    let status_line = response.lines().next().unwrap();
+    let status = status_line.split_whitespace().nth(1).unwrap();
+    axum::http::StatusCode::from_bytes(status.as_bytes()).unwrap()
+}
+
+#[tokio::test]
+async fn websocket_security_accepts_local_same_origin_handshake() {
+    let (app_state, _temp_dir) = build_populated_app_state();
+    let base_url = start_test_server(app_state).await;
+    let authority = base_url.strip_prefix("http://").unwrap();
+
+    let status = raw_websocket_handshake(&base_url, authority, &base_url).await;
+
+    assert_eq!(status, axum::http::StatusCode::SWITCHING_PROTOCOLS);
+}
+
+#[tokio::test]
+async fn websocket_security_rejects_foreign_origin_and_host_before_upgrade() {
+    let (app_state, _temp_dir) = build_populated_app_state();
+    let base_url = start_test_server(app_state).await;
+    let authority = base_url.strip_prefix("http://").unwrap();
+
+    let foreign_origin =
+        raw_websocket_handshake(&base_url, authority, "http://attacker.example").await;
+    let hostile_host =
+        raw_websocket_handshake(&base_url, "attacker.example", "http://attacker.example").await;
+
+    assert_eq!(foreign_origin, axum::http::StatusCode::FORBIDDEN);
+    assert_eq!(hostile_host, axum::http::StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]

--- a/crates/ensemble-desktop/src/server.rs
+++ b/crates/ensemble-desktop/src/server.rs
@@ -16,6 +16,7 @@ use ensemble_core::api::bootstrap::{
 };
 use ensemble_core::api::router::create_api_router;
 use ensemble_core::api::router::AppState;
+use ensemble_core::api::security::ApiExposure;
 use ensemble_core::config::draft::recover_and_load_config_state;
 use ensemble_core::config_watcher::{start_config_watcher, ConfigWatcherHandle};
 use ensemble_core::observability::events::EventBus;
@@ -52,9 +53,9 @@ impl Drop for DesktopServer {
 /// Start the local HTTP server for the desktop app.
 ///
 /// This server:
-/// 1. Loads config state (which may be missing/invalid)
-/// 2. Creates the API router with the appropriate state
-/// 3. Binds to 127.0.0.1:0 (random available port)
+/// 1. Binds to 127.0.0.1:0 (random available port)
+/// 2. Loads config state (which may be missing/invalid)
+/// 3. Creates the API router with the appropriate state
 /// 4. Serves both API and SPA routes
 ///
 /// The server continues running regardless of config state.
@@ -64,6 +65,19 @@ pub async fn start_desktop_server(
     config_path: PathBuf,
     event_bus: EventBus,
 ) -> Result<DesktopServer, DesktopError> {
+    // Reserve the loopback listener before starting the watcher or orchestrator so a bind failure
+    // cannot leave background runtime work alive after startup returns an error.
+    let bind_addr = "127.0.0.1:0";
+    info!(addr = %bind_addr, "Binding desktop HTTP server");
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
+        .map_err(|e| DesktopError::BindFailed {
+            addr: bind_addr.to_string(),
+            source: e,
+        })?;
+    let actual_addr = listener.local_addr()?;
+    let server_url = url::Url::parse(&format!("http://{}", actual_addr))?;
+
     info!(
         config_dir = %config_dir.display(),
         config_path = %config_path.display(),
@@ -113,24 +127,10 @@ pub async fn start_desktop_server(
     }
 
     // Create combined router: API routes + SPA fallback
-    let api_router = create_api_router(app_state.clone());
+    let api_router = create_api_router(app_state.clone(), ApiExposure::TrustedLocal);
     let spa_router = spa_router();
 
     let router = api_router.merge(spa_router);
-
-    // Bind to loopback with random port
-    let bind_addr = "127.0.0.1:0";
-    info!(addr = %bind_addr, "Binding desktop HTTP server");
-
-    let listener = tokio::net::TcpListener::bind(bind_addr)
-        .await
-        .map_err(|e| DesktopError::BindFailed {
-            addr: bind_addr.to_string(),
-            source: e,
-        })?;
-
-    let actual_addr = listener.local_addr()?;
-    let server_url = url::Url::parse(&format!("http://{}", actual_addr))?;
 
     info!(
         url = %server_url,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -40,6 +40,17 @@ Important boundary:
 - A successful run may end at a workflow-defined handoff state (for example `Human Review`), not
   necessarily `Done`.
 
+Web-host security boundary:
+
+- The web and desktop control surfaces are unauthenticated, trusted-local, single-operator
+  surfaces. Default and supported operation uses a loopback listener.
+- A web host must reject a resolved non-loopback listener before loading configuration or starting
+  runtime components, unless its CLI invocation contains an explicit unsafe remote-exposure opt-in.
+  That opt-in does not create an authenticated or supported remote-control mode.
+- Listener exposure is host runtime policy, not `config.yaml` policy. WebSocket upgrades must check
+  valid HTTP(S) `Origin` and `Host` authorities before upgrade and require them to match. Trusted
+  local listeners must additionally require a loopback authority.
+
 ## 2. Goals and Non-Goals
 
 ### 2.1 Goals

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,25 @@ This opens the resolved configuration directory in your system's file manager. I
 
 **Legacy note:** The old `ENSEMBLE_CONFIG` environment variable and `--config` flag are no longer supported. Use `ENSEMBLE_CONFIG_DIR` and `--config-dir` instead.
 
+## Web listener security
+
+HTTP listener settings are command-line runtime settings, not `config.yaml` fields. The web and
+desktop dashboards expose unauthenticated control and configuration APIs for one trusted local
+operator. `ensemble web` defaults to `127.0.0.1` and rejects a resolved non-loopback `--host`
+before loading configuration, starting watchers, or starting the orchestrator. The desktop host is
+always loopback-only.
+
+Remote binding is available only as this conspicuous opt-in:
+
+```sh
+ensemble web --host 192.168.1.20 --port 3000 --unsafe-allow-remote
+```
+
+`--unsafe-allow-remote` does not enable authentication, authorization, TLS, reverse-proxy trust, or
+multi-user operation. It is unsupported and should only be used when the network boundary is fully
+trusted. WebSocket upgrades require a syntactically valid HTTP(S) `Origin` whose authority exactly
+matches `Host`; trusted-local listeners additionally accept only `localhost` or loopback IP hosts.
+
 ## Auto-loading .env
 
 If a `.env` file exists in the configuration directory, Ensemble automatically loads it before expanding `$VAR` references in the configuration. This means you don't need to manually source `.env` files—environment variables defined there are automatically available for config expansion.


### PR DESCRIPTION
Closes #315

## Summary

- fail closed when the web dashboard resolves to a non-loopback listener
- add the explicit CLI-only `--unsafe-allow-remote` escape hatch for unsupported unauthenticated remote exposure
- require matching, valid `Host` and HTTP(S) `Origin` authorities before WebSocket upgrade
- reserve web and desktop listeners before configuration, watcher, or orchestrator startup
- document the trusted-local runtime boundary

## Validation

- `cargo test --workspace --exclude ensemble-desktop`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-desktop`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`
- focused CLI parsing, security policy, bootstrap, and raw WebSocket handshake tests
- review-and-simplify-changes: clean
- ponytail-review: Lean already. Ship.
