### PR TITLE
Remove unsupported agent max turns

### DIFF
--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -1888,7 +1888,6 @@ on_failure: Failed
                     timeout_ms: 60000,
                 },
                 agent: crate::config::form::GuidedAgentRuntimeForm {
-                    max_turns: 20,
                     max_retry_backoff_ms: 300000,
                     command: "claude-code".to_string(),
                     session_mode: "code".to_string(),
@@ -2039,7 +2038,6 @@ on_failure: Failed
                     timeout_ms: 60000,
                 },
                 agent: crate::config::form::GuidedAgentRuntimeForm {
-                    max_turns: 20,
                     max_retry_backoff_ms: 300000,
                     command: "claude-code".to_string(),
                     session_mode: "code".to_string(),
@@ -2206,7 +2204,6 @@ on_failure: Failed
                     timeout_ms: 60000,
                 },
                 agent: crate::config::form::GuidedAgentRuntimeForm {
-                    max_turns: 20,
                     max_retry_backoff_ms: 300000,
                     command: "claude-code".to_string(),
                     session_mode: "code".to_string(),

--- a/crates/ensemble-core/src/api/openapi.rs
+++ b/crates/ensemble-core/src/api/openapi.rs
@@ -171,6 +171,21 @@ mod tests {
     }
 
     #[test]
+    fn test_openapi_omits_unsupported_agent_max_turns() {
+        let spec: serde_json::Value =
+            serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+
+        for schema in ["AgentRuntimeConfig", "GuidedAgentRuntimeForm"] {
+            assert!(
+                spec["components"]["schemas"][schema]["properties"]
+                    .get("max_turns")
+                    .is_none(),
+                "{schema} must not expose max_turns"
+            );
+        }
+    }
+
+    #[test]
     fn test_openapi_documents_runtime_restart_failures_for_save_endpoints() {
         let spec: serde_json::Value =
             serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -107,7 +107,16 @@ pub(crate) fn parse_raw_yaml_with_dotenv(
 
     match parsed {
         Ok(document) => {
-            let typed: Result<EnsembleConfig, _> = serde_yaml::from_value(document.clone());
+            let typed: Result<EnsembleConfig, ConfigError> =
+                crate::config::ensemble::reject_unsupported_agent_max_turns(&document).and_then(
+                    |_| {
+                        serde_yaml::from_value(document.clone()).map_err(|e| {
+                            ConfigError::ConfigParseError {
+                                reason: e.to_string(),
+                            }
+                        })
+                    },
+                );
             match typed {
                 Ok(mut config) => {
                     let mut report = validate_document(&document);
@@ -784,6 +793,35 @@ on_failure: Failed
     }
 
     #[test]
+    fn parse_raw_yaml_rejects_unsupported_agent_max_turns() {
+        let raw = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+agent:
+  max_turns: 20
+"#;
+
+        let state = parse_raw_yaml(PathBuf::from("/tmp/test.yaml"), raw.to_string());
+
+        assert_eq!(state.kind, ConfigStateKind::Parsed);
+        assert!(state.active_config.is_none());
+        assert!(state.validation.issues.iter().any(|issue| {
+            issue.kind == ValidationIssueKind::Config
+                && issue.message.contains("agent.max_turns")
+                && issue.message.contains("no longer supported")
+        }));
+    }
+
+    #[test]
     fn parse_raw_yaml_returns_parsed_state_with_config_issues_for_typed_invalid_config() {
         let raw = r#"
 tracker:
@@ -934,6 +972,35 @@ on_failure: Failed
         let result = save_raw_yaml_atomically(&path, invalid_config);
 
         assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ConfigError::ConfigWriteRejected { .. }
+        ));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn save_raw_yaml_atomically_rejects_unsupported_agent_max_turns() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        let invalid_config = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+steps:
+  - name: build
+    agent: builder
+on_success: Done
+on_failure: Failed
+agent:
+  max_turns: 20
+"#;
+
+        let result = save_raw_yaml_atomically(&path, invalid_config);
+
         assert!(matches!(
             result.unwrap_err(),
             ConfigError::ConfigWriteRejected { .. }

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -815,7 +815,7 @@ pub fn parse_config(yaml: &str) -> Result<EnsembleConfig, crate::error::ConfigEr
     })
 }
 
-fn reject_unsupported_agent_max_turns(
+pub(crate) fn reject_unsupported_agent_max_turns(
     value: &serde_yaml::Value,
 ) -> Result<(), crate::error::ConfigError> {
     let Some(agent) = value

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -502,8 +502,6 @@ impl Default for HooksConfig {
 /// Runtime configuration for the agent executor.
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct AgentRuntimeConfig {
-    #[serde(default = "default_agent_max_turns")]
-    pub max_turns: u32,
     #[serde(default = "default_max_retry_backoff_ms")]
     pub max_retry_backoff_ms: u64,
     #[serde(default = "default_agent_command")]
@@ -601,10 +599,6 @@ pub enum InteractionPolicyOverrideMode {
     Off,
 }
 
-fn default_agent_max_turns() -> u32 {
-    20
-}
-
 fn default_max_retry_backoff_ms() -> u64 {
     300_000
 }
@@ -640,7 +634,6 @@ fn default_inject_interaction_policy_instructions() -> bool {
 impl Default for AgentRuntimeConfig {
     fn default() -> Self {
         Self {
-            max_turns: default_agent_max_turns(),
             max_retry_backoff_ms: default_max_retry_backoff_ms(),
             command: default_agent_command(),
             session_mode: default_session_mode(),
@@ -814,11 +807,32 @@ pub fn parse_config(yaml: &str) -> Result<EnsembleConfig, crate::error::ConfigEr
         serde_yaml::from_str(yaml).map_err(|e| crate::error::ConfigError::ConfigParseError {
             reason: e.to_string(),
         })?;
+    reject_unsupported_agent_max_turns(&value)?;
     reject_legacy_agent_permission_policy(&value)?;
     reject_legacy_notion_tracker_keys(&value)?;
     serde_yaml::from_value(value).map_err(|e| crate::error::ConfigError::ConfigParseError {
         reason: e.to_string(),
     })
+}
+
+fn reject_unsupported_agent_max_turns(
+    value: &serde_yaml::Value,
+) -> Result<(), crate::error::ConfigError> {
+    let Some(agent) = value
+        .as_mapping()
+        .and_then(|root| root.get(serde_yaml::Value::String("agent".to_string())))
+        .and_then(serde_yaml::Value::as_mapping)
+    else {
+        return Ok(());
+    };
+
+    if agent.contains_key(serde_yaml::Value::String("max_turns".to_string())) {
+        return Err(crate::error::ConfigError::ConfigParseError {
+            reason: "agent.max_turns is no longer supported because Ensemble cannot enforce provider-internal model turns".to_string(),
+        });
+    }
+
+    Ok(())
 }
 
 fn reject_legacy_notion_tracker_keys(
@@ -1630,7 +1644,6 @@ on_failure: Failed
         assert_eq!(config.hooks.timeout_ms, 60_000);
 
         // AgentRuntimeConfig defaults
-        assert_eq!(config.agent.max_turns, 20);
         assert_eq!(config.agent.max_retry_backoff_ms, 300_000);
         assert_eq!(config.agent.command, "claude-code");
         assert_eq!(config.agent.session_mode, "code");
@@ -1657,6 +1670,19 @@ on_failure: Failed
             config.human_interaction.default_resume_mode,
             HumanResumeMode::Manual
         );
+    }
+
+    #[test]
+    fn rejects_unsupported_agent_max_turns() {
+        let yaml = format!("{}\nagent:\n  max_turns: 20\n", minimal_yaml());
+
+        let error = parse_config(&yaml).unwrap_err();
+
+        assert!(matches!(
+            error,
+            crate::error::ConfigError::ConfigParseError { reason }
+                if reason.contains("agent.max_turns") && reason.contains("no longer supported")
+        ));
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -121,7 +121,6 @@ pub struct GuidedHooksForm {
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct GuidedAgentRuntimeForm {
-    pub max_turns: u32,
     pub max_retry_backoff_ms: u64,
     pub command: String,
     pub session_mode: String,
@@ -262,7 +261,6 @@ fn config_to_guided_form(config: &crate::config::ensemble::EnsembleConfig) -> Gu
                 timeout_ms: config.hooks.timeout_ms,
             },
             agent: GuidedAgentRuntimeForm {
-                max_turns: config.agent.max_turns,
                 max_retry_backoff_ms: config.agent.max_retry_backoff_ms,
                 command: config.agent.command.clone(),
                 session_mode: config.agent.session_mode.clone(),
@@ -576,7 +574,7 @@ pub fn apply_guided_form(
         .entry("agent".into())
         .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
     if let serde_yaml::Value::Mapping(ref mut am) = *agent_val {
-        am.insert("max_turns".into(), form.runtime.agent.max_turns.into());
+        am.remove("max_turns");
         am.insert(
             "max_retry_backoff_ms".into(),
             form.runtime.agent.max_retry_backoff_ms.into(),
@@ -743,6 +741,57 @@ on_failure: Failed
     }
 
     #[test]
+    fn guided_form_omits_max_turns_and_preserves_supported_agent_runtime_fields() {
+        let raw = r#"
+tracker:
+  kind: todo_file
+agents:
+  build:
+    acpx_agent: claude
+    prompt: Build it.
+steps:
+  - name: build
+    agent: build
+on_success: Done
+on_failure: Failed
+agent:
+  max_retry_backoff_ms: 456
+  command: custom-agent
+  session_mode: architect
+  permission_request_policy:
+    mode: reject_all
+  turn_timeout_ms: 123
+  read_timeout_ms: 234
+  stall_timeout_ms: 345
+"#;
+        let form = extract_guided_form(raw).unwrap();
+        let json = serde_json::to_string(&form).unwrap();
+
+        assert!(!json.contains("max_turns"));
+        assert_eq!(form.runtime.agent.max_retry_backoff_ms, 456);
+        assert_eq!(form.runtime.agent.command, "custom-agent");
+        assert_eq!(form.runtime.agent.session_mode, "architect");
+        assert_eq!(
+            form.runtime.agent.permission_request_policy.mode,
+            "reject_all"
+        );
+        assert_eq!(form.runtime.agent.turn_timeout_ms, 123);
+        assert_eq!(form.runtime.agent.read_timeout_ms, 234);
+        assert_eq!(form.runtime.agent.stall_timeout_ms, 345);
+
+        let legacy_base = format!("{raw}  max_turns: 20\n");
+        let merged: serde_yaml::Value =
+            serde_yaml::from_str(&apply_guided_form(&legacy_base, &form).unwrap()).unwrap();
+        assert!(merged["agent"].get("max_turns").is_none());
+        assert_eq!(merged["agent"]["max_retry_backoff_ms"], 456);
+        assert_eq!(merged["agent"]["command"], "custom-agent");
+        assert_eq!(merged["agent"]["session_mode"], "architect");
+        assert_eq!(merged["agent"]["turn_timeout_ms"], 123);
+        assert_eq!(merged["agent"]["read_timeout_ms"], 234);
+        assert_eq!(merged["agent"]["stall_timeout_ms"], 345);
+    }
+
+    #[test]
     fn guided_secret_edits_replace_reference_or_remove_explicitly() {
         let base = r#"
 tracker:
@@ -879,7 +928,6 @@ on_failure: Failed
                     timeout_ms: 60000,
                 },
                 agent: GuidedAgentRuntimeForm {
-                    max_turns: 20,
                     max_retry_backoff_ms: 300000,
                     command: "claude-code".to_string(),
                     session_mode: "code".to_string(),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -8553,7 +8553,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
   permission_request_policy:
@@ -8633,7 +8632,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
   permission_request_policy:
@@ -10227,7 +10225,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
 "#;
@@ -10765,7 +10762,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
   permission_request_policy:
@@ -10803,7 +10799,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
   permission_request_policy:
@@ -10887,7 +10882,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
 "#;
@@ -10923,7 +10917,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
 "#;
@@ -10961,7 +10954,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
 "#
@@ -10997,7 +10989,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
 "#
@@ -11055,7 +11046,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
 "#;
@@ -13249,7 +13239,6 @@ polling:
 workspace:
   root: /tmp/ensemble-test
 agent:
-  max_turns: 3
   command: "echo test"
   session_mode: code
 "#,

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.test.tsx
@@ -41,7 +41,6 @@ const initialForm: GuidedForm = {
     workspace: {},
     hooks: { timeout_ms: 1000 },
     agent: {
-      max_turns: 1,
       max_retry_backoff_ms: 1,
       command: "agent",
       session_mode: "code",

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
@@ -122,7 +122,6 @@ export interface GuidedForm {
       timeout_ms: number;
     };
     agent: {
-      max_turns: number;
       max_retry_backoff_ms: number;
       command: string;
       session_mode: string;

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
@@ -150,7 +150,6 @@ describe("ConfigPage", () => {
           workspace: {},
           hooks: { timeout_ms: 1000 },
           agent: {
-            max_turns: 1,
             max_retry_backoff_ms: 1,
             command: "agent",
             session_mode: "code",
@@ -191,7 +190,6 @@ describe("ConfigPage", () => {
           workspace: {},
           hooks: { timeout_ms: 1000 },
           agent: {
-            max_turns: 1,
             max_retry_backoff_ms: 1,
             command: "agent",
             session_mode: "code",
@@ -258,7 +256,6 @@ describe("ConfigPage", () => {
           workspace: {},
           hooks: { timeout_ms: 1000 },
           agent: {
-            max_turns: 1,
             max_retry_backoff_ms: 1,
             command: "agent",
             session_mode: "code",
@@ -362,7 +359,6 @@ function parsedConfigData() {
         workspace: {},
         hooks: { timeout_ms: 1000 },
         agent: {
-          max_turns: 1,
           max_retry_backoff_ms: 1,
           command: "agent",
           session_mode: "code",

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigStatus.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigStatus.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import ConfigStatus from "./ConfigStatus";
+import { renderWithProviders } from "@/test/render";
+
+vi.mock("@/hooks", () => ({
+  useConfigStateQuery: () => ({
+    data: {
+      state: "parsed",
+      config_path: "/tmp/ensemble/config.yaml",
+      issues: [],
+      guided_form: {
+        tracker: { kind: "todo_file", active_states: [], terminal_states: [], labels_filter: [] },
+        agents: {},
+        steps: [],
+        runtime: {
+          max_cycles: 1,
+          concurrency: { max_concurrent_agents: 1, max_step_parallelism: 1 },
+          polling: { interval_ms: 1000 },
+          workspace: {},
+          hooks: { timeout_ms: 1000 },
+          agent: {
+            max_retry_backoff_ms: 1,
+            command: "agent",
+            session_mode: "code",
+            permission_request_policy: { mode: "approve_all" },
+            turn_timeout_ms: 1,
+            read_timeout_ms: 1,
+            stall_timeout_ms: 1,
+          },
+        },
+        transitions: { on_success: "Done", on_failure: "Failed" },
+      },
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+describe("ConfigStatus", () => {
+  it("does not display the unsupported maximum-turns setting", () => {
+    renderWithProviders(<ConfigStatus />, { route: "/config" });
+
+    expect(screen.queryByText("Max Turns")).not.toBeInTheDocument();
+    expect(screen.getByText("Max Concurrent")).toBeInTheDocument();
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigStatus.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigStatus.tsx
@@ -162,10 +162,6 @@ export default function ConfigStatus() {
                   <dt className="text-sm font-medium text-muted-foreground">Tracker</dt>
                   <dd className="text-sm">{config.tracker.kind}</dd>
                 </div>
-                <div>
-                  <dt className="text-sm font-medium text-muted-foreground">Max Turns</dt>
-                  <dd className="text-sm">{config.runtime.agent.max_turns}</dd>
-                </div>
               </dl>
             </CardContent>
           </Card>

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1151,16 +1151,12 @@ worker events after marking every live handle as drain-owned.
 Important nuance:
 
 - A successful worker exit does not mean the issue is done forever.
-- The worker may continue through multiple back-to-back coding-agent turns before it exits.
-- After each normal turn completion, the worker re-checks the tracker issue state.
-- If the issue is still in an active state, the worker should start another turn on the same live
-  coding-agent thread in the same workspace.
-- The first turn should use the full rendered task prompt.
-- Continuation turns should send only continuation guidance to the existing thread, not resend the
-  original task prompt that is already present in thread history.
-- Once the worker exits normally, the orchestrator still schedules a short continuation retry
-  (about 1 second) so it can re-check whether the issue remains active and needs another worker
-  session.
+- Each worker invokes one configured agent run with the full rendered task prompt. A provider may
+  perform its own internal turns within that run, but Ensemble does not drive an in-process
+  continuation loop or reuse a worker session for another run.
+- Once a worker exits normally, the orchestrator schedules a short continuation retry (about
+  1 second). It re-checks whether the issue remains active and, if eligible, dispatches a new
+  worker session in the existing workspace.
 
 ### 7.2 Run Attempt Lifecycle
 
@@ -1191,8 +1187,7 @@ Distinct terminal reasons are important because retry logic and logs differ.
 - `Worker Exit (normal)`
   - Remove running entry.
   - Update aggregate runtime totals.
-  - Schedule continuation retry (attempt `1`) after the worker exhausts or finishes its in-process
-    turn loop.
+  - Schedule continuation retry (attempt `1`) for a fresh worker session.
 
 - `Worker Exit (abnormal)`
   - Remove running entry.
@@ -2856,51 +2851,25 @@ function run_agent_attempt(issue, attempt, local_events):
   if run_hook("before_run", workspace.path) failed:
     fail_worker("before_run hook error")
 
-  session = acp_client.start_session(workspace=workspace.path)
-  if session failed:
-    run_hook_best_effort("after_run", workspace.path)
-    fail_worker("agent session startup error")
-
-  turn_number = 1
-
-  while true:
-    prompt = build_turn_prompt(workflow_template, issue, attempt, turn_number)
-    if prompt failed:
-      acp_client.cancel_session(session)
-      run_hook_best_effort("after_run", workspace.path)
-      fail_worker("prompt error")
-
-    turn_result = acp_client.send_prompt(
-      session=session,
-      prompt=prompt,
-      issue=issue,
-      on_message=(msg) -> send(local_events, {agent_update, issue.id, msg})
-    )
-
-    if turn_result failed:
-      acp_client.cancel_session(session)
-      run_hook_best_effort("after_run", workspace.path)
-      fail_worker("agent turn error")
-
-    refreshed_issue = tracker.fetch_issue_states_by_ids([issue.id])
-    if refreshed_issue failed:
-      acp_client.cancel_session(session)
-      run_hook_best_effort("after_run", workspace.path)
-      fail_worker("issue state refresh error")
-
-    issue = refreshed_issue[0] or issue
-
-    if issue.state is not active:
-      break
-
-    turn_number = turn_number + 1
-
-  acp_client.cancel_session(session)
+  result = agent_runner.run(
+    issue=issue,
+    attempt=attempt,
+    workspace=workspace.path,
+    turn_number=1,
+    on_message=(msg) -> send(local_events, {agent_update, issue.id, msg})
+  )
   run_hook_best_effort("after_run", workspace.path)
+
+  if result failed:
+    fail_worker("agent run error")
 
   send(local_events, {worker_exit, issue.id, normal})
   close(local_events)
 ```
+
+An agent run may use provider-internal turns. Direct ACP runs may also issue a hidden verdict
+extraction turn in the same session. Neither is an Ensemble-managed continuation or a tracker
+refresh between prompts; a later continuation retry creates a fresh worker session.
 
 The worker sends its final exit through the same local channel. The bridge signals completion only
 after that channel closes and all prior events have been forwarded. The orchestrator validates the

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1093,7 +1093,6 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `hooks.after_run`: shell script or null
 - `hooks.before_remove`: shell script or null
 - `hooks.timeout_ms`: integer, default `60000`
-- `agent.max_turns`: integer, default `20`
 - `agent.max_retry_backoff_ms`: integer, default `300000` (5m)
 - `agent.command`: command string (tokenized into program + args, no shell interpolation), default implementation-defined
 - `agent.session_mode`: string (`code`, `architect`, `ask`), default `code`
@@ -1154,7 +1153,7 @@ Important nuance:
 - The worker may continue through multiple back-to-back coding-agent turns before it exits.
 - After each normal turn completion, the worker re-checks the tracker issue state.
 - If the issue is still in an active state, the worker should start another turn on the same live
-  coding-agent thread in the same workspace, up to `agent.max_turns`.
+  coding-agent thread in the same workspace.
 - The first turn should use the full rendered task prompt.
 - Continuation turns should send only continuation guidance to the existing thread, not resend the
   original task prompt that is already present in thread history.
@@ -2860,11 +2859,10 @@ function run_agent_attempt(issue, attempt, local_events):
     run_hook_best_effort("after_run", workspace.path)
     fail_worker("agent session startup error")
 
-  max_turns = config.agent.max_turns
   turn_number = 1
 
   while true:
-    prompt = build_turn_prompt(workflow_template, issue, attempt, turn_number, max_turns)
+    prompt = build_turn_prompt(workflow_template, issue, attempt, turn_number)
     if prompt failed:
       acp_client.cancel_session(session)
       run_hook_best_effort("after_run", workspace.path)
@@ -2891,9 +2889,6 @@ function run_agent_attempt(issue, attempt, local_events):
     issue = refreshed_issue[0] or issue
 
     if issue.state is not active:
-      break
-
-    if turn_number >= max_turns:
       break
 
     turn_number = turn_number + 1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,7 +224,6 @@ polling:
   interval_ms: 30000
 
 agent:
-  max_turns: 20
   turn_timeout_ms: 3600000
   inject_interaction_policy_instructions: true
   interaction_policy_overrides:
@@ -515,9 +514,11 @@ This section configures Ensemble's runtime behavior after the agent is launched.
 Agent step results are extracted by Ensemble through a hidden second turn in the same runtime
 session. There is no config switch for this behavior.
 
+`agent.max_turns` is unsupported and rejected during configuration parsing. Remove it from
+existing configurations: Ensemble cannot enforce provider-internal model turns.
+
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `max_turns` | integer | `20` | Maximum agent conversation turns per session |
 | `max_retry_backoff_ms` | integer | `300000` | Cap on exponential backoff delay between retries |
 | `command` | string | `"claude-code"` | Agent binary command |
 | `session_mode` | string | `"code"` | Agent session mode |


### PR DESCRIPTION
## Summary

Removes the unsupported `agent.max_turns` configuration contract. Ensemble cannot observe or cap provider-internal model turns, so accepting this field silently had no effect.

- Rejects exactly `agent.max_turns` with an actionable parse error.
- Removes it from runtime and guided-form types, OpenAPI, UI status/editor shapes, fixtures, and documentation.
- Preserves all supported agent runtime settings and prevents guided-form merges from re-emitting the obsolete key.

Fixes #414

## Validation

- `cargo test -p ensemble-core config::ensemble::tests`
- `cargo test -p ensemble-core config::form::tests`
- `cargo test -p ensemble-core openapi`
- `cargo test -p ensemble-core orchestrator::tests`
- `pnpm test`
- `pnpm run build`
- `cargo test -p ensemble-core --lib -- --test-threads=1`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`

## Residual risk

Existing configurations containing `agent.max_turns` now fail startup/validation until the obsolete key is removed. This is intentional because the former setting was unenforceable; no replacement provider-specific turn limit is introduced.
