### PR TITLE
Configure GitHub Project work roles

### DIFF
--- a/docs/agents/run-github-project.md
+++ b/docs/agents/run-github-project.md
@@ -31,6 +31,17 @@
 - Done name: `Done`
 - Done option ID: `98236657`
 
+## Triage
+
+- Needs-triage label: `needs-triage`
+
+## Work Roles
+
+- Epic label: `epic`
+- Epic label ID: `LA_kwDORzdwYM8AAAACuWX7NA`
+- Human-work label: `ready-for-human`
+- Human-work label ID: `LA_kwDORzdwYM8AAAACuAxOsQ`
+
 ## Priority
 
 - Field name: `Priority`


### PR DESCRIPTION
## Summary

- map the repository's `needs-triage` label into the trusted Project configuration
- configure the new `epic` work-shape label and its verified node ID
- configure `ready-for-human` as the human-work role with its verified node ID

## Why

The current `run-github-project` workflow requires trusted mappings for Backlog triage, epic reconciliation, and human-work frontiers. The committed configuration predates those required fields, so queue execution correctly stops at its fail-closed configuration gate.

## Impact

This enables the runner to classify Backlog epics and human actions without inferring roles from issue prose. It changes no runtime code or Project field schema.

## Validation

- verified all three label names and node IDs against live GitHub repository labels
- verified the existing Project field and option mappings remain unchanged
- `git diff --check`
