### PR TITLE
Record acceptance result timing

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -82,6 +82,10 @@ async fn web_cli_runs_todo_issue_to_completion_with_mock_acpx() {
     let acceptance = &history["acceptance_attempts"][0]["results"][0];
     assert_eq!(acceptance["name"], "verify");
     assert_eq!(acceptance["status"], "passed");
+    assert_eq!(acceptance["timing"]["kind"], "observed");
+    assert!(acceptance["timing"]["started_at"].is_string());
+    assert!(acceptance["timing"]["completed_at"].is_string());
+    assert!(acceptance["timing"]["duration_ms"].is_u64());
     assert_eq!(acceptance["stdout"]["total_bytes"], 40_000);
     assert_eq!(acceptance["stdout"]["truncated"], true);
     assert_eq!(
@@ -152,6 +156,7 @@ async fn acceptance_failure_dominates_successful_agent_and_exhausts_the_issue() 
     let acceptance = &history["acceptance_attempts"][0]["results"][0];
     assert_eq!(acceptance["name"], "verify");
     assert_eq!(acceptance["status"], "failed");
+    assert_eq!(acceptance["timing"]["kind"], "observed");
     assert_eq!(acceptance["exit_code"], 7);
     assert!(acceptance["stderr"]["tail"]
         .as_str()

--- a/crates/ensemble-core/src/acceptance/mod.rs
+++ b/crates/ensemble-core/src/acceptance/mod.rs
@@ -1,5 +1,7 @@
 mod model;
 mod runner;
 
-pub use model::{AcceptanceAttempt, AcceptanceOutput, AcceptanceResult, AcceptanceStatus};
+pub use model::{
+    AcceptanceAttempt, AcceptanceOutput, AcceptanceResult, AcceptanceStatus, AcceptanceTiming,
+};
 pub use runner::{AcceptanceCommandRunner, ShellAcceptanceCommandRunner};

--- a/crates/ensemble-core/src/acceptance/model.rs
+++ b/crates/ensemble-core/src/acceptance/model.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
@@ -7,6 +8,18 @@ pub enum AcceptanceStatus {
     Failed,
     TimedOut,
     Unavailable,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AcceptanceTiming {
+    Observed {
+        started_at: DateTime<Utc>,
+        completed_at: DateTime<Utc>,
+        duration_ms: u64,
+    },
+    #[default]
+    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
@@ -20,6 +33,8 @@ pub struct AcceptanceOutput {
 pub struct AcceptanceResult {
     pub name: String,
     pub status: AcceptanceStatus,
+    #[serde(default)]
+    pub timing: AcceptanceTiming,
     pub exit_code: Option<i32>,
     pub stdout: AcceptanceOutput,
     pub stderr: AcceptanceOutput,
@@ -30,4 +45,46 @@ pub struct AcceptanceResult {
 pub struct AcceptanceAttempt {
     pub cycle: u32,
     pub results: Vec<AcceptanceResult>,
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+
+    #[test]
+    fn legacy_result_defaults_timing_to_unknown() {
+        let value = serde_json::json!({
+            "name": "tests",
+            "status": "passed",
+            "exit_code": 0,
+            "stdout": {"tail": "ok", "total_bytes": 2, "truncated": false},
+            "stderr": {"tail": "", "total_bytes": 0, "truncated": false},
+            "summary": "acceptance command 'tests' passed"
+        });
+
+        let result: AcceptanceResult = serde_json::from_value(value).unwrap();
+
+        assert_eq!(result.timing, AcceptanceTiming::Unknown);
+    }
+
+    #[test]
+    fn observed_timing_uses_the_tagged_wire_shape() {
+        let timing = AcceptanceTiming::Observed {
+            started_at: Utc.with_ymd_and_hms(2026, 8, 4, 9, 0, 0).unwrap(),
+            completed_at: Utc.with_ymd_and_hms(2026, 8, 4, 9, 0, 1).unwrap(),
+            duration_ms: 1_234,
+        };
+
+        assert_eq!(
+            serde_json::to_value(timing).unwrap(),
+            serde_json::json!({
+                "kind": "observed",
+                "started_at": "2026-08-04T09:00:00Z",
+                "completed_at": "2026-08-04T09:00:01Z",
+                "duration_ms": 1234
+            })
+        );
+    }
 }

--- a/crates/ensemble-core/src/acceptance/runner.rs
+++ b/crates/ensemble-core/src/acceptance/runner.rs
@@ -1,12 +1,13 @@
 use std::path::Path;
 use std::process::Stdio;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use chrono::Utc;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
 
-use crate::acceptance::{AcceptanceOutput, AcceptanceResult, AcceptanceStatus};
+use crate::acceptance::{AcceptanceOutput, AcceptanceResult, AcceptanceStatus, AcceptanceTiming};
 use crate::config::ensemble::AcceptanceCommandConfig;
 
 const OUTPUT_TAIL_LIMIT: usize = 32 * 1024;
@@ -30,6 +31,7 @@ impl AcceptanceCommandRunner for ShellAcceptanceCommandRunner {
         command_config: &AcceptanceCommandConfig,
         issue_workspace: &Path,
     ) -> AcceptanceResult {
+        let timer = AcceptanceTimer::start();
         let mut command = Command::new("/bin/sh");
         command
             .arg("-lc")
@@ -45,10 +47,10 @@ impl AcceptanceCommandRunner for ShellAcceptanceCommandRunner {
         let mut child = match command.spawn() {
             Ok(child) => child,
             Err(error) => {
-                return unavailable_result(
+                return timer.finish(unavailable_result(
                     &command_config.name,
                     format!("acceptance command unavailable: {error}"),
-                );
+                ));
             }
         };
         let child_id = child.id();
@@ -67,10 +69,10 @@ impl AcceptanceCommandRunner for ShellAcceptanceCommandRunner {
             Ok(wait_result) => match wait_result {
                 Ok(status) => Some(status),
                 Err(error) => {
-                    return unavailable_result(
+                    return timer.finish(unavailable_result(
                         &command_config.name,
                         format!("acceptance command unavailable while waiting: {error}"),
-                    );
+                    ));
                 }
             },
             Err(_) => None,
@@ -80,13 +82,18 @@ impl AcceptanceCommandRunner for ShellAcceptanceCommandRunner {
         if let Some(status) = status {
             match tokio::time::timeout_at(deadline, &mut output_collection).await {
                 Ok(Ok((stdout, stderr))) => {
-                    return finish_result(&command_config.name, status, stdout, stderr);
+                    return timer.finish(finish_result(
+                        &command_config.name,
+                        status,
+                        stdout,
+                        stderr,
+                    ));
                 }
                 Ok(Err(error)) => {
-                    return unavailable_result(
+                    return timer.finish(unavailable_result(
                         &command_config.name,
                         format!("acceptance command output unavailable: {error}"),
-                    );
+                    ));
                 }
                 Err(_) => {}
             }
@@ -95,25 +102,26 @@ impl AcceptanceCommandRunner for ShellAcceptanceCommandRunner {
         terminate_process_group(child_id);
         if status.is_none() {
             if let Err(error) = child.wait().await {
-                return unavailable_result(
+                return timer.finish(unavailable_result(
                     &command_config.name,
                     format!("acceptance command unavailable while reaping timeout: {error}"),
-                );
+                ));
             }
         }
 
         let (stdout, stderr) = match output_collection.await {
             Ok(outputs) => outputs,
             Err(error) => {
-                return unavailable_result(
+                return timer.finish(unavailable_result(
                     &command_config.name,
                     format!("acceptance command output unavailable: {error}"),
-                );
+                ));
             }
         };
-        AcceptanceResult {
+        timer.finish(AcceptanceResult {
             name: command_config.name.clone(),
             status: AcceptanceStatus::TimedOut,
+            timing: AcceptanceTiming::Unknown,
             exit_code: None,
             stdout,
             stderr,
@@ -121,7 +129,30 @@ impl AcceptanceCommandRunner for ShellAcceptanceCommandRunner {
                 "acceptance command '{}' timed out after {}ms",
                 command_config.name, command_config.timeout_ms
             ),
+        })
+    }
+}
+
+struct AcceptanceTimer {
+    started_at: chrono::DateTime<Utc>,
+    started: Instant,
+}
+
+impl AcceptanceTimer {
+    fn start() -> Self {
+        Self {
+            started_at: Utc::now(),
+            started: Instant::now(),
         }
+    }
+
+    fn finish(self, mut result: AcceptanceResult) -> AcceptanceResult {
+        result.timing = AcceptanceTiming::Observed {
+            started_at: self.started_at,
+            completed_at: Utc::now(),
+            duration_ms: u64::try_from(self.started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        };
+        result
     }
 }
 
@@ -144,6 +175,7 @@ fn finish_result(
     AcceptanceResult {
         name: name.to_string(),
         status: acceptance_status,
+        timing: AcceptanceTiming::Unknown,
         exit_code: status.code(),
         stdout,
         stderr,
@@ -208,6 +240,7 @@ fn unavailable_result(name: &str, summary: String) -> AcceptanceResult {
     AcceptanceResult {
         name: name.to_string(),
         status: AcceptanceStatus::Unavailable,
+        timing: AcceptanceTiming::Unknown,
         exit_code: None,
         stdout: empty_output(),
         stderr: empty_output(),
@@ -240,7 +273,7 @@ fn terminate_process_group(_child_id: Option<u32>) {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::acceptance::AcceptanceStatus;
+    use crate::acceptance::{AcceptanceStatus, AcceptanceTiming};
     use crate::config::ensemble::AcceptanceCommandConfig;
     use crate::test_support::env::ENV_LOCK;
 
@@ -249,6 +282,20 @@ mod tests {
             name: name.to_string(),
             run: run.to_string(),
             timeout_ms,
+        }
+    }
+
+    fn observed_duration_ms(result: &AcceptanceResult) -> u64 {
+        match &result.timing {
+            AcceptanceTiming::Observed {
+                started_at,
+                completed_at,
+                duration_ms,
+            } => {
+                assert!(completed_at >= started_at);
+                *duration_ms
+            }
+            AcceptanceTiming::Unknown => panic!("new command result must have observed timing"),
         }
     }
 
@@ -281,6 +328,7 @@ mod tests {
         assert_eq!(result.stdout.total_bytes, result.stdout.tail.len() as u64);
         assert!(!result.stdout.truncated);
         assert_eq!(result.name, "context");
+        observed_duration_ms(&result);
     }
 
     #[tokio::test]
@@ -303,6 +351,8 @@ mod tests {
         assert_eq!(signal.status, AcceptanceStatus::Failed);
         assert_eq!(signal.exit_code, None);
         assert!(signal.summary.contains("signal"));
+        observed_duration_ms(&nonzero);
+        observed_duration_ms(&signal);
     }
 
     #[tokio::test]
@@ -355,6 +405,7 @@ mod tests {
 
         assert_eq!(result.status, AcceptanceStatus::TimedOut);
         assert_eq!(result.exit_code, None);
+        assert!(observed_duration_ms(&result) >= 40);
         assert!(
             !marker.exists(),
             "timed-out descendant escaped its process group"
@@ -405,5 +456,6 @@ mod tests {
         assert!(!result.summary.contains("super-secret-command"));
         assert!(result.stdout.tail.is_empty());
         assert!(result.stderr.tail.is_empty());
+        observed_duration_ms(&result);
     }
 }

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -490,6 +490,11 @@ mod tests {
             results: vec![crate::acceptance::AcceptanceResult {
                 name: "test".into(),
                 status: crate::acceptance::AcceptanceStatus::Passed,
+                timing: crate::acceptance::AcceptanceTiming::Observed {
+                    started_at: "2026-08-04T09:00:00Z".parse().unwrap(),
+                    completed_at: "2026-08-04T09:00:01Z".parse().unwrap(),
+                    duration_ms: 1_234,
+                },
                 exit_code: Some(0),
                 stdout: crate::acceptance::AcceptanceOutput {
                     tail: "ok".into(),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -9058,6 +9058,7 @@ mod tests {
             crate::acceptance::AcceptanceResult {
                 name: command.name.clone(),
                 status: AcceptanceStatus::Passed,
+                timing: crate::acceptance::AcceptanceTiming::Unknown,
                 exit_code: Some(0),
                 stdout: crate::acceptance::AcceptanceOutput {
                     tail: String::new(),
@@ -9093,6 +9094,7 @@ mod tests {
                 .unwrap_or(AcceptanceStatus::Passed);
             crate::acceptance::AcceptanceResult {
                 name: command.name.clone(),
+                timing: crate::acceptance::AcceptanceTiming::Unknown,
                 exit_code: (status == AcceptanceStatus::Passed).then_some(0),
                 summary: format!("{}: {status:?}", command.name),
                 status,
@@ -10506,6 +10508,7 @@ agent:
                     results: vec![crate::acceptance::AcceptanceResult {
                         name: "first".into(),
                         status: AcceptanceStatus::Passed,
+                        timing: crate::acceptance::AcceptanceTiming::Unknown,
                         exit_code: Some(0),
                         stdout: crate::acceptance::AcceptanceOutput {
                             tail: String::new(),
@@ -10933,6 +10936,7 @@ agent:
             results: vec![crate::acceptance::AcceptanceResult {
                 name: "old-name".into(),
                 status: AcceptanceStatus::Passed,
+                timing: crate::acceptance::AcceptanceTiming::Unknown,
                 exit_code: Some(0),
                 stdout: crate::acceptance::AcceptanceOutput {
                     tail: String::new(),
@@ -10966,6 +10970,7 @@ agent:
             results: vec![crate::acceptance::AcceptanceResult {
                 name: "old-name".into(),
                 status: AcceptanceStatus::Passed,
+                timing: crate::acceptance::AcceptanceTiming::Unknown,
                 exit_code: Some(0),
                 stdout: crate::acceptance::AcceptanceOutput {
                     tail: String::new(),

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -2044,6 +2044,7 @@ mod tests {
             results: vec![crate::acceptance::AcceptanceResult {
                 name: "test".to_string(),
                 status: crate::acceptance::AcceptanceStatus::Passed,
+                timing: crate::acceptance::AcceptanceTiming::Unknown,
                 exit_code: Some(0),
                 stdout: crate::acceptance::AcceptanceOutput {
                     tail: "ok".to_string(),

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -301,8 +301,11 @@ Per-issue pipeline execution state:
 - `acceptance_attempts` (ordered list, default empty)
   - Each attempt contains its 1-based pipeline `cycle` and declaration-order `results` prefix.
   - Each result contains `name`, `status` (`passed`, `failed`, `timed_out`, or `unavailable`),
-    optional `exit_code`, bounded `stdout` and `stderr`, and a human-readable `summary`. The
-    configured command string is never part of durable evidence.
+    `timing`, optional `exit_code`, bounded `stdout` and `stderr`, and a human-readable `summary`.
+    The configured command string is never part of durable evidence.
+  - Newly executed results use tagged observed timing with UTC `started_at` and `completed_at`
+    boundaries plus monotonic `duration_ms`. Legacy results without timing deserialize as tagged
+    `unknown` timing and remain readable without invented timestamps.
   - Each stream contains a lossy-UTF-8 `tail`, `total_bytes`, and `truncated`; the retained tail is
     independently limited to the final 32,768 raw bytes while the runner continues counting and
     draining all bytes.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -187,12 +187,27 @@ store a lossy-UTF-8 rendering of only the final 32,768 raw bytes, the total obse
 a `truncated` flag. The runner drains both streams concurrently and terminates and reaps the command
 process group on timeout.
 
+Every newly executed result also records tagged timing:
+
+```json
+{
+  "kind": "observed",
+  "started_at": "2026-08-04T09:00:00Z",
+  "completed_at": "2026-08-04T09:00:01Z",
+  "duration_ms": 1234
+}
+```
+
+The boundaries use UTC wall-clock timestamps, while `duration_ms` uses a monotonic clock. Legacy
+results without a `timing` field deserialize as `{"kind":"unknown"}`; Ensemble preserves their
+evidence without inventing timestamps.
+
 Phase start and every completed result are journaled before Ensemble advances. After restart, the
 current cycle's durable results must be a declaration-order prefix of configured command names;
 Ensemble resumes with the first missing command. Thus an interrupted command without a durable result
 may repeat, while a durable prefix does not. Legacy snapshots and history records default to no
-attempts. Ordered attempts are also preserved in JSONL history, SQLite history, and pending terminal
-reconciliation records.
+attempts, and legacy results within an existing attempt default to unknown timing. Ordered attempts
+are also preserved in JSONL history, SQLite history, and pending terminal reconciliation records.
 
 If an append outcome is ambiguous, Ensemble keeps the active owner and retries only the journal
 visibility check on later poll ticks. An exactly visible result advances without executing the


### PR DESCRIPTION
## Summary

- add tagged observed/unknown timing to acceptance results
- measure all new command outcomes with UTC boundaries and monotonic duration
- preserve legacy evidence and document the durable wire contract

## Validation

- cargo test --workspace --exclude ensemble-desktop
- SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
- SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check

Fixes #417