### PR TITLE
Add per-state live worker concurrency caps

### DIFF
--- a/crates/ensemble-core/src/agent/cancellation.rs
+++ b/crates/ensemble-core/src/agent/cancellation.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -8,10 +8,12 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 use crate::agent::events::WorkerIdentity;
+use crate::config::ensemble::normalize_state_worker_cap_key;
 
 struct ActiveWorker {
     cancellation: CancellationToken,
     completion: watch::Receiver<bool>,
+    state_bucket: String,
     reconciliation_owned: bool,
     launched: bool,
 }
@@ -29,6 +31,24 @@ pub(crate) enum WorkerReservationError {
     DuplicateIdentity,
     GlobalCapacityExhausted,
     IssueCapacityExhausted,
+    StateCapacityExhausted,
+}
+
+pub(crate) struct StateWorkerCapacity<'a> {
+    issue_state: &'a str,
+    max_workers_by_state: &'a BTreeMap<String, u32>,
+}
+
+impl<'a> StateWorkerCapacity<'a> {
+    pub(crate) fn new(
+        issue_state: &'a str,
+        max_workers_by_state: &'a BTreeMap<String, u32>,
+    ) -> Self {
+        Self {
+            issue_state,
+            max_workers_by_state,
+        }
+    }
 }
 
 pub fn new_cancellation_registry() -> CancellationRegistry {
@@ -47,6 +67,7 @@ pub fn register_worker(
         ActiveWorker {
             cancellation,
             completion,
+            state_bucket: String::new(),
             reconciliation_owned: false,
             launched: true,
         },
@@ -60,6 +81,7 @@ pub(crate) fn try_reserve_worker(
     completion: watch::Receiver<bool>,
     max_global_workers: u32,
     max_issue_workers: u32,
+    state_capacity: StateWorkerCapacity<'_>,
 ) -> Result<(), WorkerReservationError> {
     let mut workers = registry_guard(registry);
     if workers.contains_key(&identity) {
@@ -76,16 +98,51 @@ pub(crate) fn try_reserve_worker(
     {
         return Err(WorkerReservationError::IssueCapacityExhausted);
     }
+    let state_bucket = normalize_state_worker_cap_key(state_capacity.issue_state);
+    if !state_worker_capacity_available(
+        &workers,
+        &state_bucket,
+        state_capacity.max_workers_by_state,
+    ) {
+        return Err(WorkerReservationError::StateCapacityExhausted);
+    }
     workers.insert(
         identity,
         ActiveWorker {
             cancellation,
             completion,
+            state_bucket,
             reconciliation_owned: false,
             launched: false,
         },
     );
     Ok(())
+}
+
+pub(crate) fn has_available_state_worker_capacity(
+    registry: &CancellationRegistry,
+    issue_state: &str,
+    max_state_workers: &BTreeMap<String, u32>,
+) -> bool {
+    if max_state_workers.is_empty() {
+        return true;
+    }
+    let state_bucket = normalize_state_worker_cap_key(issue_state);
+    state_worker_capacity_available(&registry_guard(registry), &state_bucket, max_state_workers)
+}
+
+fn state_worker_capacity_available(
+    workers: &HashMap<WorkerIdentity, ActiveWorker>,
+    state_bucket: &str,
+    max_state_workers: &BTreeMap<String, u32>,
+) -> bool {
+    max_state_workers.get(state_bucket).is_none_or(|limit| {
+        workers
+            .values()
+            .filter(|worker| worker.state_bucket == state_bucket)
+            .count()
+            < *limit as usize
+    })
 }
 
 pub(crate) fn mark_worker_launched(
@@ -465,6 +522,7 @@ mod tests {
                 first_completion,
                 2,
                 1,
+                StateWorkerCapacity::new("", &BTreeMap::new()),
             ),
             Ok(())
         );
@@ -476,6 +534,7 @@ mod tests {
                 second_completion,
                 2,
                 1,
+                StateWorkerCapacity::new("", &BTreeMap::new()),
             ),
             Err(WorkerReservationError::IssueCapacityExhausted)
         );
@@ -487,6 +546,7 @@ mod tests {
                 other_completion,
                 2,
                 1,
+                StateWorkerCapacity::new("", &BTreeMap::new()),
             ),
             Ok(())
         );
@@ -505,6 +565,7 @@ mod tests {
                 global_completion,
                 2,
                 1,
+                StateWorkerCapacity::new("", &BTreeMap::new()),
             ),
             Err(WorkerReservationError::GlobalCapacityExhausted)
         );
@@ -518,6 +579,7 @@ mod tests {
                 duplicate_completion,
                 3,
                 2,
+                StateWorkerCapacity::new("", &BTreeMap::new()),
             ),
             Err(WorkerReservationError::DuplicateIdentity)
         );
@@ -541,6 +603,7 @@ mod tests {
                         completion,
                         1,
                         1,
+                        StateWorkerCapacity::new("", &BTreeMap::new()),
                     )
                 })
             })
