### PR TITLE
Make delivery recovery durable

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,10 @@ _Avoid_: Prompt, comment
 The recoverable post-pipeline phase that performs configured repository publication, if any, before an issue is considered complete.
 _Avoid_: Completion, cleanup
 
+**Delivery**:
+The durable owner of configured repository publication after pipeline work and approval are complete. It preserves exact local and remote identity until publication is confirmed, waiting on a pull request, or blocked for operator recovery.
+_Avoid_: Worker, tracker state
+
 **Workspace**:
 The issue-owned filesystem area in which repository worktrees and run artifacts persist across steps and retries.
 _Avoid_: Checkout, repository

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -1705,6 +1705,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(previous_snapshot.clone()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -1,0 +1,1141 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::time::timeout;
+use tracing::warn;
+
+use super::pipeline_journal::{PipelineTransitionInput, PipelineTransitionKind, TerminalOutcome};
+use super::state::{FinalizeStatus, IssueFinalizeState, RepoFinalizeState};
+use super::Orchestrator;
+use crate::pipeline::engine::{PipelineRun, PipelineRunSnapshot};
+use crate::workspace::finalize::FinalizeMode;
+
+const DELIVERY_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
+const PULL_REQUEST_DISCOVERY_LIMIT: usize = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DeliveryMode {
+    Push,
+    PushAndPr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DeliveryPhase {
+    Prepared,
+    PushInFlight,
+    ReconcilingPush,
+    PrCreateInFlight,
+    ReconcilingPr,
+    Waiting,
+    Published,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DeliveryRepository {
+    pub mode: DeliveryMode,
+    pub phase: DeliveryPhase,
+    pub remote: String,
+    pub base_branch: String,
+    pub head_branch: String,
+    pub local_sha: String,
+    pub observed_remote_sha: Option<String>,
+    pub marker: String,
+    pub pr_number: Option<u64>,
+    pub pr_url: Option<String>,
+    pub last_error: Option<String>,
+    pub retry_from: Option<DeliveryPhase>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DeliveryRecord {
+    pub issue_id: String,
+    pub identifier: String,
+    pub run_id: String,
+    pub repositories: BTreeMap<String, DeliveryRepository>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeliveryAggregate {
+    Active,
+    Waiting,
+    Published,
+    Blocked,
+}
+
+impl DeliveryRecord {
+    pub(crate) fn aggregate(&self) -> DeliveryAggregate {
+        if self
+            .repositories
+            .values()
+            .any(|repo| repo.phase == DeliveryPhase::Blocked)
+        {
+            DeliveryAggregate::Blocked
+        } else if self
+            .repositories
+            .values()
+            .all(|repo| repo.phase == DeliveryPhase::Published)
+        {
+            DeliveryAggregate::Published
+        } else if self.repositories.values().all(|repo| {
+            matches!(
+                repo.phase,
+                DeliveryPhase::Waiting | DeliveryPhase::Published
+            )
+        }) {
+            DeliveryAggregate::Waiting
+        } else {
+            DeliveryAggregate::Active
+        }
+    }
+}
+
+pub(crate) fn canonical_marker(run_id: &str, issue_id: &str, repository_key: &str) -> String {
+    fn hex(value: &str) -> String {
+        value
+            .as_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    format!(
+        "<!-- ensemble:delivery:v1 run={} issue={} repository={} -->",
+        hex(run_id),
+        hex(issue_id),
+        hex(repository_key)
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemotePullRequest {
+    pub repository_key: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub head_sha: String,
+    pub body: String,
+    pub number: u64,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LocalRepositoryIdentity {
+    pub head_branch: String,
+    pub local_sha: String,
+}
+
+#[async_trait]
+pub(crate) trait DeliveryRemote: Send + Sync {
+    async fn local_identity(
+        &self,
+        repository_path: &Path,
+    ) -> Result<LocalRepositoryIdentity, String>;
+
+    async fn remote_head(
+        &self,
+        repository_path: &Path,
+        remote: &str,
+        head_branch: &str,
+    ) -> Result<Option<String>, String>;
+
+    async fn push(
+        &self,
+        repository_path: &Path,
+        remote: &str,
+        head_branch: &str,
+        local_sha: &str,
+    ) -> Result<(), String>;
+
+    async fn list_pull_requests(
+        &self,
+        repository_path: &Path,
+        repository_key: &str,
+    ) -> Result<Vec<RemotePullRequest>, String>;
+
+    async fn create_pull_request(
+        &self,
+        repository_path: &Path,
+        base_branch: &str,
+        head_branch: &str,
+        marker: &str,
+    ) -> Result<(), String>;
+}
+
+pub(crate) struct CliDeliveryRemote;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhPullRequest {
+    number: u64,
+    url: String,
+    body: String,
+    head_ref_name: String,
+    base_ref_name: String,
+    head_ref_oid: String,
+}
+
+#[async_trait]
+impl DeliveryRemote for CliDeliveryRemote {
+    async fn local_identity(
+        &self,
+        repository_path: &Path,
+    ) -> Result<LocalRepositoryIdentity, String> {
+        Ok(LocalRepositoryIdentity {
+            head_branch: command_stdout(
+                repository_path,
+                "git",
+                &["rev-parse", "--abbrev-ref", "HEAD"],
+            )
+            .await?,
+            local_sha: command_stdout(repository_path, "git", &["rev-parse", "HEAD"]).await?,
+        })
+    }
+
+    async fn remote_head(
+        &self,
+        repository_path: &Path,
+        remote: &str,
+        head_branch: &str,
+    ) -> Result<Option<String>, String> {
+        let reference = format!("refs/heads/{head_branch}");
+        let stdout = command_stdout(
+            repository_path,
+            "git",
+            &["ls-remote", "--heads", remote, &reference],
+        )
+        .await?;
+        if stdout.is_empty() {
+            return Ok(None);
+        }
+        let mut lines = stdout.lines();
+        let line = lines.next().expect("non-empty output has one line");
+        if lines.next().is_some() {
+            return Err(format!(
+                "remote '{remote}' returned multiple heads for '{reference}'"
+            ));
+        }
+        let (sha, observed_reference) = line
+            .split_once(char::is_whitespace)
+            .ok_or_else(|| "git ls-remote returned malformed output".to_string())?;
+        if observed_reference.trim() != reference {
+            return Err(format!(
+                "git ls-remote returned unexpected reference '{}'",
+                observed_reference.trim()
+            ));
+        }
+        Ok(Some(sha.to_string()))
+    }
+
+    async fn push(
+        &self,
+        repository_path: &Path,
+        remote: &str,
+        head_branch: &str,
+        local_sha: &str,
+    ) -> Result<(), String> {
+        let refspec = format!("{local_sha}:refs/heads/{head_branch}");
+        command_stdout(repository_path, "git", &["push", remote, &refspec])
+            .await
+            .map(|_| ())
+    }
+
+    async fn list_pull_requests(
+        &self,
+        repository_path: &Path,
+        repository_key: &str,
+    ) -> Result<Vec<RemotePullRequest>, String> {
+        let stdout = command_stdout(
+            repository_path,
+            "gh",
+            &[
+                "pr",
+                "list",
+                "--state",
+                "all",
+                "--limit",
+                "1000",
+                "--json",
+                "number,url,body,headRefName,baseRefName,headRefOid",
+            ],
+        )
+        .await?;
+        let pull_requests: Vec<GhPullRequest> = serde_json::from_str(&stdout)
+            .map_err(|error| format!("invalid gh pr list output: {error}"))?;
+        if pull_requests.len() == PULL_REQUEST_DISCOVERY_LIMIT {
+            return Err(format!(
+                "pull request discovery reached its {PULL_REQUEST_DISCOVERY_LIMIT}-item limit"
+            ));
+        }
+        Ok(pull_requests
+            .into_iter()
+            .map(|pull_request| RemotePullRequest {
+                repository_key: repository_key.to_string(),
+                head_branch: pull_request.head_ref_name,
+                base_branch: pull_request.base_ref_name,
+                head_sha: pull_request.head_ref_oid,
+                body: pull_request.body,
+                number: pull_request.number,
+                url: pull_request.url,
+            })
+            .collect())
+    }
+
+    async fn create_pull_request(
+        &self,
+        repository_path: &Path,
+        base_branch: &str,
+        head_branch: &str,
+        marker: &str,
+    ) -> Result<(), String> {
+        command_stdout(
+            repository_path,
+            "gh",
+            &[
+                "pr",
+                "create",
+                "--fill",
+                "--head",
+                head_branch,
+                "--base",
+                base_branch,
+                "--body",
+                marker,
+            ],
+        )
+        .await
+        .map(|_| ())
+    }
+}
+
+async fn command_stdout(
+    repository_path: &Path,
+    program: &str,
+    arguments: &[&str],
+) -> Result<String, String> {
+    let output = timeout(
+        DELIVERY_COMMAND_TIMEOUT,
+        tokio::process::Command::new(program)
+            .args(arguments)
+            .current_dir(repository_path)
+            .output(),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "{program} command timed out after {}s",
+            DELIVERY_COMMAND_TIMEOUT.as_secs()
+        )
+    })?
+    .map_err(|error| format!("failed to run {program}: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "{program} command failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PushReconciliation {
+    Push,
+    Advance,
+    Blocked { error: String },
+}
+
+pub(crate) fn reconcile_push(
+    repository: &DeliveryRepository,
+    remote_sha: Option<String>,
+) -> PushReconciliation {
+    match remote_sha {
+        None => PushReconciliation::Push,
+        Some(remote_sha) if remote_sha == repository.local_sha => PushReconciliation::Advance,
+        Some(remote_sha) => PushReconciliation::Blocked {
+            error: format!(
+                "remote head is {remote_sha}, expected {}",
+                repository.local_sha
+            ),
+        },
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PullRequestReconciliation {
+    Create,
+    Adopted { number: u64, url: String },
+    Blocked { error: String },
+}
+
+pub(crate) fn reconcile_pull_requests(
+    repository_key: &str,
+    repository: &DeliveryRepository,
+    pull_requests: &[RemotePullRequest],
+) -> PullRequestReconciliation {
+    if repository.observed_remote_sha.as_deref() != Some(repository.local_sha.as_str()) {
+        return PullRequestReconciliation::Blocked {
+            error: "remote head was not confirmed at the intended SHA".to_string(),
+        };
+    }
+
+    let same_identity = |pull_request: &&RemotePullRequest| {
+        pull_request.repository_key == repository_key
+            && pull_request.head_branch == repository.head_branch
+            && pull_request.base_branch == repository.base_branch
+    };
+    let marker_matches =
+        |pull_request: &&RemotePullRequest| pull_request.body.contains(repository.marker.as_str());
+
+    if pull_requests
+        .iter()
+        .filter(same_identity)
+        .any(|pull_request| !marker_matches(&pull_request))
+    {
+        return PullRequestReconciliation::Blocked {
+            error: "pull request identity matched but its delivery marker did not".to_string(),
+        };
+    }
+    if pull_requests
+        .iter()
+        .filter(marker_matches)
+        .any(|pull_request| !same_identity(&pull_request))
+    {
+        return PullRequestReconciliation::Blocked {
+            error: "delivery marker matched a different repository or branch identity".to_string(),
+        };
+    }
+
+    let matches: Vec<&RemotePullRequest> = pull_requests
+        .iter()
+        .filter(same_identity)
+        .filter(marker_matches)
+        .collect();
+    match matches.as_slice() {
+        [] => PullRequestReconciliation::Create,
+        [pull_request] if pull_request.head_sha == repository.local_sha => {
+            PullRequestReconciliation::Adopted {
+                number: pull_request.number,
+                url: pull_request.url.clone(),
+            }
+        }
+        [pull_request] => PullRequestReconciliation::Blocked {
+            error: format!(
+                "pull request head is {}, expected {}",
+                pull_request.head_sha, repository.local_sha
+            ),
+        },
+        _ => PullRequestReconciliation::Blocked {
+            error: "multiple pull requests match the delivery identity".to_string(),
+        },
+    }
+}
+
+impl Orchestrator {
+    pub(super) async fn process_delivery_recovery(&self) {
+        let deliveries = {
+            let state = self.state.read().await;
+            state
+                .delivery
+                .values()
+                .filter(|delivery| {
+                    matches!(
+                        delivery.aggregate(),
+                        DeliveryAggregate::Active | DeliveryAggregate::Published
+                    )
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        for delivery in deliveries {
+            if delivery.aggregate() == DeliveryAggregate::Published {
+                self.complete_published_delivery(&delivery).await;
+                continue;
+            }
+            let workspace = match self
+                .workspace_mgr
+                .prepare_workspace(&delivery.issue_id, &delivery.identifier)
+                .await
+            {
+                Ok(workspace) => workspace,
+                Err(error) => {
+                    let mut blocked = delivery.clone();
+                    for repository in blocked.repositories.values_mut().filter(|repository| {
+                        !matches!(
+                            repository.phase,
+                            DeliveryPhase::Waiting
+                                | DeliveryPhase::Published
+                                | DeliveryPhase::Blocked
+                        )
+                    }) {
+                        repository.retry_from = Some(repository.phase);
+                        repository.phase = DeliveryPhase::Blocked;
+                        repository.last_error = Some(error.to_string());
+                    }
+                    let _ = self.persist_delivery_record(&blocked, None).await;
+                    continue;
+                }
+            };
+            let snapshot = self
+                .pipeline_journal
+                .latest_live_record_for_issue(&delivery.issue_id)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|record| record.snapshot);
+            let delivery = self
+                .advance_delivery_record(delivery, &workspace, snapshot.as_ref())
+                .await;
+            self.project_delivery_artifacts(&delivery.issue_id, &delivery)
+                .await;
+            if delivery.aggregate() == DeliveryAggregate::Published {
+                self.complete_published_delivery(&delivery).await;
+                continue;
+            }
+            let finalize = Self::finalize_state_from_delivery(&delivery);
+            self.state
+                .write()
+                .await
+                .set_finalize_state(&delivery.issue_id, finalize);
+        }
+    }
+
+    async fn complete_published_delivery(&self, delivery: &DeliveryRecord) {
+        let config = self.config.read().await.clone();
+        let finalize = Self::finalize_state_from_delivery(delivery);
+        self.state
+            .write()
+            .await
+            .set_finalize_state(&delivery.issue_id, finalize.clone());
+        let issue = self
+            .tracker
+            .fetch_issue_states_by_ids(std::slice::from_ref(&delivery.issue_id))
+            .await
+            .ok()
+            .and_then(|issues| issues.into_iter().next());
+        self.begin_terminal_transition_for_identity(
+            &delivery.issue_id,
+            &delivery.identifier,
+            issue,
+            TerminalOutcome::Succeeded,
+            config.on_success,
+            None,
+        )
+        .await;
+    }
+    pub(super) async fn project_delivery_artifacts(
+        &self,
+        issue_id: &str,
+        delivery: &DeliveryRecord,
+    ) {
+        let mut state = self.state.write().await;
+        let Some(artifacts) = state.artifacts.get_mut(issue_id) else {
+            return;
+        };
+        for artifact in &mut artifacts.repos {
+            let Some(repository) = delivery.repositories.get(&artifact.repo) else {
+                continue;
+            };
+            artifact.finalize_status = match repository.phase {
+                DeliveryPhase::Waiting => "waiting",
+                DeliveryPhase::Published => "succeeded",
+                DeliveryPhase::Blocked => "failed",
+                _ => "in_progress",
+            }
+            .to_string();
+            artifact.pushed_ref = repository
+                .observed_remote_sha
+                .as_ref()
+                .map(|_| format!("{}/{}", repository.remote, repository.head_branch));
+            artifact.pr_url = repository.pr_url.clone();
+            artifact.last_error = repository.last_error.clone();
+        }
+    }
+    pub(super) fn finalize_state_from_delivery(delivery: &DeliveryRecord) -> IssueFinalizeState {
+        IssueFinalizeState {
+            issue_identifier: delivery.identifier.clone(),
+            status: match delivery.aggregate() {
+                DeliveryAggregate::Published => FinalizeStatus::Succeeded,
+                DeliveryAggregate::Blocked => FinalizeStatus::Failed,
+                DeliveryAggregate::Active | DeliveryAggregate::Waiting => {
+                    FinalizeStatus::InProgress
+                }
+            },
+            repos: Self::finalize_repositories_from_delivery(delivery),
+        }
+    }
+    pub(super) fn finalize_repositories_from_delivery(
+        delivery: &DeliveryRecord,
+    ) -> Vec<RepoFinalizeState> {
+        delivery
+            .repositories
+            .iter()
+            .map(|(repository_key, repository)| RepoFinalizeState {
+                repo: repository_key.clone(),
+                mode: match repository.mode {
+                    DeliveryMode::Push => "push",
+                    DeliveryMode::PushAndPr => "push_and_pr",
+                }
+                .to_string(),
+                approval_required: false,
+                status: match repository.phase {
+                    DeliveryPhase::Published => FinalizeStatus::Succeeded,
+                    DeliveryPhase::Blocked => FinalizeStatus::Failed,
+                    _ => FinalizeStatus::InProgress,
+                },
+                last_error: repository.last_error.clone(),
+            })
+            .collect()
+    }
+    pub(super) async fn advance_delivery_record(
+        &self,
+        mut delivery: DeliveryRecord,
+        workspace: &crate::workspace::manager::WorkspaceResult,
+        snapshot: Option<&PipelineRunSnapshot>,
+    ) -> DeliveryRecord {
+        let repository_keys = delivery.repositories.keys().cloned().collect::<Vec<_>>();
+        for repository_key in repository_keys {
+            let Some(repository_path) = workspace
+                .worktrees
+                .get(&repository_key)
+                .map(|worktree| worktree.path.clone())
+            else {
+                delivery = self
+                    .block_delivery_repository(
+                        &delivery,
+                        &repository_key,
+                        DeliveryPhase::Prepared,
+                        "delivery worktree is missing".to_string(),
+                        snapshot,
+                    )
+                    .await;
+                continue;
+            };
+            let mut created_pull_request = false;
+            for _ in 0..16 {
+                let before = delivery.clone();
+                let mut created_this_iteration = false;
+                let phase = delivery.repositories[&repository_key].phase;
+                delivery = match phase {
+                    DeliveryPhase::Prepared
+                    | DeliveryPhase::PushInFlight
+                    | DeliveryPhase::ReconcilingPush => {
+                        self.advance_delivery_push(
+                            delivery,
+                            &repository_key,
+                            &repository_path,
+                            snapshot,
+                        )
+                        .await
+                    }
+                    DeliveryPhase::PrCreateInFlight | DeliveryPhase::ReconcilingPr => {
+                        let (next, created) = self
+                            .advance_delivery_pull_request(
+                                delivery,
+                                &repository_key,
+                                &repository_path,
+                                snapshot,
+                                !created_pull_request,
+                            )
+                            .await;
+                        created_this_iteration = created;
+                        created_pull_request |= created;
+                        next
+                    }
+                    DeliveryPhase::Waiting | DeliveryPhase::Published | DeliveryPhase::Blocked => {
+                        break
+                    }
+                };
+                let entry = &delivery.repositories[&repository_key];
+                if (delivery == before && !created_this_iteration)
+                    || (matches!(
+                        entry.phase,
+                        DeliveryPhase::PushInFlight | DeliveryPhase::PrCreateInFlight
+                    ) && entry.last_error.is_some())
+                {
+                    break;
+                }
+            }
+        }
+        delivery
+    }
+    async fn advance_delivery_pull_request(
+        &self,
+        mut delivery: DeliveryRecord,
+        repository_key: &str,
+        repository_path: &Path,
+        snapshot: Option<&PipelineRunSnapshot>,
+        allow_create: bool,
+    ) -> (DeliveryRecord, bool) {
+        if delivery.repositories[repository_key].phase == DeliveryPhase::PrCreateInFlight {
+            let mut reconciling = delivery.clone();
+            let entry = reconciling.repositories.get_mut(repository_key).unwrap();
+            entry.phase = DeliveryPhase::ReconcilingPr;
+            entry.last_error = None;
+            delivery = match self
+                .persist_delivery_candidate(&delivery, reconciling, snapshot)
+                .await
+            {
+                Ok(persisted) => persisted,
+                Err(authoritative) => return (authoritative, false),
+            };
+        }
+        let repository = delivery.repositories[repository_key].clone();
+        if repository.phase != DeliveryPhase::ReconcilingPr {
+            return (delivery, false);
+        }
+        let pull_requests = match self
+            .delivery_remote
+            .list_pull_requests(repository_path, repository_key)
+            .await
+        {
+            Ok(pull_requests) => pull_requests,
+            Err(error) => {
+                return (
+                    self.block_delivery_repository(
+                        &delivery,
+                        repository_key,
+                        DeliveryPhase::ReconcilingPr,
+                        error,
+                        snapshot,
+                    )
+                    .await,
+                    false,
+                )
+            }
+        };
+        match reconcile_pull_requests(repository_key, &repository, &pull_requests) {
+            PullRequestReconciliation::Adopted { number, url } => {
+                let mut waiting = delivery.clone();
+                let entry = waiting.repositories.get_mut(repository_key).unwrap();
+                entry.phase = DeliveryPhase::Waiting;
+                entry.pr_number = Some(number);
+                entry.pr_url = Some(url);
+                entry.last_error = None;
+                entry.retry_from = None;
+                (
+                    self.persist_delivery_candidate(&delivery, waiting, snapshot)
+                        .await
+                        .unwrap_or_else(|authoritative| authoritative),
+                    false,
+                )
+            }
+            PullRequestReconciliation::Create if !allow_create => (delivery, false),
+            PullRequestReconciliation::Create => {
+                let mut in_flight = delivery.clone();
+                let entry = in_flight.repositories.get_mut(repository_key).unwrap();
+                entry.phase = DeliveryPhase::PrCreateInFlight;
+                entry.last_error = None;
+                delivery = match self
+                    .persist_delivery_candidate(&delivery, in_flight, snapshot)
+                    .await
+                {
+                    Ok(persisted) => persisted,
+                    Err(authoritative) => return (authoritative, false),
+                };
+                let result = self
+                    .delivery_remote
+                    .create_pull_request(
+                        repository_path,
+                        &repository.base_branch,
+                        &repository.head_branch,
+                        &repository.marker,
+                    )
+                    .await;
+                let mut after_create = delivery.clone();
+                let entry = after_create.repositories.get_mut(repository_key).unwrap();
+                match result {
+                    Ok(_) => {
+                        entry.phase = DeliveryPhase::ReconcilingPr;
+                        entry.last_error = None;
+                    }
+                    Err(error) => entry.last_error = Some(error),
+                }
+                let persisted = self
+                    .persist_delivery_candidate(&delivery, after_create, snapshot)
+                    .await
+                    .unwrap_or_else(|authoritative| authoritative);
+                let created =
+                    persisted.repositories[repository_key].phase == DeliveryPhase::ReconcilingPr;
+                (persisted, created)
+            }
+            PullRequestReconciliation::Blocked { error } => (
+                self.block_delivery_repository(
+                    &delivery,
+                    repository_key,
+                    DeliveryPhase::ReconcilingPr,
+                    error,
+                    snapshot,
+                )
+                .await,
+                false,
+            ),
+        }
+    }
+    async fn advance_delivery_push(
+        &self,
+        mut delivery: DeliveryRecord,
+        repository_key: &str,
+        repository_path: &Path,
+        snapshot: Option<&PipelineRunSnapshot>,
+    ) -> DeliveryRecord {
+        let phase = delivery.repositories[repository_key].phase;
+        if matches!(phase, DeliveryPhase::Prepared | DeliveryPhase::PushInFlight) {
+            let mut reconciling = delivery.clone();
+            let entry = reconciling.repositories.get_mut(repository_key).unwrap();
+            entry.phase = DeliveryPhase::ReconcilingPush;
+            entry.last_error = None;
+            entry.retry_from = None;
+            delivery = match self
+                .persist_delivery_candidate(&delivery, reconciling, snapshot)
+                .await
+            {
+                Ok(persisted) => persisted,
+                Err(authoritative) => return authoritative,
+            };
+        }
+        let repository = delivery.repositories[repository_key].clone();
+        if repository.phase != DeliveryPhase::ReconcilingPush {
+            return delivery;
+        }
+        let observed = match self
+            .delivery_remote
+            .remote_head(repository_path, &repository.remote, &repository.head_branch)
+            .await
+        {
+            Ok(observed) => observed,
+            Err(error) => {
+                return self
+                    .block_delivery_repository(
+                        &delivery,
+                        repository_key,
+                        DeliveryPhase::ReconcilingPush,
+                        error,
+                        snapshot,
+                    )
+                    .await
+            }
+        };
+        match reconcile_push(&repository, observed.clone()) {
+            PushReconciliation::Push => {
+                let mut in_flight = delivery.clone();
+                let entry = in_flight.repositories.get_mut(repository_key).unwrap();
+                entry.phase = DeliveryPhase::PushInFlight;
+                entry.last_error = None;
+                delivery = match self
+                    .persist_delivery_candidate(&delivery, in_flight, snapshot)
+                    .await
+                {
+                    Ok(persisted) => persisted,
+                    Err(authoritative) => return authoritative,
+                };
+                let result = self
+                    .delivery_remote
+                    .push(
+                        repository_path,
+                        &repository.remote,
+                        &repository.head_branch,
+                        &repository.local_sha,
+                    )
+                    .await;
+                let mut after_push = delivery.clone();
+                let entry = after_push.repositories.get_mut(repository_key).unwrap();
+                match result {
+                    Ok(_) => {
+                        entry.phase = DeliveryPhase::ReconcilingPush;
+                        entry.last_error = None;
+                    }
+                    Err(error) => entry.last_error = Some(error),
+                }
+                self.persist_delivery_candidate(&delivery, after_push, snapshot)
+                    .await
+                    .unwrap_or_else(|authoritative| authoritative)
+            }
+            PushReconciliation::Advance => {
+                let mut advanced = delivery.clone();
+                let entry = advanced.repositories.get_mut(repository_key).unwrap();
+                entry.observed_remote_sha = observed;
+                entry.last_error = None;
+                entry.retry_from = None;
+                entry.phase = match entry.mode {
+                    DeliveryMode::Push => DeliveryPhase::Published,
+                    DeliveryMode::PushAndPr => DeliveryPhase::ReconcilingPr,
+                };
+                self.persist_delivery_candidate(&delivery, advanced, snapshot)
+                    .await
+                    .unwrap_or_else(|authoritative| authoritative)
+            }
+            PushReconciliation::Blocked { error } => {
+                self.block_delivery_repository(
+                    &delivery,
+                    repository_key,
+                    DeliveryPhase::ReconcilingPush,
+                    error,
+                    snapshot,
+                )
+                .await
+            }
+        }
+    }
+    async fn block_delivery_repository(
+        &self,
+        current: &DeliveryRecord,
+        repository_key: &str,
+        retry_from: DeliveryPhase,
+        error: String,
+        snapshot: Option<&PipelineRunSnapshot>,
+    ) -> DeliveryRecord {
+        let mut blocked = current.clone();
+        if let Some(repository) = blocked.repositories.get_mut(repository_key) {
+            repository.phase = DeliveryPhase::Blocked;
+            repository.last_error = Some(error);
+            repository.retry_from = Some(retry_from);
+        }
+        self.persist_delivery_candidate(current, blocked, snapshot)
+            .await
+            .unwrap_or_else(|authoritative| authoritative)
+    }
+    async fn persist_delivery_candidate(
+        &self,
+        current: &DeliveryRecord,
+        candidate: DeliveryRecord,
+        snapshot: Option<&PipelineRunSnapshot>,
+    ) -> Result<DeliveryRecord, DeliveryRecord> {
+        match self.persist_delivery_record(&candidate, snapshot).await {
+            Ok(()) => Ok(candidate),
+            Err(error) => {
+                warn!(
+                    issue_id = %candidate.issue_id,
+                    error = %error,
+                    "failed to persist delivery transition; retaining the prior durable owner"
+                );
+                Err(current.clone())
+            }
+        }
+    }
+    pub(super) async fn persist_delivery_record(
+        &self,
+        delivery: &DeliveryRecord,
+        snapshot: Option<&PipelineRunSnapshot>,
+    ) -> Result<(), String> {
+        let snapshot = match snapshot {
+            Some(snapshot) => Some(snapshot.clone()),
+            None => self
+                .pipeline_journal
+                .latest_live_record_for_issue(&delivery.issue_id)
+                .await
+                .map_err(|error| {
+                    format!("failed to carry the pipeline snapshot into delivery: {error}")
+                })?
+                .filter(|record| record.run_id.as_deref() == Some(delivery.run_id.as_str()))
+                .and_then(|record| record.snapshot),
+        };
+        let input = PipelineTransitionInput {
+            kind: PipelineTransitionKind::DeliveryOwned,
+            issue_id: delivery.issue_id.clone(),
+            identifier: delivery.identifier.clone(),
+            run_id: Some(delivery.run_id.clone()),
+            cycle: snapshot.as_ref().map_or(0, |snapshot| snapshot.cycle),
+            step: None,
+            reason: None,
+            retry: None,
+            snapshot,
+            terminal_transition: None,
+            delivery: Some(delivery.clone()),
+        };
+        let transaction = self
+            .pipeline_journal
+            .begin_issue_transition(&delivery.issue_id)
+            .await;
+        if let Err(append_error) = transaction.append(input.clone()).await {
+            match transaction.latest_record_matches(&input).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    return Err(format!(
+                        "delivery transition was not persisted: {append_error}"
+                    ));
+                }
+                Err(read_error) => {
+                    return Err(format!(
+                        "delivery transition append was ambiguous: {append_error}; reconciliation read failed: {read_error}"
+                    ));
+                }
+            }
+        }
+        drop(transaction);
+
+        let mut state = self.state.write().await;
+        state.add_claimed(&delivery.issue_id);
+        state
+            .delivery
+            .insert(delivery.issue_id.clone(), delivery.clone());
+        Ok(())
+    }
+    pub(super) async fn prepare_delivery_record(
+        &self,
+        issue_id: &str,
+        issue_identifier: &str,
+        workspace: &crate::workspace::manager::WorkspaceResult,
+        repository_keys: &[String],
+    ) -> Result<(DeliveryRecord, Option<PipelineRunSnapshot>), String> {
+        let (run_id, snapshot) = {
+            let state = self.state.read().await;
+            let run_id = state
+                .running
+                .get(issue_id)
+                .and_then(|entry| entry.run_id.clone())
+                .or_else(|| state.issue_run_ids.get(issue_id).cloned())
+                .ok_or_else(|| "delivery requires a stable run ID".to_string())?;
+            let snapshot = state
+                .get_pipeline_run(issue_id)
+                .map(PipelineRun::to_snapshot);
+            (run_id, snapshot)
+        };
+        let configured_repositories = self.workspace_mgr.repos();
+        let mut repositories = std::collections::BTreeMap::new();
+        for repository_key in repository_keys {
+            let config = configured_repositories
+                .get(repository_key)
+                .ok_or_else(|| format!("repository '{repository_key}' is no longer configured"))?;
+            let worktree = workspace.worktrees.get(repository_key).ok_or_else(|| {
+                format!("worktree for repository '{repository_key}' was not prepared")
+            })?;
+            let identity = self.delivery_remote.local_identity(&worktree.path).await?;
+            let mode = match config.finalize.mode {
+                FinalizeMode::Push => DeliveryMode::Push,
+                FinalizeMode::PushAndPr => DeliveryMode::PushAndPr,
+                FinalizeMode::None => continue,
+            };
+            repositories.insert(
+                repository_key.clone(),
+                DeliveryRepository {
+                    mode,
+                    phase: DeliveryPhase::Prepared,
+                    remote: config.git_remote.clone(),
+                    base_branch: config.branch.clone(),
+                    head_branch: identity.head_branch,
+                    local_sha: identity.local_sha,
+                    observed_remote_sha: None,
+                    marker: canonical_marker(&run_id, issue_id, repository_key),
+                    pr_number: None,
+                    pr_url: None,
+                    last_error: None,
+                    retry_from: None,
+                },
+            );
+        }
+        Ok((
+            DeliveryRecord {
+                issue_id: issue_id.to_string(),
+                identifier: issue_identifier.to_string(),
+                run_id,
+                repositories,
+            },
+            snapshot,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repository(phase: DeliveryPhase) -> DeliveryRepository {
+        DeliveryRepository {
+            mode: DeliveryMode::PushAndPr,
+            phase,
+            remote: "origin".to_string(),
+            base_branch: "main".to_string(),
+            head_branch: "ensemble/issue-420".to_string(),
+            local_sha: "0123456789abcdef".to_string(),
+            observed_remote_sha: None,
+            marker: "<!-- ensemble:delivery:v1 -->".to_string(),
+            pr_number: None,
+            pr_url: None,
+            last_error: None,
+            retry_from: None,
+        }
+    }
+
+    fn pull_request(marker: &str, head_sha: &str) -> RemotePullRequest {
+        RemotePullRequest {
+            repository_key: "primary".to_string(),
+            head_branch: "ensemble/issue-420".to_string(),
+            base_branch: "main".to_string(),
+            head_sha: head_sha.to_string(),
+            body: marker.to_string(),
+            number: 420,
+            url: "https://github.com/example/project/pull/420".to_string(),
+        }
+    }
+
+    #[test]
+    fn delivery_record_derives_aggregate_without_serializing_it() {
+        let mut repositories = BTreeMap::new();
+        repositories.insert("zeta".to_string(), repository(DeliveryPhase::Published));
+        repositories.insert("alpha".to_string(), repository(DeliveryPhase::Waiting));
+        let record = DeliveryRecord {
+            issue_id: "issue-420".to_string(),
+            identifier: "ensemble#420".to_string(),
+            run_id: "run-420".to_string(),
+            repositories,
+        };
+
+        assert_eq!(record.aggregate(), DeliveryAggregate::Waiting);
+        let json = serde_json::to_string(&record).unwrap();
+        assert!(json.find("alpha").unwrap() < json.find("zeta").unwrap());
+        assert!(!json.contains("aggregate"));
+    }
+
+    #[test]
+    fn push_reconciliation_blocks_a_divergent_remote() {
+        let repo = repository(DeliveryPhase::ReconcilingPush);
+
+        assert_eq!(
+            reconcile_push(&repo, Some("fedcba9876543210".to_string())),
+            PushReconciliation::Blocked {
+                error: "remote head is fedcba9876543210, expected 0123456789abcdef".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn pr_reconciliation_requires_one_exact_identity_at_the_intended_sha() {
+        let mut repo = repository(DeliveryPhase::ReconcilingPr);
+        repo.observed_remote_sha = Some(repo.local_sha.clone());
+        let exact = pull_request(&repo.marker, &repo.local_sha);
+
+        assert_eq!(
+            reconcile_pull_requests("primary", &repo, std::slice::from_ref(&exact)),
+            PullRequestReconciliation::Adopted {
+                number: exact.number,
+                url: exact.url.clone(),
+            }
+        );
+
+        let wrong_head = pull_request(&repo.marker, "aaaaaaaaaaaaaaaa");
+        assert!(matches!(
+            reconcile_pull_requests("primary", &repo, &[wrong_head]),
+            PullRequestReconciliation::Blocked { .. }
+        ));
+        assert!(matches!(
+            reconcile_pull_requests("primary", &repo, &[exact.clone(), exact]),
+            PullRequestReconciliation::Blocked { .. }
+        ));
+    }
+
+    #[test]
+    fn zero_pr_matches_after_confirmed_push_allows_one_create_retry() {
+        let mut repo = repository(DeliveryPhase::ReconcilingPr);
+        repo.observed_remote_sha = Some(repo.local_sha.clone());
+
+        assert_eq!(
+            reconcile_pull_requests("primary", &repo, &[]),
+            PullRequestReconciliation::Create
+        );
+    }
+}

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod delivery;
 pub mod pipeline_journal;
 pub mod reconciler;
 pub mod retry;
@@ -16,7 +17,7 @@ use std::time::Duration;
 use chrono::Utc;
 use tokio::sync::RwLock;
 use tokio::sync::{mpsc, watch};
-use tokio::time::{sleep, timeout};
+use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
 use crate::acceptance::{AcceptanceCommandRunner, AcceptanceStatus, ShellAcceptanceCommandRunner};
@@ -35,7 +36,7 @@ use crate::agent::events::{
 use crate::agent::{AgentRunRequest, AgentRunner, InteractionResponseEnvelope};
 use crate::config::ensemble::{EnsembleConfig, OnFailure, StepKind};
 use crate::error::{AgentError, EnsembleError};
-use crate::history::artifacts::{FinalizeActionOutput, RunArtifacts};
+use crate::history::artifacts::{finalize_mode_name, RunArtifacts};
 use crate::history::model::{HistoryRecord, TokenTotals};
 use crate::history::writer::HistoryWriter;
 use crate::history_store::store::HistoryStore;
@@ -53,6 +54,11 @@ use crate::observability::events_contract::{
     ORCH_TICK_STARTED, STEP_STARTED, TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED,
     TRACKER_TRANSITION_SUCCEEDED,
 };
+#[cfg(test)]
+use crate::orchestrator::delivery::{
+    canonical_marker, DeliveryMode, DeliveryRecord, DeliveryRepository,
+};
+use crate::orchestrator::delivery::{CliDeliveryRemote, DeliveryPhase, DeliveryRemote};
 use crate::orchestrator::pipeline_journal::{
     PendingTerminalTransition, PipelineRunJournal, PipelineTransitionInput, PipelineTransitionKind,
     PipelineTransitionRecord, TerminalOutcome,
@@ -369,6 +375,7 @@ pub struct Orchestrator {
     tracker: Arc<dyn IssueTracker>,
     agent_runner: Arc<dyn AgentRunner>,
     acceptance_runner: Arc<dyn AcceptanceCommandRunner>,
+    delivery_remote: Arc<dyn DeliveryRemote>,
     workspace_mgr: Arc<WorkspaceManager>,
     interaction_store: InteractionStore,
     refresh_requested: Arc<tokio::sync::Notify>,
@@ -395,7 +402,6 @@ pub struct Orchestrator {
 }
 
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
-const FINALIZE_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Default)]
 pub(crate) struct QuiescingLatch(Arc<std::sync::Mutex<bool>>);
@@ -547,6 +553,7 @@ impl Orchestrator {
             tracker: parts.tracker,
             agent_runner: parts.agent_runner,
             acceptance_runner: parts.acceptance_runner,
+            delivery_remote: Arc::new(CliDeliveryRemote),
             interaction_store: InteractionStore::new(config_dir.to_path_buf()),
             workspace_mgr: Arc::new(parts.workspace_mgr),
             refresh_requested: parts.refresh_requested,
@@ -703,23 +710,22 @@ impl Orchestrator {
 
         // Startup terminal workspace cleanup
         {
-            let (terminal_states, pending_terminal_issue_ids) = {
+            let (terminal_states, retained_issue_ids) = {
                 let config = self.config.read().await;
                 let state = self.state.read().await;
-                (
-                    config.tracker.terminal_states.clone(),
-                    state
-                        .pending_terminal_transitions
-                        .keys()
-                        .cloned()
-                        .collect::<HashSet<_>>(),
-                )
+                let mut retained = state
+                    .pending_terminal_transitions
+                    .keys()
+                    .cloned()
+                    .collect::<HashSet<_>>();
+                retained.extend(state.delivery.keys().cloned());
+                (config.tracker.terminal_states.clone(), retained)
             };
             startup_terminal_cleanup(
                 self.tracker.as_ref(),
                 &terminal_states,
                 &self.workspace_mgr,
-                &pending_terminal_issue_ids,
+                &retained_issue_ids,
             )
             .await;
         }
@@ -853,6 +859,7 @@ impl Orchestrator {
         self.reconcile_pending_terminal_transitions().await;
         self.hydrate_waiting_on_human_from_store().await;
         self.process_interaction_thread_commands().await;
+        self.process_delivery_recovery().await;
         self.process_finalize_retries().await;
 
         // Pre-compute lowercase state lists once per tick
@@ -1134,6 +1141,7 @@ impl Orchestrator {
     fn restored_pipeline_ready_for_dispatch(state: &OrchestratorState, issue_id: &str) -> bool {
         if state.pending_terminal_transitions.contains_key(issue_id)
             || state.finalize.contains_key(issue_id)
+            || state.delivery.contains_key(issue_id)
         {
             return false;
         }
@@ -2021,6 +2029,7 @@ impl Orchestrator {
                 retry: None,
                 snapshot: Some(candidate_snapshot.clone()),
                 terminal_transition: None,
+                delivery: None,
             };
             let journal_transaction = self
                 .pipeline_journal
@@ -5510,6 +5519,7 @@ impl Orchestrator {
             interactions.retain(|interaction| {
                 !state.is_running(&interaction.issue_id)
                     && !state.is_waiting_on_human(&interaction.issue_id)
+                    && !state.delivery.contains_key(&interaction.issue_id)
                     && !state
                         .pending_terminal_transitions
                         .contains_key(&interaction.issue_id)
@@ -5539,6 +5549,7 @@ impl Orchestrator {
         for interaction in interactions {
             if state.is_running(&interaction.issue_id)
                 || state.is_waiting_on_human(&interaction.issue_id)
+                || state.delivery.contains_key(&interaction.issue_id)
                 || state
                     .pending_terminal_transitions
                     .contains_key(&interaction.issue_id)
@@ -5633,6 +5644,20 @@ impl Orchestrator {
         config_snapshot: Arc<EnsembleConfig>,
         issues_by_id: &HashMap<String, Issue>,
     ) -> Result<(), EnsembleError> {
+        if let Some(delivery) = record.delivery.clone() {
+            let mut state = self.state.write().await;
+            if state.delivery.contains_key(&record.issue_id) {
+                return Ok(());
+            }
+            let finalize = Self::finalize_state_from_delivery(&delivery);
+            state.add_claimed(&record.issue_id);
+            state
+                .issue_run_ids
+                .insert(record.issue_id.clone(), delivery.run_id.clone());
+            state.set_finalize_state(&record.issue_id, finalize);
+            state.delivery.insert(record.issue_id.clone(), delivery);
+            return Ok(());
+        }
         let snapshot = record
             .snapshot
             .clone()
@@ -5865,6 +5890,7 @@ impl Orchestrator {
             retry: None,
             snapshot: Some(snapshot),
             terminal_transition: Some(transition.clone()),
+            delivery: None,
         };
 
         if let Err(error) = self.pipeline_journal.append(input).await {
@@ -6255,6 +6281,7 @@ impl Orchestrator {
             retry: None,
             snapshot: Some(run.to_snapshot()),
             terminal_transition: Some(pending.transition.clone()),
+            delivery: None,
         })
     }
 
@@ -6308,6 +6335,7 @@ impl Orchestrator {
             retry,
             snapshot: Some(run.to_snapshot()),
             terminal_transition: None,
+            delivery: None,
         })
     }
 
@@ -6492,6 +6520,7 @@ impl Orchestrator {
             None
         };
 
+        let mut delivery_repo_names = Vec::new();
         for (repo_name, repo_config) in configured_repos {
             if !repo_config.finalize.enabled
                 || matches!(repo_config.finalize.mode, FinalizeMode::None)
@@ -6499,12 +6528,7 @@ impl Orchestrator {
                 continue;
             }
 
-            let mode_name = match repo_config.finalize.mode {
-                FinalizeMode::None => "none",
-                FinalizeMode::Push => "push",
-                FinalizeMode::PushAndPr => "push_and_pr",
-            }
-            .to_string();
+            let mode_name = finalize_mode_name(&repo_config.finalize.mode).to_string();
 
             if repo_config.finalize.approval_required {
                 let status = if headless {
@@ -6523,66 +6547,47 @@ impl Orchestrator {
                     .await;
                 continue;
             }
+            delivery_repo_names.push(repo_name.clone());
+        }
 
-            let worktree_path = prepared_workspace
-                .as_ref()
-                .and_then(|workspace| workspace.worktrees.get(repo_name))
-                .map(|wt| wt.path.clone());
-
-            let Some(worktree_path) = worktree_path else {
-                repos.push(RepoFinalizeState {
-                    repo: repo_name.clone(),
-                    mode: mode_name,
-                    approval_required: false,
-                    status: FinalizeStatus::Failed,
-                    last_error: Some("worktree not found for repo".to_string()),
-                });
-                self.update_repo_artifact_finalize_status(
-                    issue_id,
-                    repo_name,
-                    FinalizeStatus::Failed,
-                    Some("worktree not found for repo".to_string()),
-                )
-                .await;
-                continue;
+        if !delivery_repo_names.is_empty() {
+            let Some(workspace) = prepared_workspace.as_ref() else {
+                unreachable!("publication repositories require a prepared workspace");
             };
-
-            let finalize_result = self
-                .execute_finalize_action(
-                    &worktree_path,
-                    &repo_config.git_remote,
-                    &repo_config.branch,
-                    &repo_config.finalize.mode,
+            let prepared = self
+                .prepare_delivery_record(
+                    issue_id,
+                    issue_identifier,
+                    workspace,
+                    &delivery_repo_names,
                 )
                 .await;
-
-            match finalize_result {
-                Ok(output) => {
-                    repos.push(RepoFinalizeState {
-                        repo: repo_name.clone(),
-                        mode: mode_name,
-                        approval_required: false,
-                        status: FinalizeStatus::Succeeded,
-                        last_error: None,
-                    });
-                    self.update_repo_artifact_finalize_output(issue_id, repo_name, output)
+            let persisted = match prepared {
+                Ok((delivery, snapshot)) => self
+                    .persist_delivery_record(&delivery, snapshot.as_ref())
+                    .await
+                    .map(|()| (delivery, snapshot)),
+                Err(error) => Err(error),
+            };
+            match persisted {
+                Ok((delivery, snapshot)) => {
+                    let delivery = self
+                        .advance_delivery_record(delivery, workspace, snapshot.as_ref())
                         .await;
+                    repos.extend(Self::finalize_repositories_from_delivery(&delivery));
+                    self.project_delivery_artifacts(issue_id, &delivery).await;
                 }
                 Err(error) => {
-                    repos.push(RepoFinalizeState {
-                        repo: repo_name.clone(),
-                        mode: mode_name,
-                        approval_required: false,
-                        status: FinalizeStatus::Failed,
-                        last_error: Some(error.clone()),
-                    });
-                    self.update_repo_artifact_finalize_status(
-                        issue_id,
-                        repo_name,
-                        FinalizeStatus::Failed,
-                        Some(error),
-                    )
-                    .await;
+                    for repo_name in delivery_repo_names {
+                        let repo_config = &configured_repos[&repo_name];
+                        repos.push(RepoFinalizeState {
+                            repo: repo_name.clone(),
+                            mode: finalize_mode_name(&repo_config.finalize.mode).to_string(),
+                            approval_required: false,
+                            status: FinalizeStatus::Failed,
+                            last_error: Some(error.clone()),
+                        });
+                    }
                 }
             }
         }
@@ -6599,6 +6604,11 @@ impl Orchestrator {
             .any(|repo| repo.status == FinalizeStatus::PendingApproval)
         {
             FinalizeStatus::PendingApproval
+        } else if repos
+            .iter()
+            .any(|repo| repo.status == FinalizeStatus::InProgress)
+        {
+            FinalizeStatus::InProgress
         } else if repos
             .iter()
             .any(|repo| repo.status == FinalizeStatus::SkippedHeadless)
@@ -6624,12 +6634,18 @@ impl Orchestrator {
             state
                 .finalize
                 .iter()
-                .filter(|(_, finalize)| {
-                    finalize.status == FinalizeStatus::InProgress
-                        || finalize
-                            .repos
-                            .iter()
-                            .any(|repo| repo.status == FinalizeStatus::InProgress)
+                .filter(|(issue_id, finalize)| {
+                    finalize.repos.iter().any(|repo| {
+                        repo.status == FinalizeStatus::InProgress
+                            && state.delivery.get(*issue_id).is_none_or(|delivery| {
+                                delivery
+                                    .repositories
+                                    .get(&repo.repo)
+                                    .is_none_or(|repository| {
+                                        repository.phase == DeliveryPhase::Blocked
+                                    })
+                            })
+                    })
                 })
                 .map(|(issue_id, finalize)| (issue_id.clone(), finalize.issue_identifier.clone()))
                 .collect()
@@ -6689,57 +6705,115 @@ impl Orchestrator {
             }
         };
 
-        let repo_configs = self.workspace_mgr.repos().clone();
-        let mut outcomes: HashMap<String, Result<FinalizeActionOutput, String>> = HashMap::new();
-
-        for repo_name in &retry_repo_names {
-            let Some(repo_config) = repo_configs.get(repo_name) else {
-                outcomes.insert(
-                    repo_name.clone(),
-                    Err("repo config missing for finalize retry".to_string()),
-                );
-                continue;
+        let existing = self.state.read().await.delivery.get(issue_id).cloned();
+        let missing_repo_names = retry_repo_names
+            .iter()
+            .filter(|repo_name| {
+                !existing
+                    .as_ref()
+                    .is_some_and(|delivery| delivery.repositories.contains_key(repo_name.as_str()))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let (mut delivery, snapshot) = if missing_repo_names.is_empty() {
+            let Some(existing) = existing else {
+                return;
             };
-            let Some(worktree) = workspace.worktrees.get(repo_name) else {
-                outcomes.insert(
-                    repo_name.clone(),
-                    Err("worktree missing for finalize retry".to_string()),
-                );
-                continue;
-            };
-
-            let result = self
-                .execute_finalize_action(
-                    &worktree.path,
-                    &repo_config.git_remote,
-                    &repo_config.branch,
-                    &repo_config.finalize.mode,
+            let snapshot = self
+                .pipeline_journal
+                .latest_live_record_for_issue(issue_id)
+                .await
+                .ok()
+                .flatten()
+                .filter(|record| record.run_id.as_deref() == Some(existing.run_id.as_str()))
+                .and_then(|record| record.snapshot);
+            (existing, snapshot)
+        } else {
+            let (mut prepared, snapshot) = match self
+                .prepare_delivery_record(
+                    issue_id,
+                    issue_identifier,
+                    &workspace,
+                    &missing_repo_names,
                 )
-                .await;
-            outcomes.insert(repo_name.clone(), result);
+                .await
+            {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    let mut state = self.state.write().await;
+                    if let Some(finalize) = state.get_finalize_state_mut(issue_id) {
+                        finalize.status = FinalizeStatus::Failed;
+                        for repo in &mut finalize.repos {
+                            if retry_repo_names.contains(&repo.repo) {
+                                repo.status = FinalizeStatus::Failed;
+                                repo.last_error = Some(error.clone());
+                            }
+                        }
+                    }
+                    return;
+                }
+            };
+            if let Some(existing) = existing {
+                if existing.run_id != prepared.run_id {
+                    warn!(
+                        issue_id = %issue_id,
+                        "refusing to merge finalization approval into a different delivery run"
+                    );
+                    return;
+                }
+                let mut repositories = existing.repositories;
+                repositories.extend(prepared.repositories);
+                prepared.repositories = repositories;
+            }
+            (prepared, snapshot)
+        };
+        for repo_name in &retry_repo_names {
+            let Some(repository) = delivery.repositories.get_mut(repo_name) else {
+                continue;
+            };
+            if repository.phase == DeliveryPhase::Blocked {
+                repository.phase = repository.retry_from.unwrap_or(DeliveryPhase::Prepared);
+                repository.retry_from = None;
+                repository.last_error = None;
+            }
         }
+        if let Err(error) = self
+            .persist_delivery_record(&delivery, snapshot.as_ref())
+            .await
+        {
+            let mut state = self.state.write().await;
+            if let Some(finalize) = state.get_finalize_state_mut(issue_id) {
+                finalize.status = FinalizeStatus::Failed;
+                for repo in &mut finalize.repos {
+                    if retry_repo_names.contains(&repo.repo) {
+                        repo.status = FinalizeStatus::Failed;
+                        repo.last_error = Some(error.clone());
+                    }
+                }
+            }
+            return;
+        }
+        let delivery = self
+            .advance_delivery_record(delivery, &workspace, snapshot.as_ref())
+            .await;
+        self.project_delivery_artifacts(issue_id, &delivery).await;
 
         let (final_status, should_complete, last_error) = {
             let mut state = self.state.write().await;
             let mut final_status = FinalizeStatus::NotRequired;
-            let mut should_complete = false;
-            let mut last_error: Option<String> = None;
+            let mut last_error = None;
 
             if let Some(finalize) = state.get_finalize_state_mut(issue_id) {
                 for repo in &mut finalize.repos {
-                    if let Some(result) = outcomes.get(&repo.repo) {
-                        match result {
-                            Ok(_) => {
-                                repo.status = FinalizeStatus::Succeeded;
-                                repo.last_error = None;
-                            }
-                            Err(error) => {
-                                repo.status = FinalizeStatus::Failed;
-                                repo.last_error = Some(error.clone());
-                                last_error = Some(error.clone());
-                            }
-                        }
-                    }
+                    let Some(repository) = delivery.repositories.get(&repo.repo) else {
+                        continue;
+                    };
+                    repo.status = match repository.phase {
+                        DeliveryPhase::Published => FinalizeStatus::Succeeded,
+                        DeliveryPhase::Blocked => FinalizeStatus::Failed,
+                        _ => FinalizeStatus::InProgress,
+                    };
+                    repo.last_error = repository.last_error.clone();
                 }
 
                 final_status = if finalize.repos.is_empty() {
@@ -6773,31 +6847,16 @@ impl Orchestrator {
                 };
 
                 finalize.status = final_status.clone();
-                should_complete = matches!(
-                    final_status,
-                    FinalizeStatus::Succeeded | FinalizeStatus::NotRequired
-                );
+                last_error = finalize
+                    .repos
+                    .iter()
+                    .find_map(|repo| repo.last_error.clone());
             }
 
-            if let Some(artifacts) = state.artifacts.get_mut(issue_id) {
-                for repo_artifact in &mut artifacts.repos {
-                    if let Some(result) = outcomes.get(&repo_artifact.repo) {
-                        match result {
-                            Ok(output) => {
-                                repo_artifact.finalize_status = "succeeded".to_string();
-                                repo_artifact.pushed_ref = output.pushed_ref.clone();
-                                repo_artifact.pr_url = output.pr_url.clone();
-                                repo_artifact.last_error = None;
-                            }
-                            Err(error) => {
-                                repo_artifact.finalize_status = "failed".to_string();
-                                repo_artifact.last_error = Some(error.clone());
-                            }
-                        }
-                    }
-                }
-            }
-
+            let should_complete = matches!(
+                final_status,
+                FinalizeStatus::Succeeded | FinalizeStatus::NotRequired
+            );
             (final_status, should_complete, last_error)
         };
 
@@ -6845,166 +6904,6 @@ impl Orchestrator {
                 error = %error,
                 "finalize retry failed"
             );
-        }
-    }
-
-    async fn execute_finalize_action(
-        &self,
-        repo_path: &std::path::Path,
-        remote: &str,
-        base_branch: &str,
-        mode: &FinalizeMode,
-    ) -> Result<FinalizeActionOutput, String> {
-        let push_output = tokio::process::Command::new("git")
-            .arg("push")
-            .arg(remote)
-            .arg("HEAD")
-            .current_dir(repo_path)
-            .output();
-        let push_output = timeout(FINALIZE_COMMAND_TIMEOUT, push_output)
-            .await
-            .map_err(|_| {
-                format!(
-                    "git push timed out after {}s",
-                    FINALIZE_COMMAND_TIMEOUT.as_secs()
-                )
-            })?
-            .map_err(|error| format!("failed to run git push: {error}"))?;
-        if !push_output.status.success() {
-            return Err(format!(
-                "git push failed: {}",
-                String::from_utf8_lossy(&push_output.stderr)
-            ));
-        }
-
-        let current_branch = Self::current_branch(repo_path).await?;
-        let mut output = FinalizeActionOutput {
-            pushed_ref: Some(format!("{remote}/{current_branch}")),
-            pr_url: None,
-        };
-
-        if matches!(mode, FinalizeMode::PushAndPr) {
-            let pr_output = tokio::process::Command::new("gh")
-                .args([
-                    "pr",
-                    "create",
-                    "--fill",
-                    "--head",
-                    &current_branch,
-                    "--base",
-                    base_branch,
-                ])
-                .current_dir(repo_path)
-                .output();
-            let pr_output = timeout(FINALIZE_COMMAND_TIMEOUT, pr_output)
-                .await
-                .map_err(|_| {
-                    format!(
-                        "gh pr create timed out after {}s",
-                        FINALIZE_COMMAND_TIMEOUT.as_secs()
-                    )
-                })?
-                .map_err(|error| format!("failed to run gh pr create: {error}"))?;
-            if !pr_output.status.success() {
-                let pr_create_stderr = String::from_utf8_lossy(&pr_output.stderr).to_string();
-                if pr_create_stderr.contains("already exists") {
-                    let pr_lookup_output = tokio::process::Command::new("gh")
-                        .args([
-                            "pr",
-                            "list",
-                            "--head",
-                            &current_branch,
-                            "--base",
-                            base_branch,
-                            "--state",
-                            "all",
-                            "--json",
-                            "url",
-                            "--limit",
-                            "1",
-                        ])
-                        .current_dir(repo_path)
-                        .output();
-                    let pr_lookup_output = timeout(FINALIZE_COMMAND_TIMEOUT, pr_lookup_output)
-                        .await
-                        .map_err(|_| {
-                            format!(
-                                "gh pr list timed out after {}s",
-                                FINALIZE_COMMAND_TIMEOUT.as_secs()
-                            )
-                        })?
-                        .map_err(|error| format!("failed to run gh pr list: {error}"))?;
-
-                    if pr_lookup_output.status.success() {
-                        let pr_lookup_stdout = String::from_utf8_lossy(&pr_lookup_output.stdout);
-                        if let Some(pr_url) = Self::parse_first_pr_url(&pr_lookup_stdout) {
-                            output.pr_url = Some(pr_url);
-                            return Ok(output);
-                        }
-                    }
-                }
-
-                return Err(format!("gh pr create failed: {pr_create_stderr}"));
-            }
-
-            output.pr_url = Self::parse_first_pr_url(&String::from_utf8_lossy(&pr_output.stdout));
-        }
-
-        Ok(output)
-    }
-
-    async fn current_branch(repo_path: &std::path::Path) -> Result<String, String> {
-        let branch_output = tokio::process::Command::new("git")
-            .args(["rev-parse", "--abbrev-ref", "HEAD"])
-            .current_dir(repo_path)
-            .output()
-            .await
-            .map_err(|error| format!("failed to resolve branch: {error}"))?;
-        if !branch_output.status.success() {
-            return Err(format!(
-                "failed to resolve current branch: {}",
-                String::from_utf8_lossy(&branch_output.stderr)
-            ));
-        }
-        Ok(String::from_utf8_lossy(&branch_output.stdout)
-            .trim()
-            .to_string())
-    }
-
-    fn parse_first_pr_url(stdout: &str) -> Option<String> {
-        let trimmed = stdout.trim();
-        if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
-            return Some(trimmed.lines().next().unwrap_or(trimmed).trim().to_string());
-        }
-        serde_json::from_str::<Vec<serde_json::Value>>(trimmed)
-            .ok()
-            .and_then(|values| {
-                values
-                    .first()
-                    .and_then(|value| value.get("url"))
-                    .and_then(|url| url.as_str())
-                    .map(ToString::to_string)
-            })
-    }
-
-    async fn update_repo_artifact_finalize_output(
-        &self,
-        issue_id: &str,
-        repo_name: &str,
-        output: FinalizeActionOutput,
-    ) {
-        let mut state = self.state.write().await;
-        if let Some(artifacts) = state.artifacts.get_mut(issue_id) {
-            if let Some(repo_artifact) = artifacts
-                .repos
-                .iter_mut()
-                .find(|artifact| artifact.repo == repo_name)
-            {
-                repo_artifact.finalize_status = "succeeded".to_string();
-                repo_artifact.pushed_ref = output.pushed_ref;
-                repo_artifact.pr_url = output.pr_url;
-                repo_artifact.last_error = None;
-            }
         }
     }
 
@@ -7685,6 +7584,7 @@ impl Orchestrator {
                                                 retry: None,
                                                 snapshot: Some(previous_run.to_snapshot()),
                                                 terminal_transition: None,
+                                                delivery: None,
                                             }),
                                         workspace_path: workspace_path.clone(),
                                         step_outputs,
@@ -9562,6 +9462,670 @@ mod tests {
         )
     }
 
+    struct SuccessfulDeliveryRemote {
+        journal: PipelineRunJournal,
+        issue_id: String,
+        remote_sha: std::sync::Mutex<Option<String>>,
+        pull_requests: std::sync::Mutex<Vec<crate::orchestrator::delivery::RemotePullRequest>>,
+        mutation_phases: std::sync::Mutex<Vec<crate::orchestrator::delivery::DeliveryPhase>>,
+    }
+
+    impl SuccessfulDeliveryRemote {
+        async fn latest_phase(&self) -> crate::orchestrator::delivery::DeliveryPhase {
+            self.journal
+                .latest_live_record_for_issue(&self.issue_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .delivery
+                .unwrap()
+                .repositories
+                .get("source-repo")
+                .unwrap()
+                .phase
+        }
+    }
+
+    #[async_trait]
+    impl crate::orchestrator::delivery::DeliveryRemote for SuccessfulDeliveryRemote {
+        async fn local_identity(
+            &self,
+            _repository_path: &Path,
+        ) -> Result<crate::orchestrator::delivery::LocalRepositoryIdentity, String> {
+            Ok(crate::orchestrator::delivery::LocalRepositoryIdentity {
+                head_branch: "ensemble/repo-1".to_string(),
+                local_sha: "0123456789abcdef".to_string(),
+            })
+        }
+
+        async fn remote_head(
+            &self,
+            _repository_path: &Path,
+            _remote: &str,
+            _head_branch: &str,
+        ) -> Result<Option<String>, String> {
+            Ok(self.remote_sha.lock().unwrap().clone())
+        }
+
+        async fn push(
+            &self,
+            _repository_path: &Path,
+            _remote: &str,
+            _head_branch: &str,
+            local_sha: &str,
+        ) -> Result<(), String> {
+            assert_eq!(local_sha, "0123456789abcdef");
+            let phase = self.latest_phase().await;
+            self.mutation_phases.lock().unwrap().push(phase);
+            *self.remote_sha.lock().unwrap() = Some("0123456789abcdef".to_string());
+            Ok(())
+        }
+
+        async fn list_pull_requests(
+            &self,
+            _repository_path: &Path,
+            _repository_key: &str,
+        ) -> Result<Vec<crate::orchestrator::delivery::RemotePullRequest>, String> {
+            Ok(self.pull_requests.lock().unwrap().clone())
+        }
+
+        async fn create_pull_request(
+            &self,
+            _repository_path: &Path,
+            base_branch: &str,
+            head_branch: &str,
+            marker: &str,
+        ) -> Result<(), String> {
+            let phase = self.latest_phase().await;
+            self.mutation_phases.lock().unwrap().push(phase);
+            self.pull_requests.lock().unwrap().push(
+                crate::orchestrator::delivery::RemotePullRequest {
+                    repository_key: "source-repo".to_string(),
+                    head_branch: head_branch.to_string(),
+                    base_branch: base_branch.to_string(),
+                    head_sha: "0123456789abcdef".to_string(),
+                    body: marker.to_string(),
+                    number: 420,
+                    url: "https://github.com/example/project/pull/420".to_string(),
+                },
+            );
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn push_and_pr_persists_delivery_before_remote_mutation_and_releases_worker_capacity() {
+        let (repo_temp, mut repo_config) = create_finalize_repo().await;
+        repo_config.finalize.mode = FinalizeMode::PushAndPr;
+        repo_config.finalize.approval_required = false;
+        let config = Arc::new(RwLock::new(make_config()));
+        let issue = test_issue("1", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(CountingRunner {
+            runs: Arc::new(AtomicUsize::new(0)),
+        });
+        let workspace_temp = tempfile::TempDir::new().unwrap();
+        let workspace_mgr =
+            WorkspaceManager::new(workspace_temp.path(), Some(vec![repo_config])).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            workspace_temp.path(),
+            shutdown_rx,
+        );
+        let remote = Arc::new(SuccessfulDeliveryRemote {
+            journal: orchestrator.pipeline_journal.clone(),
+            issue_id: issue.id.clone(),
+            remote_sha: std::sync::Mutex::new(None),
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            mutation_phases: std::sync::Mutex::new(Vec::new()),
+        });
+        orchestrator.delivery_remote = remote.clone();
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+            run.start();
+            run.mark_running("build", "session-1".to_string());
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, None);
+            state.insert_pipeline_run(&issue.id, run, Arc::new(cfg.clone()));
+        }
+
+        orchestrator
+            .handle_worker_exit(
+                &issue.id,
+                "build",
+                WorkerResult::Success {
+                    output: succeeded_step_output(),
+                    approval_request: None,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        let delivery = state.delivery.get(&issue.id).expect("delivery owner");
+        assert_eq!(
+            delivery.repositories["source-repo"].phase,
+            crate::orchestrator::delivery::DeliveryPhase::Waiting
+        );
+        assert_eq!(delivery.repositories["source-repo"].pr_number, Some(420));
+        assert!(!state.is_running(&issue.id));
+        assert!(state.is_claimed(&issue.id));
+        assert_eq!(live_worker_count(&orchestrator.cancellation_registry), 0);
+        drop(state);
+
+        assert_eq!(
+            *remote.mutation_phases.lock().unwrap(),
+            vec![
+                crate::orchestrator::delivery::DeliveryPhase::PushInFlight,
+                crate::orchestrator::delivery::DeliveryPhase::PrCreateInFlight,
+            ]
+        );
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        let prepared = records
+            .iter()
+            .position(|record| {
+                record.delivery.as_ref().is_some_and(|delivery| {
+                    delivery.repositories["source-repo"].phase
+                        == crate::orchestrator::delivery::DeliveryPhase::Prepared
+                })
+            })
+            .expect("prepared record");
+        let first_mutation = records
+            .iter()
+            .position(|record| {
+                record.delivery.as_ref().is_some_and(|delivery| {
+                    delivery.repositories["source-repo"].phase
+                        == crate::orchestrator::delivery::DeliveryPhase::PushInFlight
+                })
+            })
+            .expect("push in flight record");
+        assert!(prepared < first_mutation);
+
+        drop(repo_temp);
+    }
+
+    struct RecoveryDeliveryRemote {
+        pull_requests: std::sync::Mutex<Vec<crate::orchestrator::delivery::RemotePullRequest>>,
+        pushes: AtomicUsize,
+        creates: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl crate::orchestrator::delivery::DeliveryRemote for RecoveryDeliveryRemote {
+        async fn local_identity(
+            &self,
+            _repository_path: &Path,
+        ) -> Result<crate::orchestrator::delivery::LocalRepositoryIdentity, String> {
+            Ok(crate::orchestrator::delivery::LocalRepositoryIdentity {
+                head_branch: "ensemble/repo-1".to_string(),
+                local_sha: "0123456789abcdef".to_string(),
+            })
+        }
+
+        async fn remote_head(
+            &self,
+            _repository_path: &Path,
+            _remote: &str,
+            _head_branch: &str,
+        ) -> Result<Option<String>, String> {
+            Ok(Some("0123456789abcdef".to_string()))
+        }
+
+        async fn push(
+            &self,
+            _repository_path: &Path,
+            _remote: &str,
+            _head_branch: &str,
+            local_sha: &str,
+        ) -> Result<(), String> {
+            assert_eq!(local_sha, "0123456789abcdef");
+            self.pushes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn list_pull_requests(
+            &self,
+            _repository_path: &Path,
+            _repository_key: &str,
+        ) -> Result<Vec<crate::orchestrator::delivery::RemotePullRequest>, String> {
+            Ok(self.pull_requests.lock().unwrap().clone())
+        }
+
+        async fn create_pull_request(
+            &self,
+            _repository_path: &Path,
+            _base_branch: &str,
+            _head_branch: &str,
+            _marker: &str,
+        ) -> Result<(), String> {
+            self.creates.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    async fn recovery_test_orchestrator(
+        remote: Arc<RecoveryDeliveryRemote>,
+    ) -> (
+        Orchestrator,
+        tempfile::TempDir,
+        tempfile::TempDir,
+        DeliveryRecord,
+    ) {
+        let (repo_temp, mut repo_config) = create_finalize_repo().await;
+        repo_config.finalize.mode = FinalizeMode::PushAndPr;
+        repo_config.finalize.approval_required = false;
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(CountingRunner {
+            runs: Arc::new(AtomicUsize::new(0)),
+        });
+        let workspace_temp = tempfile::TempDir::new().unwrap();
+        let workspace_mgr =
+            WorkspaceManager::new(workspace_temp.path(), Some(vec![repo_config])).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            workspace_temp.path(),
+            shutdown_rx,
+        );
+        orchestrator.delivery_remote = remote;
+        let marker = canonical_marker("run-1", "1", "source-repo");
+        let delivery = DeliveryRecord {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            run_id: "run-1".to_string(),
+            repositories: [(
+                "source-repo".to_string(),
+                DeliveryRepository {
+                    mode: DeliveryMode::PushAndPr,
+                    phase: DeliveryPhase::PrCreateInFlight,
+                    remote: "origin".to_string(),
+                    base_branch: "main".to_string(),
+                    head_branch: "ensemble/repo-1".to_string(),
+                    local_sha: "0123456789abcdef".to_string(),
+                    observed_remote_sha: Some("0123456789abcdef".to_string()),
+                    marker,
+                    pr_number: None,
+                    pr_url: None,
+                    last_error: Some("create response was ambiguous".to_string()),
+                    retry_from: None,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        };
+        orchestrator
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+        (orchestrator, workspace_temp, repo_temp, delivery)
+    }
+
+    #[tokio::test]
+    async fn ambiguous_pr_creation_reconciles_existing_pull_request_before_retry() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        remote.pull_requests.lock().unwrap().push(
+            crate::orchestrator::delivery::RemotePullRequest {
+                repository_key: "source-repo".to_string(),
+                head_branch: "ensemble/repo-1".to_string(),
+                base_branch: "main".to_string(),
+                head_sha: "0123456789abcdef".to_string(),
+                body: delivery.repositories["source-repo"].marker.clone(),
+                number: 420,
+                url: "https://github.com/example/project/pull/420".to_string(),
+            },
+        );
+
+        orchestrator.process_delivery_recovery().await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(
+            state.delivery["1"].repositories["source-repo"].phase,
+            DeliveryPhase::Waiting
+        );
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn ambiguous_publication_conflict_enters_blocked_without_mutation() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let exact = crate::orchestrator::delivery::RemotePullRequest {
+            repository_key: "source-repo".to_string(),
+            head_branch: "ensemble/repo-1".to_string(),
+            base_branch: "main".to_string(),
+            head_sha: "0123456789abcdef".to_string(),
+            body: delivery.repositories["source-repo"].marker.clone(),
+            number: 420,
+            url: "https://github.com/example/project/pull/420".to_string(),
+        };
+        *remote.pull_requests.lock().unwrap() = vec![exact.clone(), exact];
+
+        orchestrator.process_delivery_recovery().await;
+
+        let state = orchestrator.state.read().await;
+        let repository = &state.delivery["1"].repositories["source-repo"];
+        assert_eq!(repository.phase, DeliveryPhase::Blocked);
+        assert_eq!(repository.retry_from, Some(DeliveryPhase::ReconcilingPr));
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn operator_retry_resumes_blocked_delivery_from_stored_identity() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Blocked;
+        repository.local_sha = "stored-delivery-sha".to_string();
+        repository.observed_remote_sha = Some("stored-delivery-sha".to_string());
+        repository.retry_from = Some(DeliveryPhase::ReconcilingPr);
+        repository.last_error = Some("ambiguous create response".to_string());
+        remote.pull_requests.lock().unwrap().push(
+            crate::orchestrator::delivery::RemotePullRequest {
+                repository_key: "source-repo".to_string(),
+                head_branch: repository.head_branch.clone(),
+                base_branch: repository.base_branch.clone(),
+                head_sha: repository.local_sha.clone(),
+                body: repository.marker.clone(),
+                number: 420,
+                url: "https://github.com/example/project/pull/420".to_string(),
+            },
+        );
+        orchestrator
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+        {
+            let mut state = orchestrator.state.write().await;
+            state.set_finalize_state(
+                "1",
+                IssueFinalizeState {
+                    issue_identifier: "repo#1".to_string(),
+                    status: FinalizeStatus::InProgress,
+                    repos: vec![RepoFinalizeState {
+                        repo: "source-repo".to_string(),
+                        mode: "push_and_pr".to_string(),
+                        approval_required: false,
+                        status: FinalizeStatus::InProgress,
+                        last_error: None,
+                    }],
+                },
+            );
+        }
+
+        orchestrator.process_finalize_retries().await;
+
+        let state = orchestrator.state.read().await;
+        let repository = &state.delivery["1"].repositories["source-repo"];
+        assert_eq!(repository.phase, DeliveryPhase::Waiting);
+        assert_eq!(repository.local_sha, "stored-delivery-sha");
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn push_only_published_recovery_continues_terminal_transition() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.mode = DeliveryMode::Push;
+        repository.phase = DeliveryPhase::Published;
+        repository.pr_number = None;
+        repository.pr_url = None;
+
+        let snapshot = {
+            let config = orchestrator.config.read().await;
+            let dag = build_dag(&config.steps).unwrap();
+            let run = PipelineRun::new(delivery.issue_id.clone(), 1, dag);
+            run.start();
+            run.to_snapshot()
+        };
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+
+        orchestrator.process_delivery_recovery().await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.delivery.contains_key("1"));
+        assert!(!state.is_claimed("1"));
+        assert!(state.completed.contains_key("1"));
+        drop(state);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    fn delivery_restart_orchestrator(
+        config_dir: &Path,
+        repo_config: crate::config::ensemble::RepoConfig,
+        remote: Arc<RecoveryDeliveryRemote>,
+        agent_runs: Arc<AtomicUsize>,
+    ) -> Orchestrator {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(CountingRunner { runs: agent_runs });
+        let workspace_mgr = WorkspaceManager::new(config_dir, Some(vec![repo_config])).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            config_dir,
+            shutdown_rx,
+        );
+        orchestrator.delivery_remote = remote;
+        orchestrator
+    }
+
+    fn creation_crash_delivery() -> DeliveryRecord {
+        let marker = canonical_marker("run-1", "1", "source-repo");
+        DeliveryRecord {
+            issue_id: "1".to_string(),
+            identifier: "repo#1".to_string(),
+            run_id: "run-1".to_string(),
+            repositories: [(
+                "source-repo".to_string(),
+                DeliveryRepository {
+                    mode: DeliveryMode::PushAndPr,
+                    phase: DeliveryPhase::PrCreateInFlight,
+                    remote: "origin".to_string(),
+                    base_branch: "main".to_string(),
+                    head_branch: "ensemble/repo-1".to_string(),
+                    local_sha: "0123456789abcdef".to_string(),
+                    observed_remote_sha: Some("0123456789abcdef".to_string()),
+                    marker,
+                    pr_number: None,
+                    pr_url: None,
+                    last_error: Some("process stopped after create".to_string()),
+                    retry_from: None,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn restart_hydrates_delivery_before_candidate_selection_without_rerunning_pipeline() {
+        let (repo_temp, mut repo_config) = create_finalize_repo().await;
+        repo_config.finalize.mode = FinalizeMode::PushAndPr;
+        repo_config.finalize.approval_required = false;
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let agent_runs = Arc::new(AtomicUsize::new(0));
+        let delivery = creation_crash_delivery();
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(vec![
+                crate::orchestrator::delivery::RemotePullRequest {
+                    repository_key: "source-repo".to_string(),
+                    head_branch: "ensemble/repo-1".to_string(),
+                    base_branch: "main".to_string(),
+                    head_sha: "0123456789abcdef".to_string(),
+                    body: delivery.repositories["source-repo"].marker.clone(),
+                    number: 420,
+                    url: "https://github.com/example/project/pull/420".to_string(),
+                },
+            ]),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+        });
+        let first = delivery_restart_orchestrator(
+            config_dir.path(),
+            repo_config.clone(),
+            Arc::clone(&remote),
+            Arc::clone(&agent_runs),
+        );
+        first
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+        drop(first);
+
+        let restart = delivery_restart_orchestrator(
+            config_dir.path(),
+            repo_config,
+            Arc::clone(&remote),
+            Arc::clone(&agent_runs),
+        );
+        restart.handle_tick().await;
+
+        let state = restart.state.read().await;
+        let restored = state.delivery.get("1").expect("delivery restored");
+        assert_eq!(restored.issue_id, delivery.issue_id);
+        assert_eq!(restored.run_id, delivery.run_id);
+        assert_eq!(
+            restored.repositories["source-repo"].head_branch,
+            "ensemble/repo-1"
+        );
+        assert_eq!(
+            restored.repositories["source-repo"].local_sha,
+            "0123456789abcdef"
+        );
+        assert_eq!(restored.repositories["source-repo"].pr_number, Some(420));
+        assert_eq!(
+            restored.repositories["source-repo"].phase,
+            DeliveryPhase::Waiting
+        );
+        assert!(state.is_claimed("1"));
+        assert!(!state.is_running("1"));
+        assert!(state.get_pipeline_run("1").is_none());
+        assert_eq!(live_worker_count(&restart.cancellation_registry), 0);
+        drop(state);
+        assert_eq!(agent_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert!(restart.workspace_mgr.workspace_path("1").exists());
+
+        drop(repo_temp);
+    }
+
+    #[tokio::test]
+    async fn repeated_delivery_recovery_preserves_identity_claim_and_workspace() {
+        let (repo_temp, mut repo_config) = create_finalize_repo().await;
+        repo_config.finalize.mode = FinalizeMode::PushAndPr;
+        repo_config.finalize.approval_required = false;
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let agent_runs = Arc::new(AtomicUsize::new(0));
+        let delivery = creation_crash_delivery();
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(vec![
+                crate::orchestrator::delivery::RemotePullRequest {
+                    repository_key: "source-repo".to_string(),
+                    head_branch: "ensemble/repo-1".to_string(),
+                    base_branch: "main".to_string(),
+                    head_sha: "0123456789abcdef".to_string(),
+                    body: delivery.repositories["source-repo"].marker.clone(),
+                    number: 420,
+                    url: "https://github.com/example/project/pull/420".to_string(),
+                },
+            ]),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+        });
+        let first = delivery_restart_orchestrator(
+            config_dir.path(),
+            repo_config.clone(),
+            Arc::clone(&remote),
+            Arc::clone(&agent_runs),
+        );
+        first
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+        drop(first);
+        let second = delivery_restart_orchestrator(
+            config_dir.path(),
+            repo_config.clone(),
+            Arc::clone(&remote),
+            Arc::clone(&agent_runs),
+        );
+        second.handle_tick().await;
+        let after_first_restart = second.state.read().await.delivery["1"].clone();
+        drop(second);
+
+        let third = delivery_restart_orchestrator(
+            config_dir.path(),
+            repo_config,
+            Arc::clone(&remote),
+            Arc::clone(&agent_runs),
+        );
+        third.handle_tick().await;
+        let state = third.state.read().await;
+        assert_eq!(state.delivery["1"], after_first_restart);
+        assert!(state.is_claimed("1"));
+        assert!(!state.is_running("1"));
+        assert_eq!(live_worker_count(&third.cancellation_registry), 0);
+        drop(state);
+        assert_eq!(agent_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+        assert!(third.workspace_mgr.workspace_path("1").exists());
+
+        drop(repo_temp);
+    }
+
     fn make_config() -> EnsembleConfig {
         let yaml = r#"
 tracker:
@@ -10509,6 +11073,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -10567,6 +11132,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -10647,6 +11213,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -10724,6 +11291,7 @@ agent:
                 retry: Some(retry),
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -10815,6 +11383,7 @@ agent:
                 retry: Some(retry),
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -10897,6 +11466,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -10946,6 +11516,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -11081,6 +11652,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -11195,6 +11767,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -11264,6 +11837,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -11330,6 +11904,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -11399,6 +11974,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -11602,6 +12178,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -11734,6 +12311,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -11861,6 +12439,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -11987,6 +12566,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -12202,6 +12782,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -12313,6 +12894,7 @@ agent:
                 retry: None,
                 snapshot: Some(stale_run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -12633,6 +13215,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -14319,6 +14902,7 @@ agent:
                 retry: Some(retry_entry.clone()),
                 snapshot: None,
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -16119,6 +16703,7 @@ agent:
                     tracker_write_confirmed: false,
                     history_record: None,
                 }),
+                delivery: None,
             })
             .await
             .unwrap();
@@ -16220,6 +16805,7 @@ agent:
                 retry: None,
                 snapshot: Some(run.to_snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -16356,6 +16942,7 @@ agent:
                     tracker_write_confirmed: true,
                     history_record: Some(history_record),
                 }),
+                delivery: None,
             })
             .await
             .unwrap();
@@ -17128,6 +17715,7 @@ agent:
                 retry: None,
                 snapshot: Some(snapshot.clone()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -10,6 +10,7 @@ use tokio::io::{AsyncBufReadExt, AsyncSeekExt, AsyncWriteExt, BufReader};
 use tracing::warn;
 
 use crate::history::model::HistoryRecord;
+use crate::orchestrator::delivery::DeliveryRecord;
 use crate::pipeline::engine::PipelineRunSnapshot;
 use crate::tracker::model::RetryEntry;
 
@@ -105,6 +106,7 @@ pub enum PipelineTransitionKind {
     PipelineSucceeded,
     PipelineFailed,
     PendingTerminalTransition,
+    DeliveryOwned,
     TerminalTransitionApplied,
     Released,
 }
@@ -144,6 +146,8 @@ pub struct PipelineTransitionRecord {
     pub snapshot: Option<PipelineRunSnapshot>,
     #[serde(default)]
     pub terminal_transition: Option<PendingTerminalTransition>,
+    #[serde(default)]
+    pub(crate) delivery: Option<DeliveryRecord>,
     pub written_at: DateTime<Utc>,
 }
 
@@ -159,6 +163,7 @@ impl PipelineTransitionRecord {
             && self.retry == input.retry
             && self.snapshot == input.snapshot
             && self.terminal_transition == input.terminal_transition
+            && self.delivery == input.delivery
     }
 }
 
@@ -174,6 +179,7 @@ pub struct PipelineTransitionInput {
     pub retry: Option<RetryEntry>,
     pub snapshot: Option<PipelineRunSnapshot>,
     pub terminal_transition: Option<PendingTerminalTransition>,
+    pub(crate) delivery: Option<DeliveryRecord>,
 }
 
 #[derive(Debug, Clone)]
@@ -266,6 +272,7 @@ impl PipelineRunJournal {
             retry: input.retry,
             snapshot: input.snapshot,
             terminal_transition: input.terminal_transition,
+            delivery: input.delivery,
             written_at: Utc::now(),
         };
 
@@ -288,6 +295,9 @@ impl PipelineRunJournal {
             return Err(write_error);
         }
         file.flush().await?;
+        if record.kind == PipelineTransitionKind::DeliveryOwned {
+            file.sync_data().await?;
+        }
         Ok(record)
     }
 
@@ -351,6 +361,7 @@ impl PipelineRunJournal {
             retry: None,
             snapshot: None,
             terminal_transition: None,
+            delivery: None,
         })
         .await
     }
@@ -388,6 +399,7 @@ impl PipelineRunJournal {
             retry: None,
             snapshot: None,
             terminal_transition: None,
+            delivery: None,
         })
         .await
         .map(Some)
@@ -554,13 +566,16 @@ fn invalid_data(reason: impl Into<String>) -> std::io::Error {
 fn is_live_restore_record(record: &PipelineTransitionRecord) -> bool {
     record.schema_version == SCHEMA_VERSION
         && !record.kind.is_terminal()
-        && record.snapshot.is_some()
+        && (record.snapshot.is_some() || record.delivery.is_some())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::ensemble::{OnFailure, StepConfig, StepKind};
+    use crate::orchestrator::delivery::{
+        DeliveryMode, DeliveryPhase, DeliveryRecord, DeliveryRepository,
+    };
     use crate::pipeline::dag::build_dag;
     use crate::pipeline::engine::{PipelineRun, StepState};
     use tempfile::tempdir;
@@ -589,6 +604,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delivery_transition_round_trips_as_latest_live_owner() {
+        let dir = tempdir().unwrap();
+        let journal = PipelineRunJournal::new(dir.path());
+        let delivery = DeliveryRecord {
+            issue_id: "issue/1".to_string(),
+            identifier: "repo#1".to_string(),
+            run_id: "run-1".to_string(),
+            repositories: [(
+                "primary".to_string(),
+                DeliveryRepository {
+                    mode: DeliveryMode::PushAndPr,
+                    phase: DeliveryPhase::Prepared,
+                    remote: "origin".to_string(),
+                    base_branch: "main".to_string(),
+                    head_branch: "ensemble/repo-1".to_string(),
+                    local_sha: "0123456789abcdef".to_string(),
+                    observed_remote_sha: None,
+                    marker: "<!-- ensemble:delivery:v1 -->".to_string(),
+                    pr_number: None,
+                    pr_url: None,
+                    last_error: None,
+                    retry_from: None,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        };
+
+        journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::DeliveryOwned,
+                issue_id: "issue/1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: None,
+                reason: None,
+                retry: None,
+                snapshot: None,
+                terminal_transition: None,
+                delivery: Some(delivery.clone()),
+            })
+            .await
+            .unwrap();
+
+        let latest = journal
+            .latest_live_record_for_issue("issue/1")
+            .await
+            .unwrap()
+            .expect("delivery remains a live owner");
+        assert_eq!(latest.delivery, Some(delivery));
+    }
+
+    #[tokio::test]
     async fn journal_appends_records_with_incrementing_seq() {
         let dir = tempdir().unwrap();
         let journal = PipelineRunJournal::new(dir.path());
@@ -605,6 +674,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -620,6 +690,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -666,6 +737,7 @@ mod tests {
                 retry: Some(old_retry.clone()),
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -701,6 +773,7 @@ mod tests {
                         retry: Some(newer_retry),
                         snapshot: Some(snapshot()),
                         terminal_transition: None,
+                        delivery: None,
                     })
                     .await
             }
@@ -741,6 +814,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -775,6 +849,7 @@ mod tests {
                 }),
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -803,6 +878,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -832,6 +908,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -857,6 +934,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -872,6 +950,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -904,6 +983,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -946,6 +1026,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: Some(pending.clone()),
+                delivery: None,
             })
             .await
             .unwrap();
@@ -971,6 +1052,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: Some(confirmed.clone()),
+                delivery: None,
             })
             .await
             .unwrap();
@@ -1021,6 +1103,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: Some(pending.clone()),
+                delivery: None,
             })
             .await
             .unwrap();
@@ -1084,6 +1167,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(snapshot()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();

--- a/crates/ensemble-core/src/orchestrator/reconciler.rs
+++ b/crates/ensemble-core/src/orchestrator/reconciler.rs
@@ -94,6 +94,11 @@ pub async fn reconcile_tracker_states(
             tracked_ids.push(issue_id.clone());
         }
     }
+    for issue_id in state.delivery.keys() {
+        if !tracked_ids.contains(issue_id) {
+            tracked_ids.push(issue_id.clone());
+        }
+    }
 
     if tracked_ids.is_empty() {
         return ReconcileTrackerResult {
@@ -126,6 +131,9 @@ pub async fn reconcile_tracker_states(
     let mut terminate_no_cleanup = Vec::new();
 
     for issue in refreshed {
+        if state.delivery.contains_key(&issue.id) {
+            continue;
+        }
         if !state.is_running(&issue.id) && !state.is_waiting_on_human(&issue.id) {
             continue;
         }

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -172,6 +172,7 @@ pub(crate) async fn queue_manual_step_retry(
                 retry: Some(retry_entry.clone()),
                 snapshot: Some(mutated_run.clone()),
                 terminal_transition: None,
+                delivery: None,
             };
             Some((retry_entry, transition, mutated_run))
         }
@@ -287,6 +288,9 @@ pub(crate) async fn queue_manual_whole_issue_retry(
         identifier,
     ) = {
         let state = state.read().await;
+        if state.delivery.contains_key(request.issue_id) {
+            return Err(ManualStepRetryError::OwnerChanged);
+        }
         let previous_retry = state.retry_attempts.get(request.issue_id).cloned();
         let previous_waiting = state.waiting_on_human.get(request.issue_id).cloned();
         if previous_retry.is_none() && previous_waiting.is_none() {
@@ -340,6 +344,7 @@ pub(crate) async fn queue_manual_whole_issue_retry(
                 .map(|run| run.to_snapshot())
                 == previous_run.as_ref().map(|run| run.to_snapshot())
             && config_is_current
+            && !state.delivery.contains_key(request.issue_id)
             && state.is_claimed(request.issue_id) == was_claimed;
         if !owner_is_current {
             false
@@ -376,6 +381,7 @@ pub(crate) async fn queue_manual_whole_issue_retry(
         retry: None,
         snapshot: None,
         terminal_transition: None,
+        delivery: None,
     };
     let transition_for_reconciliation = transition.clone();
     if let Err(error) = transaction.append(transition).await {
@@ -800,6 +806,9 @@ mod tests {
         InteractionKind, InteractionRequest, InteractionResumeStrategy, InteractionStatus,
     };
     use crate::interaction::InteractionResponse;
+    use crate::orchestrator::delivery::{
+        canonical_marker, DeliveryMode, DeliveryPhase, DeliveryRecord, DeliveryRepository,
+    };
     use crate::orchestrator::state::WaitingOnHumanEntry;
     use crate::pipeline::dag::build_dag;
     use crate::pipeline::engine::PipelineRun;
@@ -1384,6 +1393,7 @@ mod tests {
                 retry: None,
                 snapshot: Some(previous_snapshot.clone()),
                 terminal_transition: None,
+                delivery: None,
             })
             .await
             .unwrap();
@@ -1426,6 +1436,68 @@ mod tests {
             .expect("the previous owner must remain restart-visible");
         assert_eq!(latest.kind, PipelineTransitionKind::PipelineHalted);
         assert_eq!(latest.snapshot, Some(previous_snapshot));
+    }
+
+    #[tokio::test]
+    async fn whole_issue_retry_rejects_delivery_owned_issue_without_releasing_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = PipelineRunJournal::new(dir.path());
+        let state = manual_retry_state();
+        let interactions = manual_retry_store(dir.path()).await;
+        let delivery = DeliveryRecord {
+            issue_id: "issue-1".to_string(),
+            identifier: "repo#1".to_string(),
+            run_id: "run-1".to_string(),
+            repositories: [(
+                "primary".to_string(),
+                DeliveryRepository {
+                    mode: DeliveryMode::PushAndPr,
+                    phase: DeliveryPhase::Waiting,
+                    remote: "origin".to_string(),
+                    base_branch: "main".to_string(),
+                    head_branch: "ensemble/repo-1".to_string(),
+                    local_sha: "0123456789abcdef".to_string(),
+                    observed_remote_sha: Some("0123456789abcdef".to_string()),
+                    marker: canonical_marker("run-1", "issue-1", "primary"),
+                    pr_number: Some(420),
+                    pr_url: Some("https://github.com/example/project/pull/420".to_string()),
+                    last_error: None,
+                    retry_from: None,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        };
+        state
+            .write()
+            .await
+            .delivery
+            .insert("issue-1".to_string(), delivery.clone());
+
+        let error = queue_manual_whole_issue_retry(
+            &state,
+            &journal,
+            &interactions,
+            ManualWholeIssueRetryRequest {
+                issue_id: "issue-1",
+                identifier: "repo#1",
+            },
+        )
+        .await
+        .expect_err("delivery owns whole-issue recovery");
+
+        assert!(matches!(error, ManualStepRetryError::OwnerChanged));
+        let state = state.read().await;
+        assert_eq!(state.delivery.get("issue-1"), Some(&delivery));
+        assert!(state.is_waiting_on_human("issue-1"));
+        assert!(state.is_claimed("issue-1"));
+        assert!(state.get_pipeline_run("issue-1").is_some());
+        drop(state);
+        assert!(journal
+            .read_records_for_issue("issue-1")
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::ensemble::{ConcurrencyConfig, EnsembleConfig};
 use crate::history::artifacts::RunArtifacts;
+use crate::orchestrator::delivery::DeliveryRecord;
 use crate::orchestrator::pipeline_journal::PendingTerminalTransition;
 use crate::pipeline::engine::PipelineRun;
 use crate::tracker::model::{AgentTotals, Issue, RetryEntry, RunningEntry};
@@ -150,6 +151,8 @@ pub struct OrchestratorState {
     pub pipeline_runs: HashMap<String, PipelineRun>,
     /// Finalization state for issues that have finished pipeline execution.
     pub finalize: HashMap<String, IssueFinalizeState>,
+    /// Durable remote-publication owners that no longer consume worker capacity.
+    pub(crate) delivery: HashMap<String, DeliveryRecord>,
     /// Terminal tracker writes that must reconcile before local run release.
     pub pending_terminal_transitions: HashMap<String, PendingTerminalEntry>,
     /// Durable run artifacts collected before history is written.
@@ -195,6 +198,7 @@ impl OrchestratorState {
             agent_rate_limits: None,
             pipeline_runs: HashMap::new(),
             finalize: HashMap::new(),
+            delivery: HashMap::new(),
             pending_terminal_transitions: HashMap::new(),
             artifacts: HashMap::new(),
             pipeline_configs: HashMap::new(),
@@ -320,6 +324,11 @@ impl OrchestratorState {
                 return Some(id.clone());
             }
         }
+        for (id, delivery) in &self.delivery {
+            if delivery.identifier == identifier {
+                return Some(id.clone());
+            }
+        }
         None
     }
 
@@ -374,6 +383,7 @@ impl OrchestratorState {
         self.resume_requested.remove(issue_id);
         self.pipeline_configs.remove(issue_id);
         self.finalize.remove(issue_id);
+        self.delivery.remove(issue_id);
         self.pending_terminal_transitions.remove(issue_id);
         self.artifacts.remove(issue_id);
         self.step_states.remove(issue_id);

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -340,8 +340,34 @@ Pipeline run recovery:
 - If an append outcome is ambiguous, Ensemble retains the active owner and retries only journal
   visibility on later poll ticks. Exact visibility advances without rerunning the command;
   confirmed absence releases the owner so only the undurable command can be dispatched again.
+- Configured `push` and `push_and_pr` publication transfers ownership to a delivery payload in the
+  same versioned per-issue journal before any remote mutation. Repository entries are keyed in
+  deterministic order and retain the run ID, issue ID, configured repository key, mode, remote and
+  base branch, exact head branch and local commit SHA, observed remote SHA, pull request identity,
+  last error, retry origin, and a stored deterministic marker.
+- Delivery repository phases are `prepared`, `push_in_flight`, `reconciling_push`,
+  `pr_create_in_flight`, `reconciling_pr`, `waiting`, `published`, and `blocked`. The issue-level
+  delivery state is derived from those repository entries rather than serialized separately.
+- Before a push or pull request creation, Ensemble persists the corresponding in-flight phase, so
+  delivery owns publication before the remote mutation. On a normal response or ambiguous failure
+  it returns to reconciliation; it does not infer success from the mutation command alone. Once the
+  successful final step hands back after delivery reaches a durable waiting, published, or blocked
+  state, its agent capacity is released.
+- Push reconciliation advances only when the configured remote head equals the stored local SHA.
+  A different remote SHA blocks delivery. Pull request reconciliation adopts exactly one request
+  matching the configured repository, head and base branches, stored marker, and intended head
+  SHA. Multiple matches or conflicting identity block delivery; confirmed zero matches permits at
+  most one guarded creation attempt before reconciliation runs again.
+- `waiting` delivery remains claimed with its workspace and artifacts but occupies no agent slot,
+  dispatches no pipeline work, and does not project a terminal tracker state. `blocked` is likewise
+  retained for operator recovery. A fully `published` push-only delivery continues the existing
+  durable terminal-transition protocol; it does not republish the branch.
 - On orchestrator startup, Ensemble restores the latest non-released snapshot for each issue before
   the first poll tick.
+- Delivery ownership is restored before candidate selection and excludes that issue from fresh
+  dispatch, tracker disappearance cleanup, and workspace cleanup. Recovery reuses the stored run,
+  claim, repository identity, and workspace and reconciles remote state before considering another
+  mutation.
 - During normal tick dispatch, before starting a candidate as a fresh pipeline, Ensemble checks that
   issue's latest journal record. If it is live and contains a snapshot, Ensemble restores that run
   instead of appending a new `run_started` record.
@@ -1170,7 +1196,8 @@ claim state.
 
 2. `Claimed`
    - Orchestrator has reserved the issue to prevent duplicate dispatch.
-   - In practice, claimed issues are either `Running` or `RetryQueued`.
+   - In practice, claimed issues are `Running`, `RetryQueued`, `DeliveryOwned`, or
+     `TerminalReconciliation`.
 
 3. `Running`
    - The issue has an active pipeline owner in the `running` map. Zero or more step workers may be
@@ -1185,7 +1212,14 @@ claim state.
    - The claim and recoverable run data remain owned by the orchestrator while tracker I/O retries
      independently of agent capacity.
 
-6. `Released`
+6. `DeliveryOwned`
+   - Pipeline work and any required approval are complete, and configured repository publication is
+     durably reconciling, waiting on a pull request, or blocked for operator recovery.
+   - The claim, workspace, artifacts, and exact repository identity remain owned without making the
+     issue dispatch-eligible. Once the successful final step hands back, delivery recovery consumes
+     no agent capacity.
+
+7. `Released`
    - Claim removed because issue is terminal, non-active, missing, or retry path completed without
      re-dispatch.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -418,6 +418,13 @@ you opt in per repo. Ensemble still records durable run artifacts for each compl
 including workspace paths, repo branch/HEAD/change metadata, per-step transcript metadata, and any
 finalize output such as pushed refs or PR URLs when finalization runs.
 
+For `push` and `push_and_pr`, Ensemble durably records the exact repository, branch, commit, and
+remote identity before mutation. Restart recovery reconciles that stored identity with the remote
+before retrying, so an ambiguous push or pull request response cannot silently duplicate
+publication. A `push_and_pr` repository remains claimed in a non-capacity-consuming waiting state
+after its uniquely matching pull request is found; merging or closing that pull request does not by
+itself project the issue to `on_success`.
+
 **Headless behavior:** if `finalize.approval_required: true` and Ensemble is running headless, startup emits a warning and finalize is skipped for that repo.
 
 **Migration note:** top-level `push_strategy` has been removed. Configure `repos[].finalize` instead.


### PR DESCRIPTION
## Summary

- persist a versioned delivery-owned record in the live per-issue journal before remote publication
- reconcile push and pull-request identity fail-closed using the stored repository, branch, SHA, and marker
- restore delivery ownership before dispatch after restart while retaining claims/workspaces without consuming worker capacity
- resume blocked operator retries safely, continue push-only terminal recovery, and reject whole-issue retries while delivery owns the issue
- document the delivery phases, recovery authority, and downstream #421/#422 boundaries

## Why

A successful `push_and_pr` finalization previously lacked durable ownership across crashes. Delivery now becomes the recoverable owner before the first remote mutation and converges on one validated pull request without redispatching the pipeline or creating duplicates.

## Verification

- `cargo test --workspace --exclude ensemble-desktop` — 1,195 core unit tests plus all CLI, integration, and doc tests
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture` — 2/2
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`
- focused delivery/recovery suite — 10/10
- correctness/spec, reuse/clarity/efficiency, and over-engineering reviews passed after fixes

## Residual risk

Production git/GitHub publication is exercised through the same private adapter contract as the in-process fake; this change intentionally does not add check/review/merge progression (#421) or tracker projection/final completion (#422).

Fixes #420