### PR TITLE
Restore Rust 1.95 dependency compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "kstring"
-version = "2.0.4"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b609e7ca5ea38f093c20a4a102335b247221c9643b7a6bc3510f196f99499a9e"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
 dependencies = [
  "serde",
  "static_assertions",


### PR DESCRIPTION
Current main CI fails its Rust 1.95 MSRV job because lockfile maintenance selected kstring 2.0.4, which requires Rust 1.96. kstring 2.0.3 has the same requirement; 2.0.2 is the newest release compatible with the project MSRV.

This dedicated repair changes only the Cargo.lock entry from kstring 2.0.4 to 2.0.2.

Validation:
- SKIP_UI_BUILD=1 cargo +1.95.0 check --workspace --all-targets
- cargo test --workspace --exclude ensemble-desktop
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check
- git diff --check

No documentation changes are needed because project behavior and public contracts are unchanged.