@@ -572,6 +635,7 @@ mod tests {
             running_complete_rx,
             2,
             2,
+            StateWorkerCapacity::new("", &BTreeMap::new()),
         )
         .unwrap();
         try_reserve_worker(
@@ -581,6 +645,7 @@ mod tests {
             peer_complete_rx,
             2,
             2,
+            StateWorkerCapacity::new("", &BTreeMap::new()),
         )
         .unwrap();
         assert!(mark_worker_launched(&registry, &running));
@@ -609,6 +674,7 @@ mod tests {
             completion_rx,
             1,
             1,
+            StateWorkerCapacity::new("", &BTreeMap::new()),
         )
         .unwrap();
 
@@ -621,5 +687,192 @@ mod tests {
         assert!(await_worker_drain(&mut drain, Duration::from_millis(10)).await);
         assert!(!contains_worker(&registry, &rejected));
         assert_eq!(live_worker_count(&registry), 0);
+    }
+
+    #[test]
+    fn state_worker_capacity_enforces_normalized_independent_atomic_buckets() {
+        let registry = new_cancellation_registry();
+        let caps = BTreeMap::from([("todo".to_string(), 1), ("review".to_string(), 1)]);
+        let reserve = |identity: WorkerIdentity, state: &str, global, per_issue| {
+            let (_, completion) = watch::channel(false);
+            try_reserve_worker(
+                &registry,
+                identity,
+                CancellationToken::new(),
+                completion,
+                global,
+                per_issue,
+                StateWorkerCapacity::new(state, &caps),
+            )
+        };
+
+        assert_eq!(reserve(identity("build", 1), " Todo ", 3, 2), Ok(()));
+        assert_eq!(
+            reserve(
+                WorkerIdentity {
+                    issue_id: "issue-2".to_string(),
+                    ..identity("build", 2)
+                },
+                "TODO",
+                3,
+                2
+            ),
+            Err(WorkerReservationError::StateCapacityExhausted)
+        );
+        assert_eq!(
+            reserve(
+                WorkerIdentity {
+                    issue_id: "issue-2".to_string(),
+                    ..identity("review", 2)
+                },
+                "Review",
+                3,
+                2
+            ),
+            Ok(())
+        );
+        assert_eq!(live_worker_count(&registry), 2);
+
+        assert_eq!(
+            reserve(identity("review", 1), "other", 3, 1),
+            Err(WorkerReservationError::IssueCapacityExhausted)
+        );
+        assert_eq!(
+            reserve(
+                WorkerIdentity {
+                    issue_id: "issue-3".to_string(),
+                    ..identity("build", 3)
+                },
+                "other",
+                2,
+                2
+            ),
+            Err(WorkerReservationError::GlobalCapacityExhausted)
+        );
+        assert_eq!(live_worker_count(&registry), 2);
+
+        let racing_registry = new_cancellation_registry();
+        let racing_caps = Arc::new(BTreeMap::from([("todo".to_string(), 1)]));
+        let start = Arc::new(std::sync::Barrier::new(9));
+        let contenders = (0..8)
+            .map(|index| {
+                let registry = racing_registry.clone();
+                let caps = Arc::clone(&racing_caps);
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    let (_, completion) = watch::channel(false);
+                    start.wait();
+                    try_reserve_worker(
+                        &registry,
+                        WorkerIdentity {
+                            issue_id: format!("issue-{index}"),
+                            ..identity("build", index + 10)
+                        },
+                        CancellationToken::new(),
+                        completion,
+                        8,
+                        1,
+                        StateWorkerCapacity::new(" todo ", &caps),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        start.wait();
+        let outcomes = contenders
+            .into_iter()
+            .map(|contender| contender.join().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(outcomes.iter().filter(|outcome| outcome.is_ok()).count(), 1);
+        assert!(outcomes
+            .iter()
+            .filter(|outcome| outcome.is_err())
+            .all(|outcome| { *outcome == Err(WorkerReservationError::StateCapacityExhausted) }));
+        assert_eq!(live_worker_count(&racing_registry), 1);
+    }
+
+    #[tokio::test]
+    async fn state_worker_capacity_releases_only_the_captured_worker_bucket() {
+        let registry = new_cancellation_registry();
+        let caps = BTreeMap::from([("todo".to_string(), 1), ("review".to_string(), 1)]);
+        let first = identity("build", 1);
+        let second = identity("review", 1);
+        let (first_complete_tx, first_complete_rx) = watch::channel(false);
+        let (_, second_complete_rx) = watch::channel(false);
+
+        try_reserve_worker(
+            &registry,
+            first.clone(),
+            CancellationToken::new(),
+            first_complete_rx,
+            3,
+            2,
+            StateWorkerCapacity::new("Todo", &caps),
+        )
+        .unwrap();
+        assert!(mark_worker_launched(&registry, &first));
+        try_reserve_worker(
+            &registry,
+            second.clone(),
+            CancellationToken::new(),
+            second_complete_rx,
+            3,
+            2,
+            StateWorkerCapacity::new("Review", &caps),
+        )
+        .unwrap();
+
+        assert!(rollback_worker_reservation(&registry, &second));
+        let (_, replacement_complete_rx) = watch::channel(false);
+        assert_eq!(
+            try_reserve_worker(
+                &registry,
+                WorkerIdentity {
+                    issue_id: "issue-2".to_string(),
+                    ..identity("review", 2)
+                },
+                CancellationToken::new(),
+                replacement_complete_rx,
+                3,
+                2,
+                StateWorkerCapacity::new(" review ", &caps),
+            ),
+            Ok(())
+        );
+
+        let (_, todo_complete_rx) = watch::channel(false);
+        assert_eq!(
+            try_reserve_worker(
+                &registry,
+                WorkerIdentity {
+                    issue_id: "issue-3".to_string(),
+                    ..identity("build", 3)
+                },
+                CancellationToken::new(),
+                todo_complete_rx,
+                3,
+                2,
+                StateWorkerCapacity::new("todo", &caps),
+            ),
+            Err(WorkerReservationError::StateCapacityExhausted)
+        );
+
+        first_complete_tx.send(true).unwrap();
+        assert!(remove_completed_worker(&registry, &first));
+        let (_, later_complete_rx) = watch::channel(false);
+        assert_eq!(
+            try_reserve_worker(
+                &registry,
+                WorkerIdentity {
+                    issue_id: "issue-1".to_string(),
+                    ..identity("build", 4)
+                },
+                CancellationToken::new(),
+                later_complete_rx,
+                3,
+                2,
+                StateWorkerCapacity::new("Todo", &caps),
+            ),
+            Ok(())
+        );
     }
 }

--- a/crates/ensemble-core/src/api/config_edit_handler.rs
+++ b/crates/ensemble-core/src/api/config_edit_handler.rs
@@ -1891,6 +1891,7 @@ on_failure: Failed
                     timeout_ms: 60000,
                 },
                 agent: crate::config::form::GuidedAgentRuntimeForm {
+                    max_concurrent_agents_by_state: std::collections::BTreeMap::new(),
                     max_retry_backoff_ms: 300000,
                     command: "claude-code".to_string(),
                     session_mode: "code".to_string(),
@@ -2041,6 +2042,7 @@ on_failure: Failed
                     timeout_ms: 60000,
                 },
                 agent: crate::config::form::GuidedAgentRuntimeForm {
+                    max_concurrent_agents_by_state: std::collections::BTreeMap::new(),
                     max_retry_backoff_ms: 300000,
                     command: "claude-code".to_string(),
                     session_mode: "code".to_string(),
@@ -2207,6 +2209,7 @@ on_failure: Failed
                     timeout_ms: 60000,
                 },
                 agent: crate::config::form::GuidedAgentRuntimeForm {
+                    max_concurrent_agents_by_state: std::collections::BTreeMap::new(),
                     max_retry_backoff_ms: 300000,
                     command: "claude-code".to_string(),
                     session_mode: "code".to_string(),

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -2,8 +2,8 @@ use crate::agent::runtime::RuntimeKind;
 use crate::config::location::default_todo_state_path;
 use crate::error::PipelineError;
 use crate::workspace::finalize::RepoFinalizeConfig;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 /// Top-level configuration parsed from `ensemble.yaml`.
@@ -519,6 +519,9 @@ impl Default for HooksConfig {
 /// Runtime configuration for the agent executor.
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct AgentRuntimeConfig {
+    #[serde(default, deserialize_with = "deserialize_state_worker_caps")]
+    #[schema(schema_with = state_worker_caps_schema)]
+    pub max_concurrent_agents_by_state: BTreeMap<String, u32>,
     #[serde(default = "default_max_retry_backoff_ms")]
     pub max_retry_backoff_ms: u64,
     #[serde(default = "default_agent_command")]
@@ -539,6 +542,77 @@ pub struct AgentRuntimeConfig {
     pub interaction_policy_text: Option<String>,
     #[serde(default)]
     pub interaction_policy_overrides: InteractionPolicyOverridesConfig,
+}
+
+fn deserialize_state_worker_caps<'de, D>(deserializer: D) -> Result<BTreeMap<String, u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let entries = serde_yaml::Mapping::deserialize(deserializer)?;
+    let mut parsed = Vec::with_capacity(entries.len());
+    for (raw_key, raw_limit) in entries {
+        let Some(state) = raw_key.as_str() else {
+            return Err(serde::de::Error::custom(format!(
+                "agent.max_concurrent_agents_by_state entry {raw_key:?} must use a state name"
+            )));
+        };
+        let Some(limit) = raw_limit
+            .as_u64()
+            .and_then(|limit| u32::try_from(limit).ok())
+        else {
+            return Err(serde::de::Error::custom(format!(
+                "agent.max_concurrent_agents_by_state entry {state:?} must be a positive integer"
+            )));
+        };
+        parsed.push((state.to_string(), limit));
+    }
+    normalize_state_worker_caps(parsed).map_err(serde::de::Error::custom)
+}
+
+pub(crate) fn normalize_state_worker_caps(
+    entries: impl IntoIterator<Item = (String, u32)>,
+) -> Result<BTreeMap<String, u32>, String> {
+    let mut normalized = BTreeMap::new();
+    let mut original_keys = BTreeMap::new();
+    for (state, limit) in entries {
+        let normalized_state = normalize_state_worker_cap_key(&state);
+        if normalized_state.is_empty() {
+            return Err(
+                "agent.max_concurrent_agents_by_state contains a blank state key".to_string(),
+            );
+        }
+        if limit == 0 {
+            return Err(format!(
+                "agent.max_concurrent_agents_by_state entry {state:?} must be a positive integer"
+            ));
+        }
+        if let Some(previous) = original_keys.insert(normalized_state.clone(), state.clone()) {
+            return Err(format!(
+                "agent.max_concurrent_agents_by_state entry {state:?} collides with {previous:?} after normalization"
+            ));
+        }
+        normalized.insert(normalized_state, limit);
+    }
+    Ok(normalized)
+}
+
+pub(crate) fn normalize_state_worker_cap_key(state: &str) -> String {
+    state.trim().to_lowercase()
+}
+
+pub(crate) fn state_worker_caps_schema() -> utoipa::openapi::schema::Object {
+    use utoipa::openapi::schema::{ObjectBuilder, Type};
+
+    ObjectBuilder::new()
+        .schema_type(Type::Object)
+        .property_names(Some(ObjectBuilder::new().schema_type(Type::String)))
+        .additional_properties(Some(
+            ObjectBuilder::new()
+                .schema_type(Type::Integer)
+                .minimum(Some(1))
+                .maximum(Some(u32::MAX)),
+        ))
+        .build()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
@@ -651,6 +725,7 @@ fn default_inject_interaction_policy_instructions() -> bool {
 impl Default for AgentRuntimeConfig {
     fn default() -> Self {
         Self {
+            max_concurrent_agents_by_state: BTreeMap::new(),
             max_retry_backoff_ms: default_max_retry_backoff_ms(),
             command: default_agent_command(),
             session_mode: default_session_mode(),
@@ -1783,6 +1858,7 @@ on_failure: Failed
         assert!(config.agent.interaction_policy_text.is_none());
         assert!(config.agent.interaction_policy_overrides.agents.is_empty());
         assert!(config.agent.interaction_policy_overrides.steps.is_empty());
+        assert!(config.agent.max_concurrent_agents_by_state.is_empty());
 
         // TrackerConfig defaults
         assert_eq!(config.tracker.active_states, vec!["Todo", "In Progress"]);
@@ -1795,6 +1871,50 @@ on_failure: Failed
             config.human_interaction.default_resume_mode,
             HumanResumeMode::Manual
         );
+    }
+
+    #[test]
+    fn max_concurrent_agents_by_state_normalizes_configured_states() {
+        let yaml = format!(
+            "{}\nagent:\n  max_concurrent_agents_by_state:\n    ' Todo ': 2\n    IN PROGRESS: 3\n",
+            minimal_yaml()
+        );
+
+        let config = parse_config(&yaml).unwrap();
+
+        assert_eq!(config.agent.max_concurrent_agents_by_state["todo"], 2);
+        assert_eq!(
+            config.agent.max_concurrent_agents_by_state["in progress"],
+            3
+        );
+    }
+
+    #[test]
+    fn max_concurrent_agents_by_state_rejects_invalid_entries_precisely() {
+        for (entries, offending) in [
+            ("    '   ': 1\n", "blank"),
+            ("    Todo: 0\n", "Todo"),
+            ("    Todo: -1\n", "Todo"),
+            ("    Todo: many\n", "Todo"),
+            ("    Todo: 1\n    ' todo ': 2\n", "todo"),
+        ] {
+            let yaml = format!(
+                "{}\nagent:\n  max_concurrent_agents_by_state:\n{entries}",
+                minimal_yaml()
+            );
+
+            let error = parse_config(&yaml).expect_err("invalid state cap must be rejected");
+            let message = error.to_string();
+
+            assert!(
+                message.contains("agent.max_concurrent_agents_by_state"),
+                "missing field path in {message:?}"
+            );
+            assert!(
+                message.to_lowercase().contains(&offending.to_lowercase()),
+                "missing offending entry {offending:?} in {message:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/form.rs
+++ b/crates/ensemble-core/src/config/form.rs
@@ -6,11 +6,13 @@
 //! round-trip to support custom user extensions.
 
 use crate::config::ensemble::{
-    ModeDefinition, ModelDefinition, PermissionRequestPolicy, PermissionRequestPolicyMode, StepKind,
+    state_worker_caps_schema, ModeDefinition, ModelDefinition, PermissionRequestPolicy,
+    PermissionRequestPolicyMode, StepKind,
 };
 use crate::config::secrets::{SecretDisplay, SecretEdit};
 use crate::error::ConfigError;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Helper to convert Option<T> to serde_yaml::Value
 fn opt_to_value<T: Into<serde_yaml::Value>>(opt: Option<T>) -> Option<serde_yaml::Value> {
@@ -122,6 +124,9 @@ pub struct GuidedHooksForm {
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct GuidedAgentRuntimeForm {
+    #[serde(default)]
+    #[schema(schema_with = state_worker_caps_schema)]
+    pub max_concurrent_agents_by_state: BTreeMap<String, u32>,
     pub max_retry_backoff_ms: u64,
     pub command: String,
     pub session_mode: String,
@@ -262,6 +267,7 @@ fn config_to_guided_form(config: &crate::config::ensemble::EnsembleConfig) -> Gu
                 timeout_ms: config.hooks.timeout_ms,
             },
             agent: GuidedAgentRuntimeForm {
+                max_concurrent_agents_by_state: config.agent.max_concurrent_agents_by_state.clone(),
                 max_retry_backoff_ms: config.agent.max_retry_backoff_ms,
                 command: config.agent.command.clone(),
                 session_mode: config.agent.session_mode.clone(),
@@ -576,6 +582,22 @@ pub fn apply_guided_form(
         .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
     if let serde_yaml::Value::Mapping(ref mut am) = *agent_val {
         am.remove("max_turns");
+        let state_caps = crate::config::ensemble::normalize_state_worker_caps(
+            form.runtime.agent.max_concurrent_agents_by_state.clone(),
+        )
+        .map_err(|reason| ConfigError::ConfigParseError { reason })?;
+        if state_caps.is_empty() {
+            am.remove("max_concurrent_agents_by_state");
+        } else {
+            am.insert(
+                "max_concurrent_agents_by_state".into(),
+                serde_yaml::to_value(state_caps).map_err(|error| {
+                    ConfigError::ConfigParseError {
+                        reason: error.to_string(),
+                    }
+                })?,
+            );
+        }
         am.insert(
             "max_retry_backoff_ms".into(),
             form.runtime.agent.max_retry_backoff_ms.into(),
@@ -781,6 +803,73 @@ on_failure: Failed
     }
 
     #[test]
+    fn guided_form_round_trips_agent_state_caps() {
+        let raw = r#"
+tracker:
+  kind: todo_file
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: Build it.
+steps:
+  - name: build
+    agent: builder
+  - name: lint
+    agent: builder
+    depends: []
+  - name: test
+    agent: builder
+    depends: [build]
+on_success: Done
+on_failure: Failed
+agent:
+  max_concurrent_agents_by_state:
+    ' Todo ': 1
+    IN PROGRESS: 2
+"#;
+
+        let mut form = extract_guided_form(raw).unwrap();
+        assert_eq!(form.runtime.agent.max_concurrent_agents_by_state["todo"], 1);
+        assert_eq!(
+            form.runtime.agent.max_concurrent_agents_by_state["in progress"],
+            2
+        );
+
+        form.runtime
+            .agent
+            .max_concurrent_agents_by_state
+            .remove("in progress");
+        form.runtime
+            .agent
+            .max_concurrent_agents_by_state
+            .insert("review".to_string(), 3);
+        let merged = apply_guided_form(raw, &form).unwrap();
+        let config = crate::config::ensemble::parse_config(&merged).unwrap();
+        assert_eq!(config.agent.max_concurrent_agents_by_state["todo"], 1);
+        assert_eq!(config.agent.max_concurrent_agents_by_state["review"], 3);
+        assert!(!config
+            .agent
+            .max_concurrent_agents_by_state
+            .contains_key("in progress"));
+
+        let merged_value = serde_yaml::from_str::<serde_yaml::Value>(&merged).unwrap();
+        let steps = merged_value["steps"].as_sequence().unwrap();
+        assert!(steps[0].get("depends").is_none());
+        assert_eq!(steps[1]["depends"], serde_yaml::Value::Sequence(vec![]));
+        assert_eq!(
+            steps[2]["depends"],
+            serde_yaml::to_value(["build"]).unwrap()
+        );
+
+        form.runtime.agent.max_concurrent_agents_by_state.clear();
+        let without_caps = apply_guided_form(&merged, &form).unwrap();
+        let without_caps = serde_yaml::from_str::<serde_yaml::Value>(&without_caps).unwrap();
+        assert!(without_caps["agent"]
+            .get("max_concurrent_agents_by_state")
+            .is_none());
+    }
+
+    #[test]
     fn guided_form_omits_max_turns_and_preserves_supported_agent_runtime_fields() {
         let raw = r#"
 tracker:
@@ -968,6 +1057,7 @@ on_failure: Failed
                     timeout_ms: 60000,
                 },
                 agent: GuidedAgentRuntimeForm {
+                    max_concurrent_agents_by_state: BTreeMap::new(),
                     max_retry_backoff_ms: 300000,
                     command: "claude-code".to_string(),
                     session_mode: "code".to_string(),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -21,10 +21,11 @@ use tracing::{debug, error, info, warn};
 
 use crate::acceptance::{AcceptanceCommandRunner, AcceptanceStatus, ShellAcceptanceCommandRunner};
 use crate::agent::cancellation::{
-    await_worker_drain, await_worker_quiescence, is_reconciliation_owned, live_worker_count,
-    mark_all_for_drain, mark_issue_for_drain, mark_worker_launched, new_cancellation_registry,
-    pending_reconciliation_issue_ids, remove_completed_worker, remove_drained_workers,
-    rollback_worker_reservation, try_reserve_worker, CancellationRegistry, WorkerDrainHandle,
+    await_worker_drain, await_worker_quiescence, has_available_state_worker_capacity,
+    is_reconciliation_owned, live_worker_count, mark_all_for_drain, mark_issue_for_drain,
+    mark_worker_launched, new_cancellation_registry, pending_reconciliation_issue_ids,
+    remove_completed_worker, remove_drained_workers, rollback_worker_reservation,
+    try_reserve_worker, CancellationRegistry, StateWorkerCapacity, WorkerDrainHandle,
     WorkerReservationError,
 };
 use crate::agent::events::{
@@ -1015,13 +1016,7 @@ impl Orchestrator {
 
             let eligible = {
                 let state = self.state.read().await;
-                is_dispatch_eligible(
-                    issue,
-                    &state,
-                    &active_lower,
-                    &terminal_lower,
-                    &HashMap::new(),
-                )
+                is_dispatch_eligible(issue, &state, &active_lower, &terminal_lower)
             };
 
             let restored_pipeline_ready = {
@@ -1032,6 +1027,13 @@ impl Orchestrator {
             if restored_pipeline_ready {
                 self.dispatch_issue(issue, None).await;
                 continue;
+            }
+
+            {
+                let config = self.config.read().await;
+                if !self.state_worker_capacity_available(issue, &config).await {
+                    continue;
+                }
             }
 
             if eligible.is_some() {
@@ -1370,6 +1372,12 @@ impl Orchestrator {
                             }
                         };
                         for req in requests {
+                            if !self
+                                .state_worker_capacity_available(issue, &config_snapshot)
+                                .await
+                            {
+                                return;
+                            }
                             let workspace_path =
                                 match self.prepare_step_workspace(issue, &config_snapshot).await {
                                     Ok(path) => path,
@@ -1528,6 +1536,12 @@ impl Orchestrator {
         // Process initial dispatch requests
         if let PipelineAction::Dispatch(requests) = action {
             for req in requests {
+                if !self
+                    .state_worker_capacity_available(issue, &config_snapshot)
+                    .await
+                {
+                    return;
+                }
                 let workspace_path =
                     match self.prepare_step_workspace(issue, &config_snapshot).await {
                         Ok(path) => path,
@@ -1626,6 +1640,25 @@ impl Orchestrator {
         }
     }
 
+    async fn state_worker_capacity_available(
+        &self,
+        issue: &Issue,
+        config: &EnsembleConfig,
+    ) -> bool {
+        let issue_state = {
+            let state = self.state.read().await;
+            state
+                .get_running(&issue.id)
+                .map(|entry| entry.issue.state.clone())
+                .unwrap_or_else(|| issue.state.clone())
+        };
+        has_available_state_worker_capacity(
+            &self.cancellation_registry,
+            &issue_state,
+            &config.agent.max_concurrent_agents_by_state,
+        )
+    }
+
     async fn dispatch_ready_steps_for_issue(&self, issue_id: &str, permit: &DispatchPermit) {
         let Some((issue, config_snapshot, attempt, requests)) = ({
             let state = self.state.read().await;
@@ -1650,6 +1683,12 @@ impl Orchestrator {
         };
 
         for request in requests {
+            if !self
+                .state_worker_capacity_available(&issue, &config_snapshot)
+                .await
+            {
+                return;
+            }
             let workspace_path = match self.prepare_step_workspace(&issue, &config_snapshot).await {
                 Ok(path) => path,
                 Err(error) => {
@@ -2238,7 +2277,7 @@ impl Orchestrator {
         dispatch: StepDispatchContext<'_>,
         _permit: &DispatchPermit,
     ) -> Result<StepDispatchOutcome, EnsembleError> {
-        let worker_identity = {
+        let (worker_identity, issue_snapshot) = {
             let state = self.state.read().await;
             let running_entry =
                 state
@@ -2267,14 +2306,18 @@ impl Orchestrator {
                         dispatch.step_name
                     ),
                 })?;
-            WorkerIdentity {
-                issue_id: issue.id.clone(),
-                run_id,
-                cycle,
-                step_name: dispatch.step_name.to_string(),
-                started_at: running_entry.started_at,
-            }
+            (
+                WorkerIdentity {
+                    issue_id: issue.id.clone(),
+                    run_id,
+                    cycle,
+                    step_name: dispatch.step_name.to_string(),
+                    started_at: running_entry.started_at,
+                },
+                running_entry.issue.clone(),
+            )
         };
+        let issue = &issue_snapshot;
         let cancel_token = tokio_util::sync::CancellationToken::new();
         let (completion_tx, completion_rx) = watch::channel(false);
         match try_reserve_worker(
@@ -2284,11 +2327,16 @@ impl Orchestrator {
             completion_rx,
             config_snapshot.concurrency.max_concurrent_agents,
             config_snapshot.concurrency.max_step_parallelism,
+            StateWorkerCapacity::new(
+                &issue.state,
+                &config_snapshot.agent.max_concurrent_agents_by_state,
+            ),
         ) {
             Ok(()) => {}
             Err(
                 WorkerReservationError::GlobalCapacityExhausted
-                | WorkerReservationError::IssueCapacityExhausted,
+                | WorkerReservationError::IssueCapacityExhausted
+                | WorkerReservationError::StateCapacityExhausted,
             ) => {
                 debug!(
                     issue_id = %issue.id,
@@ -2333,6 +2381,12 @@ impl Orchestrator {
                 );
                 match self.tracker.set_issue_state(&issue.id, state_name).await {
                     Ok(()) => {
+                        let mut transitioned_issue = issue.clone();
+                        transitioned_issue.state = state_name.to_string();
+                        self.state
+                            .write()
+                            .await
+                            .update_issue_snapshot(&issue.id, transitioned_issue);
                         info!(
                             event = TRACKER_TRANSITION_SUCCEEDED,
                             issue_id = %issue.id,
@@ -3381,6 +3435,12 @@ impl Orchestrator {
                                     return;
                                 };
                                 for (req, step_outputs) in dispatch_contexts {
+                                    if !self
+                                        .state_worker_capacity_available(issue, &config_snapshot)
+                                        .await
+                                    {
+                                        return;
+                                    }
                                     let workspace_path = match self
                                         .prepare_step_workspace(issue, &config_snapshot)
                                         .await
@@ -7172,7 +7232,6 @@ impl Orchestrator {
                     reason: format!("issue '{}' is not waiting on human", issue.identifier),
                 })?
         };
-
         if waiting.step_name != interaction.step_name {
             return Err(AgentError::PromptError {
                 reason: format!(
@@ -7295,11 +7354,35 @@ impl Orchestrator {
             }
         }
 
-        if !current_config.agents.contains_key(&current_step.agent) {
+        let (pipeline_config, pipeline_step) = {
+            let state = self.state.read().await;
+            let config = state
+                .get_pipeline_config(&issue.id)
+                .cloned()
+                .ok_or_else(|| AgentError::PromptError {
+                    reason: format!(
+                        "issue '{}' is missing its pipeline config snapshot",
+                        issue.identifier
+                    ),
+                })?;
+            let step = state
+                .get_pipeline_run(&issue.id)
+                .and_then(|run| run.step(&waiting.step_name))
+                .cloned()
+                .ok_or_else(|| AgentError::PromptError {
+                    reason: format!(
+                        "issue '{}' is missing blocked step '{}'",
+                        issue.identifier, waiting.step_name
+                    ),
+                })?;
+            (config, step)
+        };
+
+        if !pipeline_config.agents.contains_key(&pipeline_step.agent) {
             return Err(AgentError::PromptError {
                 reason: format!(
                     "blocked step agent '{}' no longer exists",
-                    current_step.agent
+                    pipeline_step.agent
                 ),
             }
             .into());
@@ -7313,7 +7396,6 @@ impl Orchestrator {
                 &state,
                 &workflow_states,
                 &current_config.tracker.terminal_states,
-                &HashMap::new(),
             ) {
                 return Err(AgentError::PromptError {
                     reason: format!("issue '{}' cannot be resumed: {reason}", issue.identifier),
@@ -7356,6 +7438,13 @@ impl Orchestrator {
                     resolved_at,
                 );
 
+                if !self
+                    .state_worker_capacity_available(issue, &pipeline_config)
+                    .await
+                {
+                    return Err(EnsembleError::RuntimeBusy);
+                }
+
                 let (attempt, step_outputs, previous_running) = {
                     let mut state = self.state.write().await;
                     let previous_running = state.get_running(&issue.id).cloned();
@@ -7365,42 +7454,42 @@ impl Orchestrator {
                         .unwrap_or(interaction.pipeline_cycle.max(1));
                     let step_outputs = state
                         .get_pipeline_run(&issue.id)
-                        .and_then(|run| run.output_context_for(&current_step.name))
+                        .and_then(|run| run.output_context_for(&pipeline_step.name))
                         .unwrap_or_default();
                     state.add_running(issue, Some(attempt));
                     (attempt, step_outputs, previous_running)
                 };
 
-                let workspace_path = match self.prepare_step_workspace(issue, &current_config).await
-                {
-                    Ok(path) => path,
-                    Err(error) => {
-                        let mut state = self.state.write().await;
-                        Self::restore_previous_running(
-                            &mut state,
-                            &issue.id,
-                            previous_running.as_ref(),
-                        );
-                        return Err(AgentError::PromptError {
-                            reason: format!("workspace error: {error}"),
+                let workspace_path =
+                    match self.prepare_step_workspace(issue, &pipeline_config).await {
+                        Ok(path) => path,
+                        Err(error) => {
+                            let mut state = self.state.write().await;
+                            Self::restore_previous_running(
+                                &mut state,
+                                &issue.id,
+                                previous_running.as_ref(),
+                            );
+                            return Err(AgentError::PromptError {
+                                reason: format!("workspace error: {error}"),
+                            }
+                            .into());
                         }
-                        .into());
-                    }
-                };
+                    };
 
                 let dispatch_outcome = match self
                     .dispatch_step(
                         issue,
-                        Arc::clone(&current_config),
+                        Arc::clone(&pipeline_config),
                         StepDispatchContext {
-                            step_name: &current_step.name,
-                            agent_name: &current_step.agent,
-                            step_kind: current_step.kind,
-                            tracker_state: current_step.tracker_state.as_deref(),
+                            step_name: &pipeline_step.name,
+                            agent_name: &pipeline_step.agent,
+                            step_kind: pipeline_step.kind,
+                            tracker_state: pipeline_step.tracker_state.as_deref(),
                             attempt: Some(attempt),
                             timeout_ms: Self::effective_step_timeout_ms(
-                                current_step.timeout_ms,
-                                &current_config,
+                                pipeline_step.timeout_ms,
+                                &pipeline_config,
                             ),
                             interaction_response: Some(interaction_response),
                             interaction_resume_id: Some(&interaction.id),
@@ -7420,7 +7509,7 @@ impl Orchestrator {
                             matches!(
                                 state
                                     .get_pipeline_run(&issue.id)
-                                    .and_then(|run| run.step_states.get(&current_step.name)),
+                                    .and_then(|run| run.step_states.get(&pipeline_step.name)),
                                 Some(StepState::Running { .. })
                             )
                         };
@@ -7476,14 +7565,14 @@ impl Orchestrator {
                             approved, reason, ..
                         } => {
                             if approved {
-                                run.approve_gate(&current_step.name)
+                                run.approve_gate(&pipeline_step.name)
                             } else {
                                 run.reject_gate(
-                                    &current_step.name,
+                                    &pipeline_step.name,
                                     reason.unwrap_or_else(|| {
                                         format!(
                                             "approval rejected for step '{}'",
-                                            current_step.name
+                                            pipeline_step.name
                                         )
                                     }),
                                 )
@@ -7521,6 +7610,16 @@ impl Orchestrator {
 
                 match action {
                     PipelineAction::Dispatch(_requests) => {
+                        if !self
+                            .state_worker_capacity_available(issue, &pipeline_config)
+                            .await
+                        {
+                            let mut state = self.state.write().await;
+                            state
+                                .pipeline_runs
+                                .insert(issue.id.clone(), previous_run.clone());
+                            return Err(EnsembleError::RuntimeBusy);
+                        }
                         let attempt = {
                             let mut state = self.state.write().await;
                             let attempt = state
@@ -7532,7 +7631,7 @@ impl Orchestrator {
                         };
 
                         let workspace_path =
-                            match self.prepare_step_workspace(issue, &current_config).await {
+                            match self.prepare_step_workspace(issue, &pipeline_config).await {
                                 Ok(path) => path,
                                 Err(error) => {
                                     let mut state = self.state.write().await;
@@ -7556,7 +7655,7 @@ impl Orchestrator {
                             let dispatch_outcome = match self
                                 .dispatch_step(
                                     issue,
-                                    Arc::clone(&current_config),
+                                    Arc::clone(&pipeline_config),
                                     StepDispatchContext {
                                         step_name: &req.step_name,
                                         agent_name: &req.agent_name,
@@ -7565,7 +7664,7 @@ impl Orchestrator {
                                         attempt: Some(attempt),
                                         timeout_ms: Self::effective_step_timeout_ms(
                                             req.timeout_ms,
-                                            &current_config,
+                                            &pipeline_config,
                                         ),
                                         interaction_response: None,
                                         interaction_resume_id: Some(&interaction.id),
@@ -7578,7 +7677,7 @@ impl Orchestrator {
                                                 identifier: issue.identifier.clone(),
                                                 run_id: waiting.run_id.clone(),
                                                 cycle: previous_run.cycle,
-                                                step: Some(current_step.name.clone()),
+                                                step: Some(pipeline_step.name.clone()),
                                                 reason: Some(format!(
                                                     "interaction '{}' retirement failed",
                                                     interaction.id
@@ -7645,7 +7744,7 @@ impl Orchestrator {
                         }
                     }
                     PipelineAction::Succeeded => {
-                        match self.run_acceptance_phase(issue, &current_config).await {
+                        match self.run_acceptance_phase(issue, &pipeline_config).await {
                             AcceptancePhaseOutcome::Passed => {}
                             AcceptancePhaseOutcome::Failed { reason, owner } => {
                                 if !interaction_was_retired {
@@ -7653,7 +7752,7 @@ impl Orchestrator {
                                 }
                                 self.schedule_acceptance_failure(
                                     issue,
-                                    &current_config,
+                                    &pipeline_config,
                                     &reason,
                                     &owner,
                                 )
@@ -7666,7 +7765,7 @@ impl Orchestrator {
                             .finalize_and_stage_terminal_transition(
                                 &issue.id,
                                 &issue.identifier,
-                                &current_config,
+                                &pipeline_config,
                             )
                             .await;
                         let completed_at = Utc::now();
@@ -7694,7 +7793,7 @@ impl Orchestrator {
                             ) {
                                 (
                                     Some(TerminalOutcome::Succeeded),
-                                    Some(current_config.on_success.clone()),
+                                    Some(pipeline_config.on_success.clone()),
                                     history_record,
                                 )
                             } else {
@@ -7709,7 +7808,7 @@ impl Orchestrator {
                                 }
                                 (
                                     is_terminal_failure.then_some(TerminalOutcome::Failed),
-                                    is_terminal_failure.then(|| current_config.on_failure.clone()),
+                                    is_terminal_failure.then(|| pipeline_config.on_failure.clone()),
                                     None,
                                 )
                             }
@@ -7750,7 +7849,7 @@ impl Orchestrator {
                         self.begin_terminal_transition(
                             issue,
                             TerminalOutcome::Failed,
-                            current_config.on_failure.clone(),
+                            pipeline_config.on_failure.clone(),
                             history_record,
                         )
                         .await;
@@ -7781,7 +7880,7 @@ impl Orchestrator {
             PipelineEvent::InputResumed {
                 issue_identifier: issue.identifier.clone(),
                 timestamp: Utc::now(),
-                step_name: current_step.name.clone(),
+                step_name: pipeline_step.name.clone(),
                 detail: format!("resumed from interaction {}", interaction.id),
             },
         )
@@ -7794,7 +7893,7 @@ impl Orchestrator {
             PipelineEvent::StepResumedFromHumanReply {
                 issue_identifier: issue.identifier.clone(),
                 timestamp: Utc::now(),
-                step_name: current_step.name.clone(),
+                step_name: pipeline_step.name.clone(),
                 ask_id: interaction.id.clone(),
                 detail: "step resumed after human reply".to_string(),
             },
@@ -11810,9 +11909,13 @@ agent:
     }
 
     #[tokio::test]
-    async fn restored_live_pipeline_run_dispatches_on_next_tick() {
+    async fn state_worker_dispatch_restored_run_waits_for_state_capacity() {
         let temp = tempfile::tempdir().unwrap();
-        let cfg = make_config();
+        let mut cfg = make_config();
+        cfg.concurrency.max_concurrent_agents = 2;
+        cfg.agent
+            .max_concurrent_agents_by_state
+            .insert("todo".to_string(), 1);
         let issue = test_issue("1", "Todo");
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
             issues: Arc::new(RwLock::new(vec![issue.clone()])),
@@ -11830,6 +11933,26 @@ agent:
             cfg.polling.interval_ms,
             &cfg.concurrency,
         )));
+        let cancellation_registry = new_cancellation_registry();
+        let peer = WorkerIdentity {
+            issue_id: "peer".to_string(),
+            run_id: "peer-run".to_string(),
+            cycle: 1,
+            step_name: "build".to_string(),
+            started_at: Utc::now(),
+        };
+        let (peer_complete_tx, peer_complete_rx) = watch::channel(false);
+        try_reserve_worker(
+            &cancellation_registry,
+            peer.clone(),
+            tokio_util::sync::CancellationToken::new(),
+            peer_complete_rx,
+            cfg.concurrency.max_concurrent_agents,
+            cfg.concurrency.max_step_parallelism,
+            StateWorkerCapacity::new("Todo", &cfg.agent.max_concurrent_agents_by_state),
+        )
+        .unwrap();
+        assert!(mark_worker_launched(&cancellation_registry, &peer));
         let orchestrator = Orchestrator::new_with_state(
             OrchestratorRuntimeParts {
                 state: Arc::clone(&state),
@@ -11840,7 +11963,7 @@ agent:
                 workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
                     .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
-                cancellation_registry: new_cancellation_registry(),
+                cancellation_registry: cancellation_registry.clone(),
                 event_bus: EventBus::new(),
                 transcript_event_bus: TranscriptEventBus::new(),
                 workspace_root: temp.path().join("workspaces"),
@@ -11873,6 +11996,33 @@ agent:
 
         orchestrator.handle_tick().await;
 
+        {
+            let lock = state.read().await;
+            assert!(lock.is_running(&issue.id));
+            assert!(matches!(
+                lock.get_pipeline_run(&issue.id)
+                    .and_then(|run| run.step_states.get("build")),
+                Some(StepState::Pending)
+            ));
+            assert!(!lock.retry_attempts.contains_key(&issue.id));
+        }
+        let prepared_workspaces = std::fs::read_dir(temp.path().join("workspaces"))
+            .map(|entries| {
+                entries
+                    .map(|entry| entry.unwrap().file_name())
+                    .filter(|name| name != ".ensemble")
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        assert!(
+            prepared_workspaces.is_empty(),
+            "state-cap deferral must not prepare a workspace: {prepared_workspaces:?}"
+        );
+
+        peer_complete_tx.send(true).unwrap();
+        assert!(remove_completed_worker(&cancellation_registry, &peer));
+        orchestrator.handle_tick().await;
+
         let lock = state.read().await;
         assert!(lock.is_running(&issue.id));
         assert!(matches!(
@@ -11880,6 +12030,90 @@ agent:
                 .and_then(|run| run.step_states.get("build")),
             Some(StepState::Running { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn state_worker_dispatch_full_bucket_does_not_claim_fresh_candidate() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut cfg = make_config();
+        cfg.concurrency.max_concurrent_agents = 2;
+        cfg.agent
+            .max_concurrent_agents_by_state
+            .insert("todo".to_string(), 1);
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let config = Arc::new(RwLock::new(cfg.clone()));
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        drop(shutdown_tx);
+        let state = Arc::new(RwLock::new(OrchestratorState::new(
+            cfg.polling.interval_ms,
+            &cfg.concurrency,
+        )));
+        let cancellation_registry = new_cancellation_registry();
+        let peer = WorkerIdentity {
+            issue_id: "peer".to_string(),
+            run_id: "peer-run".to_string(),
+            cycle: 1,
+            step_name: "build".to_string(),
+            started_at: Utc::now(),
+        };
+        let (_peer_complete_tx, peer_complete_rx) = watch::channel(false);
+        try_reserve_worker(
+            &cancellation_registry,
+            peer.clone(),
+            tokio_util::sync::CancellationToken::new(),
+            peer_complete_rx,
+            cfg.concurrency.max_concurrent_agents,
+            cfg.concurrency.max_step_parallelism,
+            StateWorkerCapacity::new("Todo", &cfg.agent.max_concurrent_agents_by_state),
+        )
+        .unwrap();
+        assert!(mark_worker_launched(&cancellation_registry, &peer));
+        let orchestrator = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&state),
+                config,
+                tracker,
+                agent_runner: Arc::new(MockRunner {
+                    delay_ms: 0,
+                    observed_commands: None,
+                    observed_timeouts: None,
+                    cancellation_probe: None,
+                }),
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
+                workspace_mgr: WorkspaceManager::new(&temp.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry,
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root: temp.path().join("workspaces"),
+            },
+            temp.path(),
+            shutdown_rx,
+        );
+
+        orchestrator.handle_tick().await;
+
+        let lock = state.read().await;
+        assert!(
+            !lock.is_claimed(&issue.id),
+            "a full state bucket must not claim a fresh candidate"
+        );
+        assert!(!lock.is_running(&issue.id));
+        assert!(lock.get_pipeline_run(&issue.id).is_none());
+        drop(lock);
+        assert!(
+            orchestrator
+                .pipeline_journal
+                .latest_live_record_for_issue(&issue.id)
+                .await
+                .unwrap()
+                .is_none(),
+            "a full state bucket must not journal a fresh run"
+        );
     }
 
     #[tokio::test]
@@ -15001,9 +15235,18 @@ agent:
     }
 
     #[tokio::test]
-    async fn question_resume_capacity_deferral_preserves_the_waiting_owner() {
+    async fn state_worker_dispatch_resume_uses_latest_reconciled_state() {
         let mut raw_config = make_config();
-        raw_config.concurrency.max_concurrent_agents = 1;
+        raw_config.concurrency.max_concurrent_agents = 3;
+        raw_config.tracker.active_states.push("Review".to_string());
+        raw_config
+            .agent
+            .max_concurrent_agents_by_state
+            .insert("todo".to_string(), 1);
+        raw_config
+            .agent
+            .max_concurrent_agents_by_state
+            .insert("review".to_string(), 1);
         let config = Arc::new(RwLock::new(raw_config));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
             issues: Arc::new(RwLock::new(vec![])),
@@ -15076,19 +15319,31 @@ agent:
             .await
             .unwrap();
 
+        let peer = WorkerIdentity {
+            issue_id: "2".to_string(),
+            run_id: "peer-run".to_string(),
+            cycle: 1,
+            step_name: "build".to_string(),
+            started_at: Utc::now(),
+        };
         let (_, peer_completion) = watch::channel(false);
-        crate::agent::cancellation::register_worker(
+        try_reserve_worker(
             &orchestrator.cancellation_registry,
-            WorkerIdentity {
-                issue_id: "2".to_string(),
-                run_id: "peer-run".to_string(),
-                cycle: 1,
-                step_name: "build".to_string(),
-                started_at: Utc::now(),
-            },
+            peer.clone(),
             tokio_util::sync::CancellationToken::new(),
             peer_completion,
-        );
+            3,
+            1,
+            StateWorkerCapacity::new(
+                "Todo",
+                &config.read().await.agent.max_concurrent_agents_by_state,
+            ),
+        )
+        .unwrap();
+        assert!(mark_worker_launched(
+            &orchestrator.cancellation_registry,
+            &peer
+        ));
 
         orchestrator
             .resume_blocked_issue(&issue)
@@ -15116,6 +15371,76 @@ agent:
                 .unwrap()
                 .awaiting_resume
         );
+
+        let review_issue = Issue {
+            state: "Review".to_string(),
+            ..issue
+        };
+        config
+            .write()
+            .await
+            .agent
+            .max_concurrent_agents_by_state
+            .remove("review");
+        let review_peer = WorkerIdentity {
+            issue_id: "3".to_string(),
+            run_id: "review-peer-run".to_string(),
+            cycle: 1,
+            step_name: "build".to_string(),
+            started_at: Utc::now(),
+        };
+        let (review_peer_complete_tx, review_peer_completion) = watch::channel(false);
+        let pipeline_config = orchestrator
+            .state
+            .read()
+            .await
+            .get_pipeline_config(&review_issue.id)
+            .unwrap()
+            .clone();
+        try_reserve_worker(
+            &orchestrator.cancellation_registry,
+            review_peer.clone(),
+            tokio_util::sync::CancellationToken::new(),
+            review_peer_completion,
+            3,
+            1,
+            StateWorkerCapacity::new(
+                "Review",
+                &pipeline_config.agent.max_concurrent_agents_by_state,
+            ),
+        )
+        .unwrap();
+        assert!(mark_worker_launched(
+            &orchestrator.cancellation_registry,
+            &review_peer
+        ));
+
+        orchestrator
+            .resume_blocked_issue(&review_issue)
+            .await
+            .expect_err("resume must retain the owning pipeline's state caps");
+        assert!(orchestrator
+            .state
+            .read()
+            .await
+            .is_waiting_on_human(&review_issue.id));
+
+        review_peer_complete_tx.send(true).unwrap();
+        assert!(remove_completed_worker(
+            &orchestrator.cancellation_registry,
+            &review_peer
+        ));
+        orchestrator
+            .resume_blocked_issue(&review_issue)
+            .await
+            .expect("latest reconciled state must select the next reservation bucket");
+
+        let state = orchestrator.state.read().await;
+        assert!(state.is_running(&review_issue.id));
+        assert!(!state.is_waiting_on_human(&review_issue.id));
+        assert!(!state.retry_attempts.contains_key(&review_issue.id));
+        drop(state);
+        assert_eq!(live_worker_count(&orchestrator.cancellation_registry), 2);
     }
 
     #[tokio::test]
@@ -21996,11 +22321,23 @@ agent:
         tokio::sync::mpsc::UnboundedReceiver<(String, String)>,
         Arc<tokio::sync::Semaphore>,
     ) {
-        let (started_tx, started_rx) = tokio::sync::mpsc::unbounded_channel();
-        let release = Arc::new(tokio::sync::Semaphore::new(0));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
             issues: Arc::new(RwLock::new(issues)),
         });
+        capacity_test_orchestrator_with_tracker(config, tracker)
+    }
+
+    fn capacity_test_orchestrator_with_tracker(
+        config: EnsembleConfig,
+        tracker: Arc<dyn IssueTracker>,
+    ) -> (
+        Orchestrator,
+        tempfile::TempDir,
+        tokio::sync::mpsc::UnboundedReceiver<(String, String)>,
+        Arc<tokio::sync::Semaphore>,
+    ) {
+        let (started_tx, started_rx) = tokio::sync::mpsc::unbounded_channel();
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
         let runner: Arc<dyn AgentRunner> = Arc::new(CapacityBlockingRunner {
             started: started_tx,
             release: Arc::clone(&release),
@@ -22100,6 +22437,155 @@ agent:
         orchestrator.handle_worker_event(event).await;
 
         receive_started_worker(&mut started).await;
+    }
+
+    #[tokio::test]
+    async fn state_worker_dispatch_initial_and_deferred_use_independent_buckets() {
+        let mut config = parallel_capacity_config(4, 2);
+        config.agent.max_concurrent_agents_by_state = std::collections::BTreeMap::from([
+            ("todo".to_string(), 1),
+            ("in progress".to_string(), 1),
+        ]);
+        let issues = vec![
+            test_issue("1", "Todo"),
+            test_issue("2", "Todo"),
+            test_issue("3", "In Progress"),
+        ];
+        let (orchestrator, _dir, mut started, release) = capacity_test_orchestrator(config, issues);
+
+        orchestrator.handle_tick().await;
+
+        let mut initial = vec![
+            receive_started_worker(&mut started).await,
+            receive_started_worker(&mut started).await,
+        ];
+        initial.sort();
+        assert_eq!(initial[0].0, "1");
+        assert_eq!(initial[1].0, "3");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), started.recv())
+                .await
+                .is_err()
+        );
+        assert!(orchestrator.state.read().await.retry_attempts.is_empty());
+
+        release.add_permits(1);
+        let completed = tokio::time::timeout(
+            Duration::from_secs(1),
+            recv_worker_event(&orchestrator.worker_rx),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        orchestrator.handle_worker_event(completed).await;
+
+        receive_started_worker(&mut started).await;
+        assert!(orchestrator.state.read().await.retry_attempts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn state_worker_dispatch_batched_roots_use_tracker_transition_bucket() {
+        let mut config = parallel_capacity_config(2, 2);
+        config.agent.max_concurrent_agents_by_state = std::collections::BTreeMap::from([
+            ("todo".to_string(), 1),
+            ("in progress".to_string(), 1),
+        ]);
+        config.steps[0].tracker_state = Some("In Progress".to_string());
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(RecordingTracker {
+            issues: Arc::new(RwLock::new(vec![issue])),
+            state_writes: Arc::new(RwLock::new(Vec::new())),
+        });
+        let (orchestrator, _dir, mut started, _release) =
+            capacity_test_orchestrator_with_tracker(config, tracker);
+
+        orchestrator.handle_tick().await;
+
+        let mut steps = vec![
+            receive_started_worker(&mut started).await.1,
+            receive_started_worker(&mut started).await.1,
+        ];
+        steps.sort();
+        assert_eq!(steps, ["first", "second"]);
+        assert_eq!(
+            orchestrator
+                .state
+                .read()
+                .await
+                .get_running("1")
+                .unwrap()
+                .issue
+                .state,
+            "In Progress"
+        );
+    }
+
+    #[tokio::test]
+    async fn state_worker_dispatch_downstream_reuses_released_bucket() {
+        let mut config = parallel_capacity_config(2, 2);
+        config.agent.max_concurrent_agents_by_state =
+            std::collections::BTreeMap::from([("todo".to_string(), 1)]);
+        config.steps[1].depends = Some(vec!["first".to_string()]);
+        let (orchestrator, _dir, mut started, release) =
+            capacity_test_orchestrator(config, vec![test_issue("1", "Todo")]);
+
+        orchestrator.handle_tick().await;
+        assert_eq!(receive_started_worker(&mut started).await.1, "first");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), started.recv())
+                .await
+                .is_err()
+        );
+
+        release.add_permits(1);
+        let completed = tokio::time::timeout(
+            Duration::from_secs(1),
+            recv_worker_event(&orchestrator.worker_rx),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        orchestrator.handle_worker_event(completed).await;
+
+        assert_eq!(receive_started_worker(&mut started).await.1, "second");
+        assert!(orchestrator.state.read().await.retry_attempts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn state_worker_dispatch_downstream_uses_successful_tracker_transition_bucket() {
+        let mut config = parallel_capacity_config(2, 2);
+        config.agent.max_concurrent_agents_by_state = std::collections::BTreeMap::from([
+            ("todo".to_string(), 1),
+            ("in progress".to_string(), 1),
+        ]);
+        config.steps[0].tracker_state = Some("In Progress".to_string());
+        config.steps[1].depends = Some(vec!["first".to_string()]);
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(RecordingTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+            state_writes: Arc::new(RwLock::new(Vec::new())),
+        });
+        let (orchestrator, _dir, mut started, release) =
+            capacity_test_orchestrator_with_tracker(config, tracker);
+
+        orchestrator.handle_tick().await;
+        assert_eq!(receive_started_worker(&mut started).await.1, "first");
+
+        release.add_permits(1);
+        let completed = tokio::time::timeout(
+            Duration::from_secs(1),
+            recv_worker_event(&orchestrator.worker_rx),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        orchestrator.handle_worker_event(completed).await;
+        assert_eq!(receive_started_worker(&mut started).await.1, "second");
+
+        orchestrator
+            .dispatch_issue(&test_issue("2", "Todo"), None)
+            .await;
+        assert_eq!(receive_started_worker(&mut started).await.0, "2");
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/scheduler.rs
+++ b/crates/ensemble-core/src/orchestrator/scheduler.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::tracker::model::Issue;
 
 use super::state::OrchestratorState;
@@ -13,7 +11,6 @@ pub fn is_dispatch_eligible(
     state: &OrchestratorState,
     active_states: &[String],
     terminal_states: &[String],
-    max_concurrent_by_state: &HashMap<String, u32>,
 ) -> Option<String> {
     // Must have required fields
     if issue.id.is_empty() {
@@ -54,13 +51,6 @@ pub fn is_dispatch_eligible(
         return Some("already completed".to_string());
     }
 
-    // Per-state concurrency check
-    if !max_concurrent_by_state.is_empty()
-        && available_state_slots(state, max_concurrent_by_state, &issue.state) == 0
-    {
-        return Some(format!("no slots available for state '{}'", issue.state));
-    }
-
     // Blocker rule: Todo issues with non-terminal blockers are not eligible
     if issue.state.eq_ignore_ascii_case("todo") && !issue.blocked_by.is_empty() {
         let has_non_terminal_blocker = issue.blocked_by.iter().any(|blocker| {
@@ -88,7 +78,6 @@ pub fn is_resume_dispatch_eligible(
     state: &OrchestratorState,
     active_states: &[String],
     terminal_states: &[String],
-    max_concurrent_by_state: &HashMap<String, u32>,
 ) -> Option<String> {
     if !state.is_waiting_on_human(&issue.id) {
         return Some("issue is not waiting on human".to_string());
@@ -120,12 +109,6 @@ pub fn is_resume_dispatch_eligible(
     if state.completed.contains_key(&issue.id) {
         return Some("already completed".to_string());
     }
-    if !max_concurrent_by_state.is_empty()
-        && available_state_slots(state, max_concurrent_by_state, &issue.state) == 0
-    {
-        return Some(format!("no slots available for state '{}'", issue.state));
-    }
-
     None
 }
 
@@ -164,23 +147,6 @@ pub fn available_global_slots(state: &OrchestratorState) -> u32 {
     state.max_concurrent_agents.saturating_sub(running)
 }
 
-/// Calculate available slots for a specific issue state.
-pub fn available_state_slots(
-    state: &OrchestratorState,
-    max_concurrent_by_state: &HashMap<String, u32>,
-    issue_state: &str,
-) -> u32 {
-    let state_lower = issue_state.to_lowercase();
-
-    if let Some(&cap) = max_concurrent_by_state.get(&state_lower) {
-        let running_in_state = state.running_count_in_state(&state_lower) as u32;
-        cap.saturating_sub(running_in_state)
-    } else {
-        // No per-state cap — fallback to global
-        available_global_slots(state)
-    }
-}
-
 /// Advisory check for admitting work that will reserve a live worker slot.
 /// The cancellation registry's atomic reservation remains authoritative.
 pub fn has_available_worker_slots(live_workers: u32, max_workers: u32) -> bool {
@@ -211,13 +177,7 @@ mod tests {
         let state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
         let issue = test_issue("1", "Todo");
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_none(), "expected eligible, got: {:?}", result);
     }
 
@@ -243,22 +203,11 @@ mod tests {
             issue: None,
         });
 
-        let normal = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let normal = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert_eq!(normal.as_deref(), Some("already claimed"));
 
-        let resumed = is_resume_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let resumed =
+            is_resume_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(
             resumed.is_none(),
             "expected resume eligibility, got: {resumed:?}"
@@ -271,13 +220,7 @@ mod tests {
         let mut issue = test_issue("", "Todo");
         issue.id = "".to_string();
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_some());
         assert!(result.unwrap().contains("missing issue id"));
     }
@@ -287,13 +230,7 @@ mod tests {
         let state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
         let issue = test_issue("1", "Backlog");
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_some());
         assert!(result.unwrap().contains("not in active states"));
     }
@@ -303,13 +240,7 @@ mod tests {
         let state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
         let issue = test_issue("1", "Done");
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_some());
     }
 
@@ -319,13 +250,7 @@ mod tests {
         let issue = test_issue("1", "Todo");
         state.add_running(&issue, None);
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_some());
         assert!(result.unwrap().contains("already running"));
     }
@@ -337,13 +262,7 @@ mod tests {
 
         let issue = test_issue("1", "Todo");
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_some());
         assert!(result.unwrap().contains("already claimed"));
     }
@@ -363,13 +282,7 @@ mod tests {
         state.running.remove("1");
         state.claimed.remove("1");
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_some());
         assert!(result.unwrap().contains("already completed"));
     }
@@ -382,24 +295,14 @@ mod tests {
     }
 
     #[test]
-    fn test_ineligible_no_state_slots() {
+    fn state_worker_caps_do_not_affect_issue_eligibility() {
         let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
         state.add_running(&test_issue("existing", "Todo"), None);
 
-        let mut by_state = HashMap::new();
-        by_state.insert("todo".to_string(), 1);
-
         let issue = test_issue("new", "Todo");
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &by_state,
-        );
-        assert!(result.is_some());
-        assert!(result.unwrap().contains("no slots available for state"));
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
+        assert!(result.is_none());
     }
 
     #[test]
@@ -412,13 +315,7 @@ mod tests {
             state: Some("In Progress".to_string()),
         }];
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_some());
         assert!(result.unwrap().contains("blocked by non-terminal"));
     }
@@ -433,13 +330,7 @@ mod tests {
             state: Some("Done".to_string()),
         }];
 
-        let result = is_dispatch_eligible(
-            &issue,
-            &state,
-            &default_active(),
-            &default_terminal(),
-            &HashMap::new(),
-        );
+        let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_none(), "expected eligible with terminal blocker");
     }
 
@@ -552,25 +443,5 @@ mod tests {
         state.add_running(&test_issue("3", "Todo"), None);
         state.add_running(&test_issue("4", "Todo"), None);
         assert_eq!(available_global_slots(&state), 0);
-    }
-
-    #[test]
-    fn test_available_state_slots_with_cap() {
-        let mut state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
-        state.add_running(&test_issue("1", "Todo"), None);
-
-        let mut by_state = HashMap::new();
-        by_state.insert("todo".to_string(), 2);
-
-        assert_eq!(available_state_slots(&state, &by_state, "Todo"), 1);
-        assert_eq!(available_state_slots(&state, &by_state, "In Progress"), 3); // no cap, falls back to global (4 - 1 running)
-    }
-
-    #[test]
-    fn test_available_state_slots_no_cap() {
-        let state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
-
-        let by_state = HashMap::new();
-        assert_eq!(available_state_slots(&state, &by_state, "Todo"), 4);
     }
 }

--- a/crates/ensemble-core/tests/openapi_spec.rs
+++ b/crates/ensemble-core/tests/openapi_spec.rs
@@ -93,6 +93,31 @@ fn openapi_keeps_editor_step_dependencies_optional() {
 }
 
 #[test]
+fn openapi_documents_agent_state_worker_caps_as_integer_maps() {
+    let spec: serde_json::Value =
+        serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+
+    for schema in ["AgentRuntimeConfig", "GuidedAgentRuntimeForm"] {
+        let state_caps =
+            &spec["components"]["schemas"][schema]["properties"]["max_concurrent_agents_by_state"];
+        assert_eq!(state_caps["type"], "object", "{schema} must expose a map");
+        assert_eq!(
+            state_caps["additionalProperties"]["type"], "integer",
+            "{schema} state limits must be integers"
+        );
+        assert_eq!(
+            state_caps["additionalProperties"]["minimum"], 1,
+            "{schema} state limits must be positive"
+        );
+        assert_eq!(
+            state_caps["additionalProperties"]["maximum"],
+            u32::MAX,
+            "{schema} state limits must fit in u32"
+        );
+    }
+}
+
+#[test]
 #[ignore = "writes generated OpenAPI output for frontend codegen"]
 fn write_openapi_spec() {
     let spec = ApiDoc::openapi().to_pretty_json().unwrap();

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.test.tsx
@@ -41,6 +41,7 @@ const initialForm: GuidedForm = {
     workspace: {},
     hooks: { timeout_ms: 1000 },
     agent: {
+      max_concurrent_agents_by_state: {},
       max_retry_backoff_ms: 1,
       command: "agent",
       session_mode: "code",
@@ -210,6 +211,71 @@ describe("GuidedEditor", () => {
     await user.click(screen.getByRole("button", { name: /save/i }));
 
     expect(onSave.mock.calls[0]?.[0].steps).toEqual(parallelRootForm.steps);
+  });
+
+  it("edits state worker caps without changing dependency shapes", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn(async (_form: GuidedForm, _baseRawYaml: string) => undefined);
+    const formWithCaps: GuidedForm = {
+      ...initialForm,
+      steps: [
+        { name: "build", agent: "builder" },
+        { name: "lint", agent: "builder", depends: [] },
+        { name: "test", agent: "builder", depends: ["build"] },
+      ],
+      runtime: {
+        ...initialForm.runtime,
+        agent: {
+          ...initialForm.runtime.agent,
+          max_concurrent_agents_by_state: { Todo: 1, Review: 2 },
+        },
+      },
+    };
+
+    renderWithProviders(
+      <GuidedEditor
+        initialForm={formWithCaps}
+        baseRawYaml={"tracker:\n  kind: todo_file\n"}
+        issues={[]}
+        onValidate={vi.fn(async () => [])}
+        onSave={onSave}
+        onReset={vi.fn()}
+      />,
+      { route: "/config" }
+    );
+
+    await user.click(screen.getByLabelText("Model"));
+    await user.click(await screen.findByRole("option", { name: "Opus" }));
+    await user.click(screen.getByRole("button", { name: /save/i }));
+    expect(onSave.mock.calls[0]?.[0].runtime.agent.max_concurrent_agents_by_state).toEqual({
+      Todo: 1,
+      Review: 2,
+    });
+
+    const limits = screen.getAllByLabelText("Limit");
+    await user.clear(limits[0]!);
+    await user.type(limits[0]!, "4294967296");
+    expect(screen.getByText(/no greater than 4294967295/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    await user.clear(limits[0]!);
+    await user.type(limits[0]!, "3");
+    const states = screen.getAllByLabelText("State");
+    await user.clear(states[1]!);
+    await user.type(states[1]!, "In Progress");
+    await user.click(screen.getByRole("button", { name: /add state limit/i }));
+    const addedStates = screen.getAllByLabelText("State");
+    const addedLimits = screen.getAllByLabelText("Limit");
+    await user.type(addedStates[2]!, "QA");
+    await user.clear(addedLimits[2]!);
+    await user.type(addedLimits[2]!, "4");
+    await user.click(screen.getByRole("button", { name: /remove in progress/i }));
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    const saved = onSave.mock.calls[1]?.[0];
+    expect(saved).toBeDefined();
+    if (!saved) throw new Error("onSave should receive edited state caps");
+    expect(saved.runtime.agent.max_concurrent_agents_by_state).toEqual({ Todo: 3, QA: 4 });
+    expect(saved.steps).toEqual(formWithCaps.steps);
   });
 
   it("saves inline agent model reasoning and mode edits", async () => {

--- a/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/config/GuidedEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -45,13 +45,53 @@ function supportedPermissionMode(value: string | undefined) {
   return value && SUPPORTED_PERMISSION_MODES.has(value) ? value : undefined;
 }
 
-function normalizeGuidedForm(form: GuidedForm): GuidedForm {
+type StateCapRow = {
+  id: number;
+  state: string;
+  limit: string;
+};
+
+function stateCapRowsFromMap(stateCaps: Record<string, number>): StateCapRow[] {
+  return Object.entries(stateCaps).map(([state, limit], id) => ({
+    id,
+    state,
+    limit: String(limit),
+  }));
+}
+
+function stateCapRowsError(rows: StateCapRow[]) {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const normalized = row.state.trim().toLowerCase();
+    if (!normalized) return "State names must not be blank.";
+    if (seen.has(normalized)) return "State names must be unique after trimming and case-folding.";
+    seen.add(normalized);
+    const limit = Number(row.limit);
+    if (!Number.isSafeInteger(limit) || limit <= 0 || limit > 4_294_967_295) {
+      return "State limits must be positive integers no greater than 4294967295.";
+    }
+  }
+  return undefined;
+}
+
+function stateCapMapFromRows(rows: StateCapRow[]) {
+  return Object.fromEntries(rows.map((row) => [row.state, Number(row.limit)]));
+}
+
+function normalizeGuidedForm(form: GuidedForm, stateCapRows: StateCapRow[]): GuidedForm {
   return {
     ...form,
     agents: form.agents.map(({ available_models: _availableModels, available_modes: _availableModes, ...agent }) => ({
       ...agent,
       permission_mode: supportedPermissionMode(agent.permission_mode),
     })),
+    runtime: {
+      ...form.runtime,
+      agent: {
+        ...form.runtime.agent,
+        max_concurrent_agents_by_state: stateCapMapFromRows(stateCapRows),
+      },
+    },
   };
 }
 
@@ -122,6 +162,7 @@ export interface GuidedForm {
       timeout_ms: number;
     };
     agent: {
+      max_concurrent_agents_by_state: Record<string, number>;
       max_retry_backoff_ms: number;
       command: string;
       session_mode: string;
@@ -155,6 +196,10 @@ export default function GuidedEditor({
   onReset,
 }: GuidedEditorProps) {
   const [form, setForm] = useState<GuidedForm>(initialForm);
+  const [stateCapRows, setStateCapRows] = useState<StateCapRow[]>(() =>
+    stateCapRowsFromMap(initialForm.runtime.agent.max_concurrent_agents_by_state)
+  );
+  const nextStateCapRowId = useRef(stateCapRows.length);
   const [isDirty, setIsDirty] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -167,6 +212,11 @@ export default function GuidedEditor({
 
   useEffect(() => {
     setForm(initialForm);
+    const rows = stateCapRowsFromMap(
+      initialForm.runtime.agent.max_concurrent_agents_by_state
+    );
+    setStateCapRows(rows);
+    nextStateCapRowId.current = rows.length;
     setIsDirty(false);
   }, [initialForm]);
 
@@ -189,9 +239,12 @@ export default function GuidedEditor({
   };
 
   const handleValidate = async () => {
-      setIsValidating(true);
+    setIsValidating(true);
     try {
-      const validatedIssues = await onValidate(normalizeGuidedForm(form), baseRawYaml);
+      const validatedIssues = await onValidate(
+        normalizeGuidedForm(form, stateCapRows),
+        baseRawYaml
+      );
       setDisplayedIssues(validatedIssues);
       setLastValidation({
         timestamp: new Date(),
@@ -205,7 +258,7 @@ export default function GuidedEditor({
   const handleSave = async () => {
     setIsSaving(true);
     try {
-      await onSave(normalizeGuidedForm(form), baseRawYaml);
+      await onSave(normalizeGuidedForm(form, stateCapRows), baseRawYaml);
       setIsDirty(false);
     } finally {
       setIsSaving(false);
@@ -214,8 +267,18 @@ export default function GuidedEditor({
 
   const handleReset = () => {
     setForm(initialForm);
+    const rows = stateCapRowsFromMap(
+      initialForm.runtime.agent.max_concurrent_agents_by_state
+    );
+    setStateCapRows(rows);
+    nextStateCapRowId.current = rows.length;
     setIsDirty(false);
     onReset();
+  };
+
+  const updateStateCapRows = (update: (rows: StateCapRow[]) => StateCapRow[]) => {
+    setStateCapRows(update);
+    setIsDirty(true);
   };
 
   const hasErrors = displayedIssues.length > 0;
@@ -225,6 +288,7 @@ export default function GuidedEditor({
   }));
   const secretEdit = form.tracker.api_key_edit ?? { action: "preserve" as const };
   const secretEditError = secretEditValidationError(secretEdit);
+  const stateCapsError = stateCapRowsError(stateCapRows);
   const secretStatus =
     form.tracker.api_key.state === "redacted"
       ? "Existing secret is configured."
@@ -262,13 +326,19 @@ export default function GuidedEditor({
           <Button
             variant="outline"
             onClick={handleValidate}
-            disabled={isValidating || Boolean(secretEditError)}
+            disabled={isValidating || Boolean(secretEditError) || Boolean(stateCapsError)}
           >
             Validate
           </Button>
           <Button
             onClick={handleSave}
-            disabled={!isDirty || isSaving || hasErrors || Boolean(secretEditError)}
+            disabled={
+              !isDirty ||
+              isSaving ||
+              hasErrors ||
+              Boolean(secretEditError) ||
+              Boolean(stateCapsError)
+            }
           >
             <Save className="h-4 w-4 mr-2" />
             {isSaving ? "Saving..." : "Save"}
@@ -665,6 +735,76 @@ export default function GuidedEditor({
                 }
               />
             </div>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <div>
+                <h4 className="font-medium">Live workers by tracker state</h4>
+                <p className="text-sm text-muted-foreground">
+                  Optional limits for simultaneously running agent processes.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                onClick={() =>
+                  updateStateCapRows((rows) => [
+                    ...rows,
+                    { id: nextStateCapRowId.current++, state: "", limit: "1" },
+                  ])
+                }
+              >
+                Add state limit
+              </Button>
+            </div>
+            {stateCapRows.map((row) => (
+              <div key={row.id} className="grid grid-cols-[1fr_8rem_auto] gap-2">
+                <Input
+                  aria-label="State"
+                  value={row.state}
+                  placeholder="In Progress"
+                  onChange={(event) =>
+                    updateStateCapRows((rows) =>
+                      rows.map((candidate) =>
+                        candidate.id === row.id
+                          ? { ...candidate, state: event.target.value }
+                          : candidate
+                      )
+                    )
+                  }
+                />
+                <Input
+                  aria-label="Limit"
+                  type="number"
+                  min={1}
+                  max={4_294_967_295}
+                  step={1}
+                  value={row.limit}
+                  onChange={(event) =>
+                    updateStateCapRows((rows) =>
+                      rows.map((candidate) =>
+                        candidate.id === row.id
+                          ? { ...candidate, limit: event.target.value }
+                          : candidate
+                      )
+                    )
+                  }
+                />
+                <Button
+                  variant="outline"
+                  aria-label={`Remove ${row.state || "blank state"}`}
+                  onClick={() =>
+                    updateStateCapRows((rows) =>
+                      rows.filter((candidate) => candidate.id !== row.id)
+                    )
+                  }
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+            {stateCapsError && (
+              <p className="text-sm text-red-600">{stateCapsError}</p>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.test.tsx
@@ -150,6 +150,7 @@ describe("ConfigPage", () => {
           workspace: {},
           hooks: { timeout_ms: 1000 },
           agent: {
+            max_concurrent_agents_by_state: {},
             max_retry_backoff_ms: 1,
             command: "agent",
             session_mode: "code",
@@ -190,6 +191,7 @@ describe("ConfigPage", () => {
           workspace: {},
           hooks: { timeout_ms: 1000 },
           agent: {
+            max_concurrent_agents_by_state: {},
             max_retry_backoff_ms: 1,
             command: "agent",
             session_mode: "code",
@@ -256,6 +258,7 @@ describe("ConfigPage", () => {
           workspace: {},
           hooks: { timeout_ms: 1000 },
           agent: {
+            max_concurrent_agents_by_state: {},
             max_retry_backoff_ms: 1,
             command: "agent",
             session_mode: "code",

--- a/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/ConfigPage.tsx
@@ -72,6 +72,8 @@ function toGuidedForm(form: GuidedConfigForm): GuidedForm {
       },
       agent: {
         ...form.runtime.agent,
+        max_concurrent_agents_by_state:
+          form.runtime.agent.max_concurrent_agents_by_state ?? {},
         permission_request_policy: toPermissionRequestPolicy(form.runtime.agent.permission_request_policy),
       },
     },

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -491,8 +491,9 @@ Fields:
 - `poll_interval_ms` (current effective poll interval)
 - `max_concurrent_agents` (current effective global concurrency limit)
 - `running` (map `issue_id -> running entry`)
-- active-worker registry (map of exact worker identity to cancellation and completion ownership;
-  authoritative for live-agent capacity)
+- active-worker registry (map of exact worker identity to cancellation, completion ownership, and
+  private normalized reservation-time state bucket; sole atomic authority for global, per-issue,
+  and per-state live-agent capacity)
 - `claimed` (set of issue IDs reserved/running/retrying)
 - `retry_attempts` (map `issue_id -> RetryEntry`)
 - `completed` (set of issue IDs; bookkeeping only, not dispatch gating)
@@ -510,6 +511,9 @@ Fields:
   - Use the sanitized value for the workspace directory name.
 - `Normalized Issue State`
   - Compare states after `lowercase`.
+- `Normalized State-Cap Bucket`
+  - Trim surrounding whitespace and apply `lowercase` to configured state-cap keys and tracker
+    states observed at worker reservation.
 - `Session ID`
   - Use the `sessionId` returned by the ACP `session/new` response.
 
@@ -891,8 +895,12 @@ Fields:
   - Changes should be re-applied at runtime and affect future retry scheduling.
 - `max_concurrent_agents_by_state` (map `state_name -> positive integer`)
   - Default: empty map.
-  - State keys are normalized (`lowercase`) for lookup.
-  - Invalid entries (non-positive or non-numeric) are ignored.
+  - State keys are normalized with `trim().lowercase()` for lookup and canonical serialization.
+  - Blank keys, non-positive or non-numeric limits, and distinct keys that collide after
+    normalization reject the complete configuration. Errors identify
+    `agent.max_concurrent_agents_by_state` and the offending entry.
+  - Omission is equivalent to an empty map. A state without an entry has no additional state limit;
+    global and per-issue worker limits still apply.
 - `command` (string command)
   - Default: implementation-defined.
   - Used by the direct ACP runtime when a step agent does not provide `executor`.
@@ -1026,6 +1034,12 @@ Dynamic reload is required:
   prompt content for future runs).
 - Reloaded config applies to future dispatch, retry scheduling, reconciliation decisions, hook
   execution, and agent launches.
+- Each active pipeline keeps its immutable config-generation snapshot. State-cap changes therefore
+  affect reservations made by a later generation and never re-bucket, cancel, or evict a live
+  worker. The serialized prepare-quiesce-commit boundary drains the previous runtime before a new
+  generation begins dispatching.
+- Process restart recovers no agent process or persisted capacity ledger. A restored pending step
+  makes a fresh reservation using the restored generation and the issue's latest reconciled state.
 - Implementations are not required to restart in-flight agent sessions automatically when config
   changes.
 - Extensions that manage their own listeners/resources (for example an HTTP server port change) may
@@ -1315,7 +1329,6 @@ An issue is dispatch-eligible only if all are true:
 - It is not already in `claimed`.
 - A live-worker slot is advisably available; the atomic reservation at step dispatch is
   authoritative.
-- Per-state concurrency slots are available.
 - Blocker rule for `Todo` state passes:
   - If the issue state is `Todo`, do not dispatch when any blocker is non-terminal.
 
@@ -1345,11 +1358,17 @@ Per-issue step limit:
 
 Per-state limit:
 
-- `max_concurrent_agents_by_state[state]` if present (state key normalized)
-- otherwise fallback to global limit
-
-Per-state limits remain issue-state admission limits and are separate from live-worker accounting.
-They do not replace either worker-capacity reservation.
+- `agent.max_concurrent_agents_by_state[normalized_reservation_state]` if present.
+- The orchestrator counts exact live workers in the matching private reservation-time bucket inside
+  the same registry lock as the global and per-issue checks, before one insertion linearization
+  point. A miss leaves the step pending without failure or retry consumption.
+- If the state is absent from the map, there is no additional state limit; there is no fallback to
+  running-issue admission or a separately named state limit.
+- A live worker keeps the bucket captured when it reserved. Tracker reconciliation never migrates,
+  cancels, evicts, or re-buckets it. A later initial, downstream, restored, resumed, or deferred
+  dispatch uses its owning issue snapshot's latest reconciled state for a new reservation.
+- These are implemented live-worker capacity limits. They do not guarantee parallel execution in
+  the trusted-local sequential first-release profile.
 
 Optional SSH host limit:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,6 +243,9 @@ polling:
   interval_ms: 30000
 
 agent:
+  max_concurrent_agents_by_state:
+    todo: 2
+    in review: 1
   turn_timeout_ms: 3600000
   inject_interaction_policy_instructions: true
   interaction_policy_overrides:
@@ -519,12 +522,13 @@ steps:
 | `max_concurrent_agents` | integer | `4` | Worker-capacity cap; concurrent dispatch is not a first-release guarantee |
 | `max_step_parallelism` | integer | `2` | Per-issue worker cap reserved for deferred multi-branch execution |
 
-These limits count live agent workers, not claimed or running issues. Ensemble reserves the global
-and per-issue slot atomically for each exact step worker before publishing the step as running or
-launching its agent. This describes the implemented capacity accounting, not a supported guarantee
-of parallel execution in the sequential MVP. If either limit is full, the ready step remains pending
-without consuming a retry cycle. Pending ready steps in claimed pipelines are reconsidered when
-worker capacity is released and before new candidate issues are admitted on the next tick.
+These limits count live agent workers, not claimed or running issues. Ensemble reserves global,
+per-issue, and any configured `agent.max_concurrent_agents_by_state` slot atomically for each exact
+step worker before publishing the step as running or launching its agent. This describes the
+implemented capacity accounting, not a supported guarantee of parallel execution in the sequential
+MVP. If any limit is full, the ready step remains pending without consuming a retry cycle. Pending
+ready steps in claimed pipelines are reconsidered when worker capacity is released and before new
+candidate issues are admitted on the next tick.
 
 A worker keeps its reservation until its event bridge has closed and quiescence is proven.
 Pre-launch errors roll back only the rejected worker's reservation; success, failure,
@@ -576,6 +580,7 @@ existing configurations: Ensemble cannot enforce provider-internal model turns.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `max_concurrent_agents_by_state` | map of positive integers | `{}` | Optional live-worker caps keyed by normalized tracker state |
 | `max_retry_backoff_ms` | integer | `300000` | Cap on exponential backoff delay between retries |
 | `command` | string | `"claude-code"` | Agent binary command |
 | `session_mode` | string | `"code"` | Agent session mode |
@@ -590,6 +595,24 @@ existing configurations: Ensemble cannot enforce provider-internal model turns.
 | `interaction_policy_overrides.agents.<agent>.text` | string | — | Required for useful `custom` overrides; policy text appended for that agent |
 | `interaction_policy_overrides.steps.<step>.mode` | string | `inherit` | Per-step override mode. Step override wins over agent override |
 | `interaction_policy_overrides.steps.<step>.text` | string | — | Required for useful `custom` per-step overrides |
+
+State-cap keys are trimmed and lowercased when configuration is parsed and when a worker reserves
+capacity. Blank keys, zero or negative limits, non-numeric limits, and distinct keys that collide
+after normalization reject the complete configuration with an error naming
+`agent.max_concurrent_agents_by_state` and the offending entry. Omitting the field is identical to
+an empty map. States not present in the map have no additional state limit; the global and per-issue
+limits still apply.
+
+The exact live-worker registry is the sole state-cap authority. A worker retains the normalized
+state bucket captured from its owning issue when it reserves; later tracker reconciliation does not
+migrate or evict it. The next initial, downstream, restored, resumed, or capacity-deferred dispatch
+uses the owning issue snapshot's latest reconciled state. A full bucket harmlessly leaves the step
+pending and consumes no retry. Config generations remain immutable for active pipelines, replacement
+uses the serialized prepare-quiesce-commit boundary, and restart restores no agent process or
+persisted capacity ledger, so restored pending work makes a fresh reservation.
+
+These limits describe implemented capacity, not guaranteed parallel execution in the trusted-local
+sequential first release.
 
 Interaction policy override precedence is: `step override` → `agent override` → global `agent.*` defaults.
 


### PR DESCRIPTION
## Summary

- expose normalized positive per-tracker-state live-worker caps through raw/guided config, OpenAPI, editor UI, and docs
- enforce global, per-issue, and reservation-time state capacity atomically in the exact worker registry
- cover initial, downstream, restored, resumed, reconciled-state, deferred, and backlog-admission paths without changing retry semantics

## Validation

- full non-desktop workspace tests (1,181 core tests)
- web-ui product E2E and feature check
- clippy with warnings denied and fmt/diff checks
- frontend codegen, 301 tests, typecheck, and production build
- final review-and-simplify-changes and review-only ponytail-review

Approved plan: https://github.com/chrisbanes/ensemble/issues/89#issuecomment-5170525864

Closes #89