### PR TITLE
Add typed acceptance requirements

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -80,18 +80,33 @@ async fn web_cli_runs_todo_issue_to_completion_with_mock_acpx() {
     assert_eq!(history["issue_identifier"], ISSUE_ID);
     assert_eq!(history["outcome"], "succeeded");
     let acceptance = &history["acceptance_attempts"][0]["results"][0];
+    assert_eq!(acceptance["version"], 2);
     assert_eq!(acceptance["name"], "verify");
     assert_eq!(acceptance["status"], "passed");
     assert_eq!(acceptance["timing"]["kind"], "observed");
     assert!(acceptance["timing"]["started_at"].is_string());
     assert!(acceptance["timing"]["completed_at"].is_string());
     assert!(acceptance["timing"]["duration_ms"].is_u64());
-    assert_eq!(acceptance["stdout"]["total_bytes"], 40_000);
-    assert_eq!(acceptance["stdout"]["truncated"], true);
+    assert_eq!(acceptance["evidence"]["kind"], "command");
+    assert_eq!(acceptance["evidence"]["stdout"]["total_bytes"], 40_000);
+    assert_eq!(acceptance["evidence"]["stdout"]["truncated"], true);
     assert_eq!(
-        acceptance["stdout"]["tail"].as_str().unwrap().len(),
+        acceptance["evidence"]["stdout"]["tail"]
+            .as_str()
+            .unwrap()
+            .len(),
         32 * 1024
     );
+    let file = &history["acceptance_attempts"][0]["results"][1];
+    assert_eq!(file["name"], "required-artifact");
+    assert_eq!(file["status"], "passed");
+    assert_eq!(file["evidence"]["kind"], "file");
+    assert_eq!(file["evidence"]["observation"], "present");
+    let handoff = &history["acceptance_attempts"][0]["results"][2];
+    assert_eq!(handoff["name"], "implementation-handoff");
+    assert_eq!(handoff["status"], "passed");
+    assert_eq!(handoff["evidence"]["kind"], "handoff");
+    assert_eq!(handoff["evidence"]["sections"][0]["observation"], "present");
     assert!(
         history["steps_traversed"]
             .as_array()
@@ -154,11 +169,13 @@ async fn acceptance_failure_dominates_successful_agent_and_exhausts_the_issue() 
     assert_eq!(history["steps_traversed"][0], "implement");
     assert_eq!(history["attempts"], 1);
     let acceptance = &history["acceptance_attempts"][0]["results"][0];
+    assert_eq!(acceptance["version"], 2);
     assert_eq!(acceptance["name"], "verify");
     assert_eq!(acceptance["status"], "failed");
     assert_eq!(acceptance["timing"]["kind"], "observed");
-    assert_eq!(acceptance["exit_code"], 7);
-    assert!(acceptance["stderr"]["tail"]
+    assert_eq!(acceptance["evidence"]["kind"], "command");
+    assert_eq!(acceptance["evidence"]["exit_code"], 7);
+    assert!(acceptance["evidence"]["stderr"]["tail"]
         .as_str()
         .unwrap()
         .ends_with("acceptance-failed"));
@@ -171,6 +188,50 @@ async fn acceptance_failure_dominates_successful_agent_and_exhausts_the_issue() 
         acpx_log.lines().filter(|line| line.contains(" prompt ")).count(),
         2,
         "one agent cycle emits its visible prompt and hidden extraction prompt; exhaustion must not launch another cycle"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_file_and_handoff_are_durable_acceptance_failures() {
+    let fixture = TestFixture::new_with_acceptance("true").expect("fixture setup");
+    let port = reserve_local_port().expect("reserve local port");
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_E2E_SKIP_REQUIRED_FILE", "1")
+        .env("ENSEMBLE_E2E_MISSING_HANDOFF", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let child = command.spawn().expect("spawn ensemble web");
+    let _guard = ChildGuard::new(child);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+
+    let history = wait_for_failed_history_record(&client, &base_url, &fixture.workspace_root)
+        .await
+        .expect("missing requirements should be durable");
+    let results = history["acceptance_attempts"][0]["results"]
+        .as_array()
+        .expect("acceptance results should be an array");
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0]["status"], "passed");
+    assert_eq!(results[1]["name"], "required-artifact");
+    assert_eq!(results[1]["status"], "failed");
+    assert_eq!(results[1]["evidence"]["observation"], "missing");
+    assert_eq!(results[2]["name"], "implementation-handoff");
+    assert_eq!(results[2]["status"], "failed");
+    assert_eq!(
+        results[2]["evidence"]["sections"][0]["observation"],
+        "missing"
     );
 }
 
@@ -192,15 +253,17 @@ impl TestFixture {
         let root = config_dir.path();
         let todo_path = root.join("TODO.md");
         let workspace_root = root.join("workspaces");
+        let repo_path = root.join("source");
         let mock_bin_dir = root.join("bin");
         let acpx_log_path = root.join("mock-acpx.log");
 
         fs::create_dir_all(&workspace_root)?;
         fs::create_dir_all(&mock_bin_dir)?;
+        init_git_repo(&repo_path)?;
         fs::write(&todo_path, todo_fixture())?;
         fs::write(
             root.join("config.yaml"),
-            config_yaml(&todo_path, &workspace_root, acceptance_run),
+            config_yaml(&todo_path, &workspace_root, &repo_path, acceptance_run),
         )?;
         fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
 
@@ -239,7 +302,12 @@ fn todo_fixture() -> String {
     )
 }
 
-fn config_yaml(todo_path: &Path, workspace_root: &Path, acceptance_run: &str) -> String {
+fn config_yaml(
+    todo_path: &Path,
+    workspace_root: &Path,
+    repo_path: &Path,
+    acceptance_run: &str,
+) -> String {
     format!(
         r#"
 tracker:
@@ -252,6 +320,9 @@ tracker:
     - Done
 workspace:
   root: {}
+repos:
+  - path: {}
+    branch: main
 agents:
   builder:
     acpx_agent: builder
@@ -265,6 +336,15 @@ acceptance:
     - name: verify
       run: {}
       timeout_ms: 5000
+  required_files:
+    - name: required-artifact
+      repo: source
+      path: acceptance.txt
+  required_handoff_sections:
+    - name: implementation-handoff
+      step: implement
+      sections:
+        - artifact
 on_success: Done
 on_failure: Failed
 max_cycles: 1
@@ -280,8 +360,39 @@ agent:
 "#,
         yaml_quote(&todo_path.display().to_string()),
         yaml_quote(&workspace_root.display().to_string()),
+        yaml_quote(&repo_path.display().to_string()),
         yaml_quote(acceptance_run)
     )
+}
+
+fn init_git_repo(repo_path: &Path) -> io::Result<()> {
+    fs::create_dir_all(repo_path)?;
+    let run = |args: &[&str]| -> io::Result<()> {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(repo_path)
+            .status()?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(io::Error::other(format!(
+                "git {} failed with {status}",
+                args.join(" ")
+            )))
+        }
+    };
+    run(&["init", "-b", "main"])?;
+    fs::write(repo_path.join("README.md"), "fixture\n")?;
+    run(&["add", "README.md"])?;
+    run(&[
+        "-c",
+        "user.name=Ensemble E2E",
+        "-c",
+        "user.email=ensemble-e2e@example.invalid",
+        "commit",
+        "-m",
+        "fixture",
+    ])
 }
 
 async fn wait_for_failed_history_record(
@@ -347,13 +458,23 @@ if [[ " $* " == *" prompt "* ]]; then
 
   mkdir -p "$cwd/.ensemble"
   cat > "$cwd/.ensemble/mock-prompt.txt"
-  cat > "$cwd/.ensemble/verdict-implement.json" <<'JSON'
-{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}}
-JSON
+  if [[ "${ENSEMBLE_E2E_MISSING_HANDOFF:-}" == "1" ]]; then
+    printf '%s\n' '{"result":"succeeded","summary":"mock agent completed","output":{}}' > "$cwd/.ensemble/verdict-implement.json"
+  else
+    printf '%s\n' '{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}}' > "$cwd/.ensemble/verdict-implement.json"
+  fi
+  if [[ "${ENSEMBLE_E2E_SKIP_REQUIRED_FILE:-}" != "1" ]]; then
+    repo_worktree="$(find "$cwd/source" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+    printf 'artifact\n' > "$repo_worktree/acceptance.txt"
+  fi
 
   printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"mock agent completed"}}}}'
   printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-1","status":"completed","content":{"type":"tool_call","name":"read_file","arguments":{"path":"Cargo.toml"}}}}}'
