### PR TITLE
Remove Greptile from required checks

### DIFF
--- a/docs/agents/run-github-project.md
+++ b/docs/agents/run-github-project.md
@@ -57,7 +57,7 @@
 - Issue closure: `closing-keyword`
 - Required reviews: `none`
 - Required checks: `Check, Test, Clippy, Format`; `Frontend Test and Build`;
-  `Tauri PR (Linux)`; `Tauri PR (Mac)`; `Greptile Review`
+  `Tauri PR (Linux)`; `Tauri PR (Mac)`
 - Done automation: `set-status`
 - Automation description: Enabled Project workflows `Item closed` and
   `Pull request merged`; verified that merged-and-closed issue #182 moved from


### PR DESCRIPTION
## Summary

- remove Greptile Review from the trusted Project required-check list
- align the binding with the active main-branch ruleset while Greptile is disabled

## Validation

- verified ruleset 14473440 requires Check, Test, Clippy, Format; Frontend Test and Build; Tauri PR (Linux); and Tauri PR (Mac)
- git diff --check