### PR TITLE
Add durable acceptance commands

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -79,6 +79,15 @@ async fn web_cli_runs_todo_issue_to_completion_with_mock_acpx() {
         .expect("history should contain completed run");
     assert_eq!(history["issue_identifier"], ISSUE_ID);
     assert_eq!(history["outcome"], "succeeded");
+    let acceptance = &history["acceptance_attempts"][0]["results"][0];
+    assert_eq!(acceptance["name"], "verify");
+    assert_eq!(acceptance["status"], "passed");
+    assert_eq!(acceptance["stdout"]["total_bytes"], 40_000);
+    assert_eq!(acceptance["stdout"]["truncated"], true);
+    assert_eq!(
+        acceptance["stdout"]["tail"].as_str().unwrap().len(),
+        32 * 1024
+    );
     assert!(
         history["steps_traversed"]
             .as_array()
@@ -109,6 +118,57 @@ async fn web_cli_runs_todo_issue_to_completion_with_mock_acpx() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn acceptance_failure_dominates_successful_agent_and_exhausts_the_issue() {
+    let fixture = TestFixture::new_with_acceptance("printf acceptance-failed >&2; exit 7")
+        .expect("fixture setup");
+    let port = reserve_local_port().expect("reserve local port");
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let child = command.spawn().expect("spawn ensemble web");
+    let _guard = ChildGuard::new(child);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+
+    let history = wait_for_failed_history_record(&client, &base_url, &fixture.workspace_root)
+        .await
+        .expect("acceptance failure should be durable");
+
+    assert_eq!(history["outcome"], "failed");
+    assert_eq!(history["steps_traversed"][0], "implement");
+    assert_eq!(history["attempts"], 1);
+    let acceptance = &history["acceptance_attempts"][0]["results"][0];
+    assert_eq!(acceptance["name"], "verify");
+    assert_eq!(acceptance["status"], "failed");
+    assert_eq!(acceptance["exit_code"], 7);
+    assert!(acceptance["stderr"]["tail"]
+        .as_str()
+        .unwrap()
+        .ends_with("acceptance-failed"));
+
+    let todo = fs::read_to_string(&fixture.todo_path).expect("read TODO.md");
+    assert!(section_contains_issue(&todo, "Failed", ISSUE_ID));
+    assert!(!section_contains_issue(&todo, "Done", ISSUE_ID));
+    let acpx_log = fs::read_to_string(&fixture.acpx_log_path).expect("read mock acpx log");
+    assert_eq!(
+        acpx_log.lines().filter(|line| line.contains(" prompt ")).count(),
+        2,
+        "one agent cycle emits its visible prompt and hidden extraction prompt; exhaustion must not launch another cycle"
+    );
+}
+
 struct TestFixture {
     config_dir: TempDir,
     todo_path: PathBuf,
@@ -119,6 +179,10 @@ struct TestFixture {
 
 impl TestFixture {
     fn new() -> io::Result<Self> {
+        Self::new_with_acceptance("yes x | head -c 40000")
+    }
+
+    fn new_with_acceptance(acceptance_run: &str) -> io::Result<Self> {
         let config_dir = TempDir::new()?;
         let root = config_dir.path();
         let todo_path = root.join("TODO.md");
@@ -131,7 +195,7 @@ impl TestFixture {
         fs::write(&todo_path, todo_fixture())?;
         fs::write(
             root.join("config.yaml"),
-            config_yaml(&todo_path, &workspace_root),
+            config_yaml(&todo_path, &workspace_root, acceptance_run),
         )?;
         fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
 
@@ -170,7 +234,7 @@ fn todo_fixture() -> String {
     )
 }
 
-fn config_yaml(todo_path: &Path, workspace_root: &Path) -> String {
+fn config_yaml(todo_path: &Path, workspace_root: &Path, acceptance_run: &str) -> String {
     format!(
         r#"
 tracker:
@@ -191,6 +255,11 @@ steps:
   - name: implement
     agent: builder
     tracker_state: In Progress
+acceptance:
+  commands:
+    - name: verify
+      run: {}
+      timeout_ms: 5000
 on_success: Done
 on_failure: Failed
 max_cycles: 1
@@ -205,8 +274,36 @@ agent:
   max_retry_backoff_ms: 100
 "#,
         yaml_quote(&todo_path.display().to_string()),
-        yaml_quote(&workspace_root.display().to_string())
+        yaml_quote(&workspace_root.display().to_string()),
+        yaml_quote(acceptance_run)
     )
+}
+
+async fn wait_for_failed_history_record(
+    client: &reqwest::Client,
+    base_url: &str,
+    workspace_root: &Path,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let url = format!("{base_url}/api/v1/history?outcome=failed&step=implement");
+    loop {
+        let response = client.get(&url).send().await.map_err(|e| e.to_string())?;
+        let json = response.json::<Value>().await.map_err(|e| e.to_string())?;
+        if let Some(record) = json["records"]
+            .as_array()
+            .and_then(|records| records.iter().find(|r| r["issue_identifier"] == ISSUE_ID))
+        {
+            return Ok(record.clone());
+        }
+        if Instant::now() >= deadline {
+            let history_path = workspace_root.join("ensemble_history.jsonl");
+            let persisted = fs::read_to_string(&history_path).unwrap_or_default();
+            return Err(format!(
+                "failed history record not found: {json:#?}\npersisted history:\n{persisted}"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 }
 
 fn yaml_quote(value: &str) -> String {

--- a/crates/ensemble-core/src/acceptance/mod.rs
+++ b/crates/ensemble-core/src/acceptance/mod.rs
@@ -1,0 +1,5 @@
+mod model;
+mod runner;
+
+pub use model::{AcceptanceAttempt, AcceptanceOutput, AcceptanceResult, AcceptanceStatus};
+pub use runner::{AcceptanceCommandRunner, ShellAcceptanceCommandRunner};

--- a/crates/ensemble-core/src/acceptance/model.rs
+++ b/crates/ensemble-core/src/acceptance/model.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AcceptanceStatus {
+    Passed,
+    Failed,
+    TimedOut,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct AcceptanceOutput {
+    pub tail: String,
+    pub total_bytes: u64,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct AcceptanceResult {
+    pub name: String,
+    pub status: AcceptanceStatus,
+    pub exit_code: Option<i32>,
+    pub stdout: AcceptanceOutput,
+    pub stderr: AcceptanceOutput,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct AcceptanceAttempt {
+    pub cycle: u32,
+    pub results: Vec<AcceptanceResult>,
+}

--- a/crates/ensemble-core/src/acceptance/runner.rs
+++ b/crates/ensemble-core/src/acceptance/runner.rs
@@ -1,0 +1,409 @@
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::Command;
+
+use crate::acceptance::{AcceptanceOutput, AcceptanceResult, AcceptanceStatus};
+use crate::config::ensemble::AcceptanceCommandConfig;
+
+const OUTPUT_TAIL_LIMIT: usize = 32 * 1024;
+
+#[async_trait]
+pub trait AcceptanceCommandRunner: Send + Sync {
+    async fn run(
+        &self,
+        command: &AcceptanceCommandConfig,
+        issue_workspace: &Path,
+    ) -> AcceptanceResult;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ShellAcceptanceCommandRunner;
+
+#[async_trait]
+impl AcceptanceCommandRunner for ShellAcceptanceCommandRunner {
+    async fn run(
+        &self,
+        command_config: &AcceptanceCommandConfig,
+        issue_workspace: &Path,
+    ) -> AcceptanceResult {
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-lc")
+            .arg(&command_config.run)
+            .current_dir(issue_workspace)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        #[cfg(unix)]
+        command.process_group(0);
+
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                return unavailable_result(
+                    &command_config.name,
+                    format!("acceptance command unavailable: {error}"),
+                );
+            }
+        };
+        let child_id = child.id();
+        let stdout = child
+            .stdout
+            .take()
+            .map(|stream| tokio::spawn(read_tail(stream)));
+        let stderr = child
+            .stderr
+            .take()
+            .map(|stream| tokio::spawn(read_tail(stream)));
+
+        let deadline =
+            tokio::time::Instant::now() + Duration::from_millis(command_config.timeout_ms);
+        let status = match tokio::time::timeout_at(deadline, child.wait()).await {
+            Ok(wait_result) => match wait_result {
+                Ok(status) => Some(status),
+                Err(error) => {
+                    return unavailable_result(
+                        &command_config.name,
+                        format!("acceptance command unavailable while waiting: {error}"),
+                    );
+                }
+            },
+            Err(_) => None,
+        };
+
+        let mut output_collection = Box::pin(collect_outputs(stdout, stderr));
+        if let Some(status) = status {
+            match tokio::time::timeout_at(deadline, &mut output_collection).await {
+                Ok(Ok((stdout, stderr))) => {
+                    return finish_result(&command_config.name, status, stdout, stderr);
+                }
+                Ok(Err(error)) => {
+                    return unavailable_result(
+                        &command_config.name,
+                        format!("acceptance command output unavailable: {error}"),
+                    );
+                }
+                Err(_) => {}
+            }
+        }
+
+        terminate_process_group(child_id);
+        if status.is_none() {
+            if let Err(error) = child.wait().await {
+                return unavailable_result(
+                    &command_config.name,
+                    format!("acceptance command unavailable while reaping timeout: {error}"),
+                );
+            }
+        }
+
+        let (stdout, stderr) = match output_collection.await {
+            Ok(outputs) => outputs,
+            Err(error) => {
+                return unavailable_result(
+                    &command_config.name,
+                    format!("acceptance command output unavailable: {error}"),
+                );
+            }
+        };
+        AcceptanceResult {
+            name: command_config.name.clone(),
+            status: AcceptanceStatus::TimedOut,
+            exit_code: None,
+            stdout,
+            stderr,
+            summary: format!(
+                "acceptance command '{}' timed out after {}ms",
+                command_config.name, command_config.timeout_ms
+            ),
+        }
+    }
+}
+
+fn finish_result(
+    name: &str,
+    status: std::process::ExitStatus,
+    stdout: AcceptanceOutput,
+    stderr: AcceptanceOutput,
+) -> AcceptanceResult {
+    let acceptance_status = if status.success() {
+        AcceptanceStatus::Passed
+    } else {
+        AcceptanceStatus::Failed
+    };
+    let summary = match status.code() {
+        Some(0) => format!("acceptance command '{name}' passed"),
+        Some(code) => format!("acceptance command '{name}' failed with exit code {code}"),
+        None => format!("acceptance command '{name}' terminated by signal"),
+    };
+    AcceptanceResult {
+        name: name.to_string(),
+        status: acceptance_status,
+        exit_code: status.code(),
+        stdout,
+        stderr,
+        summary,
+    }
+}
+
+async fn collect_outputs(
+    stdout: Option<tokio::task::JoinHandle<std::io::Result<AcceptanceOutput>>>,
+    stderr: Option<tokio::task::JoinHandle<std::io::Result<AcceptanceOutput>>>,
+) -> std::io::Result<(AcceptanceOutput, AcceptanceOutput)> {
+    let stdout = collect_output(stdout).await?;
+    let stderr = collect_output(stderr).await?;
+    Ok((stdout, stderr))
+}
+
+async fn collect_output(
+    output: Option<tokio::task::JoinHandle<std::io::Result<AcceptanceOutput>>>,
+) -> std::io::Result<AcceptanceOutput> {
+    match output {
+        Some(output) => output.await.map_err(std::io::Error::other)?,
+        None => Ok(empty_output()),
+    }
+}
+
+async fn read_tail(mut stream: impl AsyncRead + Unpin) -> std::io::Result<AcceptanceOutput> {
+    let mut tail = Vec::with_capacity(OUTPUT_TAIL_LIMIT);
+    let mut buffer = [0_u8; 8192];
+    let mut total_bytes = 0_u64;
+    loop {
+        let read = stream.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        total_bytes = total_bytes.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
+        append_tail(&mut tail, &buffer[..read]);
+    }
+    Ok(AcceptanceOutput {
+        tail: String::from_utf8_lossy(&tail).into_owned(),
+        total_bytes,
+        truncated: total_bytes > u64::try_from(OUTPUT_TAIL_LIMIT).unwrap_or(u64::MAX),
+    })
+}
+
+fn append_tail(tail: &mut Vec<u8>, chunk: &[u8]) {
+    if chunk.len() >= OUTPUT_TAIL_LIMIT {
+        tail.clear();
+        tail.extend_from_slice(&chunk[chunk.len() - OUTPUT_TAIL_LIMIT..]);
+        return;
+    }
+    let excess = tail
+        .len()
+        .saturating_add(chunk.len())
+        .saturating_sub(OUTPUT_TAIL_LIMIT);
+    if excess > 0 {
+        tail.drain(..excess);
+    }
+    tail.extend_from_slice(chunk);
+}
+
+fn unavailable_result(name: &str, summary: String) -> AcceptanceResult {
+    AcceptanceResult {
+        name: name.to_string(),
+        status: AcceptanceStatus::Unavailable,
+        exit_code: None,
+        stdout: empty_output(),
+        stderr: empty_output(),
+        summary,
+    }
+}
+
+fn empty_output() -> AcceptanceOutput {
+    AcceptanceOutput {
+        tail: String::new(),
+        total_bytes: 0,
+        truncated: false,
+    }
+}
+
+#[cfg(unix)]
+fn terminate_process_group(child_id: Option<u32>) {
+    let Some(child_id) = child_id.and_then(|id| i32::try_from(id).ok()) else {
+        return;
+    };
+    // SAFETY: a negative PID targets the process group created for this child.
+    unsafe {
+        libc::kill(-child_id, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate_process_group(_child_id: Option<u32>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acceptance::AcceptanceStatus;
+    use crate::config::ensemble::AcceptanceCommandConfig;
+    use crate::test_support::env::ENV_LOCK;
+
+    fn command(name: &str, run: &str, timeout_ms: u64) -> AcceptanceCommandConfig {
+        AcceptanceCommandConfig {
+            name: name.to_string(),
+            run: run.to_string(),
+            timeout_ms,
+        }
+    }
+
+    #[tokio::test]
+    async fn shell_runner_inherits_environment_and_uses_issue_workspace() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let workspace = tempfile::tempdir().unwrap();
+        let variable = "ENSEMBLE_ACCEPTANCE_RUNNER_TEST";
+        std::env::set_var(variable, "inherited-value");
+        let command = AcceptanceCommandConfig {
+            name: "context".to_string(),
+            run: format!("printf '%s\\n%s' \"${variable}\" \"$PWD\""),
+            timeout_ms: 5_000,
+        };
+
+        let result = ShellAcceptanceCommandRunner
+            .run(&command, workspace.path())
+            .await;
+
+        std::env::remove_var(variable);
+        assert_eq!(result.status, AcceptanceStatus::Passed);
+        assert_eq!(result.exit_code, Some(0));
+        let expected_workspace = std::fs::canonicalize(workspace.path()).unwrap();
+        assert_eq!(
+            result.stdout.tail,
+            format!("inherited-value\n{}", expected_workspace.display())
+        );
+        assert_eq!(result.stdout.total_bytes, result.stdout.tail.len() as u64);
+        assert!(!result.stdout.truncated);
+        assert_eq!(result.name, "context");
+    }
+
+    #[tokio::test]
+    async fn shell_runner_maps_nonzero_and_signal_termination_to_failed() {
+        let workspace = tempfile::tempdir().unwrap();
+
+        let nonzero = ShellAcceptanceCommandRunner
+            .run(
+                &command("nonzero", "printf failure >&2; exit 23", 5_000),
+                workspace.path(),
+            )
+            .await;
+        let signal = ShellAcceptanceCommandRunner
+            .run(&command("signal", "kill -TERM $$", 5_000), workspace.path())
+            .await;
+
+        assert_eq!(nonzero.status, AcceptanceStatus::Failed);
+        assert_eq!(nonzero.exit_code, Some(23));
+        assert!(nonzero.stderr.tail.ends_with("failure"));
+        assert_eq!(signal.status, AcceptanceStatus::Failed);
+        assert_eq!(signal.exit_code, None);
+        assert!(signal.summary.contains("signal"));
+    }
+
+    #[tokio::test]
+    async fn shell_runner_retains_independent_final_stream_tails_and_lossy_utf8() {
+        let workspace = tempfile::tempdir().unwrap();
+        let noisy = ShellAcceptanceCommandRunner
+            .run(
+                &command(
+                    "noisy",
+                    "yes o | head -c 40000; yes e | head -c 41000 >&2",
+                    5_000,
+                ),
+                workspace.path(),
+            )
+            .await;
+        let lossy = ShellAcceptanceCommandRunner
+            .run(
+                &command("lossy", "printf '\\377x'", 5_000),
+                workspace.path(),
+            )
+            .await;
+
+        assert_eq!(noisy.status, AcceptanceStatus::Passed);
+        assert_eq!(noisy.stdout.total_bytes, 40_000);
+        assert!(noisy.stderr.total_bytes >= 41_000);
+        assert!(noisy.stdout.truncated);
+        assert!(noisy.stderr.truncated);
+        assert_eq!(noisy.stdout.tail.len(), OUTPUT_TAIL_LIMIT);
+        assert_eq!(noisy.stderr.tail.len(), OUTPUT_TAIL_LIMIT);
+        assert_eq!(lossy.stdout.total_bytes, 2);
+        assert_eq!(lossy.stdout.tail, "�x");
+    }
+
+    #[tokio::test]
+    async fn shell_runner_times_out_and_terminates_descendants() {
+        let workspace = tempfile::tempdir().unwrap();
+        let marker = workspace.path().join("descendant-survived");
+
+        let result = ShellAcceptanceCommandRunner
+            .run(
+                &command(
+                    "timeout",
+                    "(sleep 0.3; touch descendant-survived) & wait",
+                    50,
+                ),
+                workspace.path(),
+            )
+            .await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert_eq!(result.status, AcceptanceStatus::TimedOut);
+        assert_eq!(result.exit_code, None);
+        assert!(
+            !marker.exists(),
+            "timed-out descendant escaped its process group"
+        );
+    }
+
+    #[tokio::test]
+    async fn shell_runner_keeps_timeout_active_while_draining_inherited_pipes() {
+        let workspace = tempfile::tempdir().unwrap();
+        let marker = workspace.path().join("background-survived");
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            ShellAcceptanceCommandRunner.run(
+                &command(
+                    "background-pipe",
+                    "exec python3 -c 'import os,time; child=os.fork(); child and os._exit(0); time.sleep(1.2); open(\"background-survived\", \"w\").close()'",
+                    700,
+                ),
+                workspace.path(),
+            ),
+        )
+        .await
+        .expect("runner must enforce its own deadline while draining output");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        assert_eq!(result.status, AcceptanceStatus::TimedOut);
+        assert!(
+            !marker.exists(),
+            "background descendant escaped the timed-out output drain"
+        );
+    }
+
+    #[tokio::test]
+    async fn shell_runner_maps_invalid_workspace_to_unavailable_without_command_text() {
+        let workspace = tempfile::tempdir().unwrap();
+        let missing = workspace.path().join("missing");
+
+        let result = ShellAcceptanceCommandRunner
+            .run(
+                &command("unavailable", "printf super-secret-command", 5_000),
+                &missing,
+            )
+            .await;
+
+        assert_eq!(result.status, AcceptanceStatus::Unavailable);
+        assert_eq!(result.exit_code, None);
+        assert!(!result.summary.contains("super-secret-command"));
+        assert!(result.stdout.tail.is_empty());
+        assert!(result.stderr.tail.is_empty());
+    }
+}

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -299,6 +299,7 @@ pub(crate) async fn prepare_orchestrator_runtime(
             config,
             tracker,
             agent_runner,
+            acceptance_runner: Arc::new(crate::acceptance::ShellAcceptanceCommandRunner),
             workspace_mgr,
             refresh_requested: Arc::clone(&app_state.refresh_requested),
             cancellation_registry: app_state.cancellation_registry.clone(),

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -774,6 +774,7 @@ mod tests {
                 last_error: Some("agent crashed".to_string()),
                 verdict: Some("failed".to_string()),
                 workspace_path: "/tmp/workspaces/todo-0".to_string(),
+                acceptance_attempts: vec![],
                 artifacts: None,
             })
             .await
@@ -826,6 +827,7 @@ mod tests {
                 last_error: Some("agent crashed".to_string()),
                 verdict: Some("failed".to_string()),
                 workspace_path: String::new(),
+                acceptance_attempts: vec![],
                 artifacts: None,
             })
             .await
@@ -917,6 +919,7 @@ on_failure: Failed
                 last_error: None,
                 verdict: Some("approved".to_string()),
                 workspace_path: "/tmp/workspaces/synth-1".to_string(),
+                acceptance_attempts: vec![],
                 artifacts: None,
             })
             .await
@@ -972,6 +975,7 @@ on_failure: Failed
                 last_error: None,
                 verdict: Some("approved".into()),
                 workspace_path: tmp.path().join("repo-77").display().to_string(),
+                acceptance_attempts: vec![],
                 artifacts: Some(crate::history::artifacts::RunArtifacts {
                     run_id: "run-77".into(),
                     workspace_path: tmp.path().join("repo-77").display().to_string(),
@@ -1023,6 +1027,7 @@ on_failure: Failed
                 last_error: None,
                 verdict: Some("approved".into()),
                 workspace_path: tmp.path().join("repo-77").display().to_string(),
+                acceptance_attempts: vec![],
                 artifacts: Some(crate::history::artifacts::RunArtifacts {
                     run_id: "run-77".into(),
                     workspace_path: tmp.path().join("repo-77").display().to_string(),

--- a/crates/ensemble-core/src/api/history_handler.rs
+++ b/crates/ensemble-core/src/api/history_handler.rs
@@ -79,6 +79,7 @@ mod tests {
             last_error: None,
             verdict: None,
             workspace_path: format!("/tmp/{}", identifier),
+            acceptance_attempts: vec![],
             artifacts: None,
         }
     }

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -311,6 +311,13 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
     use crate::error::PipelineError;
 
     match e {
+        PipelineError::InvalidAcceptanceCommand { name, reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("invalid acceptance command '{}': {}", name, reason),
+            section: "acceptance".to_string(),
+            field: Some(name.clone()),
+            path: Some(format!("acceptance.commands.{}", name)),
+        },
         PipelineError::UnknownAgent { name } => ValidationIssue {
             kind: ValidationIssueKind::Config,
             message: format!("unknown agent reference: {}", name),

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -35,6 +35,23 @@ pub struct EnsembleConfig {
     pub agent: AgentRuntimeConfig,
     #[serde(default)]
     pub human_interaction: HumanInteractionConfig,
+    #[serde(default)]
+    pub acceptance: AcceptanceConfig,
+}
+
+/// Commands that must pass after the pipeline and its approval gates succeed.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct AcceptanceConfig {
+    #[serde(default)]
+    pub commands: Vec<AcceptanceCommandConfig>,
+}
+
+/// One named acceptance command executed by `/bin/sh -lc`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct AcceptanceCommandConfig {
+    pub name: String,
+    pub run: String,
+    pub timeout_ms: u64,
 }
 
 /// Runtime configuration for blocked-on-human interaction handling.
@@ -915,6 +932,32 @@ fn reject_legacy_agent_permission_policy(
 
 /// Validate the config for consistency: prompt config, agent references, step name uniqueness, etc.
 pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
+    let mut acceptance_names = std::collections::HashSet::new();
+    for command in &config.acceptance.commands {
+        let display_name = if command.name.trim().is_empty() {
+            "<unnamed>"
+        } else {
+            command.name.as_str()
+        };
+        let reason = if command.name.trim().is_empty() {
+            Some("name must not be empty")
+        } else if !acceptance_names.insert(command.name.as_str()) {
+            Some("name must be unique")
+        } else if command.run.trim().is_empty() {
+            Some("run must not be empty")
+        } else if command.timeout_ms == 0 {
+            Some("timeout_ms must be greater than 0")
+        } else {
+            None
+        };
+        if let Some(reason) = reason {
+            return Err(PipelineError::InvalidAcceptanceCommand {
+                name: display_name.to_string(),
+                reason: reason.to_string(),
+            });
+        }
+    }
+
     for (name, agent) in &config.agents {
         match (&agent.prompt, &agent.prompt_template) {
             (Some(_), Some(_)) | (None, None) => {
@@ -1139,6 +1182,88 @@ on_failure: Failed
         assert_eq!(config.steps[0].agent, "build");
         assert_eq!(config.on_success, "Done");
         assert_eq!(config.on_failure, "Failed");
+        assert!(config.acceptance.commands.is_empty());
+    }
+
+    #[test]
+    fn parses_acceptance_commands() {
+        let yaml = format!(
+            "{}\nacceptance:\n  commands:\n    - name: test\n      run: \"  cargo test --workspace  \"\n      timeout_ms: 120000\n",
+            minimal_yaml()
+        );
+
+        let config = parse_config(&yaml).unwrap();
+
+        assert_eq!(
+            config.acceptance.commands,
+            vec![AcceptanceCommandConfig {
+                name: "test".to_string(),
+                run: "  cargo test --workspace  ".to_string(),
+                timeout_ms: 120_000,
+            }]
+        );
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn empty_acceptance_defaults_to_no_commands() {
+        let yaml = format!("{}\nacceptance: {{}}\n", minimal_yaml());
+
+        let config = parse_config(&yaml).unwrap();
+
+        assert!(config.acceptance.commands.is_empty());
+    }
+
+    #[test]
+    fn validates_acceptance_commands() {
+        let invalid_cases = [
+            ("", "echo ok", 1, "name must not be empty"),
+            ("check", "", 1, "run must not be empty"),
+            ("check", "echo ok", 0, "timeout_ms must be greater than 0"),
+        ];
+
+        for (name, run, timeout_ms, expected_reason) in invalid_cases {
+            let expected_name = if name.trim().is_empty() {
+                "<unnamed>"
+            } else {
+                name
+            };
+            let yaml = format!(
+                "{}\nacceptance:\n  commands:\n    - name: {:?}\n      run: {:?}\n      timeout_ms: {}\n",
+                minimal_yaml(),
+                name,
+                run,
+                timeout_ms
+            );
+            let config = parse_config(&yaml).unwrap();
+            let error = validate_config(&config).unwrap_err();
+
+            assert!(
+                matches!(
+                    error,
+                    PipelineError::InvalidAcceptanceCommand { ref name, ref reason }
+                        if name == expected_name && reason == expected_reason
+                ),
+                "unexpected error: {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_acceptance_command_names_are_invalid() {
+        let yaml = format!(
+            "{}\nacceptance:\n  commands:\n    - name: test\n      run: cargo test\n      timeout_ms: 1000\n    - name: test\n      run: cargo test --doc\n      timeout_ms: 1000\n",
+            minimal_yaml()
+        );
+        let config = parse_config(&yaml).unwrap();
+
+        let error = validate_config(&config).unwrap_err();
+
+        assert!(matches!(
+            error,
+            PipelineError::InvalidAcceptanceCommand { ref name, ref reason }
+                if name == "test" && reason == "name must be unique"
+        ));
     }
 
     #[test]

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -132,6 +132,8 @@ pub enum AgentError {
 
 #[derive(Debug, Error)]
 pub enum PipelineError {
+    #[error("invalid acceptance command {name}: {reason}")]
+    InvalidAcceptanceCommand { name: String, reason: String },
     #[error("unknown agent reference: {name}")]
     UnknownAgent { name: String },
     #[error("unknown step dependency: {step} depends on {dependency}")]

--- a/crates/ensemble-core/src/history/model.rs
+++ b/crates/ensemble-core/src/history/model.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::acceptance::AcceptanceAttempt;
 use crate::history::artifacts::RunArtifacts;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
@@ -17,6 +18,8 @@ pub struct HistoryRecord {
     pub last_error: Option<String>,
     pub verdict: Option<String>,
     pub workspace_path: String,
+    #[serde(default)]
+    pub acceptance_attempts: Vec<AcceptanceAttempt>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifacts: Option<RunArtifacts>,
 }
@@ -26,4 +29,31 @@ pub struct TokenTotals {
     pub input_tokens: u64,
     pub output_tokens: u64,
     pub total_tokens: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_record_defaults_acceptance_attempts_to_empty() {
+        let value = serde_json::json!({
+            "issue_identifier": "repo#1",
+            "issue_id": "node-1",
+            "outcome": "succeeded",
+            "steps_traversed": ["build"],
+            "attempts": 1,
+            "tokens": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            "duration_seconds": 4,
+            "started_at": "2026-08-03T00:00:00Z",
+            "completed_at": "2026-08-03T00:00:01Z",
+            "last_error": null,
+            "verdict": "approved",
+            "workspace_path": "/tmp/workspace"
+        });
+
+        let record: HistoryRecord = serde_json::from_value(value).unwrap();
+
+        assert!(record.acceptance_attempts.is_empty());
+    }
 }

--- a/crates/ensemble-core/src/history/reader.rs
+++ b/crates/ensemble-core/src/history/reader.rs
@@ -120,6 +120,7 @@ mod tests {
             last_error: None,
             verdict: None,
             workspace_path: format!("/tmp/{}", identifier),
+            acceptance_attempts: vec![],
             artifacts: None,
         }
     }

--- a/crates/ensemble-core/src/history/writer.rs
+++ b/crates/ensemble-core/src/history/writer.rs
@@ -80,6 +80,7 @@ mod tests {
             last_error: None,
             verdict: Some("approved".into()),
             workspace_path: "/tmp/ensemble_workspaces/MT-648".into(),
+            acceptance_attempts: vec![],
             artifacts: None,
         }
     }

--- a/crates/ensemble-core/src/history_store/model.rs
+++ b/crates/ensemble-core/src/history_store/model.rs
@@ -27,6 +27,15 @@ pub(crate) fn row_to_history_record(row: &Row<'_>) -> rusqlite::Result<HistoryRe
         .map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
         })?;
+    let acceptance_attempts_json: Option<String> = row.get("acceptance_attempts")?;
+    let acceptance_attempts = acceptance_attempts_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })?
+        .unwrap_or_default();
 
     Ok(HistoryRecord {
         issue_identifier: row.get("issue_identifier")?,
@@ -45,6 +54,7 @@ pub(crate) fn row_to_history_record(row: &Row<'_>) -> rusqlite::Result<HistoryRe
         last_error: row.get("last_error")?,
         verdict: row.get("verdict")?,
         workspace_path: row.get("workspace_path")?,
+        acceptance_attempts,
         artifacts,
     })
 }

--- a/crates/ensemble-core/src/history_store/schema.rs
+++ b/crates/ensemble-core/src/history_store/schema.rs
@@ -26,7 +26,8 @@ pub fn bootstrap_schema(conn: &Connection) -> rusqlite::Result<()> {
             input_tokens INTEGER NOT NULL,
             output_tokens INTEGER NOT NULL,
             total_tokens INTEGER NOT NULL,
-            artifacts TEXT
+            artifacts TEXT,
+            acceptance_attempts TEXT
         );
 
         CREATE TABLE IF NOT EXISTS run_events (
@@ -49,6 +50,7 @@ pub fn bootstrap_schema(conn: &Connection) -> rusqlite::Result<()> {
         "#,
     )?;
     add_column_if_missing(conn, "runs", "artifacts", "TEXT")?;
+    add_column_if_missing(conn, "runs", "acceptance_attempts", "TEXT")?;
     Ok(())
 }
 
@@ -149,5 +151,13 @@ mod tests {
             )
             .unwrap();
         assert_eq!(artifacts_column_count, 1);
+        let acceptance_column_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('runs') WHERE name = 'acceptance_attempts'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(acceptance_column_count, 1);
     }
 }

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -55,13 +55,16 @@ impl HistoryStore {
                 .map(serde_json::to_string)
                 .transpose()
                 .map_err(io::Error::other)?;
+            let acceptance_attempts_json =
+                serde_json::to_string(&record.acceptance_attempts).map_err(io::Error::other)?;
             tx.execute(
                 r#"
                 INSERT INTO runs (
                     run_id, issue_id, issue_identifier, outcome, steps_traversed, attempts,
                     duration_seconds, started_at, completed_at, last_error, verdict,
-                    workspace_path, input_tokens, output_tokens, total_tokens, artifacts
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+                    workspace_path, input_tokens, output_tokens, total_tokens, artifacts,
+                    acceptance_attempts
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
                 ON CONFLICT(run_id) DO UPDATE SET
                     issue_id = excluded.issue_id,
                     issue_identifier = excluded.issue_identifier,
@@ -77,7 +80,8 @@ impl HistoryStore {
                     input_tokens = excluded.input_tokens,
                     output_tokens = excluded.output_tokens,
                     total_tokens = excluded.total_tokens,
-                    artifacts = excluded.artifacts
+                    artifacts = excluded.artifacts,
+                    acceptance_attempts = excluded.acceptance_attempts
                 "#,
                 params![
                     run_id,
@@ -96,6 +100,7 @@ impl HistoryStore {
                     record.tokens.output_tokens,
                     record.tokens.total_tokens,
                     artifacts_json,
+                    acceptance_attempts_json,
                 ],
             )
             .map_err(io::Error::other)?;
@@ -215,7 +220,7 @@ impl HistoryStore {
             })?;
 
             let page_sql = format!(
-                "SELECT issue_id, issue_identifier, outcome, steps_traversed, attempts, duration_seconds, started_at, completed_at, last_error, verdict, workspace_path, input_tokens, output_tokens, total_tokens, artifacts FROM runs{where_sql} ORDER BY completed_at DESC LIMIT ? OFFSET ?"
+                "SELECT issue_id, issue_identifier, outcome, steps_traversed, attempts, duration_seconds, started_at, completed_at, last_error, verdict, workspace_path, input_tokens, output_tokens, total_tokens, artifacts, acceptance_attempts FROM runs{where_sql} ORDER BY completed_at DESC LIMIT ? OFFSET ?"
             );
             let mut page_params = base_params;
             page_params.push(Value::from(limit_i64));
@@ -395,6 +400,7 @@ mod tests {
             last_error: None,
             verdict: Some("approved".into()),
             workspace_path: format!("/tmp/{identifier}"),
+            acceptance_attempts: vec![],
             artifacts: None,
         }
     }
@@ -470,6 +476,42 @@ mod tests {
             Some("https://github.com/acme/repo/pull/12")
         );
         assert_eq!(artifacts.transcripts[0].step_name, "build");
+    }
+
+    #[tokio::test]
+    async fn append_history_record_round_trips_acceptance_attempts() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = HistoryStore::new(dir.path().join("history.db"))
+            .await
+            .unwrap();
+        let mut record = sample_history("repo#1");
+        record.acceptance_attempts = vec![crate::acceptance::AcceptanceAttempt {
+            cycle: 1,
+            results: vec![crate::acceptance::AcceptanceResult {
+                name: "test".into(),
+                status: crate::acceptance::AcceptanceStatus::Passed,
+                exit_code: Some(0),
+                stdout: crate::acceptance::AcceptanceOutput {
+                    tail: "ok".into(),
+                    total_bytes: 2,
+                    truncated: false,
+                },
+                stderr: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+                summary: "passed".into(),
+            }],
+        }];
+
+        store.append_history_record("run-1", &record).await.unwrap();
+
+        let response = store.read_history(&HistoryQuery::default()).await.unwrap();
+        assert_eq!(
+            response.records[0].acceptance_attempts,
+            record.acceptance_attempts
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod acceptance;
 pub mod agent;
 pub mod api;
 pub mod config;

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -1007,6 +1007,7 @@ mod tests {
             hooks: Default::default(),
             agent: Default::default(),
             human_interaction: Default::default(),
+            acceptance: Default::default(),
         })
     }
 

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -19,6 +19,7 @@ use tokio::sync::{mpsc, watch};
 use tokio::time::{sleep, timeout};
 use tracing::{debug, error, info, warn};
 
+use crate::acceptance::{AcceptanceCommandRunner, AcceptanceStatus, ShellAcceptanceCommandRunner};
 use crate::agent::cancellation::{
     await_worker_drain, await_worker_quiescence, is_reconciliation_owned, mark_all_for_drain,
     mark_issue_for_drain, new_cancellation_registry, pending_reconciliation_issue_ids,
@@ -61,7 +62,7 @@ use crate::pipeline::engine::{
 };
 use crate::pipeline::verdict::StepResult;
 use crate::timeline::persistence::TimelinePersistence;
-use crate::tracker::model::{Issue, RetryEntry};
+use crate::tracker::model::{Issue, RetryEntry, RunningEntry};
 use crate::tracker::IssueTracker;
 use crate::transcript::events::TranscriptEventBus;
 use crate::transcript::model::TranscriptRecordKind;
@@ -118,6 +119,23 @@ struct ExhaustedRetryTerminal {
 enum WholeIssueFailureRetry {
     Scheduled(Option<Box<PipelineTransitionInput>>),
     Exhausted(Box<ExhaustedRetryTerminal>),
+}
+
+enum AcceptancePhaseOutcome {
+    Passed,
+    Failed {
+        reason: String,
+        owner: AcceptanceOwnerIdentity,
+    },
+    RetainedForRecovery,
+}
+
+#[derive(Clone)]
+struct PendingAcceptanceTransition {
+    expected: PipelineTransitionInput,
+    candidate: PipelineRunSnapshot,
+    owner: AcceptanceOwnerIdentity,
+    baseline: PipelineRunSnapshot,
 }
 
 #[derive(Debug, Clone)]
@@ -187,6 +205,48 @@ impl RunningAttemptIdentity {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+enum AcceptanceOwnerIdentity {
+    Running(RunningAttemptIdentity),
+    Waiting {
+        interaction_request_id: String,
+        run_id: Option<String>,
+        requested_at: chrono::DateTime<Utc>,
+    },
+}
+
+impl AcceptanceOwnerIdentity {
+    fn capture(state: &OrchestratorState, issue_id: &str) -> Option<Self> {
+        RunningAttemptIdentity::capture(state, issue_id)
+            .map(Self::Running)
+            .or_else(|| {
+                state
+                    .waiting_on_human
+                    .get(issue_id)
+                    .map(|entry| Self::Waiting {
+                        interaction_request_id: entry.interaction_request_id.clone(),
+                        run_id: entry.run_id.clone(),
+                        requested_at: entry.requested_at,
+                    })
+            })
+    }
+
+    fn is_current(&self, state: &OrchestratorState, issue_id: &str) -> bool {
+        match self {
+            Self::Running(identity) => identity.is_current(state, issue_id),
+            Self::Waiting {
+                interaction_request_id,
+                run_id,
+                requested_at,
+            } => state.waiting_on_human.get(issue_id).is_some_and(|entry| {
+                entry.interaction_request_id == *interaction_request_id
+                    && entry.run_id == *run_id
+                    && entry.requested_at == *requested_at
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ReconciliationOwner {
     attempt: Option<RunningAttemptIdentity>,
     pipeline_cycle: Option<u32>,
@@ -252,6 +312,7 @@ pub struct Orchestrator {
     config: Arc<RwLock<EnsembleConfig>>,
     tracker: Arc<dyn IssueTracker>,
     agent_runner: Arc<dyn AgentRunner>,
+    acceptance_runner: Arc<dyn AcceptanceCommandRunner>,
     workspace_mgr: Arc<WorkspaceManager>,
     interaction_store: InteractionStore,
     refresh_requested: Arc<tokio::sync::Notify>,
@@ -260,6 +321,7 @@ pub struct Orchestrator {
     history_store: Option<HistoryStore>,
     pipeline_journal: PipelineRunJournal,
     pipeline_journal_restored: AtomicBool,
+    pending_acceptance_transitions: std::sync::Mutex<HashMap<String, PendingAcceptanceTransition>>,
     event_bus: EventBus,
     timeline_persistence: Option<TimelinePersistence>,
     transcript_persistence: Option<TranscriptPersistence>,
@@ -314,6 +376,7 @@ pub struct OrchestratorRuntimeParts {
     pub config: Arc<RwLock<EnsembleConfig>>,
     pub tracker: Arc<dyn IssueTracker>,
     pub agent_runner: Arc<dyn AgentRunner>,
+    pub acceptance_runner: Arc<dyn AcceptanceCommandRunner>,
     pub workspace_mgr: WorkspaceManager,
     pub refresh_requested: Arc<tokio::sync::Notify>,
     pub cancellation_registry: CancellationRegistry,
@@ -379,6 +442,7 @@ impl Orchestrator {
                 config,
                 tracker,
                 agent_runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr,
                 refresh_requested,
                 cancellation_registry: new_cancellation_registry(),
@@ -426,6 +490,7 @@ impl Orchestrator {
             config: parts.config,
             tracker: parts.tracker,
             agent_runner: parts.agent_runner,
+            acceptance_runner: parts.acceptance_runner,
             interaction_store: InteractionStore::new(config_dir.to_path_buf()),
             workspace_mgr: Arc::new(parts.workspace_mgr),
             refresh_requested: parts.refresh_requested,
@@ -434,6 +499,7 @@ impl Orchestrator {
             history_store,
             pipeline_journal: PipelineRunJournal::new(config_dir.to_path_buf()),
             pipeline_journal_restored: AtomicBool::new(false),
+            pending_acceptance_transitions: std::sync::Mutex::new(HashMap::new()),
             event_bus: parts.event_bus,
             timeline_persistence,
             transcript_persistence: Some(TranscriptPersistence::new_with_event_bus(
@@ -726,6 +792,7 @@ impl Orchestrator {
             state.last_tick_at = Some(Utc::now());
         }
 
+        self.reconcile_pending_acceptance_transitions().await;
         self.restore_pipeline_runs_from_journal().await;
         self.reconcile_pending_terminal_transitions().await;
         self.hydrate_waiting_on_human_from_store().await;
@@ -1128,6 +1195,20 @@ impl Orchestrator {
                             issue_id = %issue.id,
                             "restored pipeline already succeeded"
                         );
+                        match self.run_acceptance_phase(issue, &config_snapshot).await {
+                            AcceptancePhaseOutcome::Passed => {}
+                            AcceptancePhaseOutcome::Failed { reason, owner } => {
+                                self.schedule_acceptance_failure(
+                                    issue,
+                                    &config_snapshot,
+                                    &reason,
+                                    &owner,
+                                )
+                                .await;
+                                return;
+                            }
+                            AcceptancePhaseOutcome::RetainedForRecovery => return,
+                        }
                         let finalize_state = self
                             .finalize_and_stage_terminal_transition(
                                 &issue.id,
@@ -1611,6 +1692,370 @@ impl Orchestrator {
         }
 
         Ok(workspace.base_path)
+    }
+
+    async fn run_acceptance_phase(
+        &self,
+        issue: &Issue,
+        config: &EnsembleConfig,
+    ) -> AcceptancePhaseOutcome {
+        loop {
+            let (baseline, mut candidate, run_id, owner) = {
+                let state = self.state.read().await;
+                let Some(run) = state.get_pipeline_run(&issue.id).cloned() else {
+                    warn!(issue_id = %issue.id, "acceptance phase has no pipeline run");
+                    return AcceptancePhaseOutcome::RetainedForRecovery;
+                };
+                let run_id = state
+                    .running
+                    .get(&issue.id)
+                    .and_then(|entry| entry.run_id.clone())
+                    .or_else(|| {
+                        state
+                            .waiting_on_human
+                            .get(&issue.id)
+                            .and_then(|entry| entry.run_id.clone())
+                    })
+                    .or_else(|| state.issue_run_ids.get(&issue.id).cloned());
+                let Some(owner) = AcceptanceOwnerIdentity::capture(&state, &issue.id) else {
+                    warn!(issue_id = %issue.id, "acceptance phase has no current owner");
+                    return AcceptancePhaseOutcome::RetainedForRecovery;
+                };
+                (run.to_snapshot(), run, run_id, owner)
+            };
+
+            if let Err(error) = validate_acceptance_attempts(&candidate.to_snapshot(), config) {
+                warn!(issue_id = %issue.id, error = %error, "acceptance evidence does not match config");
+                return AcceptancePhaseOutcome::RetainedForRecovery;
+            }
+            if config.acceptance.commands.is_empty() {
+                return AcceptancePhaseOutcome::Passed;
+            }
+
+            let current_attempt = candidate
+                .acceptance_attempts
+                .iter()
+                .position(|attempt| attempt.cycle == candidate.cycle);
+            let command_to_run = if let Some(attempt_index) = current_attempt {
+                let results = &candidate.acceptance_attempts[attempt_index].results;
+                if results.len() == config.acceptance.commands.len() {
+                    if results
+                        .iter()
+                        .all(|result| result.status == AcceptanceStatus::Passed)
+                    {
+                        return AcceptancePhaseOutcome::Passed;
+                    }
+                    let summary = results
+                        .iter()
+                        .find(|result| result.status != AcceptanceStatus::Passed)
+                        .map(|result| result.summary.clone())
+                        .unwrap_or_else(|| "acceptance failed".to_string());
+                    return AcceptancePhaseOutcome::Failed {
+                        reason: summary,
+                        owner,
+                    };
+                }
+                config.acceptance.commands.get(results.len()).cloned()
+            } else {
+                candidate
+                    .acceptance_attempts
+                    .push(crate::acceptance::AcceptanceAttempt {
+                        cycle: candidate.cycle,
+                        results: Vec::new(),
+                    });
+                None
+            };
+            let transition_kind = if command_to_run.is_some() {
+                PipelineTransitionKind::AcceptanceCommandCompleted
+            } else {
+                PipelineTransitionKind::AcceptanceStarted
+            };
+
+            let result = if let Some(command) = command_to_run.as_ref() {
+                let workspace_path = self.workspace_mgr.workspace_path(&issue.id);
+                Some(self.acceptance_runner.run(command, &workspace_path).await)
+            } else {
+                None
+            };
+            {
+                let state = self.state.read().await;
+                if !Self::acceptance_owner_matches_run(&state, &issue.id, &owner, &baseline) {
+                    warn!(issue_id = %issue.id, "acceptance execution belongs to a stale running attempt");
+                    return AcceptancePhaseOutcome::RetainedForRecovery;
+                }
+            }
+            let reason = if let Some(result) = result {
+                let Some(attempt) = candidate
+                    .acceptance_attempts
+                    .iter_mut()
+                    .find(|attempt| attempt.cycle == candidate.cycle)
+                else {
+                    return AcceptancePhaseOutcome::RetainedForRecovery;
+                };
+                let summary = result.summary.clone();
+                attempt.results.push(result);
+                Some(summary)
+            } else {
+                None
+            };
+            let candidate_snapshot = candidate.to_snapshot();
+            let transition = PipelineTransitionInput {
+                kind: transition_kind,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id,
+                cycle: candidate.cycle,
+                step: None,
+                reason,
+                retry: None,
+                snapshot: Some(candidate_snapshot.clone()),
+                terminal_transition: None,
+            };
+            let journal_transaction = self
+                .pipeline_journal
+                .begin_issue_transition(&issue.id)
+                .await;
+            if let Err(error) = journal_transaction.append(transition.clone()).await {
+                match journal_transaction.latest_record_matches(&transition).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        drop(journal_transaction);
+                        warn!(issue_id = %issue.id, error = %error, "acceptance transition was not journaled; scheduling in-process recovery");
+                        self.release_acceptance_owner_for_recovery(
+                            &issue.id, &owner, &baseline, None,
+                        )
+                        .await;
+                        return AcceptancePhaseOutcome::RetainedForRecovery;
+                    }
+                    Err(reconciliation_error) => {
+                        warn!(issue_id = %issue.id, append_error = %error, reconciliation_error = %reconciliation_error, "acceptance transition outcome is ambiguous; retaining the active owner for recovery");
+                        self.pending_acceptance_transitions
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .insert(
+                                issue.id.clone(),
+                                PendingAcceptanceTransition {
+                                    expected: transition,
+                                    candidate: candidate_snapshot,
+                                    owner,
+                                    baseline,
+                                },
+                            );
+                        self.refresh_requested.notify_one();
+                        return AcceptancePhaseOutcome::RetainedForRecovery;
+                    }
+                }
+            }
+            drop(journal_transaction);
+
+            let mut state = self.state.write().await;
+            let owner_is_current =
+                Self::acceptance_owner_matches_run(&state, &issue.id, &owner, &baseline);
+            let Some(current) = state.get_pipeline_run_mut(&issue.id) else {
+                return AcceptancePhaseOutcome::RetainedForRecovery;
+            };
+            if !owner_is_current {
+                warn!(issue_id = %issue.id, "acceptance result belongs to a stale running attempt");
+                return AcceptancePhaseOutcome::RetainedForRecovery;
+            }
+            current.acceptance_attempts = candidate.acceptance_attempts;
+        }
+    }
+
+    async fn reconcile_pending_acceptance_transitions(&self) {
+        let pending = self
+            .pending_acceptance_transitions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for pending in pending {
+            let issue_id = pending.expected.issue_id.clone();
+            let journal_transaction = self
+                .pipeline_journal
+                .begin_issue_transition(&issue_id)
+                .await;
+            let visibility = journal_transaction
+                .latest_record_matches(&pending.expected)
+                .await;
+            drop(journal_transaction);
+            match visibility {
+                Ok(is_exact) => {
+                    let released = self
+                        .release_acceptance_owner_for_recovery(
+                            &issue_id,
+                            &pending.owner,
+                            &pending.baseline,
+                            is_exact.then_some(&pending.candidate),
+                        )
+                        .await;
+                    let owner_is_still_current = if released {
+                        false
+                    } else {
+                        let state = self.state.read().await;
+                        Self::acceptance_owner_matches_run(
+                            &state,
+                            &issue_id,
+                            &pending.owner,
+                            &pending.baseline,
+                        )
+                    };
+                    if released || !owner_is_still_current {
+                        self.pending_acceptance_transitions
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .remove(&issue_id);
+                    }
+                }
+                Err(error) => warn!(
+                    issue_id,
+                    error = %error,
+                    "acceptance transition remains ambiguous; retaining the active owner"
+                ),
+            }
+        }
+    }
+
+    fn acceptance_owner_matches_run(
+        state: &OrchestratorState,
+        issue_id: &str,
+        owner: &AcceptanceOwnerIdentity,
+        baseline: &PipelineRunSnapshot,
+    ) -> bool {
+        owner.is_current(state, issue_id)
+            && state
+                .get_pipeline_run(issue_id)
+                .is_some_and(|run| run.to_snapshot() == *baseline)
+    }
+
+    async fn release_acceptance_owner_for_recovery(
+        &self,
+        issue_id: &str,
+        owner: &AcceptanceOwnerIdentity,
+        baseline: &PipelineRunSnapshot,
+        replacement: Option<&PipelineRunSnapshot>,
+    ) -> bool {
+        if let AcceptanceOwnerIdentity::Waiting {
+            interaction_request_id,
+            ..
+        } = owner
+        {
+            let is_current = {
+                let state = self.state.read().await;
+                Self::acceptance_owner_matches_run(&state, issue_id, owner, baseline)
+            };
+            if !is_current {
+                return false;
+            }
+            let (previous, cleared) = match self
+                .interaction_store
+                .retire_waiting_state(interaction_request_id)
+                .await
+            {
+                Ok(retired) => retired,
+                Err(error) => {
+                    warn!(issue_id, interaction_id = interaction_request_id, error = %error, "failed to retire acceptance recovery interaction owner");
+                    return false;
+                }
+            };
+            let released = {
+                let mut state = self.state.write().await;
+                let is_current =
+                    Self::acceptance_owner_matches_run(&state, issue_id, owner, baseline);
+                if is_current {
+                    if let (Some(current), Some(replacement)) =
+                        (state.get_pipeline_run_mut(issue_id), replacement)
+                    {
+                        current.acceptance_attempts = replacement.acceptance_attempts.clone();
+                    }
+                    state.remove_waiting_on_human(issue_id);
+                }
+                is_current
+            };
+            if released {
+                self.refresh_requested.notify_one();
+            } else if let Err(error) = self
+                .interaction_store
+                .restore_waiting_state_after_failed_transition(&cleared, &previous)
+                .await
+            {
+                warn!(issue_id, interaction_id = interaction_request_id, error = %error, "failed to restore stale acceptance interaction owner");
+            }
+            return released;
+        }
+
+        let released = {
+            let mut state = self.state.write().await;
+            let is_current = Self::acceptance_owner_matches_run(&state, issue_id, owner, baseline);
+            if !is_current {
+                false
+            } else {
+                if let (Some(current), Some(replacement)) =
+                    (state.get_pipeline_run_mut(issue_id), replacement)
+                {
+                    current.acceptance_attempts = replacement.acceptance_attempts.clone();
+                }
+                state.remove_running(issue_id);
+                true
+            }
+        };
+        if released {
+            self.refresh_requested.notify_one();
+        }
+        released
+    }
+
+    async fn schedule_acceptance_failure(
+        &self,
+        issue: &Issue,
+        config: &EnsembleConfig,
+        reason: &str,
+        owner: &AcceptanceOwnerIdentity,
+    ) {
+        let outcome = {
+            let mut state = self.state.write().await;
+            if !owner.is_current(&state, &issue.id) {
+                warn!(issue_id = %issue.id, "acceptance failure belongs to a stale owner");
+                return;
+            }
+            let entry = state.remove_running(&issue.id).or_else(|| {
+                state
+                    .remove_waiting_on_human(&issue.id)
+                    .map(|waiting| RunningEntry {
+                        issue_id: issue.id.clone(),
+                        identifier: issue.identifier.clone(),
+                        run_id: waiting
+                            .run_id
+                            .or_else(|| state.issue_run_ids.get(&issue.id).cloned()),
+                        issue: issue.clone(),
+                        session_id: None,
+                        agent_pid: None,
+                        last_agent_event: None,
+                        last_agent_timestamp: None,
+                        last_agent_message: None,
+                        agent_input_tokens: waiting.agent_input_tokens,
+                        agent_output_tokens: waiting.agent_output_tokens,
+                        agent_total_tokens: waiting.agent_total_tokens,
+                        last_reported_input_tokens: waiting.agent_input_tokens,
+                        last_reported_output_tokens: waiting.agent_output_tokens,
+                        last_reported_total_tokens: waiting.agent_total_tokens,
+                        turn_count: 0,
+                        retry_attempt: waiting.retry_attempt,
+                        started_at: waiting.started_at.unwrap_or(waiting.requested_at),
+                    })
+            });
+            entry.map(|entry| {
+                self.schedule_whole_issue_failure_retry(
+                    &mut state,
+                    config,
+                    entry,
+                    reason,
+                    ScheduledRetryPipeline::Release,
+                )
+            })
+        };
+        self.commit_whole_issue_failure_retry(outcome).await;
     }
 
     /// Dispatch a single pipeline step after its workspace is ready.
@@ -2759,11 +3204,35 @@ impl Orchestrator {
                                 .unwrap_or_else(|| issue_id.to_string());
                             let finalize_attempt =
                                 RunningAttemptIdentity::capture(&state, issue_id);
+                            let acceptance_issue = issue_snapshot.clone().or_else(|| {
+                                state.running.get(issue_id).map(|entry| entry.issue.clone())
+                            });
                             let config_snapshot = config.clone();
                             drop(config);
                             drop(state);
                             if let Some(input) = step_transition {
                                 self.append_pipeline_transition(input).await;
+                            }
+                            let Some(acceptance_issue) = acceptance_issue else {
+                                warn!(issue_id = %issue_id, "pipeline success has no issue identity for acceptance");
+                                return;
+                            };
+                            match self
+                                .run_acceptance_phase(&acceptance_issue, &config_snapshot)
+                                .await
+                            {
+                                AcceptancePhaseOutcome::Passed => {}
+                                AcceptancePhaseOutcome::Failed { reason, owner } => {
+                                    self.schedule_acceptance_failure(
+                                        &acceptance_issue,
+                                        &config_snapshot,
+                                        &reason,
+                                        &owner,
+                                    )
+                                    .await;
+                                    return;
+                                }
+                                AcceptancePhaseOutcome::RetainedForRecovery => return,
                             }
                             let finalize_state = self
                                 .finalize_and_stage_terminal_transition(
@@ -3427,11 +3896,13 @@ impl Orchestrator {
         retry_entry: RetryEntry,
     ) -> Option<PipelineTransitionInput> {
         let dag = build_dag(&config.steps).ok()?;
-        state.insert_pipeline_run(
-            issue_id,
-            PipelineRun::new(issue_id.to_string(), retry_entry.attempt, dag),
-            Arc::new(config.clone()),
-        );
+        let acceptance_attempts = state
+            .get_pipeline_run(issue_id)
+            .map(|run| run.acceptance_attempts.clone())
+            .unwrap_or_default();
+        let mut next_run = PipelineRun::new(issue_id.to_string(), retry_entry.attempt, dag);
+        next_run.acceptance_attempts = acceptance_attempts;
+        state.insert_pipeline_run(issue_id, next_run, Arc::new(config.clone()));
         Self::transition_input_for_run(
             state,
             issue_id,
@@ -6290,6 +6761,7 @@ impl Orchestrator {
             last_error: input.last_error,
             verdict: Self::history_verdict(input.run),
             workspace_path,
+            acceptance_attempts: input.run.acceptance_attempts.clone(),
             artifacts: input.artifacts,
         }
     }
@@ -6331,6 +6803,7 @@ impl Orchestrator {
             last_error: input.last_error,
             verdict: Self::history_verdict(input.run),
             workspace_path,
+            acceptance_attempts: input.run.acceptance_attempts.clone(),
             artifacts: input.artifacts,
         }
     }
@@ -6861,6 +7334,23 @@ impl Orchestrator {
                         }
                     }
                     PipelineAction::Succeeded => {
+                        match self.run_acceptance_phase(issue, &current_config).await {
+                            AcceptancePhaseOutcome::Passed => {}
+                            AcceptancePhaseOutcome::Failed { reason, owner } => {
+                                if !interaction_was_retired {
+                                    self.interaction_store.mark_resumed(&interaction.id).await?;
+                                }
+                                self.schedule_acceptance_failure(
+                                    issue,
+                                    &current_config,
+                                    &reason,
+                                    &owner,
+                                )
+                                .await;
+                                return Ok(());
+                            }
+                            AcceptancePhaseOutcome::RetainedForRecovery => return Ok(()),
+                        }
                         let finalize_state = self
                             .finalize_and_stage_terminal_transition(
                                 &issue.id,
@@ -7573,6 +8063,7 @@ fn validate_restored_snapshot_against_config(
     snapshot: &PipelineRunSnapshot,
     config: &EnsembleConfig,
 ) -> Result<(), EnsembleError> {
+    validate_acceptance_attempts(snapshot, config)?;
     for persisted_step in &snapshot.dag_steps {
         if snapshot
             .synthetic_fixup_steps
@@ -7606,6 +8097,46 @@ fn validate_restored_snapshot_against_config(
         }
     }
 
+    Ok(())
+}
+
+fn validate_acceptance_attempts(
+    snapshot: &PipelineRunSnapshot,
+    config: &EnsembleConfig,
+) -> Result<(), EnsembleError> {
+    let mut previous_cycle = 0;
+    for attempt in &snapshot.acceptance_attempts {
+        if attempt.cycle == 0 || attempt.cycle > snapshot.cycle || attempt.cycle <= previous_cycle {
+            return Err(AgentError::PromptError {
+                reason: "persisted acceptance attempts have invalid cycle ordering".to_string(),
+            }
+            .into());
+        }
+        previous_cycle = attempt.cycle;
+        if attempt.cycle != snapshot.cycle {
+            continue;
+        }
+        if attempt.results.len() > config.acceptance.commands.len() {
+            return Err(AgentError::PromptError {
+                reason: format!(
+                    "persisted acceptance attempt {} has more results than configured commands",
+                    attempt.cycle
+                ),
+            }
+            .into());
+        }
+        for (result, command) in attempt.results.iter().zip(&config.acceptance.commands) {
+            if result.name != command.name {
+                return Err(AgentError::PromptError {
+                    reason: format!(
+                        "persisted acceptance result '{}' no longer matches configured command '{}'",
+                        result.name, command.name
+                    ),
+                }
+                .into());
+            }
+        }
+    }
     Ok(())
 }
 
@@ -8177,6 +8708,80 @@ mod tests {
         responses: Arc<RwLock<Vec<Option<InteractionResponseEnvelope>>>>,
     }
 
+    struct RecordingAcceptanceRunner {
+        statuses: std::sync::Mutex<std::collections::VecDeque<AcceptanceStatus>>,
+        calls: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    struct BlockingAcceptanceRunner {
+        started: Arc<tokio::sync::Barrier>,
+        release: Arc<tokio::sync::Barrier>,
+    }
+
+    #[async_trait]
+    impl AcceptanceCommandRunner for BlockingAcceptanceRunner {
+        async fn run(
+            &self,
+            command: &crate::config::ensemble::AcceptanceCommandConfig,
+            _issue_workspace: &Path,
+        ) -> crate::acceptance::AcceptanceResult {
+            self.started.wait().await;
+            self.release.wait().await;
+            crate::acceptance::AcceptanceResult {
+                name: command.name.clone(),
+                status: AcceptanceStatus::Passed,
+                exit_code: Some(0),
+                stdout: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+                stderr: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+                summary: "passed".into(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AcceptanceCommandRunner for RecordingAcceptanceRunner {
+        async fn run(
+            &self,
+            command: &crate::config::ensemble::AcceptanceCommandConfig,
+            _issue_workspace: &Path,
+        ) -> crate::acceptance::AcceptanceResult {
+            self.calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(command.name.clone());
+            let status = self
+                .statuses
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .pop_front()
+                .unwrap_or(AcceptanceStatus::Passed);
+            crate::acceptance::AcceptanceResult {
+                name: command.name.clone(),
+                exit_code: (status == AcceptanceStatus::Passed).then_some(0),
+                summary: format!("{}: {status:?}", command.name),
+                status,
+                stdout: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+                stderr: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+            }
+        }
+    }
+
     #[async_trait]
     impl AgentRunner for InteractionCaptureRunner {
         async fn run(&self, request: AgentRunRequest<'_>) -> Result<WorkerResult, AgentError> {
@@ -8679,6 +9284,7 @@ agent:
                 config: Arc::new(RwLock::new(cfg.clone())),
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&workspace_root, None).unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
                 cancellation_registry: new_cancellation_registry(),
@@ -8690,6 +9296,749 @@ agent:
             shutdown_rx,
         );
         (orchestrator, state)
+    }
+
+    fn make_acceptance_test_orchestrator(
+        temp: &tempfile::TempDir,
+        cfg: &EnsembleConfig,
+        issue: &Issue,
+        acceptance_runner: Arc<dyn AcceptanceCommandRunner>,
+    ) -> (Orchestrator, Arc<RwLock<OrchestratorState>>) {
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let workspace_root = temp.path().join("workspaces");
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config: Arc::new(RwLock::new(cfg.clone())),
+                tracker,
+                agent_runner: Arc::new(MockRunner {
+                    delay_ms: 0,
+                    observed_commands: None,
+                    observed_timeouts: None,
+                    cancellation_probe: None,
+                }),
+                acceptance_runner,
+                workspace_mgr: WorkspaceManager::new(&workspace_root, None).unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root,
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+        (orchestrator, state)
+    }
+
+    fn acceptance_config(names: &[&str]) -> EnsembleConfig {
+        let mut config = make_config();
+        config.acceptance.commands = names
+            .iter()
+            .map(|name| crate::config::ensemble::AcceptanceCommandConfig {
+                name: (*name).to_string(),
+                run: format!("run-{name}"),
+                timeout_ms: 1_000,
+            })
+            .collect();
+        config
+    }
+
+    async fn install_succeeded_run(
+        state: &Arc<RwLock<OrchestratorState>>,
+        issue: &Issue,
+        config: &EnsembleConfig,
+    ) {
+        let dag = build_dag(&config.steps).unwrap();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        for step in run.step_states.values_mut() {
+            *step = StepState::Passed;
+        }
+        let mut state = state.write().await;
+        state.insert_pipeline_run(&issue.id, run, Arc::new(config.clone()));
+        state.add_running(issue, None);
+    }
+
+    async fn install_acceptance_started(
+        orchestrator: &Orchestrator,
+        state: &Arc<RwLock<OrchestratorState>>,
+        issue: &Issue,
+    ) {
+        let transition = {
+            let mut state = state.write().await;
+            let run = state.get_pipeline_run_mut(&issue.id).unwrap();
+            run.acceptance_attempts
+                .push(crate::acceptance::AcceptanceAttempt {
+                    cycle: run.cycle,
+                    results: Vec::new(),
+                });
+            Orchestrator::transition_input_for_run(
+                &state,
+                &issue.id,
+                &issue.identifier,
+                PipelineTransitionKind::AcceptanceStarted,
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+        };
+        orchestrator
+            .pipeline_journal
+            .append(transition)
+            .await
+            .unwrap();
+    }
+
+    async fn install_acceptance_waiting_owner(
+        orchestrator: &Orchestrator,
+        state: &Arc<RwLock<OrchestratorState>>,
+        issue: &Issue,
+        interaction_id: &str,
+    ) {
+        let mut interaction = test_question_interaction(issue, 1, interaction_id);
+        interaction.status = InteractionStatus::Resolved;
+        interaction.awaiting_resume = true;
+        interaction.response = Some(InteractionResponse::Question {
+            response_schema_version: 1,
+            text: "continue".to_string(),
+            selected_option: None,
+        });
+        interaction.resolved_at = Some(Utc::now());
+        orchestrator
+            .interaction_store
+            .create(interaction.clone())
+            .await
+            .unwrap();
+        let mut state = state.write().await;
+        let running = state.remove_running(&issue.id).unwrap();
+        state.add_waiting_on_human(WaitingOnHumanEntry {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            interaction_request_id: interaction_id.to_string(),
+            step_name: "build".to_string(),
+            kind: InteractionKind::Question,
+            prompt: "continue".to_string(),
+            agent_name: "builder".to_string(),
+            retry_attempt: Some(1),
+            started_at: Some(running.started_at),
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: interaction.requested_at,
+            run_id: running.run_id,
+            issue: Some(issue.clone()),
+        });
+    }
+
+    #[tokio::test]
+    async fn acceptance_runs_all_commands_in_order_and_journals_before_advancing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-order", "In Progress");
+        let config = acceptance_config(&["first", "second", "third"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new(
+                [
+                    AcceptanceStatus::Failed,
+                    AcceptanceStatus::Passed,
+                    AcceptanceStatus::TimedOut,
+                ]
+                .into(),
+            ),
+            calls: Arc::clone(&calls),
+        });
+        let (orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+
+        let outcome = orchestrator.run_acceptance_phase(&issue, &config).await;
+
+        assert!(matches!(outcome, AcceptancePhaseOutcome::Failed { .. }));
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["first", "second", "third"]
+        );
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        assert_eq!(records[0].kind, PipelineTransitionKind::AcceptanceStarted);
+        assert!(records[1..]
+            .iter()
+            .all(|record| record.kind == PipelineTransitionKind::AcceptanceCommandCompleted));
+        for pair in records.windows(2) {
+            assert!(pair[0].seq < pair[1].seq);
+            assert!(
+                pair[0].snapshot.as_ref().unwrap().acceptance_attempts[0]
+                    .results
+                    .len()
+                    < pair[1].snapshot.as_ref().unwrap().acceptance_attempts[0]
+                        .results
+                        .len()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn acceptance_recovery_resumes_after_durable_prefix() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-resume", "In Progress");
+        let config = acceptance_config(&["first", "second"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new([AcceptanceStatus::Passed].into()),
+            calls: Arc::clone(&calls),
+        });
+        let (orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+        {
+            let mut state = state.write().await;
+            state
+                .get_pipeline_run_mut(&issue.id)
+                .unwrap()
+                .acceptance_attempts
+                .push(crate::acceptance::AcceptanceAttempt {
+                    cycle: 1,
+                    results: vec![crate::acceptance::AcceptanceResult {
+                        name: "first".into(),
+                        status: AcceptanceStatus::Passed,
+                        exit_code: Some(0),
+                        stdout: crate::acceptance::AcceptanceOutput {
+                            tail: String::new(),
+                            total_bytes: 0,
+                            truncated: false,
+                        },
+                        stderr: crate::acceptance::AcceptanceOutput {
+                            tail: String::new(),
+                            total_bytes: 0,
+                            truncated: false,
+                        },
+                        summary: "first passed".into(),
+                    }],
+                });
+        }
+
+        let outcome = orchestrator.run_acceptance_phase(&issue, &config).await;
+
+        assert!(matches!(outcome, AcceptancePhaseOutcome::Passed));
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["second"]
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptance_journal_failures_do_not_advance_execution_or_evidence() {
+        for fail_on_call in [1, 2] {
+            let temp = tempfile::TempDir::new().unwrap();
+            let issue = test_issue(&format!("acceptance-journal-{fail_on_call}"), "In Progress");
+            let config = acceptance_config(&["first", "second"]);
+            let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let runner = Arc::new(RecordingAcceptanceRunner {
+                statuses: std::sync::Mutex::new([AcceptanceStatus::Passed].into()),
+                calls: Arc::clone(&calls),
+            });
+            let (mut orchestrator, state) =
+                make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+            orchestrator
+                .pipeline_journal
+                .transaction_append_error_on_call =
+                Some((Arc::new(AtomicUsize::new(0)), fail_on_call));
+            install_succeeded_run(&state, &issue, &config).await;
+
+            let outcome = orchestrator.run_acceptance_phase(&issue, &config).await;
+
+            assert!(matches!(
+                outcome,
+                AcceptancePhaseOutcome::RetainedForRecovery
+            ));
+            let calls = calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone();
+            if fail_on_call == 1 {
+                assert!(calls.is_empty());
+                assert!(state
+                    .read()
+                    .await
+                    .get_pipeline_run(&issue.id)
+                    .unwrap()
+                    .acceptance_attempts
+                    .is_empty());
+            } else {
+                assert_eq!(calls, vec!["first"]);
+                let state = state.read().await;
+                let attempt = &state
+                    .get_pipeline_run(&issue.id)
+                    .unwrap()
+                    .acceptance_attempts[0];
+                assert!(attempt.results.is_empty());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn acceptance_journal_failure_is_redispatched_on_the_next_tick() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-journal-recovery", "In Progress");
+        let config = acceptance_config(&["test"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new(
+                [AcceptanceStatus::Passed, AcceptanceStatus::Passed].into(),
+            ),
+            calls: Arc::clone(&calls),
+        });
+        let (mut orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 2));
+        install_succeeded_run(&state, &issue, &config).await;
+
+        assert!(matches!(
+            orchestrator.run_acceptance_phase(&issue, &config).await,
+            AcceptancePhaseOutcome::RetainedForRecovery
+        ));
+        orchestrator.handle_tick().await;
+
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test", "test"]
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptance_journal_failure_retires_a_waiting_owner_before_redispatch() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-waiting-recovery", "In Progress");
+        let config = acceptance_config(&["test"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new(
+                [AcceptanceStatus::Passed, AcceptanceStatus::Passed].into(),
+            ),
+            calls: Arc::clone(&calls),
+        });
+        let (mut orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 2));
+        install_succeeded_run(&state, &issue, &config).await;
+        let interaction_id = "acceptance-waiting-interaction";
+        install_acceptance_waiting_owner(&orchestrator, &state, &issue, interaction_id).await;
+
+        assert!(matches!(
+            orchestrator.run_acceptance_phase(&issue, &config).await,
+            AcceptancePhaseOutcome::RetainedForRecovery
+        ));
+        orchestrator.handle_tick().await;
+
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test", "test"]
+        );
+        assert!(
+            !orchestrator
+                .interaction_store
+                .get(interaction_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .awaiting_resume
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptance_late_append_error_uses_the_exact_durable_transition() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-late-append", "In Progress");
+        let config = acceptance_config(&["test"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new([AcceptanceStatus::Passed].into()),
+            calls: Arc::clone(&calls),
+        });
+        let (mut orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        orchestrator.pipeline_journal.transaction_append_late_error = true;
+        install_succeeded_run(&state, &issue, &config).await;
+
+        let outcome = orchestrator.run_acceptance_phase(&issue, &config).await;
+
+        assert!(matches!(outcome, AcceptancePhaseOutcome::Passed));
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test"]
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptance_ambiguous_append_reconciles_exact_visibility_on_a_later_tick() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-ambiguous-exact", "In Progress");
+        let config = acceptance_config(&["test"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new([AcceptanceStatus::Passed].into()),
+            calls: Arc::clone(&calls),
+        });
+        let (mut orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+        install_acceptance_started(&orchestrator, &state, &issue).await;
+        orchestrator.pipeline_journal.transaction_append_late_error = true;
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = true;
+
+        assert!(matches!(
+            orchestrator.run_acceptance_phase(&issue, &config).await,
+            AcceptancePhaseOutcome::RetainedForRecovery
+        ));
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test"]
+        );
+        assert!(state
+            .read()
+            .await
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .acceptance_attempts[0]
+            .results
+            .is_empty());
+
+        orchestrator.handle_tick().await;
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test"],
+            "an unreadable acceptance transition must remain fail-closed"
+        );
+        assert!(state.read().await.is_running(&issue.id));
+
+        orchestrator.pipeline_journal.transaction_append_late_error = false;
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = false;
+        orchestrator.handle_tick().await;
+
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test"],
+            "an exactly visible acceptance result must not execute again"
+        );
+        assert!(
+            !state.read().await.is_running(&issue.id),
+            "the retained owner must advance after journal visibility recovers"
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptance_ambiguous_append_redispatches_after_confirmed_absence() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-ambiguous-absent", "In Progress");
+        let config = acceptance_config(&["test"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new(
+                [AcceptanceStatus::Passed, AcceptanceStatus::Passed].into(),
+            ),
+            calls: Arc::clone(&calls),
+        });
+        let (mut orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+        install_acceptance_started(&orchestrator, &state, &issue).await;
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 1));
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = true;
+
+        assert!(matches!(
+            orchestrator.run_acceptance_phase(&issue, &config).await,
+            AcceptancePhaseOutcome::RetainedForRecovery
+        ));
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test"]
+        );
+        assert!(state.read().await.is_running(&issue.id));
+
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = false;
+        orchestrator.handle_tick().await;
+
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test", "test"],
+            "only the command whose result was confirmed absent may execute again"
+        );
+        assert!(
+            !state.read().await.is_running(&issue.id),
+            "confirmed absence must release the retained owner for redispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptance_ambiguous_reconciliation_retries_waiting_owner_retirement() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-ambiguous-waiting", "In Progress");
+        let config = acceptance_config(&["test"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new([AcceptanceStatus::Passed].into()),
+            calls: Arc::clone(&calls),
+        });
+        let (mut orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+        install_acceptance_started(&orchestrator, &state, &issue).await;
+        let interaction_id = "acceptance-ambiguous-waiting-interaction";
+        install_acceptance_waiting_owner(&orchestrator, &state, &issue, interaction_id).await;
+        orchestrator.pipeline_journal.transaction_append_late_error = true;
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = true;
+
+        assert!(matches!(
+            orchestrator.run_acceptance_phase(&issue, &config).await,
+            AcceptancePhaseOutcome::RetainedForRecovery
+        ));
+        orchestrator.pipeline_journal.transaction_append_late_error = false;
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = false;
+        orchestrator.interaction_store.fail_next_writes(1);
+
+        orchestrator
+            .reconcile_pending_acceptance_transitions()
+            .await;
+        assert!(state.read().await.is_waiting_on_human(&issue.id));
+        assert!(
+            orchestrator
+                .interaction_store
+                .get(interaction_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .awaiting_resume
+        );
+
+        orchestrator
+            .reconcile_pending_acceptance_transitions()
+            .await;
+
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test"]
+        );
+        let state = state.read().await;
+        assert!(!state.is_waiting_on_human(&issue.id));
+        assert_eq!(
+            state
+                .get_pipeline_run(&issue.id)
+                .unwrap()
+                .acceptance_attempts[0]
+                .results
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptance_does_not_commit_a_result_for_a_replaced_running_attempt() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-stale", "In Progress");
+        let config = acceptance_config(&["test"]);
+        let started = Arc::new(tokio::sync::Barrier::new(2));
+        let release = Arc::new(tokio::sync::Barrier::new(2));
+        let runner = Arc::new(BlockingAcceptanceRunner {
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        });
+        let (orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+        let orchestrator = Arc::new(orchestrator);
+        let execution = {
+            let orchestrator = Arc::clone(&orchestrator);
+            let issue = issue.clone();
+            let config = config.clone();
+            tokio::spawn(async move { orchestrator.run_acceptance_phase(&issue, &config).await })
+        };
+        started.wait().await;
+        {
+            let mut state = state.write().await;
+            state.running.get_mut(&issue.id).unwrap().started_at += chrono::Duration::seconds(1);
+        }
+        release.wait().await;
+
+        assert!(matches!(
+            execution.await.unwrap(),
+            AcceptancePhaseOutcome::RetainedForRecovery
+        ));
+        let state = state.read().await;
+        assert!(state
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .acceptance_attempts[0]
+            .results
+            .is_empty());
+        drop(state);
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].kind, PipelineTransitionKind::AcceptanceStarted);
+    }
+
+    #[test]
+    fn acceptance_recovery_rejects_a_name_mismatch() {
+        let config = acceptance_config(&["configured"]);
+        let dag = build_dag(&config.steps).unwrap();
+        let mut run = PipelineRun::new("issue".into(), 1, dag);
+        run.acceptance_attempts = vec![crate::acceptance::AcceptanceAttempt {
+            cycle: 1,
+            results: vec![crate::acceptance::AcceptanceResult {
+                name: "old-name".into(),
+                status: AcceptanceStatus::Passed,
+                exit_code: Some(0),
+                stdout: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+                stderr: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+                summary: "passed".into(),
+            }],
+        }];
+
+        let error =
+            validate_restored_snapshot_against_config(&run.to_snapshot(), &config).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("no longer matches configured command"));
+    }
+
+    #[test]
+    fn acceptance_recovery_allows_historical_attempts_from_an_older_config() {
+        let config = acceptance_config(&["configured"]);
+        let dag = build_dag(&config.steps).unwrap();
+        let mut run = PipelineRun::new("issue".into(), 2, dag);
+        run.acceptance_attempts = vec![crate::acceptance::AcceptanceAttempt {
+            cycle: 1,
+            results: vec![crate::acceptance::AcceptanceResult {
+                name: "old-name".into(),
+                status: AcceptanceStatus::Passed,
+                exit_code: Some(0),
+                stdout: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+                stderr: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+                summary: "passed".into(),
+            }],
+        }];
+
+        validate_restored_snapshot_against_config(&run.to_snapshot(), &config).unwrap();
+    }
+
+    #[tokio::test]
+    async fn acceptance_retry_preserves_completed_attempts_in_the_next_cycle() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-retry", "In Progress");
+        let config = acceptance_config(&["test"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new([AcceptanceStatus::Failed].into()),
+            calls,
+        });
+        let (orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+        assert!(matches!(
+            orchestrator.run_acceptance_phase(&issue, &config).await,
+            AcceptancePhaseOutcome::Failed { .. }
+        ));
+
+        let transition = {
+            let mut state = state.write().await;
+            Orchestrator::prepare_whole_issue_retry(
+                &mut state,
+                &config,
+                &issue.id,
+                &issue.identifier,
+                "acceptance failed",
+                RetryEntry {
+                    issue_id: issue.id.clone(),
+                    identifier: issue.identifier.clone(),
+                    attempt: 2,
+                    due_at_ms: 0,
+                    error: Some("acceptance failed".into()),
+                    retry_from_step: None,
+                    with_fixup: false,
+                },
+            )
+            .unwrap()
+        };
+
+        let snapshot = transition.snapshot.unwrap();
+        assert_eq!(snapshot.cycle, 2);
+        assert_eq!(snapshot.acceptance_attempts.len(), 1);
+        assert_eq!(snapshot.acceptance_attempts[0].cycle, 1);
+        assert_eq!(
+            snapshot.acceptance_attempts[0].results[0].status,
+            AcceptanceStatus::Failed
+        );
     }
 
     #[tokio::test]
@@ -8842,6 +10191,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr,
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
                 cancellation_registry: new_cancellation_registry(),
@@ -8908,6 +10258,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
@@ -8998,6 +10349,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
@@ -9083,6 +10435,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
@@ -9750,6 +11103,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&workspace_root, None).unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
                 cancellation_registry: new_cancellation_registry(),
@@ -9877,6 +11231,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&workspace_root, None).unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
                 cancellation_registry: new_cancellation_registry(),
@@ -10012,6 +11367,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&workspace_root, None).unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
                 cancellation_registry: new_cancellation_registry(),
@@ -10151,6 +11507,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
@@ -10252,6 +11609,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
@@ -10353,6 +11711,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
@@ -10452,6 +11811,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
@@ -10549,6 +11909,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
@@ -10672,6 +12033,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
@@ -12491,6 +13853,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr,
                 refresh_requested: Arc::clone(&refresh_requested),
                 cancellation_registry: new_cancellation_registry(),
@@ -12565,6 +13928,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr,
                 refresh_requested,
                 cancellation_registry: new_cancellation_registry(),
@@ -13201,6 +14565,108 @@ agent:
             run.step_states.get("review"),
             Some(crate::pipeline::engine::StepState::Running { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn exhausted_acceptance_failure_retires_the_resolved_approval_interaction() {
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("1", "Todo");
+        let mut config = make_single_step_always_approval_config(1);
+        config.acceptance.commands = vec![crate::config::ensemble::AcceptanceCommandConfig {
+            name: "test".to_string(),
+            run: "run-test".to_string(),
+            timeout_ms: 1_000,
+        }];
+        let config = Arc::new(RwLock::new(config));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(FailingWriteTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let acceptance_runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new([AcceptanceStatus::Failed].into()),
+            calls: Arc::clone(&calls),
+        });
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            config.read().await.polling.interval_ms,
+            &config.read().await.concurrency,
+        )));
+        let workspace_root = config_dir.path().join("workspaces");
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state,
+                config: Arc::clone(&config),
+                tracker,
+                agent_runner: Arc::new(MockRunner {
+                    delay_ms: 0,
+                    observed_commands: None,
+                    observed_timeouts: None,
+                    cancellation_probe: None,
+                }),
+                acceptance_runner,
+                workspace_mgr: WorkspaceManager::new(&workspace_root, None).unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root,
+            },
+            config_dir.path(),
+            shutdown_rx,
+        );
+        install_approval_waiting_run(&orchestrator, &config, "approval-1").await;
+        write_raw_interaction(
+            config_dir.path(),
+            "approval-1",
+            serde_json::json!({
+                "id": "approval-1",
+                "schema_version": 1,
+                "issue_id": "1",
+                "issue_identifier": "repo#1",
+                "pipeline_cycle": 1,
+                "completed_steps": [],
+                "step_name": "build",
+                "agent_name": "builder",
+                "step_depends": [],
+                "step_tracker_state": null,
+                "kind": "approval_gate",
+                "status": "resolved",
+                "blocking": true,
+                "awaiting_resume": true,
+                "resume_strategy": "advance_after_step",
+                "title": "Approve build",
+                "body": "Please review the build output.",
+                "options": [],
+                "artifacts": [],
+                "response": {
+                    "kind": "approval",
+                    "response_schema_version": 1,
+                    "approved": true,
+                    "reason": "looks good"
+                },
+                "requested_at": Utc::now(),
+                "resolved_at": Utc::now(),
+            }),
+        )
+        .await;
+
+        orchestrator.resume_blocked_issue(&issue).await.unwrap();
+
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["test"]
+        );
+        assert!(
+            !orchestrator
+                .interaction_store
+                .get("approval-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .awaiting_resume
+        );
     }
 
     #[tokio::test]
@@ -13900,6 +15366,7 @@ agent:
             last_error: None,
             verdict: Some(HISTORY_VERDICT_APPROVED.to_string()),
             workspace_path: config_dir.path().display().to_string(),
+            acceptance_attempts: vec![],
             artifacts: None,
         };
         let history_store = orchestrator.history_store.as_ref().unwrap();
@@ -13984,6 +15451,7 @@ agent:
             last_error: None,
             verdict: Some(HISTORY_VERDICT_APPROVED.to_string()),
             workspace_path: config_dir.path().display().to_string(),
+            acceptance_attempts: vec![],
             artifacts: None,
         };
         HistoryWriter::new(config_dir.path().join("ensemble_history.jsonl"))
@@ -17734,6 +19202,7 @@ agent:
                 config,
                 tracker,
                 agent_runner: runner,
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
                 workspace_mgr,
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
                 cancellation_registry: new_cancellation_registry(),

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -97,6 +97,8 @@ pub enum PipelineTransitionKind {
     StepBlockedOnHuman,
     StepAwaitingApproval,
     ApprovalResolved,
+    AcceptanceStarted,
+    AcceptanceCommandCompleted,
     StepRetryScheduled,
     FixupRetryScheduled,
     PipelineHalted,
@@ -1050,6 +1052,20 @@ mod tests {
 
         let record: PipelineTransitionRecord = serde_json::from_value(legacy).unwrap();
         assert!(record.terminal_transition.is_none());
+    }
+
+    #[test]
+    fn acceptance_transition_kinds_round_trip() {
+        for kind in [
+            PipelineTransitionKind::AcceptanceStarted,
+            PipelineTransitionKind::AcceptanceCommandCompleted,
+        ] {
+            let json = serde_json::to_string(&kind).unwrap();
+            assert_eq!(
+                serde_json::from_str::<PipelineTransitionKind>(&json).unwrap(),
+                kind
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
+use crate::acceptance::AcceptanceAttempt;
 use crate::config::ensemble::{OnFailure, StepKind};
 use crate::pipeline::dag::{DagStep, StepDag};
 use crate::pipeline::verdict::{StepOutput, StepResult};
@@ -119,6 +120,8 @@ pub struct PipelineRun {
     pub step_states: HashMap<String, StepState>,
     /// Stored outputs from completed steps.
     pub step_outputs: HashMap<String, StepOutput>,
+    /// Durable acceptance evidence retained across whole-issue cycles.
+    pub acceptance_attempts: Vec<AcceptanceAttempt>,
     /// The resolved, validated step DAG.
     dag: StepDag,
     /// Synthetic fixup steps generated for step-level retries.
@@ -131,6 +134,8 @@ pub struct PipelineRunSnapshot {
     pub cycle: u32,
     pub step_states: HashMap<String, StepState>,
     pub step_outputs: HashMap<String, StepOutput>,
+    #[serde(default)]
+    pub acceptance_attempts: Vec<AcceptanceAttempt>,
     pub dag_steps: Vec<DagStep>,
     pub synthetic_fixup_steps: HashSet<String>,
 }
@@ -149,6 +154,7 @@ impl PipelineRun {
             cycle,
             step_states,
             step_outputs: HashMap::new(),
+            acceptance_attempts: Vec::new(),
             dag,
             synthetic_fixup_steps: HashSet::new(),
         }
@@ -160,6 +166,7 @@ impl PipelineRun {
             cycle: self.cycle,
             step_states: self.step_states.clone(),
             step_outputs: self.step_outputs.clone(),
+            acceptance_attempts: self.acceptance_attempts.clone(),
             dag_steps: self.dag.steps.clone(),
             synthetic_fixup_steps: self.synthetic_fixup_steps.clone(),
         }
@@ -174,6 +181,7 @@ impl PipelineRun {
             cycle: snapshot.cycle,
             step_states: snapshot.step_states,
             step_outputs: snapshot.step_outputs,
+            acceptance_attempts: snapshot.acceptance_attempts,
             dag: StepDag {
                 steps: snapshot.dag_steps,
             },
@@ -2026,5 +2034,40 @@ mod tests {
         assert_eq!(run.dag.steps, original_steps);
         assert_eq!(run.step_states, original_states);
         assert!(!run.step_states.contains_key("fixup-unknown"));
+    }
+
+    #[test]
+    fn snapshot_round_trip_preserves_acceptance_attempts_and_legacy_defaults_empty() {
+        let mut run = make_run(&[make_step("build", "builder", &[])]);
+        run.acceptance_attempts = vec![crate::acceptance::AcceptanceAttempt {
+            cycle: 1,
+            results: vec![crate::acceptance::AcceptanceResult {
+                name: "test".to_string(),
+                status: crate::acceptance::AcceptanceStatus::Passed,
+                exit_code: Some(0),
+                stdout: crate::acceptance::AcceptanceOutput {
+                    tail: "ok".to_string(),
+                    total_bytes: 2,
+                    truncated: false,
+                },
+                stderr: crate::acceptance::AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+                summary: "passed".to_string(),
+            }],
+        }];
+
+        let restored = PipelineRun::from_snapshot(run.to_snapshot()).unwrap();
+        assert_eq!(restored.acceptance_attempts, run.acceptance_attempts);
+
+        let mut legacy = serde_json::to_value(run.to_snapshot()).unwrap();
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("acceptance_attempts");
+        let legacy: PipelineRunSnapshot = serde_json::from_value(legacy).unwrap();
+        assert!(legacy.acceptance_attempts.is_empty());
     }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -223,6 +223,10 @@ Parsed `config.yaml` payload:
   - `max_concurrent_agents` (global cap) and `max_step_parallelism` (per-issue cap).
 - `max_cycles` (integer, default 3)
   - Maximum pipeline cycle number an issue can enter. Scheduler deferrals do not consume cycles.
+- `acceptance` (AcceptanceConfig, optional)
+  - `commands` is an ordered list of `{ name, run, timeout_ms }` command definitions. Names must be
+    unique and non-blank, `run` must be non-blank, and the required timeout must be positive.
+  - Missing `acceptance`, missing `commands`, and an empty list all mean no acceptance phase.
 
 #### 4.1.3 Agent Config
 
@@ -283,6 +287,14 @@ Per-issue pipeline execution state:
 - `issue_id` (string)
 - `cycle` (integer, 1-based) — which pipeline cycle this is (bounded by `max_cycles`)
 - `step_states` (map of step name to StepState)
+- `acceptance_attempts` (ordered list, default empty)
+  - Each attempt contains its 1-based pipeline `cycle` and declaration-order `results` prefix.
+  - Each result contains `name`, `status` (`passed`, `failed`, `timed_out`, or `unavailable`),
+    optional `exit_code`, bounded `stdout` and `stderr`, and a human-readable `summary`. The
+    configured command string is never part of durable evidence.
+  - Each stream contains a lossy-UTF-8 `tail`, `total_bytes`, and `truncated`; the retained tail is
+    independently limited to the final 32,768 raw bytes while the runner continues counting and
+    draining all bytes.
 
 Step states:
 
@@ -308,6 +320,15 @@ Pipeline run recovery:
 - Ensemble appends pipeline transition records to
   `<config_dir>/state/pipeline-runs/<encoded_issue_id>.jsonl`.
 - Each recoverable transition includes a full `PipelineRun` snapshot.
+- Acceptance appends `acceptance_started` before its first command and
+  `acceptance_command_completed` after every completed result. A failed append stops the phase
+  before the next command, finalization, or retry decision. On restore, the current cycle's durable
+  results must match the configured command-name prefix; Ensemble resumes at the first missing
+  command, so only a
+  command interrupted before its result became durable may run again.
+- If an append outcome is ambiguous, Ensemble retains the active owner and retries only journal
+  visibility on later poll ticks. Exact visibility advances without rerunning the command;
+  confirmed absence releases the owner so only the undurable command can be dispatched again.
 - On orchestrator startup, Ensemble restores the latest non-released snapshot for each issue before
   the first poll tick.
 - During normal tick dispatch, before starting a candidate as a fresh pipeline, Ensemble checks that

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,6 +203,12 @@ steps:
       - build
     tracker_state: In Review
 
+acceptance:
+  commands:
+    - name: test
+      run: cargo test --workspace
+      timeout_ms: 900000
+
 on_success: Done
 on_failure: Failed
 
@@ -234,6 +240,31 @@ agent:
 ```
 
 ## Reference
+
+### acceptance
+
+`acceptance` is optional. Its `commands` list defaults to empty, which preserves the direct
+pipeline-success-to-finalization behavior.
+
+```yaml
+acceptance:
+  commands:
+    - name: unit-tests
+      run: cargo test --workspace
+      timeout_ms: 900000
+```
+
+Each command requires a unique, non-blank `name`, a non-blank `run` string, and a positive
+`timeout_ms`. Ensemble preserves `run` exactly and executes it as `/bin/sh -lc <run>`; there is no
+interpolation, command-specific environment, working-directory override, output-limit setting,
+parallelism, or acceptance-specific retry option. Commands inherit the orchestrator environment,
+run sequentially in declaration order in the issue workspace, and all commands run even after an
+earlier command does not pass.
+
+Acceptance starts only after every pipeline step and approval gate has passed, and before repository
+finalization. A non-passing command uses the existing whole-issue `max_cycles` retry path and, on
+exhaustion, writes `on_failure`; per-step `on_failure` settings do not apply. See
+[Pipeline Guide](pipelines.md#acceptance-commands) for evidence, recovery, and retry semantics.
 
 ### tracker
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -153,6 +153,53 @@ Verdict files and default-success fallback are not part of the runtime result co
 
 **Failed** means the step failed. The `summary` field explains why. Ensemble applies the step's `on_failure` behavior.
 
+## Acceptance commands
+
+Acceptance commands provide deterministic checks after all steps and approval gates pass but before
+repository finalization or the `on_success` tracker transition:
+
+```yaml
+acceptance:
+  commands:
+    - name: tests
+      run: cargo test --workspace
+      timeout_ms: 900000
+    - name: formatting
+      run: cargo fmt --all -- --check
+      timeout_ms: 120000
+```
+
+Ensemble runs these sequentially in declaration order as `/bin/sh -lc` in the issue workspace,
+inheriting the orchestrator environment unchanged. It runs the complete list even if an earlier
+command fails, times out, or cannot launch. Commands are not DAG steps, do not run through an agent,
+and cannot be parallelized or given acceptance-specific retries. Missing or empty commands skip the
+phase entirely.
+
+Each durable result contains the configured `name` but never the command string. `status` is
+`passed`, `failed`, `timed_out`, or `unavailable`; `exit_code` is optional because signals, timeouts,
+launch/cwd failures, or collection failures may not provide one. `stdout` and `stderr` independently
+store a lossy-UTF-8 rendering of only the final 32,768 raw bytes, the total observed byte count, and
+a `truncated` flag. The runner drains both streams concurrently and terminates and reaps the command
+process group on timeout.
+
+Phase start and every completed result are journaled before Ensemble advances. After restart, the
+current cycle's durable results must be a declaration-order prefix of configured command names;
+Ensemble resumes with the first missing command. Thus an interrupted command without a durable result
+may repeat, while a durable prefix does not. Legacy snapshots and history records default to no
+attempts. Ordered attempts are also preserved in JSONL history, SQLite history, and pending terminal
+reconciliation records.
+
+If an append outcome is ambiguous, Ensemble keeps the active owner and retries only the journal
+visibility check on later poll ticks. An exactly visible result advances without executing the
+command again; confirmed absence releases the owner so only that undurable command can be
+redispatched.
+
+Any non-passing result dominates a succeeded or concern step output and prevents finalization. It
+uses whole-issue retry regardless of per-step `on_failure`: a new cycle reruns the full pipeline and
+the full acceptance list while retaining prior attempts. Exhausting `max_cycles` records every
+attempt and moves the issue to `on_failure`. Artifact/handoff validation and Mission Control or
+generated-client presentation are separate contracts and are not performed by acceptance commands.
+
 ## Retries and cycles
 
 When a step fails or an agent errors out, Ensemble can retry. The `max_cycles` setting controls how many times:


### PR DESCRIPTION
## Summary

- add validated acceptance command configuration and a bounded shell runner
- journal per-cycle command evidence and preserve it through recovery, retry, terminal reconciliation, JSONL, and SQLite history
- gate finalization on durable acceptance results, with whole-issue retry semantics
- document the public contract and add focused plus product-level coverage

## Validation

- cargo test --workspace --exclude ensemble-desktop
- SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
- SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check

## Residual risk

- Unix process-group timeout behavior is covered with a descendant-termination test; CI provides the remaining cross-host validation.

Fixes #417