-  printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"turn_complete","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7},"verdict":{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}},"stopReason":"end_turn"}}}'
+  if [[ "${ENSEMBLE_E2E_MISSING_HANDOFF:-}" == "1" ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"turn_complete","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7},"verdict":{"result":"succeeded","summary":"mock agent completed","output":{}},"stopReason":"end_turn"}}}'
+  else
+    printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"turn_complete","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7},"verdict":{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}},"stopReason":"end_turn"}}}'
+  fi
   exit 0
 fi
 

--- a/crates/ensemble-core/src/acceptance/mod.rs
+++ b/crates/ensemble-core/src/acceptance/mod.rs
@@ -1,7 +1,13 @@
 mod model;
+mod requirements;
 mod runner;
 
+pub(crate) use requirements::{evaluate_file_requirement, evaluate_handoff_requirement};
+pub(crate) use runner::AcceptanceTimer;
+
 pub use model::{
-    AcceptanceAttempt, AcceptanceOutput, AcceptanceResult, AcceptanceStatus, AcceptanceTiming,
+    AcceptanceAttempt, AcceptanceEvidence, AcceptanceOutput, AcceptanceResult, AcceptanceStatus,
+    AcceptanceTiming, FileObservation, HandoffOutputObservation, HandoffSectionEvidence,
+    HandoffSectionObservation, JsonValueKind, PullRequestDeliveryPhase, ResolvedAcceptancePlan,
 };
 pub use runner::{AcceptanceCommandRunner, ShellAcceptanceCommandRunner};

--- a/crates/ensemble-core/src/acceptance/model.rs
+++ b/crates/ensemble-core/src/acceptance/model.rs
@@ -1,7 +1,12 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use sha2::{Digest, Sha256};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+use crate::config::ensemble::{
+    AcceptanceFileConfig, AcceptanceHandoffConfig, AcceptancePullRequestConfig, EnsembleConfig,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AcceptanceStatus {
     Passed,
@@ -30,21 +35,300 @@ pub struct AcceptanceOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FileObservation {
+    Present,
+    Missing,
+    NotRegularFile,
+    OutsideRepository,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum JsonValueKind {
+    Null,
+    Boolean,
+    Number,
+    String,
+    Array,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HandoffOutputObservation {
+    Object,
+    Missing,
+    NonObject { value_kind: JsonValueKind },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HandoffSectionObservation {
+    Present,
+    Missing,
+    Null,
+    BlankString,
+    EmptyObject,
+    EmptyArray,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct HandoffSectionEvidence {
+    pub name: String,
+    pub observation: HandoffSectionObservation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PullRequestDeliveryPhase {
+    Prepared,
+    PushInFlight,
+    ReconcilingPush,
+    PrCreateInFlight,
+    ReconcilingPr,
+    Waiting,
+    Published,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AcceptanceEvidence {
+    Command {
+        exit_code: Option<i32>,
+        stdout: AcceptanceOutput,
+        stderr: AcceptanceOutput,
+    },
+    File {
+        repo: String,
+        path: String,
+        observation: FileObservation,
+    },
+    Handoff {
+        step: String,
+        output: HandoffOutputObservation,
+        sections: Vec<HandoffSectionEvidence>,
+    },
+    PullRequest {
+        repo: String,
+        delivery_phase: PullRequestDeliveryPhase,
+        base_branch: Option<String>,
+        head_branch: Option<String>,
+        head_sha: Option<String>,
+        pr_number: Option<u64>,
+        pr_url: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, utoipa::ToSchema)]
 pub struct AcceptanceResult {
+    version: u8,
     pub name: String,
     pub status: AcceptanceStatus,
+    pub summary: String,
     #[serde(default)]
     pub timing: AcceptanceTiming,
-    pub exit_code: Option<i32>,
-    pub stdout: AcceptanceOutput,
-    pub stderr: AcceptanceOutput,
-    pub summary: String,
+    pub evidence: AcceptanceEvidence,
+}
+
+impl AcceptanceResult {
+    pub const VERSION: u8 = 2;
+
+    pub fn new(
+        name: String,
+        status: AcceptanceStatus,
+        summary: String,
+        evidence: AcceptanceEvidence,
+    ) -> Self {
+        Self {
+            version: Self::VERSION,
+            name,
+            status,
+            summary,
+            timing: AcceptanceTiming::Unknown,
+            evidence,
+        }
+    }
+
+    pub fn version(&self) -> u8 {
+        self.version
+    }
+
+    pub(crate) fn command(
+        name: String,
+        status: AcceptanceStatus,
+        summary: String,
+        exit_code: Option<i32>,
+        stdout: AcceptanceOutput,
+        stderr: AcceptanceOutput,
+    ) -> Self {
+        Self::new(
+            name,
+            status,
+            summary,
+            AcceptanceEvidence::Command {
+                exit_code,
+                stdout,
+                stderr,
+            },
+        )
+    }
+}
+
+#[derive(Deserialize)]
+struct AcceptanceResultWire {
+    version: Option<u8>,
+    name: String,
+    status: AcceptanceStatus,
+    summary: String,
+    #[serde(default)]
+    timing: AcceptanceTiming,
+    evidence: Option<AcceptanceEvidence>,
+    #[serde(default, deserialize_with = "deserialize_present")]
+    exit_code: Present<i32>,
+    #[serde(default, deserialize_with = "deserialize_present")]
+    stdout: Present<AcceptanceOutput>,
+    #[serde(default, deserialize_with = "deserialize_present")]
+    stderr: Present<AcceptanceOutput>,
+}
+
+struct Present<T> {
+    value: Option<T>,
+    present: bool,
+}
+
+impl<T> Default for Present<T> {
+    fn default() -> Self {
+        Self {
+            value: None,
+            present: false,
+        }
+    }
+}
+
+fn deserialize_present<'de, D, T>(deserializer: D) -> Result<Present<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Present {
+        value: Option::<T>::deserialize(deserializer)?,
+        present: true,
+    })
+}
+
+impl<'de> Deserialize<'de> for AcceptanceResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = AcceptanceResultWire::deserialize(deserializer)?;
+        let evidence = match wire.version {
+            Some(Self::VERSION) => {
+                if wire.exit_code.present || wire.stdout.present || wire.stderr.present {
+                    return Err(D::Error::custom(
+                        "version 2 acceptance result must not contain legacy command fields",
+                    ));
+                }
+                wire.evidence.ok_or_else(|| {
+                    D::Error::custom("version 2 acceptance result is missing evidence")
+                })?
+            }
+            Some(version) => {
+                return Err(D::Error::custom(format!(
+                    "unsupported acceptance result version {version}"
+                )));
+            }
+            None => {
+                if wire.evidence.is_some() {
+                    return Err(D::Error::custom(
+                        "unversioned acceptance result must use legacy flat command fields",
+                    ));
+                }
+                AcceptanceEvidence::Command {
+                    exit_code: wire.exit_code.value,
+                    stdout: wire.stdout.value.ok_or_else(|| {
+                        D::Error::custom("legacy acceptance result is missing stdout")
+                    })?,
+                    stderr: wire.stderr.value.ok_or_else(|| {
+                        D::Error::custom("legacy acceptance result is missing stderr")
+                    })?,
+                }
+            }
+        };
+        Ok(Self {
+            version: Self::VERSION,
+            name: wire.name,
+            status: wire.status,
+            summary: wire.summary,
+            timing: wire.timing,
+            evidence,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct AcceptanceAttempt {
     pub cycle: u32,
     pub results: Vec<AcceptanceResult>,
+}
+
+/// Non-secret acceptance descriptors frozen with a run before acceptance begins.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedAcceptancePlan {
+    pub config_digest: String,
+    pub commands: Vec<String>,
+    pub required_files: Vec<AcceptanceFileConfig>,
+    pub required_handoff_sections: Vec<AcceptanceHandoffConfig>,
+    pub required_pull_requests: Vec<AcceptancePullRequestConfig>,
+}
+
+impl ResolvedAcceptancePlan {
+    pub fn from_config(config: &EnsembleConfig) -> Result<Self, serde_json::Error> {
+        Ok(Self {
+            config_digest: semantic_config_digest(config)?,
+            commands: config
+                .acceptance
+                .commands
+                .iter()
+                .map(|command| command.name.clone())
+                .collect(),
+            required_files: config.acceptance.required_files.clone(),
+            required_handoff_sections: config.acceptance.required_handoff_sections.clone(),
+            required_pull_requests: config.acceptance.required_pull_requests.clone(),
+        })
+    }
+
+    pub fn matches_config(&self, config: &EnsembleConfig) -> bool {
+        semantic_config_digest(config).is_ok_and(|digest| digest == self.config_digest)
+    }
+
+    pub fn pre_final_len(&self) -> usize {
+        self.commands.len() + self.required_files.len() + self.required_handoff_sections.len()
+    }
+}
+
+fn semantic_config_digest(config: &EnsembleConfig) -> Result<String, serde_json::Error> {
+    fn canonicalize(value: serde_json::Value) -> serde_json::Value {
+        match value {
+            serde_json::Value::Array(values) => {
+                serde_json::Value::Array(values.into_iter().map(canonicalize).collect())
+            }
+            serde_json::Value::Object(values) => {
+                let sorted = values
+                    .into_iter()
+                    .map(|(key, value)| (key, canonicalize(value)))
+                    .collect::<std::collections::BTreeMap<_, _>>();
+                serde_json::Value::Object(sorted.into_iter().collect())
+            }
+            value => value,
+        }
+    }
+
+    let value = canonicalize(serde_json::to_value(config)?);
+    let bytes = serde_json::to_vec(&value)?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
 }
 
 #[cfg(test)]
@@ -67,6 +351,23 @@ mod tests {
         let result: AcceptanceResult = serde_json::from_value(value).unwrap();
 
         assert_eq!(result.timing, AcceptanceTiming::Unknown);
+        assert_eq!(
+            result.evidence,
+            AcceptanceEvidence::Command {
+                exit_code: Some(0),
+                stdout: AcceptanceOutput {
+                    tail: "ok".to_string(),
+                    total_bytes: 2,
+                    truncated: false,
+                },
+                stderr: AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+            }
+        );
+        assert_eq!(serde_json::to_value(result).unwrap()["version"], 2);
     }
 
     #[test]
@@ -86,5 +387,150 @@ mod tests {
                 "duration_ms": 1234
             })
         );
+    }
+
+    #[test]
+    fn version_two_serializes_each_typed_evidence_variant() {
+        let cases = [
+            (
+                AcceptanceEvidence::Command {
+                    exit_code: Some(0),
+                    stdout: AcceptanceOutput {
+                        tail: "ok".into(),
+                        total_bytes: 2,
+                        truncated: false,
+                    },
+                    stderr: AcceptanceOutput {
+                        tail: String::new(),
+                        total_bytes: 0,
+                        truncated: false,
+                    },
+                },
+                serde_json::json!({
+                    "kind": "command",
+                    "exit_code": 0,
+                    "stdout": {"tail": "ok", "total_bytes": 2, "truncated": false},
+                    "stderr": {"tail": "", "total_bytes": 0, "truncated": false}
+                }),
+            ),
+            (
+                AcceptanceEvidence::File {
+                    repo: "ensemble".into(),
+                    path: "docs/release.md".into(),
+                    observation: FileObservation::Present,
+                },
+                serde_json::json!({
+                    "kind": "file",
+                    "repo": "ensemble",
+                    "path": "docs/release.md",
+                    "observation": "present"
+                }),
+            ),
+            (
+                AcceptanceEvidence::Handoff {
+                    step: "synthesize".into(),
+                    output: HandoffOutputObservation::Object,
+                    sections: vec![HandoffSectionEvidence {
+                        name: "summary".into(),
+                        observation: HandoffSectionObservation::Present,
+                    }],
+                },
+                serde_json::json!({
+                    "kind": "handoff",
+                    "step": "synthesize",
+                    "output": {"kind": "object"},
+                    "sections": [{"name": "summary", "observation": "present"}]
+                }),
+            ),
+            (
+                AcceptanceEvidence::PullRequest {
+                    repo: "ensemble".into(),
+                    delivery_phase: PullRequestDeliveryPhase::Blocked,
+                    base_branch: None,
+                    head_branch: Some("issue-418".into()),
+                    head_sha: None,
+                    pr_number: None,
+                    pr_url: None,
+                },
+                serde_json::json!({
+                    "kind": "pull_request",
+                    "repo": "ensemble",
+                    "delivery_phase": "blocked",
+                    "base_branch": null,
+                    "head_branch": "issue-418",
+                    "head_sha": null,
+                    "pr_number": null,
+                    "pr_url": null
+                }),
+            ),
+        ];
+
+        for (evidence, expected_evidence) in cases {
+            let result = AcceptanceResult::new(
+                "rule".into(),
+                AcceptanceStatus::Failed,
+                "precise reason".into(),
+                evidence,
+            );
+            let value = serde_json::to_value(&result).unwrap();
+            assert_eq!(value["version"], 2);
+            assert_eq!(value["evidence"], expected_evidence);
+            assert!(value.get("exit_code").is_none());
+            assert_eq!(
+                serde_json::from_value::<AcceptanceResult>(value).unwrap(),
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_explicit_version_fails_closed() {
+        let error = serde_json::from_value::<AcceptanceResult>(serde_json::json!({
+            "version": 3,
+            "name": "future",
+            "status": "passed",
+            "summary": "future",
+            "timing": {"kind": "unknown"},
+            "evidence": {
+                "kind": "file",
+                "repo": "ensemble",
+                "path": "README.md",
+                "observation": "present"
+            }
+        }))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("unsupported acceptance result version 3"));
+    }
+
+    #[test]
+    fn version_two_rejects_legacy_fields_even_when_null() {
+        for field in ["exit_code", "stdout", "stderr"] {
+            let mut value = serde_json::json!({
+                "version": 2,
+                "name": "rule",
+                "status": "passed",
+                "summary": "passed",
+                "timing": {"kind": "unknown"},
+                "evidence": {
+                    "kind": "file",
+                    "repo": "ensemble",
+                    "path": "README.md",
+                    "observation": "present"
+                }
+            });
+            value[field] = serde_json::Value::Null;
+
+            let error = serde_json::from_value::<AcceptanceResult>(value).unwrap_err();
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("version 2 acceptance result must not contain legacy command fields"),
+                "unexpected error for {field}: {error}"
+            );
+        }
     }
 }

--- a/crates/ensemble-core/src/acceptance/requirements.rs
+++ b/crates/ensemble-core/src/acceptance/requirements.rs
@@ -1,0 +1,475 @@
+use std::collections::HashMap;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+
+use crate::acceptance::{
+    AcceptanceEvidence, AcceptanceResult, AcceptanceStatus, FileObservation,
+    HandoffOutputObservation, HandoffSectionEvidence, HandoffSectionObservation, JsonValueKind,
+};
+use crate::config::ensemble::{AcceptanceFileConfig, AcceptanceHandoffConfig};
+use crate::pipeline::verdict::StepOutput;
+
+use super::runner::AcceptanceTimer;
+
+pub(crate) fn evaluate_file_requirement(
+    rule: &AcceptanceFileConfig,
+    worktrees: &HashMap<String, PathBuf>,
+) -> AcceptanceResult {
+    let timer = AcceptanceTimer::start();
+    let (status, observation, summary) = match worktrees.get(&rule.repo) {
+        None => (
+            AcceptanceStatus::Unavailable,
+            FileObservation::Unavailable,
+            format!(
+                "required file '{}' is unavailable because repository '{}' has no owned worktree",
+                rule.name, rule.repo
+            ),
+        ),
+        Some(root) => evaluate_file_path(rule, root),
+    };
+    timer.finish(AcceptanceResult::new(
+        rule.name.clone(),
+        status,
+        summary,
+        AcceptanceEvidence::File {
+            repo: rule.repo.clone(),
+            path: rule.path.to_string_lossy().into_owned(),
+            observation,
+        },
+    ))
+}
+
+fn evaluate_file_path(
+    rule: &AcceptanceFileConfig,
+    root: &std::path::Path,
+) -> (AcceptanceStatus, FileObservation, String) {
+    let canonical_root = match std::fs::canonicalize(root) {
+        Ok(root) => root,
+        Err(error) => {
+            return (
+                AcceptanceStatus::Unavailable,
+                FileObservation::Unavailable,
+                format!(
+                    "required file '{}' is unavailable because repository '{}' worktree cannot be resolved: {error}",
+                    rule.name, rule.repo
+                ),
+            );
+        }
+    };
+    let target = root.join(&rule.path);
+    let canonical_target = match std::fs::canonicalize(&target) {
+        Ok(path) => path,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return (
+                AcceptanceStatus::Failed,
+                FileObservation::Missing,
+                format!(
+                    "required file '{}' is missing at '{}' in repository '{}'",
+                    rule.name,
+                    rule.path.display(),
+                    rule.repo
+                ),
+            );
+        }
+        Err(error) => {
+            return (
+                AcceptanceStatus::Unavailable,
+                FileObservation::Unavailable,
+                format!(
+                    "required file '{}' could not be inspected in repository '{}': {error}",
+                    rule.name, rule.repo
+                ),
+            );
+        }
+    };
+    if !canonical_target.starts_with(&canonical_root) {
+        return (
+            AcceptanceStatus::Failed,
+            FileObservation::OutsideRepository,
+            format!(
+                "required file '{}' at '{}' resolves outside repository '{}'",
+                rule.name,
+                rule.path.display(),
+                rule.repo
+            ),
+        );
+    }
+    match std::fs::metadata(&canonical_target) {
+        Ok(metadata) if metadata.is_file() => (
+            AcceptanceStatus::Passed,
+            FileObservation::Present,
+            format!(
+                "required file '{}' is present at '{}' in repository '{}'",
+                rule.name,
+                rule.path.display(),
+                rule.repo
+            ),
+        ),
+        Ok(_) => (
+            AcceptanceStatus::Failed,
+            FileObservation::NotRegularFile,
+            format!(
+                "required file '{}' at '{}' in repository '{}' is not a regular file",
+                rule.name,
+                rule.path.display(),
+                rule.repo
+            ),
+        ),
+        Err(error) => (
+            AcceptanceStatus::Unavailable,
+            FileObservation::Unavailable,
+            format!(
+                "required file '{}' could not be inspected in repository '{}': {error}",
+                rule.name, rule.repo
+            ),
+        ),
+    }
+}
+
+pub(crate) fn evaluate_handoff_requirement(
+    rule: &AcceptanceHandoffConfig,
+    step_outputs: &HashMap<String, StepOutput>,
+) -> AcceptanceResult {
+    let timer = AcceptanceTimer::start();
+    let (status, output, sections, summary) = match step_outputs
+        .get(&rule.step)
+        .and_then(|step_output| step_output.output.as_ref())
+    {
+        None => (
+            AcceptanceStatus::Failed,
+            HandoffOutputObservation::Missing,
+            Vec::new(),
+            format!(
+                "required handoff '{}' has no persisted output for step '{}'",
+                rule.name, rule.step
+            ),
+        ),
+        Some(serde_json::Value::Object(object)) => {
+            let sections = rule
+                .sections
+                .iter()
+                .map(|name| HandoffSectionEvidence {
+                    name: name.clone(),
+                    observation: section_observation(object.get(name)),
+                })
+                .collect::<Vec<_>>();
+            let failed = sections
+                .iter()
+                .filter(|section| section.observation != HandoffSectionObservation::Present)
+                .map(|section| format!("{} is {:?}", section.name, section.observation))
+                .collect::<Vec<_>>();
+            if failed.is_empty() {
+                (
+                    AcceptanceStatus::Passed,
+                    HandoffOutputObservation::Object,
+                    sections,
+                    format!(
+                        "required handoff '{}' contains every configured section",
+                        rule.name
+                    ),
+                )
+            } else {
+                (
+                    AcceptanceStatus::Failed,
+                    HandoffOutputObservation::Object,
+                    sections,
+                    format!(
+                        "required handoff '{}' has invalid sections: {}",
+                        rule.name,
+                        failed.join(", ")
+                    ),
+                )
+            }
+        }
+        Some(value) => (
+            AcceptanceStatus::Failed,
+            HandoffOutputObservation::NonObject {
+                value_kind: json_value_kind(value),
+            },
+            Vec::new(),
+            format!(
+                "required handoff '{}' step '{}' output is not an object",
+                rule.name, rule.step
+            ),
+        ),
+    };
+    timer.finish(AcceptanceResult::new(
+        rule.name.clone(),
+        status,
+        summary,
+        AcceptanceEvidence::Handoff {
+            step: rule.step.clone(),
+            output,
+            sections,
+        },
+    ))
+}
+
+fn section_observation(value: Option<&serde_json::Value>) -> HandoffSectionObservation {
+    match value {
+        None => HandoffSectionObservation::Missing,
+        Some(serde_json::Value::Null) => HandoffSectionObservation::Null,
+        Some(serde_json::Value::String(value)) if value.trim().is_empty() => {
+            HandoffSectionObservation::BlankString
+        }
+        Some(serde_json::Value::Object(value)) if value.is_empty() => {
+            HandoffSectionObservation::EmptyObject
+        }
+        Some(serde_json::Value::Array(value)) if value.is_empty() => {
+            HandoffSectionObservation::EmptyArray
+        }
+        Some(_) => HandoffSectionObservation::Present,
+    }
+}
+
+fn json_value_kind(value: &serde_json::Value) -> JsonValueKind {
+    match value {
+        serde_json::Value::Null => JsonValueKind::Null,
+        serde_json::Value::Bool(_) => JsonValueKind::Boolean,
+        serde_json::Value::Number(_) => JsonValueKind::Number,
+        serde_json::Value::String(_) => JsonValueKind::String,
+        serde_json::Value::Array(_) => JsonValueKind::Array,
+        serde_json::Value::Object(_) => unreachable!("objects are handled before classification"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_requirement_reports_present_and_missing() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("present.txt"), "ok").unwrap();
+        let worktrees = HashMap::from([("repo".to_string(), root.path().to_path_buf())]);
+
+        let present = evaluate_file_requirement(
+            &AcceptanceFileConfig {
+                name: "present".into(),
+                repo: "repo".into(),
+                path: "present.txt".into(),
+            },
+            &worktrees,
+        );
+        let missing = evaluate_file_requirement(
+            &AcceptanceFileConfig {
+                name: "missing".into(),
+                repo: "repo".into(),
+                path: "missing.txt".into(),
+            },
+            &worktrees,
+        );
+
+        assert_eq!(present.status, AcceptanceStatus::Passed);
+        assert!(matches!(
+            present.evidence,
+            AcceptanceEvidence::File {
+                observation: FileObservation::Present,
+                ..
+            }
+        ));
+        assert_eq!(missing.status, AcceptanceStatus::Failed);
+        assert!(matches!(
+            missing.evidence,
+            AcceptanceEvidence::File {
+                observation: FileObservation::Missing,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn file_requirement_enforces_regular_file_and_worktree_boundary() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("directory")).unwrap();
+        std::fs::write(root.path().join("target.txt"), "inside").unwrap();
+        std::fs::write(outside.path().join("outside.txt"), "outside").unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("target.txt", root.path().join("inside-link.txt")).unwrap();
+            std::os::unix::fs::symlink(
+                outside.path().join("outside.txt"),
+                root.path().join("outside-link.txt"),
+            )
+            .unwrap();
+        }
+        let worktrees = HashMap::from([("repo".to_string(), root.path().to_path_buf())]);
+
+        let evaluate = |name: &str, path: &str| {
+            evaluate_file_requirement(
+                &AcceptanceFileConfig {
+                    name: name.into(),
+                    repo: "repo".into(),
+                    path: path.into(),
+                },
+                &worktrees,
+            )
+        };
+        assert!(matches!(
+            evaluate("directory", "directory").evidence,
+            AcceptanceEvidence::File {
+                observation: FileObservation::NotRegularFile,
+                ..
+            }
+        ));
+        #[cfg(unix)]
+        {
+            assert_eq!(
+                evaluate("inside", "inside-link.txt").status,
+                AcceptanceStatus::Passed
+            );
+            let escaping = evaluate("escaping", "outside-link.txt");
+            assert_eq!(escaping.status, AcceptanceStatus::Failed);
+            assert!(matches!(
+                escaping.evidence,
+                AcceptanceEvidence::File {
+                    observation: FileObservation::OutsideRepository,
+                    ..
+                }
+            ));
+            assert!(!escaping
+                .summary
+                .contains(&outside.path().display().to_string()));
+        }
+    }
+
+    #[test]
+    fn file_requirement_reports_unavailable_without_an_owned_worktree() {
+        let result = evaluate_file_requirement(
+            &AcceptanceFileConfig {
+                name: "artifact".into(),
+                repo: "repo".into(),
+                path: "artifact.bin".into(),
+            },
+            &HashMap::new(),
+        );
+
+        assert_eq!(result.status, AcceptanceStatus::Unavailable);
+        assert!(matches!(
+            result.evidence,
+            AcceptanceEvidence::File {
+                observation: FileObservation::Unavailable,
+                ..
+            }
+        ));
+    }
+
+    fn step_output(output: Option<serde_json::Value>) -> StepOutput {
+        StepOutput {
+            result: crate::pipeline::verdict::StepResult::Succeeded,
+            summary: None,
+            output,
+        }
+    }
+
+    #[test]
+    fn handoff_requirement_reports_every_section_in_configuration_order() {
+        let rule = AcceptanceHandoffConfig {
+            name: "handoff".into(),
+            step: "synthesize".into(),
+            sections: vec![
+                "present_false".into(),
+                "present_zero".into(),
+                "missing".into(),
+                "null".into(),
+                "blank".into(),
+                "object".into(),
+                "array".into(),
+            ],
+        };
+        let outputs = HashMap::from([(
+            "synthesize".into(),
+            step_output(Some(serde_json::json!({
+                "present_false": false,
+                "present_zero": 0,
+                "null": null,
+                "blank": "  ",
+                "object": {},
+                "array": []
+            }))),
+        )]);
+
+        let result = evaluate_handoff_requirement(&rule, &outputs);
+
+        assert_eq!(result.status, AcceptanceStatus::Failed);
+        let AcceptanceEvidence::Handoff {
+            output, sections, ..
+        } = result.evidence
+        else {
+            panic!("expected handoff evidence")
+        };
+        assert_eq!(output, HandoffOutputObservation::Object);
+        assert_eq!(
+            sections,
+            vec![
+                HandoffSectionEvidence {
+                    name: "present_false".into(),
+                    observation: HandoffSectionObservation::Present,
+                },
+                HandoffSectionEvidence {
+                    name: "present_zero".into(),
+                    observation: HandoffSectionObservation::Present,
+                },
+                HandoffSectionEvidence {
+                    name: "missing".into(),
+                    observation: HandoffSectionObservation::Missing,
+                },
+                HandoffSectionEvidence {
+                    name: "null".into(),
+                    observation: HandoffSectionObservation::Null,
+                },
+                HandoffSectionEvidence {
+                    name: "blank".into(),
+                    observation: HandoffSectionObservation::BlankString,
+                },
+                HandoffSectionEvidence {
+                    name: "object".into(),
+                    observation: HandoffSectionObservation::EmptyObject,
+                },
+                HandoffSectionEvidence {
+                    name: "array".into(),
+                    observation: HandoffSectionObservation::EmptyArray,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn handoff_requirement_distinguishes_missing_and_non_object_output() {
+        let rule = AcceptanceHandoffConfig {
+            name: "handoff".into(),
+            step: "synthesize".into(),
+            sections: vec!["summary".into()],
+        };
+        let missing = evaluate_handoff_requirement(&rule, &HashMap::new());
+        assert!(matches!(
+            missing.evidence,
+            AcceptanceEvidence::Handoff {
+                output: HandoffOutputObservation::Missing,
+                ref sections,
+                ..
+            } if sections.is_empty()
+        ));
+
+        let cases = [
+            (serde_json::Value::Null, JsonValueKind::Null),
+            (serde_json::json!(false), JsonValueKind::Boolean),
+            (serde_json::json!(0), JsonValueKind::Number),
+            (serde_json::json!("text"), JsonValueKind::String),
+            (serde_json::json!([]), JsonValueKind::Array),
+        ];
+        for (value, expected_kind) in cases {
+            let outputs = HashMap::from([("synthesize".into(), step_output(Some(value)))]);
+            let result = evaluate_handoff_requirement(&rule, &outputs);
+            assert!(matches!(
+                result.evidence,
+                AcceptanceEvidence::Handoff {
+                    output: HandoffOutputObservation::NonObject { value_kind },
+                    ref sections,
+                    ..
+                } if value_kind == expected_kind && sections.is_empty()
+            ));
+        }
+    }
+}

--- a/crates/ensemble-core/src/acceptance/runner.rs
+++ b/crates/ensemble-core/src/acceptance/runner.rs
@@ -118,35 +118,34 @@ impl AcceptanceCommandRunner for ShellAcceptanceCommandRunner {
                 ));
             }
         };
-        timer.finish(AcceptanceResult {
-            name: command_config.name.clone(),
-            status: AcceptanceStatus::TimedOut,
-            timing: AcceptanceTiming::Unknown,
-            exit_code: None,
-            stdout,
-            stderr,
-            summary: format!(
+        timer.finish(AcceptanceResult::command(
+            command_config.name.clone(),
+            AcceptanceStatus::TimedOut,
+            format!(
                 "acceptance command '{}' timed out after {}ms",
                 command_config.name, command_config.timeout_ms
             ),
-        })
+            None,
+            stdout,
+            stderr,
+        ))
     }
 }
 
-struct AcceptanceTimer {
+pub(crate) struct AcceptanceTimer {
     started_at: chrono::DateTime<Utc>,
     started: Instant,
 }
 
 impl AcceptanceTimer {
-    fn start() -> Self {
+    pub(crate) fn start() -> Self {
         Self {
             started_at: Utc::now(),
             started: Instant::now(),
         }
     }
 
-    fn finish(self, mut result: AcceptanceResult) -> AcceptanceResult {
+    pub(crate) fn finish(self, mut result: AcceptanceResult) -> AcceptanceResult {
         result.timing = AcceptanceTiming::Observed {
             started_at: self.started_at,
             completed_at: Utc::now(),
@@ -172,15 +171,14 @@ fn finish_result(
         Some(code) => format!("acceptance command '{name}' failed with exit code {code}"),
         None => format!("acceptance command '{name}' terminated by signal"),
     };
-    AcceptanceResult {
-        name: name.to_string(),
-        status: acceptance_status,
-        timing: AcceptanceTiming::Unknown,
-        exit_code: status.code(),
+    AcceptanceResult::command(
+        name.to_string(),
+        acceptance_status,
+        summary,
+        status.code(),
         stdout,
         stderr,
-        summary,
-    }
+    )
 }
 
 async fn collect_outputs(
@@ -237,15 +235,14 @@ fn append_tail(tail: &mut Vec<u8>, chunk: &[u8]) {
 }
 
 fn unavailable_result(name: &str, summary: String) -> AcceptanceResult {
-    AcceptanceResult {
-        name: name.to_string(),
-        status: AcceptanceStatus::Unavailable,
-        timing: AcceptanceTiming::Unknown,
-        exit_code: None,
-        stdout: empty_output(),
-        stderr: empty_output(),
+    AcceptanceResult::command(
+        name.to_string(),
+        AcceptanceStatus::Unavailable,
         summary,
-    }
+        None,
+        empty_output(),
+        empty_output(),
+    )
 }
 
 fn empty_output() -> AcceptanceOutput {
@@ -273,7 +270,7 @@ fn terminate_process_group(_child_id: Option<u32>) {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::acceptance::{AcceptanceStatus, AcceptanceTiming};
+    use crate::acceptance::{AcceptanceEvidence, AcceptanceStatus, AcceptanceTiming};
     use crate::config::ensemble::AcceptanceCommandConfig;
     use crate::test_support::env::ENV_LOCK;
 
@@ -299,6 +296,19 @@ mod tests {
         }
     }
 
+    fn command_evidence(
+        result: &AcceptanceResult,
+    ) -> (Option<i32>, &AcceptanceOutput, &AcceptanceOutput) {
+        match &result.evidence {
+            AcceptanceEvidence::Command {
+                exit_code,
+                stdout,
+                stderr,
+            } => (*exit_code, stdout, stderr),
+            evidence => panic!("expected command evidence, got {evidence:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn shell_runner_inherits_environment_and_uses_issue_workspace() {
         let _guard = ENV_LOCK
@@ -319,14 +329,15 @@ mod tests {
 
         std::env::remove_var(variable);
         assert_eq!(result.status, AcceptanceStatus::Passed);
-        assert_eq!(result.exit_code, Some(0));
+        let (exit_code, stdout, _) = command_evidence(&result);
+        assert_eq!(exit_code, Some(0));
         let expected_workspace = std::fs::canonicalize(workspace.path()).unwrap();
         assert_eq!(
-            result.stdout.tail,
+            stdout.tail,
             format!("inherited-value\n{}", expected_workspace.display())
         );
-        assert_eq!(result.stdout.total_bytes, result.stdout.tail.len() as u64);
-        assert!(!result.stdout.truncated);
+        assert_eq!(stdout.total_bytes, stdout.tail.len() as u64);
+        assert!(!stdout.truncated);
         assert_eq!(result.name, "context");
         observed_duration_ms(&result);
     }
@@ -346,10 +357,11 @@ mod tests {
             .await;
 
         assert_eq!(nonzero.status, AcceptanceStatus::Failed);
-        assert_eq!(nonzero.exit_code, Some(23));
-        assert!(nonzero.stderr.tail.ends_with("failure"));
+        let (nonzero_exit_code, _, nonzero_stderr) = command_evidence(&nonzero);
+        assert_eq!(nonzero_exit_code, Some(23));
+        assert!(nonzero_stderr.tail.ends_with("failure"));
         assert_eq!(signal.status, AcceptanceStatus::Failed);
-        assert_eq!(signal.exit_code, None);
+        assert_eq!(command_evidence(&signal).0, None);
         assert!(signal.summary.contains("signal"));
         observed_duration_ms(&nonzero);
         observed_duration_ms(&signal);
@@ -376,14 +388,16 @@ mod tests {
             .await;
 
         assert_eq!(noisy.status, AcceptanceStatus::Passed);
-        assert_eq!(noisy.stdout.total_bytes, 40_000);
-        assert!(noisy.stderr.total_bytes >= 41_000);
-        assert!(noisy.stdout.truncated);
-        assert!(noisy.stderr.truncated);
-        assert_eq!(noisy.stdout.tail.len(), OUTPUT_TAIL_LIMIT);
-        assert_eq!(noisy.stderr.tail.len(), OUTPUT_TAIL_LIMIT);
-        assert_eq!(lossy.stdout.total_bytes, 2);
-        assert_eq!(lossy.stdout.tail, "�x");
+        let (_, noisy_stdout, noisy_stderr) = command_evidence(&noisy);
+        assert_eq!(noisy_stdout.total_bytes, 40_000);
+        assert!(noisy_stderr.total_bytes >= 41_000);
+        assert!(noisy_stdout.truncated);
+        assert!(noisy_stderr.truncated);
+        assert_eq!(noisy_stdout.tail.len(), OUTPUT_TAIL_LIMIT);
+        assert_eq!(noisy_stderr.tail.len(), OUTPUT_TAIL_LIMIT);
+        let (_, lossy_stdout, _) = command_evidence(&lossy);
+        assert_eq!(lossy_stdout.total_bytes, 2);
+        assert_eq!(lossy_stdout.tail, "�x");
     }
 
     #[tokio::test]
@@ -404,7 +418,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         assert_eq!(result.status, AcceptanceStatus::TimedOut);
-        assert_eq!(result.exit_code, None);
+        assert_eq!(command_evidence(&result).0, None);
         assert!(observed_duration_ms(&result) >= 40);
         assert!(
             !marker.exists(),
@@ -452,10 +466,11 @@ mod tests {
             .await;
 
         assert_eq!(result.status, AcceptanceStatus::Unavailable);
-        assert_eq!(result.exit_code, None);
+        let (exit_code, stdout, stderr) = command_evidence(&result);
+        assert_eq!(exit_code, None);
         assert!(!result.summary.contains("super-secret-command"));
-        assert!(result.stdout.tail.is_empty());
-        assert!(result.stderr.tail.is_empty());
+        assert!(stdout.tail.is_empty());
+        assert!(stderr.tail.is_empty());
         observed_duration_ms(&result);
     }
 }

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -318,6 +318,13 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
             field: Some(name.clone()),
             path: Some(format!("acceptance.commands.{}", name)),
         },
+        PipelineError::InvalidAcceptanceRequirement { kind, name, reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("invalid acceptance {kind} requirement '{name}': {reason}"),
+            section: "acceptance".to_string(),
+            field: Some(name.clone()),
+            path: Some(format!("acceptance.{kind}.{name}")),
+        },
         PipelineError::UnknownAgent { name } => ValidationIssue {
             kind: ValidationIssueKind::Config,
             message: format!("unknown agent reference: {}", name),

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -44,6 +44,12 @@ pub struct EnsembleConfig {
 pub struct AcceptanceConfig {
     #[serde(default)]
     pub commands: Vec<AcceptanceCommandConfig>,
+    #[serde(default)]
+    pub required_files: Vec<AcceptanceFileConfig>,
+    #[serde(default)]
+    pub required_handoff_sections: Vec<AcceptanceHandoffConfig>,
+    #[serde(default)]
+    pub required_pull_requests: Vec<AcceptancePullRequestConfig>,
 }
 
 /// One named acceptance command executed by `/bin/sh -lc`.
@@ -52,6 +58,38 @@ pub struct AcceptanceCommandConfig {
     pub name: String,
     pub run: String,
     pub timeout_ms: u64,
+}
+
+/// One exact repository-relative file required before finalization.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct AcceptanceFileConfig {
+    pub name: String,
+    pub repo: String,
+    #[schema(value_type = String)]
+    pub path: PathBuf,
+}
+
+/// Named top-level sections required in one persisted step output.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct AcceptanceHandoffConfig {
+    pub name: String,
+    pub step: String,
+    pub sections: Vec<String>,
+}
+
+/// One durable pull-request identity required after finalization.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct AcceptancePullRequestConfig {
+    pub name: String,
+    pub repo: String,
+}
+
+pub(crate) fn repository_key(repo: &RepoConfig, index: usize) -> String {
+    Path::new(&repo.path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("repo-{index}"))
 }
 
 /// Runtime configuration for blocked-on-human interaction handling.
@@ -1016,7 +1054,7 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         };
         let reason = if command.name.trim().is_empty() {
             Some("name must not be empty")
-        } else if !acceptance_names.insert(command.name.as_str()) {
+        } else if !acceptance_names.insert(command.name.clone()) {
             Some("name must be unique")
         } else if command.run.trim().is_empty() {
             Some("run must not be empty")
@@ -1029,6 +1067,143 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
             return Err(PipelineError::InvalidAcceptanceCommand {
                 name: display_name.to_string(),
                 reason: reason.to_string(),
+            });
+        }
+    }
+
+    let repository_matches = |key: &str| {
+        config
+            .repos
+            .iter()
+            .enumerate()
+            .filter(|(index, repo)| repository_key(repo, *index) == key)
+            .map(|(_, repo)| repo)
+            .collect::<Vec<_>>()
+    };
+    let validate_name = |names: &mut std::collections::HashSet<String>,
+                         kind: &str,
+                         name: &str|
+     -> Result<(), PipelineError> {
+        let display_name = if name.trim().is_empty() {
+            "<unnamed>"
+        } else {
+            name
+        };
+        let reason = if name.trim().is_empty() {
+            Some("name must not be empty")
+        } else if !names.insert(name.to_string()) {
+            Some("name must be unique across all acceptance checks")
+        } else {
+            None
+        };
+        if let Some(reason) = reason {
+            return Err(PipelineError::InvalidAcceptanceRequirement {
+                kind: kind.to_string(),
+                name: display_name.to_string(),
+                reason: reason.to_string(),
+            });
+        }
+        Ok(())
+    };
+
+    for rule in &config.acceptance.required_files {
+        validate_name(&mut acceptance_names, "file", &rule.name)?;
+        let matches = repository_matches(&rule.repo);
+        if matches.len() != 1 {
+            return Err(PipelineError::InvalidAcceptanceRequirement {
+                kind: "file".to_string(),
+                name: rule.name.clone(),
+                reason: format!(
+                    "repository key '{}' must resolve to exactly one configured repository (found {})",
+                    rule.repo,
+                    matches.len()
+                ),
+            });
+        }
+        if rule.path.as_os_str().is_empty()
+            || rule.path.is_absolute()
+            || rule.path.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_)
+                )
+            })
+        {
+            return Err(PipelineError::InvalidAcceptanceRequirement {
+                kind: "file".to_string(),
+                name: rule.name.clone(),
+                reason:
+                    "path must be a non-empty repository-relative path without parent traversal"
+                        .to_string(),
+            });
+        }
+    }
+
+    for rule in &config.acceptance.required_handoff_sections {
+        validate_name(&mut acceptance_names, "handoff", &rule.name)?;
+        if !config.steps.iter().any(|step| step.name == rule.step) {
+            return Err(PipelineError::InvalidAcceptanceRequirement {
+                kind: "handoff".to_string(),
+                name: rule.name.clone(),
+                reason: format!("unknown step '{}'", rule.step),
+            });
+        }
+        if rule.sections.is_empty() {
+            return Err(PipelineError::InvalidAcceptanceRequirement {
+                kind: "handoff".to_string(),
+                name: rule.name.clone(),
+                reason: "sections must not be empty".to_string(),
+            });
+        }
+        let mut sections = std::collections::HashSet::new();
+        if let Some(section) = rule
+            .sections
+            .iter()
+            .find(|section| section.trim().is_empty() || !sections.insert(section.as_str()))
+        {
+            let reason = if section.trim().is_empty() {
+                "section names must not be empty".to_string()
+            } else {
+                format!("duplicate section '{section}'")
+            };
+            return Err(PipelineError::InvalidAcceptanceRequirement {
+                kind: "handoff".to_string(),
+                name: rule.name.clone(),
+                reason,
+            });
+        }
+    }
+
+    for rule in &config.acceptance.required_pull_requests {
+        validate_name(&mut acceptance_names, "pull_request", &rule.name)?;
+        let matches = repository_matches(&rule.repo);
+        if matches.len() != 1 {
+            return Err(PipelineError::InvalidAcceptanceRequirement {
+                kind: "pull_request".to_string(),
+                name: rule.name.clone(),
+                reason: format!(
+                    "repository key '{}' must resolve to exactly one configured repository (found {})",
+                    rule.repo,
+                    matches.len()
+                ),
+            });
+        }
+        let repo = matches[0];
+        if !repo.finalize.enabled
+            || !matches!(
+                repo.finalize.mode,
+                crate::workspace::finalize::FinalizeMode::PushAndPr
+            )
+        {
+            return Err(PipelineError::InvalidAcceptanceRequirement {
+                kind: "pull_request".to_string(),
+                name: rule.name.clone(),
+                reason: format!(
+                    "repository '{}' must use enabled finalize.mode: push_and_pr",
+                    rule.repo
+                ),
             });
         }
     }
@@ -1258,6 +1433,121 @@ on_failure: Failed
         assert_eq!(config.on_success, "Done");
         assert_eq!(config.on_failure, "Failed");
         assert!(config.acceptance.commands.is_empty());
+        assert!(config.acceptance.required_files.is_empty());
+        assert!(config.acceptance.required_handoff_sections.is_empty());
+        assert!(config.acceptance.required_pull_requests.is_empty());
+    }
+
+    #[test]
+    fn acceptance_parses_requirements() {
+        let yaml = format!(
+            "{}\nrepos:\n  - path: /tmp/ensemble\n    branch: main\n    finalize:\n      mode: push_and_pr\nacceptance:\n  required_files:\n    - name: release-notes\n      repo: ensemble\n      path: docs/release.md\n  required_handoff_sections:\n    - name: implementation-handoff\n      step: build\n      sections: [summary, testing]\n  required_pull_requests:\n    - name: ensemble-pr\n      repo: ensemble\n",
+            minimal_yaml()
+        );
+
+        let config = parse_config(&yaml).unwrap();
+
+        assert_eq!(
+            config.acceptance.required_files,
+            vec![AcceptanceFileConfig {
+                name: "release-notes".to_string(),
+                repo: "ensemble".to_string(),
+                path: PathBuf::from("docs/release.md"),
+            }]
+        );
+        assert_eq!(
+            config.acceptance.required_handoff_sections,
+            vec![AcceptanceHandoffConfig {
+                name: "implementation-handoff".to_string(),
+                step: "build".to_string(),
+                sections: vec!["summary".to_string(), "testing".to_string()],
+            }]
+        );
+        assert_eq!(
+            config.acceptance.required_pull_requests,
+            vec![AcceptancePullRequestConfig {
+                name: "ensemble-pr".to_string(),
+                repo: "ensemble".to_string(),
+            }]
+        );
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn acceptance_rejects_invalid_requirements() {
+        let cases = [
+            (
+                "blank name",
+                "required_files:\n    - name: '  '\n      repo: ensemble\n      path: docs/release.md",
+                "name must not be empty",
+            ),
+            (
+                "cross-kind duplicate",
+                "commands:\n    - name: duplicate\n      run: echo ok\n      timeout_ms: 1\n  required_files:\n    - name: duplicate\n      repo: ensemble\n      path: docs/release.md",
+                "unique across all acceptance checks",
+            ),
+            (
+                "unknown repository",
+                "required_files:\n    - name: file\n      repo: missing\n      path: docs/release.md",
+                "found 0",
+            ),
+            (
+                "unknown step",
+                "required_handoff_sections:\n    - name: handoff\n      step: missing\n      sections: [summary]",
+                "unknown step 'missing'",
+            ),
+            (
+                "empty sections",
+                "required_handoff_sections:\n    - name: handoff\n      step: build\n      sections: []",
+                "sections must not be empty",
+            ),
+            (
+                "duplicate sections",
+                "required_handoff_sections:\n    - name: handoff\n      step: build\n      sections: [summary, summary]",
+                "duplicate section 'summary'",
+            ),
+            (
+                "absolute path",
+                "required_files:\n    - name: file\n      repo: ensemble\n      path: /tmp/release.md",
+                "repository-relative path",
+            ),
+            (
+                "parent path",
+                "required_files:\n    - name: file\n      repo: ensemble\n      path: ../release.md",
+                "repository-relative path",
+            ),
+            (
+                "wrong delivery mode",
+                "required_pull_requests:\n    - name: pr\n      repo: other",
+                "push_and_pr",
+            ),
+        ];
+
+        for (label, acceptance, expected) in cases {
+            let yaml = format!(
+                "{}\nrepos:\n  - path: /tmp/ensemble\n    branch: main\n    finalize:\n      mode: push_and_pr\n  - path: /tmp/other\n    branch: main\n    finalize:\n      mode: push\nacceptance:\n  {acceptance}\n",
+                minimal_yaml()
+            );
+            let config = parse_config(&yaml).unwrap();
+            let error = validate_config(&config).expect_err(label);
+            assert!(
+                error.to_string().contains(expected),
+                "{label}: expected {expected:?}, got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn acceptance_rejects_ambiguous_repository_keys() {
+        let yaml = format!(
+            "{}\nrepos:\n  - path: /tmp/one/ensemble\n    branch: main\n  - path: /tmp/two/ensemble\n    branch: main\nacceptance:\n  required_files:\n    - name: file\n      repo: ensemble\n      path: docs/release.md\n",
+            minimal_yaml()
+        );
+
+        let config = parse_config(&yaml).unwrap();
+        let error = validate_config(&config).unwrap_err();
+
+        assert!(error.to_string().contains("found 2"));
     }
 
     #[test]

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -134,6 +134,12 @@ pub enum AgentError {
 pub enum PipelineError {
     #[error("invalid acceptance command {name}: {reason}")]
     InvalidAcceptanceCommand { name: String, reason: String },
+    #[error("invalid acceptance {kind} requirement {name}: {reason}")]
+    InvalidAcceptanceRequirement {
+        kind: String,
+        name: String,
+        reason: String,
+    },
     #[error("unknown agent reference: {name}")]
     UnknownAgent { name: String },
     #[error("unknown step dependency: {step} depends on {dependency}")]

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -485,29 +485,69 @@ mod tests {
             .await
             .unwrap();
         let mut record = sample_history("repo#1");
+        let mut command_result = crate::acceptance::AcceptanceResult::command(
+            "test".into(),
+            crate::acceptance::AcceptanceStatus::Passed,
+            "passed".into(),
+            Some(0),
+            crate::acceptance::AcceptanceOutput {
+                tail: "ok".into(),
+                total_bytes: 2,
+                truncated: false,
+            },
+            crate::acceptance::AcceptanceOutput {
+                tail: String::new(),
+                total_bytes: 0,
+                truncated: false,
+            },
+        );
+        command_result.timing = crate::acceptance::AcceptanceTiming::Observed {
+            started_at: "2026-08-04T09:00:00Z".parse().unwrap(),
+            completed_at: "2026-08-04T09:00:01Z".parse().unwrap(),
+            duration_ms: 1_234,
+        };
         record.acceptance_attempts = vec![crate::acceptance::AcceptanceAttempt {
             cycle: 1,
-            results: vec![crate::acceptance::AcceptanceResult {
-                name: "test".into(),
-                status: crate::acceptance::AcceptanceStatus::Passed,
-                timing: crate::acceptance::AcceptanceTiming::Observed {
-                    started_at: "2026-08-04T09:00:00Z".parse().unwrap(),
-                    completed_at: "2026-08-04T09:00:01Z".parse().unwrap(),
-                    duration_ms: 1_234,
-                },
-                exit_code: Some(0),
-                stdout: crate::acceptance::AcceptanceOutput {
-                    tail: "ok".into(),
-                    total_bytes: 2,
-                    truncated: false,
-                },
-                stderr: crate::acceptance::AcceptanceOutput {
-                    tail: String::new(),
-                    total_bytes: 0,
-                    truncated: false,
-                },
-                summary: "passed".into(),
-            }],
+            results: vec![
+                command_result,
+                crate::acceptance::AcceptanceResult::new(
+                    "artifact".into(),
+                    crate::acceptance::AcceptanceStatus::Passed,
+                    "present".into(),
+                    crate::acceptance::AcceptanceEvidence::File {
+                        repo: "repo".into(),
+                        path: "artifact.txt".into(),
+                        observation: crate::acceptance::FileObservation::Present,
+                    },
+                ),
+                crate::acceptance::AcceptanceResult::new(
+                    "handoff".into(),
+                    crate::acceptance::AcceptanceStatus::Passed,
+                    "complete".into(),
+                    crate::acceptance::AcceptanceEvidence::Handoff {
+                        step: "build".into(),
+                        output: crate::acceptance::HandoffOutputObservation::Object,
+                        sections: vec![crate::acceptance::HandoffSectionEvidence {
+                            name: "summary".into(),
+                            observation: crate::acceptance::HandoffSectionObservation::Present,
+                        }],
+                    },
+                ),
+                crate::acceptance::AcceptanceResult::new(
+                    "pull-request".into(),
+                    crate::acceptance::AcceptanceStatus::Passed,
+                    "published".into(),
+                    crate::acceptance::AcceptanceEvidence::PullRequest {
+                        repo: "repo".into(),
+                        delivery_phase: crate::acceptance::PullRequestDeliveryPhase::Published,
+                        base_branch: Some("main".into()),
+                        head_branch: Some("issue-1".into()),
+                        head_sha: Some("abc123".into()),
+                        pr_number: Some(12),
+                        pr_url: Some("https://github.com/acme/repo/pull/12".into()),
+                    },
+                ),
+            ],
         }];
 
         store.append_history_record("run-1", &record).await.unwrap();

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -434,7 +434,107 @@ pub(crate) fn reconcile_pull_requests(
     }
 }
 
+fn pull_request_delivery_phase(
+    phase: DeliveryPhase,
+) -> crate::acceptance::PullRequestDeliveryPhase {
+    use crate::acceptance::PullRequestDeliveryPhase as EvidencePhase;
+    match phase {
+        DeliveryPhase::Prepared => EvidencePhase::Prepared,
+        DeliveryPhase::PushInFlight => EvidencePhase::PushInFlight,
+        DeliveryPhase::ReconcilingPush => EvidencePhase::ReconcilingPush,
+        DeliveryPhase::PrCreateInFlight => EvidencePhase::PrCreateInFlight,
+        DeliveryPhase::ReconcilingPr => EvidencePhase::ReconcilingPr,
+        DeliveryPhase::Waiting => EvidencePhase::Waiting,
+        DeliveryPhase::Published => EvidencePhase::Published,
+        DeliveryPhase::Blocked => EvidencePhase::Blocked,
+    }
+}
+
+fn evaluate_pull_request_requirement(
+    rule: &crate::config::ensemble::AcceptancePullRequestConfig,
+    repository: &DeliveryRepository,
+) -> crate::acceptance::AcceptanceResult {
+    let timer = crate::acceptance::AcceptanceTimer::start();
+    let mut failures = Vec::new();
+    if !matches!(
+        repository.phase,
+        DeliveryPhase::Waiting | DeliveryPhase::Published
+    ) {
+        failures.push(format!(
+            "delivery phase is {:?}, expected waiting or published",
+            repository.phase
+        ));
+    }
+    if repository.pr_number.is_none() {
+        failures.push("durable pull request number is missing".to_string());
+    }
+    if repository.pr_url.is_none() {
+        failures.push("durable pull request URL is missing".to_string());
+    }
+    let complete_identity = if failures.is_empty() {
+        repository.pr_number.zip(repository.pr_url.as_deref())
+    } else {
+        None
+    };
+    let (status, summary) = if let Some((number, url)) = complete_identity {
+        (
+            crate::acceptance::AcceptanceStatus::Passed,
+            format!(
+                "required pull request '{}' has durable identity #{} at {}",
+                rule.name, number, url
+            ),
+        )
+    } else {
+        (
+            crate::acceptance::AcceptanceStatus::Failed,
+            format!(
+                "required pull request '{}' failed: {}",
+                rule.name,
+                failures.join(", ")
+            ),
+        )
+    };
+    timer.finish(crate::acceptance::AcceptanceResult::new(
+        rule.name.clone(),
+        status,
+        summary,
+        crate::acceptance::AcceptanceEvidence::PullRequest {
+            repo: rule.repo.clone(),
+            delivery_phase: pull_request_delivery_phase(repository.phase),
+            base_branch: Some(repository.base_branch.clone()),
+            head_branch: Some(repository.head_branch.clone()),
+            head_sha: Some(repository.local_sha.clone()),
+            pr_number: repository.pr_number,
+            pr_url: repository.pr_url.clone(),
+        },
+    ))
+}
+
 impl Orchestrator {
+    pub(super) async fn load_delivery_snapshot(
+        &self,
+        delivery: &DeliveryRecord,
+    ) -> Result<Option<PipelineRunSnapshot>, String> {
+        let record = self
+            .pipeline_journal
+            .latest_live_record_for_issue(&delivery.issue_id)
+            .await
+            .map_err(|error| format!("failed to read durable delivery owner: {error}"))?
+            .ok_or_else(|| {
+                format!(
+                    "missing durable delivery owner for issue '{}'",
+                    delivery.issue_id
+                )
+            })?;
+        if record.run_id.as_deref() != Some(delivery.run_id.as_str()) {
+            return Err(format!(
+                "durable delivery owner for issue '{}' belongs to a different run",
+                delivery.issue_id
+            ));
+        }
+        Ok(record.snapshot)
+    }
+
     pub(super) async fn process_delivery_recovery(&self) {
         let deliveries = {
             let state = self.state.read().await;
@@ -444,7 +544,9 @@ impl Orchestrator {
                 .filter(|delivery| {
                     matches!(
                         delivery.aggregate(),
-                        DeliveryAggregate::Active | DeliveryAggregate::Published
+                        DeliveryAggregate::Active
+                            | DeliveryAggregate::Waiting
+                            | DeliveryAggregate::Published
                     )
                 })
                 .cloned()
@@ -452,8 +554,32 @@ impl Orchestrator {
         };
 
         for delivery in deliveries {
+            let snapshot = match self.load_delivery_snapshot(&delivery).await {
+                Ok(snapshot) => snapshot,
+                Err(error) => {
+                    warn!(
+                        issue_id = %delivery.issue_id,
+                        error = %error,
+                        "delivery recovery could not load its durable snapshot"
+                    );
+                    continue;
+                }
+            };
+            let delivery = self
+                .evaluate_post_final_acceptance(delivery, snapshot.as_ref())
+                .await;
             if delivery.aggregate() == DeliveryAggregate::Published {
                 self.complete_published_delivery(&delivery).await;
+                continue;
+            }
+            if delivery.aggregate() == DeliveryAggregate::Waiting {
+                self.project_delivery_artifacts(&delivery.issue_id, &delivery)
+                    .await;
+                let finalize = Self::finalize_state_from_delivery(&delivery);
+                self.state
+                    .write()
+                    .await
+                    .set_finalize_state(&delivery.issue_id, finalize);
                 continue;
             }
             let workspace = match self
@@ -480,13 +606,6 @@ impl Orchestrator {
                     continue;
                 }
             };
-            let snapshot = self
-                .pipeline_journal
-                .latest_live_record_for_issue(&delivery.issue_id)
-                .await
-                .ok()
-                .flatten()
-                .and_then(|record| record.snapshot);
             let delivery = self
                 .advance_delivery_record(delivery, &workspace, snapshot.as_ref())
                 .await;
@@ -661,7 +780,131 @@ impl Orchestrator {
                 }
             }
         }
-        delivery
+        self.evaluate_post_final_acceptance(delivery, snapshot)
+            .await
+    }
+
+    pub(super) async fn evaluate_post_final_acceptance(
+        &self,
+        delivery: DeliveryRecord,
+        snapshot: Option<&PipelineRunSnapshot>,
+    ) -> DeliveryRecord {
+        let Some(mut candidate_snapshot) = snapshot.cloned() else {
+            return delivery;
+        };
+        let Some(plan) = candidate_snapshot.resolved_acceptance_plan.clone() else {
+            return delivery;
+        };
+        let rules = &plan.required_pull_requests;
+        if rules.is_empty()
+            || rules.iter().any(|rule| {
+                delivery
+                    .repositories
+                    .get(&rule.repo)
+                    .is_none_or(|repository| {
+                        !matches!(
+                            repository.phase,
+                            DeliveryPhase::Waiting | DeliveryPhase::Published
+                        )
+                    })
+            })
+        {
+            return delivery;
+        }
+        let Some(attempt_index) = candidate_snapshot
+            .acceptance_attempts
+            .iter()
+            .position(|attempt| attempt.cycle == candidate_snapshot.cycle)
+        else {
+            return delivery;
+        };
+        let pre_final_len = plan.pre_final_len();
+        let result_len = candidate_snapshot.acceptance_attempts[attempt_index]
+            .results
+            .len();
+        if result_len < pre_final_len {
+            return delivery;
+        }
+        let suffix_len = result_len - pre_final_len;
+        let retry_requested = rules.iter().any(|rule| {
+            delivery
+                .repositories
+                .get(&rule.repo)
+                .is_some_and(|repository| repository.retry_from == Some(DeliveryPhase::Waiting))
+        });
+        if suffix_len > 0 && suffix_len % rules.len() == 0 && !retry_requested {
+            let latest = &candidate_snapshot.acceptance_attempts[attempt_index].results
+                [result_len - rules.len()..result_len];
+            if latest
+                .iter()
+                .all(|result| result.status == crate::acceptance::AcceptanceStatus::Passed)
+            {
+                return delivery;
+            }
+            return self
+                .apply_post_final_acceptance_outcome(delivery, &candidate_snapshot, rules, latest)
+                .await;
+        }
+
+        let resume_index = suffix_len % rules.len();
+        let current = delivery;
+        for rule in rules.iter().skip(resume_index) {
+            let Some(repository) = current.repositories.get(&rule.repo) else {
+                return current;
+            };
+            let result = evaluate_pull_request_requirement(rule, repository);
+            candidate_snapshot.acceptance_attempts[attempt_index]
+                .results
+                .push(result);
+            if let Err(error) = self
+                .persist_delivery_record(&current, Some(&candidate_snapshot))
+                .await
+            {
+                warn!(
+                    issue_id = %current.issue_id,
+                    error = %error,
+                    "failed to persist post-final acceptance result"
+                );
+                return current;
+            }
+        }
+
+        let results = &candidate_snapshot.acceptance_attempts[attempt_index].results;
+        let latest = &results[results.len() - rules.len()..];
+        self.apply_post_final_acceptance_outcome(current, &candidate_snapshot, rules, latest)
+            .await
+    }
+
+    async fn apply_post_final_acceptance_outcome(
+        &self,
+        current: DeliveryRecord,
+        snapshot: &PipelineRunSnapshot,
+        rules: &[crate::config::ensemble::AcceptancePullRequestConfig],
+        latest: &[crate::acceptance::AcceptanceResult],
+    ) -> DeliveryRecord {
+        let mut candidate = current.clone();
+        for (rule, result) in rules.iter().zip(latest) {
+            let Some(repository) = candidate.repositories.get_mut(&rule.repo) else {
+                continue;
+            };
+            if result.status == crate::acceptance::AcceptanceStatus::Passed {
+                if repository.retry_from == Some(DeliveryPhase::Waiting) {
+                    repository.phase = DeliveryPhase::Waiting;
+                    repository.retry_from = None;
+                    repository.last_error = None;
+                }
+            } else {
+                repository.phase = DeliveryPhase::Blocked;
+                repository.retry_from = Some(DeliveryPhase::Waiting);
+                repository.last_error = Some(result.summary.clone());
+            }
+        }
+        if candidate == current {
+            return current;
+        }
+        self.persist_delivery_candidate(&current, candidate, Some(snapshot))
+            .await
+            .unwrap_or_else(|authoritative| authoritative)
     }
     async fn advance_delivery_pull_request(
         &self,
@@ -934,6 +1177,7 @@ impl Orchestrator {
                 .filter(|record| record.run_id.as_deref() == Some(delivery.run_id.as_str()))
                 .and_then(|record| record.snapshot),
         };
+        let persisted_snapshot = snapshot.clone();
         let input = PipelineTransitionInput {
             kind: PipelineTransitionKind::DeliveryOwned,
             issue_id: delivery.issue_id.clone(),
@@ -973,6 +1217,15 @@ impl Orchestrator {
         state
             .delivery
             .insert(delivery.issue_id.clone(), delivery.clone());
+        if let Some(snapshot) = persisted_snapshot
+            .as_ref()
+            .filter(|snapshot| snapshot.issue_id == delivery.issue_id)
+        {
+            if let Some(run) = state.get_pipeline_run_mut(&delivery.issue_id) {
+                run.acceptance_attempts = snapshot.acceptance_attempts.clone();
+                run.resolved_acceptance_plan = snapshot.resolved_acceptance_plan.clone();
+            }
+        }
         Ok(())
     }
     pub(super) async fn prepare_delivery_record(
@@ -1137,5 +1390,32 @@ mod tests {
             reconcile_pull_requests("primary", &repo, &[]),
             PullRequestReconciliation::Create
         );
+    }
+
+    #[test]
+    fn post_finalize_acceptance_projects_only_retained_delivery_identity() {
+        let rule = crate::config::ensemble::AcceptancePullRequestConfig {
+            name: "primary-pr".into(),
+            repo: "primary".into(),
+        };
+        let mut repo = repository(DeliveryPhase::Waiting);
+        repo.pr_number = Some(420);
+        repo.pr_url = Some("https://github.com/example/project/pull/420".into());
+
+        let passed = evaluate_pull_request_requirement(&rule, &repo);
+        repo.pr_url = None;
+        let failed = evaluate_pull_request_requirement(&rule, &repo);
+
+        assert_eq!(passed.status, crate::acceptance::AcceptanceStatus::Passed);
+        assert_eq!(failed.status, crate::acceptance::AcceptanceStatus::Failed);
+        assert!(matches!(
+            passed.evidence,
+            crate::acceptance::AcceptanceEvidence::PullRequest {
+                pr_number: Some(420),
+                ref pr_url,
+                ..
+            } if pr_url.as_deref() == Some("https://github.com/example/project/pull/420")
+        ));
+        assert!(failed.summary.contains("URL"));
     }
 }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1969,14 +1969,15 @@ impl Orchestrator {
                 warn!(issue_id = %issue.id, error = %error, "acceptance evidence does not match config");
                 return AcceptancePhaseOutcome::RetainedForRecovery;
             }
-            if plan.pre_final_len() == 0 {
-                return AcceptancePhaseOutcome::Passed;
-            }
-
             let current_attempt = candidate
                 .acceptance_attempts
                 .iter()
                 .position(|attempt| attempt.cycle == candidate.cycle);
+            if plan.pre_final_len() == 0
+                && (plan.required_pull_requests.is_empty() || current_attempt.is_some())
+            {
+                return AcceptancePhaseOutcome::Passed;
+            }
             let check_to_run = if let Some(attempt_index) = current_attempt {
                 let results = &candidate.acceptance_attempts[attempt_index].results;
                 if results.len() >= plan.pre_final_len() {
@@ -10832,6 +10833,53 @@ agent:
                         .len()
             );
         }
+    }
+
+    #[tokio::test]
+    async fn acceptance_creates_a_durable_attempt_for_a_pull_request_only_plan() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-pr-only", "In Progress");
+        let mut config = acceptance_config(&[]);
+        let mut repo = crate::config::ensemble::RepoConfig {
+            path: "/tmp/primary".into(),
+            branch: "main".into(),
+            git_remote: "origin".into(),
+            finalize: Default::default(),
+        };
+        repo.finalize.mode = crate::workspace::finalize::FinalizeMode::PushAndPr;
+        config.repos = vec![repo];
+        config.acceptance.required_pull_requests =
+            vec![crate::config::ensemble::AcceptancePullRequestConfig {
+                name: "primary-pr".into(),
+                repo: "primary".into(),
+            }];
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new(Default::default()),
+            calls: Arc::new(std::sync::Mutex::new(Vec::new())),
+        });
+        let (orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+
+        let outcome = orchestrator.run_acceptance_phase(&issue, &config).await;
+
+        assert!(matches!(outcome, AcceptancePhaseOutcome::Passed));
+        let state = state.read().await;
+        let attempts = &state
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .acceptance_attempts;
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].cycle, 1);
+        assert!(attempts[0].results.is_empty());
+        drop(state);
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].kind, PipelineTransitionKind::AcceptanceStarted);
     }
 
     fn mixed_acceptance_config() -> EnsembleConfig {

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -20,7 +20,10 @@ use tokio::sync::{mpsc, watch};
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
-use crate::acceptance::{AcceptanceCommandRunner, AcceptanceStatus, ShellAcceptanceCommandRunner};
+use crate::acceptance::{
+    evaluate_file_requirement, evaluate_handoff_requirement, AcceptanceCommandRunner,
+    AcceptanceEvidence, AcceptanceStatus, ResolvedAcceptancePlan, ShellAcceptanceCommandRunner,
+};
 use crate::agent::cancellation::{
     await_worker_drain, await_worker_quiescence, has_available_state_worker_capacity,
     is_reconciliation_owned, live_worker_count, mark_all_for_drain, mark_issue_for_drain,
@@ -190,6 +193,12 @@ enum AcceptancePhaseOutcome {
         owner: AcceptanceOwnerIdentity,
     },
     RetainedForRecovery,
+}
+
+enum PreFinalAcceptanceCheck {
+    Command(crate::config::ensemble::AcceptanceCommandConfig),
+    File(crate::config::ensemble::AcceptanceFileConfig),
+    Handoff(crate::config::ensemble::AcceptanceHandoffConfig),
 }
 
 #[derive(Clone)]
@@ -1507,7 +1516,15 @@ impl Orchestrator {
             }
         };
 
-        let pipeline_run = PipelineRun::new(issue.id.clone(), cycle, dag);
+        let mut pipeline_run = PipelineRun::new(issue.id.clone(), cycle, dag);
+        let acceptance_plan = match ResolvedAcceptancePlan::from_config(&config_snapshot) {
+            Ok(plan) => plan,
+            Err(error) => {
+                warn!(issue_id = %issue.id, error = %error, "failed to freeze acceptance plan");
+                return;
+            }
+        };
+        pipeline_run.resolved_acceptance_plan = Some(acceptance_plan);
         let action = pipeline_run.start();
 
         info!(
@@ -1918,6 +1935,7 @@ impl Orchestrator {
         issue: &Issue,
         config: &EnsembleConfig,
     ) -> AcceptancePhaseOutcome {
+        let mut owned_worktrees = None;
         loop {
             let (baseline, mut candidate, run_id, owner) = {
                 let state = self.state.read().await;
@@ -1943,11 +1961,15 @@ impl Orchestrator {
                 (run.to_snapshot(), run, run_id, owner)
             };
 
+            let plan = candidate
+                .resolved_acceptance_plan
+                .clone()
+                .unwrap_or_else(|| legacy_command_plan(config));
             if let Err(error) = validate_acceptance_attempts(&candidate.to_snapshot(), config) {
                 warn!(issue_id = %issue.id, error = %error, "acceptance evidence does not match config");
                 return AcceptancePhaseOutcome::RetainedForRecovery;
             }
-            if config.acceptance.commands.is_empty() {
+            if plan.pre_final_len() == 0 {
                 return AcceptancePhaseOutcome::Passed;
             }
 
@@ -1955,10 +1977,10 @@ impl Orchestrator {
                 .acceptance_attempts
                 .iter()
                 .position(|attempt| attempt.cycle == candidate.cycle);
-            let command_to_run = if let Some(attempt_index) = current_attempt {
+            let check_to_run = if let Some(attempt_index) = current_attempt {
                 let results = &candidate.acceptance_attempts[attempt_index].results;
-                if results.len() == config.acceptance.commands.len() {
-                    if results
+                if results.len() >= plan.pre_final_len() {
+                    if results[..plan.pre_final_len()]
                         .iter()
                         .all(|result| result.status == AcceptanceStatus::Passed)
                     {
@@ -1974,7 +1996,32 @@ impl Orchestrator {
                         owner,
                     };
                 }
-                config.acceptance.commands.get(results.len()).cloned()
+                let index = results.len();
+                if index < plan.commands.len() {
+                    if candidate.resolved_acceptance_plan.is_some() && !plan.matches_config(config)
+                    {
+                        warn!(issue_id = %issue.id, "configuration changed before an unfinished acceptance command");
+                        return AcceptancePhaseOutcome::RetainedForRecovery;
+                    }
+                    let Some(command) = config.acceptance.commands.get(index) else {
+                        return AcceptancePhaseOutcome::RetainedForRecovery;
+                    };
+                    if command.name != plan.commands[index] {
+                        return AcceptancePhaseOutcome::RetainedForRecovery;
+                    }
+                    Some(PreFinalAcceptanceCheck::Command(command.clone()))
+                } else {
+                    let index = index - plan.commands.len();
+                    if let Some(rule) = plan.required_files.get(index) {
+                        Some(PreFinalAcceptanceCheck::File(rule.clone()))
+                    } else {
+                        let index = index - plan.required_files.len();
+                        plan.required_handoff_sections
+                            .get(index)
+                            .cloned()
+                            .map(PreFinalAcceptanceCheck::Handoff)
+                    }
+                }
             } else {
                 candidate
                     .acceptance_attempts
@@ -1984,17 +2031,29 @@ impl Orchestrator {
                     });
                 None
             };
-            let transition_kind = if command_to_run.is_some() {
-                PipelineTransitionKind::AcceptanceCommandCompleted
+            let transition_kind = if check_to_run.is_some() {
+                PipelineTransitionKind::AcceptanceCheckCompleted
             } else {
                 PipelineTransitionKind::AcceptanceStarted
             };
 
-            let result = if let Some(command) = command_to_run.as_ref() {
-                let workspace_path = self.workspace_mgr.workspace_path(&issue.id);
-                Some(self.acceptance_runner.run(command, &workspace_path).await)
-            } else {
-                None
+            let result = match check_to_run.as_ref() {
+                Some(PreFinalAcceptanceCheck::Command(command)) => {
+                    let workspace_path = self.workspace_mgr.workspace_path(&issue.id);
+                    Some(self.acceptance_runner.run(command, &workspace_path).await)
+                }
+                Some(PreFinalAcceptanceCheck::File(rule)) => {
+                    let worktrees = owned_worktrees.get_or_insert_with(|| {
+                        self.workspace_mgr
+                            .owned_worktree_paths(&issue.id)
+                            .unwrap_or_default()
+                    });
+                    Some(evaluate_file_requirement(rule, worktrees))
+                }
+                Some(PreFinalAcceptanceCheck::Handoff(rule)) => {
+                    Some(evaluate_handoff_requirement(rule, &candidate.step_outputs))
+                }
+                None => None,
             };
             {
                 let state = self.state.read().await;
@@ -4227,6 +4286,7 @@ impl Orchestrator {
             .unwrap_or_default();
         let mut next_run = PipelineRun::new(issue_id.to_string(), retry_entry.attempt, dag);
         next_run.acceptance_attempts = acceptance_attempts;
+        next_run.resolved_acceptance_plan = Some(ResolvedAcceptancePlan::from_config(config).ok()?);
         state.insert_pipeline_run(issue_id, next_run, Arc::new(config.clone()));
         Self::transition_input_for_run(
             state,
@@ -6719,14 +6779,17 @@ impl Orchestrator {
             let Some(existing) = existing else {
                 return;
             };
-            let snapshot = self
-                .pipeline_journal
-                .latest_live_record_for_issue(issue_id)
-                .await
-                .ok()
-                .flatten()
-                .filter(|record| record.run_id.as_deref() == Some(existing.run_id.as_str()))
-                .and_then(|record| record.snapshot);
+            let snapshot = match self.load_delivery_snapshot(&existing).await {
+                Ok(snapshot) => snapshot,
+                Err(error) => {
+                    warn!(
+                        issue_id,
+                        error = %error,
+                        "finalize retry could not load its durable delivery snapshot"
+                    );
+                    return;
+                }
+            };
             (existing, snapshot)
         } else {
             let (mut prepared, snapshot) = match self
@@ -6772,8 +6835,11 @@ impl Orchestrator {
                 continue;
             };
             if repository.phase == DeliveryPhase::Blocked {
-                repository.phase = repository.retry_from.unwrap_or(DeliveryPhase::Prepared);
-                repository.retry_from = None;
+                let retry_from = repository.retry_from.unwrap_or(DeliveryPhase::Prepared);
+                repository.phase = retry_from;
+                if retry_from != DeliveryPhase::Waiting {
+                    repository.retry_from = None;
+                }
                 repository.last_error = None;
             }
         }
@@ -8428,10 +8494,29 @@ fn validate_restored_snapshot_against_config(
     Ok(())
 }
 
+fn legacy_command_plan(config: &EnsembleConfig) -> ResolvedAcceptancePlan {
+    ResolvedAcceptancePlan {
+        config_digest: String::new(),
+        commands: config
+            .acceptance
+            .commands
+            .iter()
+            .map(|command| command.name.clone())
+            .collect(),
+        required_files: Vec::new(),
+        required_handoff_sections: Vec::new(),
+        required_pull_requests: Vec::new(),
+    }
+}
+
 fn validate_acceptance_attempts(
     snapshot: &PipelineRunSnapshot,
     config: &EnsembleConfig,
 ) -> Result<(), EnsembleError> {
+    let plan = snapshot
+        .resolved_acceptance_plan
+        .clone()
+        .unwrap_or_else(|| legacy_command_plan(config));
     let mut previous_cycle = 0;
     for attempt in &snapshot.acceptance_attempts {
         if attempt.cycle == 0 || attempt.cycle > snapshot.cycle || attempt.cycle <= previous_cycle {
@@ -8444,21 +8529,48 @@ fn validate_acceptance_attempts(
         if attempt.cycle != snapshot.cycle {
             continue;
         }
-        if attempt.results.len() > config.acceptance.commands.len() {
+        let pre_final_len = plan.pre_final_len();
+        if attempt.results.len() > pre_final_len && plan.required_pull_requests.is_empty() {
             return Err(AgentError::PromptError {
                 reason: format!(
-                    "persisted acceptance attempt {} has more results than configured commands",
+                    "persisted acceptance attempt {} has results beyond the frozen acceptance plan",
                     attempt.cycle
                 ),
             }
             .into());
         }
-        for (result, command) in attempt.results.iter().zip(&config.acceptance.commands) {
-            if result.name != command.name {
+        for (index, result) in attempt.results.iter().enumerate() {
+            let (expected_name, expected_kind) = if index < plan.commands.len() {
+                (&plan.commands[index], "command")
+            } else if index < plan.commands.len() + plan.required_files.len() {
+                let rule = &plan.required_files[index - plan.commands.len()];
+                (&rule.name, "file")
+            } else if index < pre_final_len {
+                let rule = &plan.required_handoff_sections
+                    [index - plan.commands.len() - plan.required_files.len()];
+                (&rule.name, "handoff")
+            } else {
+                let rule_index = (index - pre_final_len) % plan.required_pull_requests.len();
+                let rule = &plan.required_pull_requests[rule_index];
+                (&rule.name, "pull_request")
+            };
+            let kind_matches = matches!(
+                (&result.evidence, expected_kind),
+                (AcceptanceEvidence::Command { .. }, "command")
+                    | (AcceptanceEvidence::File { .. }, "file")
+                    | (AcceptanceEvidence::Handoff { .. }, "handoff")
+                    | (AcceptanceEvidence::PullRequest { .. }, "pull_request")
+            );
+            if result.name != *expected_name || !kind_matches {
+                let noun = if snapshot.resolved_acceptance_plan.is_none() {
+                    "configured command"
+                } else {
+                    "frozen acceptance check"
+                };
                 return Err(AgentError::PromptError {
                     reason: format!(
-                        "persisted acceptance result '{}' no longer matches configured command '{}'",
-                        result.name, command.name
+                        "persisted acceptance result '{}' no longer matches {noun} '{}'",
+                        result.name, expected_name
                     ),
                 }
                 .into());
@@ -9055,23 +9167,11 @@ mod tests {
         ) -> crate::acceptance::AcceptanceResult {
             self.started.wait().await;
             self.release.wait().await;
-            crate::acceptance::AcceptanceResult {
-                name: command.name.clone(),
-                status: AcceptanceStatus::Passed,
-                timing: crate::acceptance::AcceptanceTiming::Unknown,
-                exit_code: Some(0),
-                stdout: crate::acceptance::AcceptanceOutput {
-                    tail: String::new(),
-                    total_bytes: 0,
-                    truncated: false,
-                },
-                stderr: crate::acceptance::AcceptanceOutput {
-                    tail: String::new(),
-                    total_bytes: 0,
-                    truncated: false,
-                },
-                summary: "passed".into(),
-            }
+            acceptance_command_result(
+                &command.name,
+                AcceptanceStatus::Passed,
+                "passed".to_string(),
+            )
         }
     }
 
@@ -9092,23 +9192,11 @@ mod tests {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .pop_front()
                 .unwrap_or(AcceptanceStatus::Passed);
-            crate::acceptance::AcceptanceResult {
-                name: command.name.clone(),
-                timing: crate::acceptance::AcceptanceTiming::Unknown,
-                exit_code: (status == AcceptanceStatus::Passed).then_some(0),
-                summary: format!("{}: {status:?}", command.name),
+            acceptance_command_result(
+                &command.name,
                 status,
-                stdout: crate::acceptance::AcceptanceOutput {
-                    tail: String::new(),
-                    total_bytes: 0,
-                    truncated: false,
-                },
-                stderr: crate::acceptance::AcceptanceOutput {
-                    tail: String::new(),
-                    total_bytes: 0,
-                    truncated: false,
-                },
-            }
+                format!("{}: {status:?}", command.name),
+            )
         }
     }
 
@@ -9662,6 +9750,7 @@ mod tests {
         pull_requests: std::sync::Mutex<Vec<crate::orchestrator::delivery::RemotePullRequest>>,
         pushes: AtomicUsize,
         creates: AtomicUsize,
+        lists: AtomicUsize,
     }
 
     #[async_trait]
@@ -9702,6 +9791,7 @@ mod tests {
             _repository_path: &Path,
             _repository_key: &str,
         ) -> Result<Vec<crate::orchestrator::delivery::RemotePullRequest>, String> {
+            self.lists.fetch_add(1, Ordering::SeqCst);
             Ok(self.pull_requests.lock().unwrap().clone())
         }
 
@@ -9780,12 +9870,241 @@ mod tests {
         (orchestrator, workspace_temp, repo_temp, delivery)
     }
 
+    fn post_finalize_acceptance_snapshot(
+        rule_names: &[&str],
+        results: Vec<crate::acceptance::AcceptanceResult>,
+    ) -> PipelineRunSnapshot {
+        let config = make_config();
+        let dag = build_dag(&config.steps).unwrap();
+        let mut run = PipelineRun::new("1".into(), 1, dag);
+        run.resolved_acceptance_plan = Some(ResolvedAcceptancePlan {
+            config_digest: "frozen".into(),
+            commands: Vec::new(),
+            required_files: Vec::new(),
+            required_handoff_sections: Vec::new(),
+            required_pull_requests: rule_names
+                .iter()
+                .map(
+                    |name| crate::config::ensemble::AcceptancePullRequestConfig {
+                        name: (*name).into(),
+                        repo: "source-repo".into(),
+                    },
+                )
+                .collect(),
+        });
+        run.acceptance_attempts = vec![crate::acceptance::AcceptanceAttempt { cycle: 1, results }];
+        run.to_snapshot()
+    }
+
+    fn retained_pr_result(
+        name: &str,
+        status: AcceptanceStatus,
+    ) -> crate::acceptance::AcceptanceResult {
+        crate::acceptance::AcceptanceResult::new(
+            name.into(),
+            status,
+            format!("{name}: {status:?}"),
+            AcceptanceEvidence::PullRequest {
+                repo: "source-repo".into(),
+                delivery_phase: crate::acceptance::PullRequestDeliveryPhase::Waiting,
+                base_branch: Some("main".into()),
+                head_branch: Some("ensemble/repo-1".into()),
+                head_sha: Some("0123456789abcdef".into()),
+                pr_number: Some(420),
+                pr_url: Some("https://github.com/example/project/pull/420".into()),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn post_finalize_acceptance_resumes_partial_batch_without_remote_calls() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".into());
+        repository.last_error = None;
+        let snapshot = post_finalize_acceptance_snapshot(
+            &["first", "second"],
+            vec![retained_pr_result("first", AcceptanceStatus::Passed)],
+        );
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+
+        let evaluated = orchestrator
+            .evaluate_post_final_acceptance(delivery.clone(), Some(&snapshot))
+            .await;
+
+        assert_eq!(evaluated, delivery);
+        let latest = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue("1")
+            .await
+            .unwrap()
+            .unwrap();
+        let results = &latest.snapshot.unwrap().acceptance_attempts[0].results;
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "second"]
+        );
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn post_finalize_acceptance_blocks_without_losing_delivery_identity() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = None;
+        repository.last_error = None;
+        let original = repository.clone();
+        let snapshot = post_finalize_acceptance_snapshot(&["required-pr"], Vec::new());
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+
+        let blocked = orchestrator
+            .evaluate_post_final_acceptance(delivery, Some(&snapshot))
+            .await;
+
+        let repository = &blocked.repositories["source-repo"];
+        assert_eq!(repository.phase, DeliveryPhase::Blocked);
+        assert_eq!(repository.retry_from, Some(DeliveryPhase::Waiting));
+        assert_eq!(repository.base_branch, original.base_branch);
+        assert_eq!(repository.head_branch, original.head_branch);
+        assert_eq!(repository.local_sha, original.local_sha);
+        assert_eq!(repository.pr_number, original.pr_number);
+        assert_eq!(repository.pr_url, original.pr_url);
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn post_finalize_acceptance_retry_appends_batch_and_returns_to_waiting() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".into());
+        repository.retry_from = Some(DeliveryPhase::Waiting);
+        repository.last_error = None;
+        let original = repository.clone();
+        let snapshot = post_finalize_acceptance_snapshot(
+            &["required-pr"],
+            vec![retained_pr_result("required-pr", AcceptanceStatus::Failed)],
+        );
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+
+        let waiting = orchestrator
+            .evaluate_post_final_acceptance(delivery, Some(&snapshot))
+            .await;
+
+        let repository = &waiting.repositories["source-repo"];
+        assert_eq!(repository.phase, DeliveryPhase::Waiting);
+        assert_eq!(repository.retry_from, None);
+        assert_eq!(repository.base_branch, original.base_branch);
+        assert_eq!(repository.head_branch, original.head_branch);
+        assert_eq!(repository.local_sha, original.local_sha);
+        assert_eq!(repository.pr_number, original.pr_number);
+        assert_eq!(repository.pr_url, original.pr_url);
+        let latest = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue("1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            latest.snapshot.unwrap().acceptance_attempts[0]
+                .results
+                .len(),
+            2
+        );
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn post_finalize_acceptance_retains_published_delivery_when_snapshot_is_missing() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Published;
+        repository.pr_number = None;
+        repository.pr_url = None;
+        repository.last_error = None;
+        let snapshot = post_finalize_acceptance_snapshot(&["required-pr"], Vec::new());
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        tokio::fs::remove_file(orchestrator.pipeline_journal.path_for_issue("1"))
+            .await
+            .unwrap();
+
+        let error = orchestrator
+            .load_delivery_snapshot(&delivery)
+            .await
+            .unwrap_err();
+        assert!(error.contains("missing durable delivery owner"));
+
+        orchestrator.process_delivery_recovery().await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(state.delivery.get("1"), Some(&delivery));
+        assert!(!state.completed.contains_key("1"));
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
     #[tokio::test]
     async fn ambiguous_pr_creation_reconciles_existing_pull_request_before_retry() {
         let remote = Arc::new(RecoveryDeliveryRemote {
             pull_requests: std::sync::Mutex::new(Vec::new()),
             pushes: AtomicUsize::new(0),
             creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
         });
         let (orchestrator, _workspace, _repo, delivery) =
             recovery_test_orchestrator(Arc::clone(&remote)).await;
@@ -9818,6 +10137,7 @@ mod tests {
             pull_requests: std::sync::Mutex::new(Vec::new()),
             pushes: AtomicUsize::new(0),
             creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
         });
         let (orchestrator, _workspace, _repo, delivery) =
             recovery_test_orchestrator(Arc::clone(&remote)).await;
@@ -9848,6 +10168,7 @@ mod tests {
             pull_requests: std::sync::Mutex::new(Vec::new()),
             pushes: AtomicUsize::new(0),
             creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
         });
         let (orchestrator, _workspace, _repo, mut delivery) =
             recovery_test_orchestrator(Arc::clone(&remote)).await;
@@ -9906,6 +10227,7 @@ mod tests {
             pull_requests: std::sync::Mutex::new(Vec::new()),
             pushes: AtomicUsize::new(0),
             creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
         });
         let (orchestrator, _workspace, _repo, mut delivery) =
             recovery_test_orchestrator(Arc::clone(&remote)).await;
@@ -10013,6 +10335,7 @@ mod tests {
             ]),
             pushes: AtomicUsize::new(0),
             creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
         });
         let first = delivery_restart_orchestrator(
             config_dir.path(),
@@ -10085,6 +10408,7 @@ mod tests {
             ]),
             pushes: AtomicUsize::new(0),
             creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
         });
         let first = delivery_restart_orchestrator(
             config_dir.path(),
@@ -10279,7 +10603,8 @@ agent:
                 tracker,
                 agent_runner: runner,
                 acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
-                workspace_mgr: WorkspaceManager::new(&workspace_root, None).unwrap(),
+                workspace_mgr: WorkspaceManager::new(&workspace_root, Some(cfg.repos.clone()))
+                    .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
                 cancellation_registry: new_cancellation_registry(),
                 event_bus: EventBus::new(),
@@ -10319,7 +10644,8 @@ agent:
                     cancellation_probe: None,
                 }),
                 acceptance_runner,
-                workspace_mgr: WorkspaceManager::new(&workspace_root, None).unwrap(),
+                workspace_mgr: WorkspaceManager::new(&workspace_root, Some(cfg.repos.clone()))
+                    .unwrap(),
                 refresh_requested: Arc::new(tokio::sync::Notify::new()),
                 cancellation_registry: new_cancellation_registry(),
                 event_bus: EventBus::new(),
@@ -10345,6 +10671,29 @@ agent:
         config
     }
 
+    fn acceptance_command_result(
+        name: &str,
+        status: AcceptanceStatus,
+        summary: String,
+    ) -> crate::acceptance::AcceptanceResult {
+        crate::acceptance::AcceptanceResult::command(
+            name.to_string(),
+            status.clone(),
+            summary,
+            (status == AcceptanceStatus::Passed).then_some(0),
+            crate::acceptance::AcceptanceOutput {
+                tail: String::new(),
+                total_bytes: 0,
+                truncated: false,
+            },
+            crate::acceptance::AcceptanceOutput {
+                tail: String::new(),
+                total_bytes: 0,
+                truncated: false,
+            },
+        )
+    }
+
     async fn install_succeeded_run(
         state: &Arc<RwLock<OrchestratorState>>,
         issue: &Issue,
@@ -10352,6 +10701,7 @@ agent:
     ) {
         let dag = build_dag(&config.steps).unwrap();
         let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+        run.resolved_acceptance_plan = Some(ResolvedAcceptancePlan::from_config(config).unwrap());
         for step in run.step_states.values_mut() {
             *step = StepState::Passed;
         }
@@ -10470,7 +10820,7 @@ agent:
         assert_eq!(records[0].kind, PipelineTransitionKind::AcceptanceStarted);
         assert!(records[1..]
             .iter()
-            .all(|record| record.kind == PipelineTransitionKind::AcceptanceCommandCompleted));
+            .all(|record| record.kind == PipelineTransitionKind::AcceptanceCheckCompleted));
         for pair in records.windows(2) {
             assert!(pair[0].seq < pair[1].seq);
             assert!(
@@ -10482,6 +10832,187 @@ agent:
                         .len()
             );
         }
+    }
+
+    fn mixed_acceptance_config() -> EnsembleConfig {
+        let mut config = acceptance_config(&["command"]);
+        config.repos = vec![crate::config::ensemble::RepoConfig {
+            path: "/tmp/repo".into(),
+            branch: "main".into(),
+            git_remote: "origin".into(),
+            finalize: Default::default(),
+        }];
+        config.acceptance.required_files = vec![crate::config::ensemble::AcceptanceFileConfig {
+            name: "file".into(),
+            repo: "repo".into(),
+            path: "artifact.txt".into(),
+        }];
+        config.acceptance.required_handoff_sections =
+            vec![crate::config::ensemble::AcceptanceHandoffConfig {
+                name: "handoff".into(),
+                step: "build".into(),
+                sections: vec!["summary".into()],
+            }];
+        config
+    }
+
+    #[tokio::test]
+    async fn acceptance_runs_the_complete_mixed_prefix_in_frozen_order() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-mixed", "In Progress");
+        let config = mixed_acceptance_config();
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new([AcceptanceStatus::Failed].into()),
+            calls: Arc::clone(&calls),
+        });
+        let (orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+        state
+            .write()
+            .await
+            .get_pipeline_run_mut(&issue.id)
+            .unwrap()
+            .step_outputs
+            .insert(
+                "build".into(),
+                crate::pipeline::verdict::StepOutput {
+                    result: StepResult::Succeeded,
+                    summary: None,
+                    output: Some(serde_json::json!({"summary": "done"})),
+                },
+            );
+
+        let outcome = orchestrator.run_acceptance_phase(&issue, &config).await;
+
+        assert!(matches!(outcome, AcceptancePhaseOutcome::Failed { .. }));
+        assert_eq!(
+            *calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["command"]
+        );
+        let state = state.read().await;
+        let results = &state
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .acceptance_attempts[0]
+            .results;
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["command", "file", "handoff"]
+        );
+        assert!(matches!(
+            results[0].evidence,
+            AcceptanceEvidence::Command { .. }
+        ));
+        assert!(matches!(
+            results[1].evidence,
+            AcceptanceEvidence::File { .. }
+        ));
+        assert!(matches!(
+            results[2].evidence,
+            AcceptanceEvidence::Handoff { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn acceptance_configuration_drift_fails_closed_before_unfinished_command() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-drift", "In Progress");
+        let config = acceptance_config(&["command"]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new([AcceptanceStatus::Passed].into()),
+            calls: Arc::clone(&calls),
+        });
+        let (orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+        let mut drifted = config.clone();
+        drifted.acceptance.commands[0].run = "different-secret-command".into();
+
+        let outcome = orchestrator.run_acceptance_phase(&issue, &drifted).await;
+
+        assert!(matches!(
+            outcome,
+            AcceptancePhaseOutcome::RetainedForRecovery
+        ));
+        assert!(calls
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn acceptance_resumes_a_mixed_prefix_at_the_first_missing_check() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let issue = test_issue("acceptance-mixed-resume", "In Progress");
+        let config = mixed_acceptance_config();
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let runner = Arc::new(RecordingAcceptanceRunner {
+            statuses: std::sync::Mutex::new(Default::default()),
+            calls: Arc::clone(&calls),
+        });
+        let (orchestrator, state) =
+            make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
+        install_succeeded_run(&state, &issue, &config).await;
+        {
+            let mut state = state.write().await;
+            let run = state.get_pipeline_run_mut(&issue.id).unwrap();
+            run.step_outputs.insert(
+                "build".into(),
+                crate::pipeline::verdict::StepOutput {
+                    result: StepResult::Succeeded,
+                    summary: None,
+                    output: Some(serde_json::json!({"summary": "done"})),
+                },
+            );
+            run.acceptance_attempts
+                .push(crate::acceptance::AcceptanceAttempt {
+                    cycle: 1,
+                    results: vec![
+                        acceptance_command_result(
+                            "command",
+                            AcceptanceStatus::Passed,
+                            "passed".into(),
+                        ),
+                        crate::acceptance::AcceptanceResult::new(
+                            "file".into(),
+                            AcceptanceStatus::Passed,
+                            "present".into(),
+                            AcceptanceEvidence::File {
+                                repo: "repo".into(),
+                                path: "artifact.txt".into(),
+                                observation: crate::acceptance::FileObservation::Present,
+                            },
+                        ),
+                    ],
+                });
+        }
+
+        let outcome = orchestrator.run_acceptance_phase(&issue, &config).await;
+
+        assert!(matches!(outcome, AcceptancePhaseOutcome::Passed));
+        assert!(calls
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_empty());
+        assert_eq!(
+            state
+                .read()
+                .await
+                .get_pipeline_run(&issue.id)
+                .unwrap()
+                .acceptance_attempts[0]
+                .results
+                .len(),
+            3
+        );
     }
 
     #[tokio::test]
@@ -10505,23 +11036,11 @@ agent:
                 .acceptance_attempts
                 .push(crate::acceptance::AcceptanceAttempt {
                     cycle: 1,
-                    results: vec![crate::acceptance::AcceptanceResult {
-                        name: "first".into(),
-                        status: AcceptanceStatus::Passed,
-                        timing: crate::acceptance::AcceptanceTiming::Unknown,
-                        exit_code: Some(0),
-                        stdout: crate::acceptance::AcceptanceOutput {
-                            tail: String::new(),
-                            total_bytes: 0,
-                            truncated: false,
-                        },
-                        stderr: crate::acceptance::AcceptanceOutput {
-                            tail: String::new(),
-                            total_bytes: 0,
-                            truncated: false,
-                        },
-                        summary: "first passed".into(),
-                    }],
+                    results: vec![acceptance_command_result(
+                        "first",
+                        AcceptanceStatus::Passed,
+                        "first passed".into(),
+                    )],
                 });
         }
 
@@ -10933,23 +11452,11 @@ agent:
         let mut run = PipelineRun::new("issue".into(), 1, dag);
         run.acceptance_attempts = vec![crate::acceptance::AcceptanceAttempt {
             cycle: 1,
-            results: vec![crate::acceptance::AcceptanceResult {
-                name: "old-name".into(),
-                status: AcceptanceStatus::Passed,
-                timing: crate::acceptance::AcceptanceTiming::Unknown,
-                exit_code: Some(0),
-                stdout: crate::acceptance::AcceptanceOutput {
-                    tail: String::new(),
-                    total_bytes: 0,
-                    truncated: false,
-                },
-                stderr: crate::acceptance::AcceptanceOutput {
-                    tail: String::new(),
-                    total_bytes: 0,
-                    truncated: false,
-                },
-                summary: "passed".into(),
-            }],
+            results: vec![acceptance_command_result(
+                "old-name",
+                AcceptanceStatus::Passed,
+                "passed".into(),
+            )],
         }];
 
         let error =
@@ -10967,23 +11474,11 @@ agent:
         let mut run = PipelineRun::new("issue".into(), 2, dag);
         run.acceptance_attempts = vec![crate::acceptance::AcceptanceAttempt {
             cycle: 1,
-            results: vec![crate::acceptance::AcceptanceResult {
-                name: "old-name".into(),
-                status: AcceptanceStatus::Passed,
-                timing: crate::acceptance::AcceptanceTiming::Unknown,
-                exit_code: Some(0),
-                stdout: crate::acceptance::AcceptanceOutput {
-                    tail: String::new(),
-                    total_bytes: 0,
-                    truncated: false,
-                },
-                stderr: crate::acceptance::AcceptanceOutput {
-                    tail: String::new(),
-                    total_bytes: 0,
-                    truncated: false,
-                },
-                summary: "passed".into(),
-            }],
+            results: vec![acceptance_command_result(
+                "old-name",
+                AcceptanceStatus::Passed,
+                "passed".into(),
+            )],
         }];
 
         validate_restored_snapshot_against_config(&run.to_snapshot(), &config).unwrap();

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -100,6 +100,7 @@ pub enum PipelineTransitionKind {
     ApprovalResolved,
     AcceptanceStarted,
     AcceptanceCommandCompleted,
+    AcceptanceCheckCompleted,
     StepRetryScheduled,
     FixupRetryScheduled,
     PipelineHalted,
@@ -1142,6 +1143,7 @@ mod tests {
         for kind in [
             PipelineTransitionKind::AcceptanceStarted,
             PipelineTransitionKind::AcceptanceCommandCompleted,
+            PipelineTransitionKind::AcceptanceCheckCompleted,
         ] {
             let json = serde_json::to_string(&kind).unwrap();
             assert_eq!(
@@ -1149,6 +1151,11 @@ mod tests {
                 kind
             );
         }
+        assert_eq!(
+            serde_json::from_str::<PipelineTransitionKind>("\"acceptance_command_completed\"")
+                .unwrap(),
+            PipelineTransitionKind::AcceptanceCommandCompleted
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -122,6 +122,8 @@ pub struct PipelineRun {
     pub step_outputs: HashMap<String, StepOutput>,
     /// Durable acceptance evidence retained across whole-issue cycles.
     pub acceptance_attempts: Vec<AcceptanceAttempt>,
+    /// Acceptance descriptors frozen from the configuration that created this run.
+    pub resolved_acceptance_plan: Option<crate::acceptance::ResolvedAcceptancePlan>,
     /// The resolved, validated step DAG.
     dag: StepDag,
     /// Synthetic fixup steps generated for step-level retries.
@@ -136,6 +138,8 @@ pub struct PipelineRunSnapshot {
     pub step_outputs: HashMap<String, StepOutput>,
     #[serde(default)]
     pub acceptance_attempts: Vec<AcceptanceAttempt>,
+    #[serde(default)]
+    pub resolved_acceptance_plan: Option<crate::acceptance::ResolvedAcceptancePlan>,
     pub dag_steps: Vec<DagStep>,
     pub synthetic_fixup_steps: HashSet<String>,
 }
@@ -155,6 +159,7 @@ impl PipelineRun {
             step_states,
             step_outputs: HashMap::new(),
             acceptance_attempts: Vec::new(),
+            resolved_acceptance_plan: None,
             dag,
             synthetic_fixup_steps: HashSet::new(),
         }
@@ -167,6 +172,7 @@ impl PipelineRun {
             step_states: self.step_states.clone(),
             step_outputs: self.step_outputs.clone(),
             acceptance_attempts: self.acceptance_attempts.clone(),
+            resolved_acceptance_plan: self.resolved_acceptance_plan.clone(),
             dag_steps: self.dag.steps.clone(),
             synthetic_fixup_steps: self.synthetic_fixup_steps.clone(),
         }
@@ -182,6 +188,7 @@ impl PipelineRun {
             step_states: snapshot.step_states,
             step_outputs: snapshot.step_outputs,
             acceptance_attempts: snapshot.acceptance_attempts,
+            resolved_acceptance_plan: snapshot.resolved_acceptance_plan,
             dag: StepDag {
                 steps: snapshot.dag_steps,
             },
@@ -2039,36 +2046,51 @@ mod tests {
     #[test]
     fn snapshot_round_trip_preserves_acceptance_attempts_and_legacy_defaults_empty() {
         let mut run = make_run(&[make_step("build", "builder", &[])]);
+        run.resolved_acceptance_plan = Some(crate::acceptance::ResolvedAcceptancePlan {
+            config_digest: "sha256:test".into(),
+            commands: vec!["test".into()],
+            required_files: Vec::new(),
+            required_handoff_sections: Vec::new(),
+            required_pull_requests: Vec::new(),
+        });
         run.acceptance_attempts = vec![crate::acceptance::AcceptanceAttempt {
             cycle: 1,
-            results: vec![crate::acceptance::AcceptanceResult {
-                name: "test".to_string(),
-                status: crate::acceptance::AcceptanceStatus::Passed,
-                timing: crate::acceptance::AcceptanceTiming::Unknown,
-                exit_code: Some(0),
-                stdout: crate::acceptance::AcceptanceOutput {
+            results: vec![crate::acceptance::AcceptanceResult::command(
+                "test".to_string(),
+                crate::acceptance::AcceptanceStatus::Passed,
+                "passed".to_string(),
+                Some(0),
+                crate::acceptance::AcceptanceOutput {
                     tail: "ok".to_string(),
                     total_bytes: 2,
                     truncated: false,
                 },
-                stderr: crate::acceptance::AcceptanceOutput {
+                crate::acceptance::AcceptanceOutput {
                     tail: String::new(),
                     total_bytes: 0,
                     truncated: false,
                 },
-                summary: "passed".to_string(),
-            }],
+            )],
         }];
 
         let restored = PipelineRun::from_snapshot(run.to_snapshot()).unwrap();
         assert_eq!(restored.acceptance_attempts, run.acceptance_attempts);
+        assert_eq!(
+            restored.resolved_acceptance_plan,
+            run.resolved_acceptance_plan
+        );
 
         let mut legacy = serde_json::to_value(run.to_snapshot()).unwrap();
         legacy
             .as_object_mut()
             .unwrap()
             .remove("acceptance_attempts");
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("resolved_acceptance_plan");
         let legacy: PipelineRunSnapshot = serde_json::from_value(legacy).unwrap();
         assert!(legacy.acceptance_attempts.is_empty());
+        assert!(legacy.resolved_acceptance_plan.is_none());
     }
 }

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -184,6 +184,20 @@ impl WorktreeCoordinator {
         Ok(created)
     }
 
+    /// Resolve the deterministic paths for already-owned worktrees without touching git.
+    pub(crate) fn worktree_paths(&self, issue_id: &str) -> HashMap<String, PathBuf> {
+        let branch = self.format_branch_name(issue_id);
+        self.repos
+            .keys()
+            .map(|repo_name| {
+                (
+                    repo_name.clone(),
+                    self.worktree_root.join(repo_name).join(&branch),
+                )
+            })
+            .collect()
+    }
+
     /// Clean up worktrees and delete branches for the given issue.
     pub async fn cleanup_worktrees(&self, issue_id: &str) -> Result<(), WorktreeError> {
         let branch = self.format_branch_name(issue_id);

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -1,4 +1,4 @@
-use crate::config::ensemble::{HooksConfig, RepoConfig};
+use crate::config::ensemble::{repository_key, HooksConfig, RepoConfig};
 use crate::error::WorkspaceError;
 use crate::observability::events_contract::{
     elapsed_ms, WORKSPACE_PREPARE_FAILED, WORKSPACE_PREPARE_FINISHED, WORKSPACE_PREPARE_STARTED,
@@ -82,11 +82,7 @@ impl WorkspaceManager {
             .map(|repo_list| {
                 let mut repos_map = HashMap::new();
                 for (index, repo) in repo_list.into_iter().enumerate() {
-                    let name = Path::new(&repo.path)
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| format!("repo-{index}"));
+                    let name = repository_key(&repo, index);
                     repos_map.insert(name, repo);
                 }
                 repos_map
@@ -117,6 +113,21 @@ impl WorkspaceManager {
     /// Get the workspace path for an immutable issue identity without creating it.
     pub fn workspace_path(&self, issue_id: &str) -> PathBuf {
         self.root.join(issue_workspace_key(issue_id))
+    }
+
+    /// Resolve paths for an existing issue-owned workspace without preparing or pulling it.
+    pub(crate) fn owned_worktree_paths(
+        &self,
+        issue_id: &str,
+    ) -> Result<HashMap<String, PathBuf>, WorkspaceError> {
+        let metadata = self.load_metadata(issue_id)?;
+        Self::verify_ownership(&self.metadata_path(issue_id), &metadata, issue_id)?;
+        let coordinator = WorktreeCoordinator::new(
+            self.repos.clone(),
+            metadata.branch_date,
+            self.workspace_path(issue_id),
+        );
+        Ok(coordinator.worktree_paths(issue_id))
     }
 
     fn metadata_dir(&self) -> PathBuf {
@@ -587,6 +598,28 @@ mod tests {
         assert_eq!(metadata.issue_id, "NODE_42");
         assert_eq!(metadata.issue_identifier, "my-repo#42");
         assert!(!result.base_path.join(".ensemble-workspace.json").exists());
+    }
+
+    #[tokio::test]
+    async fn owned_worktree_paths_resolves_existing_paths_without_preparation() {
+        let root = TempDir::new().unwrap();
+        let (_repo, config) = setup_repo("owned");
+        let mgr = WorkspaceManager::new(root.path(), Some(vec![config])).unwrap();
+        let prepared = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+
+        let resolved = mgr.owned_worktree_paths("NODE_42").unwrap();
+
+        assert_eq!(
+            resolved,
+            prepared
+                .worktrees
+                .into_iter()
+                .map(|(name, worktree)| (name, worktree.path))
+                .collect()
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/tests/openapi_spec.rs
+++ b/crates/ensemble-core/tests/openapi_spec.rs
@@ -118,6 +118,30 @@ fn openapi_documents_agent_state_worker_caps_as_integer_maps() {
 }
 
 #[test]
+fn openapi_documents_versioned_acceptance_evidence() {
+    let spec: serde_json::Value =
+        serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+    let result = &spec["components"]["schemas"]["AcceptanceResult"];
+
+    assert_eq!(result["properties"]["version"]["type"], "integer");
+    assert_eq!(
+        result["properties"]["evidence"]["$ref"],
+        "#/components/schemas/AcceptanceEvidence"
+    );
+    assert!(result["properties"].get("exit_code").is_none());
+    assert!(result["properties"].get("stdout").is_none());
+    assert!(result["properties"].get("stderr").is_none());
+
+    let evidence = &spec["components"]["schemas"]["AcceptanceEvidence"];
+    assert_eq!(evidence["oneOf"].as_array().map(Vec::len), Some(4));
+    for variant in evidence["oneOf"].as_array().unwrap() {
+        assert!(variant["required"]
+            .as_array()
+            .is_some_and(|required| required.iter().any(|field| field == "kind")));
+    }
+}
+
+#[test]
 #[ignore = "writes generated OpenAPI output for frontend codegen"]
 fn write_openapi_spec() {
     let spec = ApiDoc::openapi().to_pretty_json().unwrap();

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -237,7 +237,15 @@ Parsed `config.yaml` payload:
 - `acceptance` (AcceptanceConfig, optional)
   - `commands` is an ordered list of `{ name, run, timeout_ms }` command definitions. Names must be
     unique and non-blank, `run` must be non-blank, and the required timeout must be positive.
-  - Missing `acceptance`, missing `commands`, and an empty list all mean no acceptance phase.
+  - `required_files` is an ordered list of `{ name, repo, path }` exact regular-file checks. `repo`
+    resolves one configured repository basename and `path` is non-empty and repository-relative,
+    without parent traversal.
+  - `required_handoff_sections` is an ordered list of `{ name, step, sections }` checks against one
+    persisted step output object. The step must exist; section names are non-blank and unique.
+  - `required_pull_requests` is an ordered list of `{ name, repo }` checks. The repository must have
+    finalization enabled in `push_and_pr` mode.
+  - Every acceptance name is non-blank and unique across all four lists. Missing lists default to
+    empty; when all four are empty there is no acceptance phase.
 
 #### 4.1.3 Agent Config
 
@@ -300,9 +308,13 @@ Per-issue pipeline execution state:
 - `step_states` (map of step name to StepState)
 - `acceptance_attempts` (ordered list, default empty)
   - Each attempt contains its 1-based pipeline `cycle` and declaration-order `results` prefix.
-  - Each result contains `name`, `status` (`passed`, `failed`, `timed_out`, or `unavailable`),
-    `timing`, optional `exit_code`, bounded `stdout` and `stderr`, and a human-readable `summary`.
-    The configured command string is never part of durable evidence.
+  - Newly written results use the version-2 envelope `{ version, name, status, summary, timing,
+    evidence }`. `status` is `passed`, `failed`, `timed_out`, or `unavailable`; `evidence.kind` is
+    `command`, `file`, `handoff`, or `pull_request`. Command evidence contains optional `exit_code`
+    and bounded `stdout`/`stderr`; the other variants retain only typed, non-secret observations.
+    Configured command strings and absolute repository paths are never durable evidence.
+  - Legacy unversioned flat command results remain readable and acquire unknown timing in memory.
+    New persistence always writes version 2; unsupported explicit versions fail to decode.
   - Newly executed results use tagged observed timing with UTC `started_at` and `completed_at`
     boundaries plus monotonic `duration_ms`. Legacy results without timing deserialize as tagged
     `unknown` timing and remain readable without invented timestamps.
@@ -334,12 +346,18 @@ Pipeline run recovery:
 - Ensemble appends pipeline transition records to
   `<config_dir>/state/pipeline-runs/<encoded_issue_id>.jsonl`.
 - Each recoverable transition includes a full `PipelineRun` snapshot.
-- Acceptance appends `acceptance_started` before its first command and
-  `acceptance_command_completed` after every completed result. A failed append stops the phase
-  before the next command, finalization, or retry decision. On restore, the current cycle's durable
-  results must match the configured command-name prefix; Ensemble resumes at the first missing
-  command, so only a
-  command interrupted before its result became durable may run again.
+- Acceptance appends `acceptance_started` before its first check and `acceptance_check_completed`
+  after every newly completed result. The legacy `acceptance_command_completed` transition remains
+  readable. A failed append stops before the next check, finalization, or retry decision.
+- A new run freezes a non-secret resolved acceptance plan and semantic configuration digest in its
+  snapshot. The plan stores command names, not command strings. Before an unfinished command,
+  digest drift retains the run for recovery rather than executing changed configuration. File and
+  handoff recovery uses the frozen descriptors. Legacy snapshots without a plan retain historical
+  command-only prefix behavior and do not gain newly configured rules.
+- Pre-final results must be a declaration-order prefix of commands, required files, then required
+  handoff sections. Ensemble resumes at the first missing check; only a check interrupted before its
+  result became durable may run again. All pre-final checks run, and any non-passing result takes the
+  whole-issue retry path.
 - If an append outcome is ambiguous, Ensemble retains the active owner and retries only journal
   visibility on later poll ticks. Exact visibility advances without rerunning the command;
   confirmed absence releases the owner so only the undurable command can be dispatched again.
@@ -365,6 +383,12 @@ Pipeline run recovery:
   dispatches no pipeline work, and does not project a terminal tracker state. `blocked` is likewise
   retained for operator recovery. A fully `published` push-only delivery continues the existing
   durable terminal-transition protocol; it does not republish the branch.
+- Required pull-request checks run only after the retained delivery identity reaches `waiting` or
+  `published`. Results form one ordered suffix batch per evaluation. Restart resumes a partial
+  batch without push, creation, or discovery; an explicit finalize retry appends a complete new
+  batch and preserves prior evidence. Failure blocks only the affected delivery repository while
+  retaining its branch, SHA, pull-request number, and URL. Retry re-evaluates that retained identity
+  and returns to `waiting` when it passes; it never enters pipeline `max_cycles`.
 - On orchestrator startup, Ensemble restores the latest non-released snapshot for each issue before
   the first poll tick.
 - Delivery ownership is restored before candidate selection and excludes that issue from fresh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,7 +259,7 @@ agent:
 
 ### acceptance
 
-`acceptance` is optional. Its `commands` list defaults to empty, which preserves the direct
+`acceptance` is optional. All four lists default to empty, which preserves the direct
 pipeline-success-to-finalization behavior.
 
 ```yaml
@@ -268,6 +268,17 @@ acceptance:
     - name: unit-tests
       run: cargo test --workspace
       timeout_ms: 900000
+  required_files:
+    - name: release-notes
+      repo: ensemble
+      path: docs/release-notes.md
+  required_handoff_sections:
+    - name: implementation-handoff
+      step: implement
+      sections: [summary, testing]
+  required_pull_requests:
+    - name: ensemble-pr
+      repo: ensemble
 ```
 
 Each command requires a unique, non-blank `name`, a non-blank `run` string, and a positive
@@ -277,10 +288,29 @@ parallelism, or acceptance-specific retry option. Commands inherit the orchestra
 run sequentially in declaration order in the issue workspace, and all commands run even after an
 earlier command does not pass.
 
-Acceptance starts only after every pipeline step and approval gate has passed, and before repository
-finalization. A non-passing command uses the existing whole-issue `max_cycles` retry path and, on
-exhaustion, writes `on_failure`; per-step `on_failure` settings do not apply. See
-[Pipeline Guide](pipelines.md#acceptance-commands) for evidence, recovery, and retry semantics.
+`required_files` runs next, in declaration order. Each entry needs a unique non-blank `name`, a
+`repo` that resolves exactly one configured repository basename, and an exact non-empty
+repository-relative `path` without `..`. The target must resolve inside Ensemble's owned worktree
+and be a regular file; symlinks that escape the repository fail.
+
+`required_handoff_sections` then checks the persisted `StepOutput.output` for a configured `step`.
+It must be an object containing every configured non-blank, unique top-level section. Missing,
+`null`, blank strings, empty arrays, and empty objects fail; `false` and `0` are present values.
+
+`required_pull_requests` runs after repository finalization. Its `repo` must resolve exactly one
+repository with `finalize.enabled: true` and `finalize.mode: push_and_pr`. It passes only when the
+retained delivery record has a pull-request number and URL in `waiting` or `published`; it does not
+search for or create a pull request.
+
+Names must be unique across commands, files, handoffs, and pull requests. Config validation rejects
+ambiguous repository basenames and invalid references before the service starts.
+
+Commands, files, and handoffs start only after every pipeline step and approval gate has passed and
+before repository finalization. Any non-passing pre-final check uses the existing whole-issue
+`max_cycles` retry path and, on exhaustion, writes `on_failure`; per-step `on_failure` settings do
+not apply. Pull-request requirements instead block the affected retained delivery and are retried by
+the finalize-retry control. See [Pipeline Guide](pipelines.md#acceptance-requirements) for evidence,
+recovery, and retry semantics.
 
 ### tracker
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -158,10 +158,9 @@ Verdict files and default-success fallback are not part of the runtime result co
 
 **Failed** means the step failed. The `summary` field explains why. Ensemble applies the step's `on_failure` behavior.
 
-## Acceptance commands
+## Acceptance requirements
 
-Acceptance commands provide deterministic checks after all steps and approval gates pass but before
-repository finalization or the `on_success` tracker transition:
+Acceptance requirements provide deterministic checks around repository finalization:
 
 ```yaml
 acceptance:
@@ -172,20 +171,42 @@ acceptance:
     - name: formatting
       run: cargo fmt --all -- --check
       timeout_ms: 120000
+  required_files:
+    - name: release-notes
+      repo: ensemble
+      path: docs/release-notes.md
+  required_handoff_sections:
+    - name: implementation-handoff
+      step: implement
+      sections: [summary, testing]
+  required_pull_requests:
+    - name: ensemble-pr
+      repo: ensemble
 ```
 
 Ensemble runs these sequentially in declaration order as `/bin/sh -lc` in the issue workspace,
 inheriting the orchestrator environment unchanged. It runs the complete list even if an earlier
 command fails, times out, or cannot launch. Commands are not DAG steps, do not run through an agent,
-and cannot be parallelized or given acceptance-specific retries. Missing or empty commands skip the
-phase entirely.
+and cannot be parallelized or given acceptance-specific retries. Ensemble next checks required files
+in owned worktrees, then required top-level sections in persisted step output objects. It runs the
+complete pre-final sequence even after a failure.
 
-Each durable result contains the configured `name` but never the command string. `status` is
-`passed`, `failed`, `timed_out`, or `unavailable`; `exit_code` is optional because signals, timeouts,
-launch/cwd failures, or collection failures may not provide one. `stdout` and `stderr` independently
-store a lossy-UTF-8 rendering of only the final 32,768 raw bytes, the total observed byte count, and
-a `truncated` flag. The runner drains both streams concurrently and terminates and reaps the command
-process group on timeout.
+Required files use exact repository-relative paths. The target must be a regular file whose resolved
+path stays inside the configured worktree. Required handoff sections treat missing, null, blank
+strings, empty objects, and empty arrays as absent; boolean `false` and numeric `0` are present.
+
+After finalization retains a pull-request identity, Ensemble evaluates required pull requests in
+declaration order. These checks project only the stored delivery phase, branch and SHA identity,
+pull-request number, and URL. They never push, create, or discover remote state.
+
+Each newly written durable result is a version-2 envelope with `name`, `status`, `summary`, `timing`,
+and tagged `evidence`. Evidence kind is `command`, `file`, `handoff`, or `pull_request`. Command
+evidence has optional `exit_code` plus `stdout` and `stderr`; each stream stores a lossy-UTF-8
+rendering of only the final 32,768 raw bytes, total observed bytes, and a `truncated` flag. The runner
+drains both streams concurrently and terminates and reaps the command process group on timeout.
+Other evidence variants contain typed observations and configured relative identifiers, never
+command strings or absolute repository paths. Unversioned legacy flat command results remain
+readable with unknown timing; unsupported explicit versions fail closed and new writes are v2.
 
 Every newly executed result also records tagged timing:
 
@@ -202,12 +223,13 @@ The boundaries use UTC wall-clock timestamps, while `duration_ms` uses a monoton
 results without a `timing` field deserialize as `{"kind":"unknown"}`; Ensemble preserves their
 evidence without inventing timestamps.
 
-Phase start and every completed result are journaled before Ensemble advances. After restart, the
-current cycle's durable results must be a declaration-order prefix of configured command names;
-Ensemble resumes with the first missing command. Thus an interrupted command without a durable result
-may repeat, while a durable prefix does not. Legacy snapshots and history records default to no
-attempts, and legacy results within an existing attempt default to unknown timing. Ordered attempts
-are also preserved in JSONL history, SQLite history, and pending terminal reconciliation records.
+Phase start and every completed result are journaled before Ensemble advances. A new run freezes a
+non-secret resolved plan and semantic config digest. Results must be a declaration-order prefix of
+commands, files, and handoffs; restart resumes the first missing check from frozen descriptors.
+Digest drift before an unfinished command retains the run instead of executing changed command
+configuration. Legacy snapshots without a plan use historical command-only recovery and do not gain
+new rules. Ordered attempts are preserved in JSONL history, SQLite history, and pending terminal
+reconciliation records.
 
 If an append outcome is ambiguous, Ensemble keeps the active owner and retries only the journal
 visibility check on later poll ticks. An exactly visible result advances without executing the
@@ -217,8 +239,13 @@ redispatched.
 Any non-passing result dominates a succeeded or concern step output and prevents finalization. It
 uses whole-issue retry regardless of per-step `on_failure`: a new cycle reruns the full pipeline and
 the full acceptance list while retaining prior attempts. Exhausting `max_cycles` records every
-attempt and moves the issue to `on_failure`. Artifact/handoff validation and Mission Control or
-generated-client presentation are separate contracts and are not performed by acceptance commands.
+attempt and moves the issue to `on_failure`.
+
+Pull-request results are an ordered suffix after the pre-final prefix. Startup resumes an incomplete
+suffix batch without remote calls. A failed batch blocks only affected delivery repositories and
+retains their exact delivery and pull-request identity. An explicit finalize retry appends a full
+new suffix batch; a passing retry returns the delivery to `waiting`, while failure remains blocked.
+This path does not consume pipeline cycles or use `max_cycles`.
 
 ## Retries and cycles
 


### PR DESCRIPTION
## Summary

- add validated file, structured handoff, and retained pull-request acceptance rules
- migrate durable acceptance results to the version 2 tagged evidence envelope while preserving legacy command reads
- freeze acceptance plans for restart-safe prefix and pull-request batch recovery
- document the configuration, evidence, ordering, retry, and delivery semantics

## Validation

- RUST_TEST_THREADS=1 cargo test --workspace --exclude ensemble-desktop
- SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture
- SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check
- pnpm --dir crates/ensemble-ui/src-ui test
- pnpm --dir crates/ensemble-ui/src-ui run build
- git diff --check

The normal parallel workspace run exposed the existing test-local PATH mutation race in restored_pending_approval_finalization_releases_running_slot; that test passes alone, and the complete serialized workspace run passed with zero failures.

## Reviews

- Standards and specification reviews repeated on the final implementation: no findings
- reuse, quality, efficiency, and clarity simplification reviews completed; findings resolved and revalidated
- ponytail review: Lean already. Ship.

Fixes #418