### PR TITLE
Run before-remove workspace hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This opens the resolved configuration directory in your system's file manager. I
 
 **Pipelines** are a DAG of steps, each referencing an agent. Steps run sequentially by default. Use `depends` to create parallel branches. This is the CI-like contract: the pipeline, not the agent, defines the delivery gates. See [Pipeline Guide](docs/pipelines.md).
 
-**Workspaces** are isolated directories created per-issue. They persist across retries and get cleaned up when the issue reaches a terminal state. Shell hooks run at lifecycle points (create, before/after run, remove).
+**Workspaces** are isolated directories created per-issue. They persist across retries and get cleaned up when the issue reaches a terminal state. Shell hooks run at lifecycle points (create, before/after run, remove); `before_remove` runs in an existing workspace before its worktrees and directory are removed, and failures or timeouts are logged without blocking cleanup.
 
 **Step outputs** are how Ensemble turns agent work into pipeline decisions. After the visible working turn, Ensemble asks the same runtime session for structured JSON with `result`, optional `summary`, and optional downstream `output`. Verdict files and default-success fallbacks are not part of the current runtime contract.
 

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -283,10 +283,14 @@ pub(crate) async fn prepare_orchestrator_runtime(
         Arc::clone(&config),
         Arc::clone(&app_state.config_runtime.document_state),
     ));
-    let workspace_mgr = WorkspaceManager::new(
-        Path::new(&app_state.workspace_root),
-        Some(config.read().await.repos.clone()),
-    )?;
+    let workspace_mgr = {
+        let config = config.read().await;
+        WorkspaceManager::new_with_hooks(
+            Path::new(&app_state.workspace_root),
+            Some(config.repos.clone()),
+            config.hooks.clone(),
+        )?
+    };
     let config_dir = config_dir_for_path(&app_state.config_runtime.config_path)?;
     let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
     let orchestrator = Orchestrator::new_with_state_and_history(

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -1,9 +1,10 @@
-use crate::config::ensemble::RepoConfig;
+use crate::config::ensemble::{HooksConfig, RepoConfig};
 use crate::error::WorkspaceError;
 use crate::observability::events_contract::{
     elapsed_ms, WORKSPACE_PREPARE_FAILED, WORKSPACE_PREPARE_FINISHED, WORKSPACE_PREPARE_STARTED,
 };
 use crate::workspace::coordinator::{WorktreeCoordinator, WorktreeInfo};
+use crate::workspace::hooks::run_hook_best_effort;
 use crate::workspace::key::issue_workspace_key;
 use std::collections::HashMap;
 use std::io::Write;
@@ -27,6 +28,7 @@ struct WorkspaceMetadata {
 pub struct WorkspaceManager {
     root: PathBuf,
     repos: HashMap<String, RepoConfig>,
+    hooks: HooksConfig,
     #[cfg(test)]
     preparation_test_barriers: Option<(Arc<tokio::sync::Barrier>, Arc<tokio::sync::Barrier>)>,
     #[cfg(test)]
@@ -64,6 +66,15 @@ impl WorkspaceManager {
     /// Pass `repos` to enable worktree-based workspace isolation.
     /// Repo names are derived from path basenames.
     pub fn new(root: &Path, repos: Option<Vec<RepoConfig>>) -> Result<Self, WorkspaceError> {
+        Self::new_with_hooks(root, repos, HooksConfig::default())
+    }
+
+    /// Create a workspace manager with lifecycle hook configuration.
+    pub fn new_with_hooks(
+        root: &Path,
+        repos: Option<Vec<RepoConfig>>,
+        hooks: HooksConfig,
+    ) -> Result<Self, WorkspaceError> {
         let root = resolve_workspace_root(root)?;
 
         let repos_map = repos
@@ -85,6 +96,7 @@ impl WorkspaceManager {
         Ok(Self {
             root,
             repos: repos_map,
+            hooks,
             #[cfg(test)]
             preparation_test_barriers: None,
             #[cfg(test)]
@@ -425,6 +437,10 @@ impl WorkspaceManager {
         if let Some((after_verification, resume_removal)) = &self.removal_test_barriers {
             after_verification.wait().await;
             resume_removal.wait().await;
+        }
+
+        if let Some(script) = &self.hooks.before_remove {
+            run_hook_best_effort("before_remove", script, &base_path, self.hooks.timeout_ms).await;
         }
 
         // Clean up worktrees first - use persisted branch date to avoid date drift
@@ -1031,6 +1047,97 @@ mod tests {
 
         mgr.remove_workspace("NODE_42").await.unwrap();
         assert!(!ws_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn before_remove_hook_runs_in_base_workspace_before_worktree_cleanup() {
+        let root = TempDir::new().unwrap();
+        let (_repo_dir, repo) = setup_repo("repo1");
+        let repo_name = Path::new(&repo.path).file_name().unwrap().to_str().unwrap();
+        let hooks = crate::config::ensemble::HooksConfig {
+            before_remove: Some(format!("test -d {repo_name} && pwd > ../before-remove-cwd")),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new_with_hooks(root.path(), Some(vec![repo]), hooks).unwrap();
+        let workspace = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        let marker = root.path().join("before-remove-cwd");
+
+        mgr.remove_workspace("NODE_42").await.unwrap();
+
+        let expected_cwd = mgr
+            .root()
+            .canonicalize()
+            .unwrap()
+            .join(&workspace.workspace_key);
+        assert_eq!(
+            std::fs::read_to_string(marker).unwrap().trim(),
+            expected_cwd.display().to_string()
+        );
+        assert!(!workspace.base_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn before_remove_hook_failure_does_not_block_cleanup() {
+        let root = TempDir::new().unwrap();
+        let hooks = HooksConfig {
+            before_remove: Some("false".to_string()),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new_with_hooks(root.path(), None, hooks).unwrap();
+        let workspace = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        let metadata_path = mgr.metadata_path("NODE_42");
+
+        mgr.remove_workspace("NODE_42").await.unwrap();
+
+        assert!(!workspace.base_path.exists());
+        assert!(!metadata_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn before_remove_hook_timeout_does_not_block_cleanup() {
+        let root = TempDir::new().unwrap();
+        let hooks = HooksConfig {
+            before_remove: Some("while :; do :; done".to_string()),
+            timeout_ms: 25,
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new_with_hooks(root.path(), None, hooks).unwrap();
+        let workspace = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        let metadata_path = mgr.metadata_path("NODE_42");
+
+        mgr.remove_workspace("NODE_42").await.unwrap();
+
+        assert!(!workspace.base_path.exists());
+        assert!(!metadata_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn before_remove_hook_is_not_run_for_an_absent_workspace() {
+        let root = TempDir::new().unwrap();
+        let marker = root.path().join("before-remove-ran");
+        let hooks = HooksConfig {
+            before_remove: Some("touch ../before-remove-ran".to_string()),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new_with_hooks(root.path(), None, hooks).unwrap();
+
+        mgr.remove_workspace("NODE_MISSING").await.unwrap();
+        mgr.remove_workspace("NODE_MISSING").await.unwrap();
+
+        assert!(!marker.exists());
     }
 
     #[tokio::test]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -833,8 +833,9 @@ Fields:
     exists.
   - Failure is logged but ignored.
 - `before_remove` (multiline shell script string, optional)
-  - Runs before workspace deletion if the directory exists.
-  - Failure is logged but ignored; cleanup still proceeds.
+  - Runs once in an existing, ownership-verified issue workspace before coordinated worktree or
+    base-directory removal.
+  - Uses `timeout_ms`; failure or timeout is logged but ignored, and cleanup still proceeds.
 - `timeout_ms` (integer, optional)
   - Default: `60000`
   - Applies to all workspace hooks.
@@ -1463,7 +1464,8 @@ Algorithm summary:
 Missing, malformed, ownerless legacy, or mismatched sidecar metadata is not repaired or adopted.
 Reuse and removal fail before any workspace side effect. Removing an absent canonical workspace
 with no sidecar remains idempotent; removing one with a valid matching leftover sidecar completes
-the interrupted cleanup. Cleanup removes repository worktrees exhaustively, then the agent
+the interrupted cleanup. For an existing ownership-verified workspace, `before_remove` runs once
+in the base workspace before cleanup removes repository worktrees exhaustively, then the agent
 workspace, then the sidecar. A sidecar-removal failure is retryable because the valid sidecar
 remains authoritative. Implementations do not scan, migrate, rename, or remove legacy
 identifier-only directories, and do not migrate or adopt in-workspace metadata.
@@ -3065,7 +3067,8 @@ resources; API saves return `409 Conflict` and watcher diagnostics expose no can
 - `after_create` hook runs only on new workspace creation
 - `before_run` hook runs before each attempt and failure/timeouts abort the current attempt
 - `after_run` hook runs after each attempt and failure/timeouts are logged and ignored
-- `before_remove` hook runs on cleanup and failures/timeouts are ignored
+- `before_remove` hook runs once in an existing ownership-verified base workspace before
+  worktree or directory removal, and failures/timeouts are ignored
 - Workspace path sanitization and root containment invariants are enforced before agent launch
 - Agent launch uses the per-issue workspace path as cwd and rejects out-of-root paths
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -497,7 +497,7 @@ Shell scripts that run at workspace lifecycle points. Each runs via `sh -lc` wit
 | `after_create` | string | — | Runs after a workspace directory is created for the first time |
 | `before_run` | string | — | Runs before each agent session starts |
 | `after_run` | string | — | Runs after each agent session completes |
-| `before_remove` | string | — | Runs before a workspace is cleaned up |
+| `before_remove` | string | — | Runs once in an existing issue workspace before worktree and directory removal; failures and timeouts are logged without blocking cleanup |
 | `timeout_ms` | integer | `60000` | Maximum time for any hook to run (milliseconds) |
 
 ### polling


### PR DESCRIPTION
Fixes #413

## Rationale

Wire the configured workspace cleanup hook into the cleanup owner. It runs once in the ownership-verified issue workspace before coordinated worktree or base-directory removal, reusing the established best-effort hook runner and configured timeout.

## Validation

- cargo test -p ensemble-core workspace::manager::tests --lib
- cargo test -p ensemble-core workspace::hooks::tests --lib
- cargo test --workspace --exclude ensemble-desktop
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Residual risk

The hook is deliberately retried on a later cleanup attempt if a prior destructive cleanup fails, consistent with retryable cleanup. Hook failures and timeouts are logged and do not block removal by design.