### PR TITLE
Expose acceptance evidence in issue details

### DIFF
--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -279,6 +279,7 @@ fn issue_snapshot_from_history_record(
             url: None,
         },
         artifacts,
+        acceptance_attempts: record.acceptance_attempts.clone(),
     })
 }
 
@@ -548,13 +549,18 @@ pub async fn method_not_allowed() -> (StatusCode, Json<ApiError>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::acceptance::{
+        AcceptanceAttempt, AcceptanceEvidence, AcceptanceOutput, AcceptanceResult,
+        AcceptanceStatus, AcceptanceTiming, FileObservation, HandoffOutputObservation,
+        HandoffSectionEvidence, HandoffSectionObservation, JsonValueKind, PullRequestDeliveryPhase,
+    };
     use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
     use crate::config::ensemble::ConcurrencyConfig;
     use crate::history::model::{HistoryRecord, TokenTotals};
     use crate::history::writer::HistoryWriter;
     use crate::orchestrator::state::OrchestratorState;
     use crate::tracker::model::{Issue, RetryEntry, RunningEntry};
-    use chrono::Utc;
+    use chrono::{TimeZone, Utc};
     use tempfile::NamedTempFile;
 
     fn test_issue() -> Issue {
@@ -607,6 +613,86 @@ mod tests {
             retry_from_step: None,
             with_fixup: false,
         }
+    }
+
+    fn persisted_acceptance_attempts() -> Vec<AcceptanceAttempt> {
+        let timing = AcceptanceTiming::Observed {
+            started_at: Utc.with_ymd_and_hms(2026, 8, 4, 9, 0, 0).single().unwrap(),
+            completed_at: Utc.with_ymd_and_hms(2026, 8, 4, 9, 0, 1).single().unwrap(),
+            duration_ms: 1_000,
+        };
+        let mut command = AcceptanceResult::new(
+            "unit tests".to_string(),
+            AcceptanceStatus::Passed,
+            "tests passed".to_string(),
+            AcceptanceEvidence::Command {
+                exit_code: Some(0),
+                stdout: AcceptanceOutput {
+                    tail: "tests passed".to_string(),
+                    total_bytes: 12,
+                    truncated: false,
+                },
+                stderr: AcceptanceOutput {
+                    tail: String::new(),
+                    total_bytes: 0,
+                    truncated: false,
+                },
+            },
+        );
+        command.timing = timing.clone();
+        let mut release_notes = AcceptanceResult::new(
+            "release notes".to_string(),
+            AcceptanceStatus::Failed,
+            "release notes are missing".to_string(),
+            AcceptanceEvidence::File {
+                repo: "ensemble".to_string(),
+                path: "docs/release.md".to_string(),
+                observation: FileObservation::Missing,
+            },
+        );
+        release_notes.timing = timing.clone();
+        let mut handoff = AcceptanceResult::new(
+            "handoff".to_string(),
+            AcceptanceStatus::TimedOut,
+            "handoff inspection timed out".to_string(),
+            AcceptanceEvidence::Handoff {
+                step: "review".to_string(),
+                output: HandoffOutputObservation::NonObject {
+                    value_kind: JsonValueKind::String,
+                },
+                sections: vec![HandoffSectionEvidence {
+                    name: "summary".to_string(),
+                    observation: HandoffSectionObservation::Missing,
+                }],
+            },
+        );
+        handoff.timing = timing.clone();
+        let mut pull_request = AcceptanceResult::new(
+            "pull request".to_string(),
+            AcceptanceStatus::Unavailable,
+            "pull request delivery is unavailable".to_string(),
+            AcceptanceEvidence::PullRequest {
+                repo: "chrisbanes/ensemble".to_string(),
+                delivery_phase: PullRequestDeliveryPhase::Blocked,
+                base_branch: Some("main".to_string()),
+                head_branch: Some("feature/acceptance".to_string()),
+                head_sha: Some("abc123".to_string()),
+                pr_number: Some(419),
+                pr_url: Some("https://github.com/chrisbanes/ensemble/pull/419".to_string()),
+            },
+        );
+        pull_request.timing = timing;
+
+        vec![
+            AcceptanceAttempt {
+                cycle: 1,
+                results: vec![command, release_notes],
+            },
+            AcceptanceAttempt {
+                cycle: 2,
+                results: vec![handoff, pull_request],
+            },
+        ]
     }
 
     fn build_populated_state() -> AppState {
@@ -785,6 +871,96 @@ mod tests {
             .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn history_backed_issue_detail_projects_persisted_acceptance_attempts_verbatim() {
+        let mut app_state = build_empty_state();
+        let tmp = NamedTempFile::new().unwrap();
+        let history_path = tmp.path().to_path_buf();
+        std::fs::remove_file(&history_path).ok();
+        app_state.history_path = history_path.clone();
+        let acceptance_attempts = persisted_acceptance_attempts();
+
+        HistoryWriter::new(history_path)
+            .append(&HistoryRecord {
+                issue_identifier: "history#419".to_string(),
+                issue_id: "NODE_419".to_string(),
+                outcome: "failed".to_string(),
+                steps_traversed: vec!["build".to_string()],
+                attempts: 2,
+                tokens: TokenTotals {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    total_tokens: 0,
+                },
+                duration_seconds: 42,
+                started_at: Utc::now(),
+                completed_at: Utc::now(),
+                last_error: None,
+                verdict: Some("failed".to_string()),
+                workspace_path: "/tmp/workspaces/history-419".to_string(),
+                acceptance_attempts: acceptance_attempts.clone(),
+                artifacts: None,
+            })
+            .await
+            .unwrap();
+
+        let response = get_issue_detail(State(app_state), Path("history#419".to_string()))
+            .await
+            .into_response();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let detail: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            detail["acceptance_attempts"],
+            serde_json::to_value(acceptance_attempts).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn history_backed_issue_detail_preserves_an_empty_acceptance_attempt_sequence() {
+        let mut app_state = build_empty_state();
+        let tmp = NamedTempFile::new().unwrap();
+        let history_path = tmp.path().to_path_buf();
+        std::fs::remove_file(&history_path).ok();
+        app_state.history_path = history_path.clone();
+
+        HistoryWriter::new(history_path)
+            .append(&HistoryRecord {
+                issue_identifier: "history#empty".to_string(),
+                issue_id: "NODE_EMPTY".to_string(),
+                outcome: "succeeded".to_string(),
+                steps_traversed: vec![],
+                attempts: 1,
+                tokens: TokenTotals {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    total_tokens: 0,
+                },
+                duration_seconds: 0,
+                started_at: Utc::now(),
+                completed_at: Utc::now(),
+                last_error: None,
+                verdict: None,
+                workspace_path: String::new(),
+                acceptance_attempts: vec![],
+                artifacts: None,
+            })
+            .await
+            .unwrap();
+
+        let response = get_issue_detail(State(app_state), Path("history#empty".to_string()))
+            .await
+            .into_response();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let detail: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(detail["acceptance_attempts"], serde_json::json!([]));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -1,3 +1,4 @@
+use crate::acceptance::AcceptanceAttempt;
 use crate::history::artifacts::{RunArtifacts, StepTranscriptArtifact};
 use crate::interaction::store::InteractionStore;
 use crate::orchestrator::state::{FinalizeStatus, OrchestratorState, RateLimitSnapshot};
@@ -132,6 +133,7 @@ pub struct IssueDetailSnapshot {
     pub workflow_steps: Vec<WorkflowStepInfo>,
     pub issue: IssueSummary,
     pub artifacts: Option<RunArtifacts>,
+    pub acceptance_attempts: Vec<AcceptanceAttempt>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -721,6 +723,9 @@ pub async fn build_issue_snapshot(
         workflow_steps,
         issue: issue_summary,
         artifacts,
+        acceptance_attempts: pipeline_run
+            .map(|run| run.acceptance_attempts.clone())
+            .unwrap_or_default(),
     })
 }
 
@@ -860,6 +865,10 @@ fn pending_input_from_current(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::acceptance::{
+        AcceptanceAttempt, AcceptanceEvidence, AcceptanceOutput, AcceptanceResult,
+        AcceptanceStatus, AcceptanceTiming,
+    };
     use crate::config::ensemble::{
         ConcurrencyConfig, EnsembleConfig, OnFailure, StepConfig, StepKind, TrackerConfig,
     };
@@ -1374,6 +1383,81 @@ mod tests {
             .unwrap();
         assert_eq!(review_step.get("state").unwrap(), "running");
         assert_eq!(review_step.get("agent").unwrap(), "reviewer");
+    }
+
+    #[tokio::test]
+    async fn issue_snapshot_projects_ordered_partial_acceptance_attempts_from_live_run() {
+        let mut state = build_test_state();
+        attach_pipeline_state(&mut state, "NODE_123");
+        let mut release_notes = AcceptanceResult::new(
+            "release notes".to_string(),
+            AcceptanceStatus::Failed,
+            "release notes are missing".to_string(),
+            AcceptanceEvidence::File {
+                repo: "ensemble".to_string(),
+                path: "docs/release.md".to_string(),
+                observation: crate::acceptance::FileObservation::Missing,
+            },
+        );
+        release_notes.timing = AcceptanceTiming::Observed {
+            started_at: chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 8, 4, 9, 0, 0)
+                .single()
+                .unwrap(),
+            completed_at: chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 8, 4, 9, 0, 1)
+                .single()
+                .unwrap(),
+            duration_ms: 1_000,
+        };
+        let attempts = vec![
+            AcceptanceAttempt {
+                cycle: 1,
+                results: vec![AcceptanceResult::new(
+                    "unit tests".to_string(),
+                    AcceptanceStatus::Passed,
+                    "tests passed".to_string(),
+                    AcceptanceEvidence::Command {
+                        exit_code: Some(0),
+                        stdout: AcceptanceOutput {
+                            tail: "ok".to_string(),
+                            total_bytes: 2,
+                            truncated: false,
+                        },
+                        stderr: AcceptanceOutput {
+                            tail: String::new(),
+                            total_bytes: 0,
+                            truncated: false,
+                        },
+                    },
+                )],
+            },
+            AcceptanceAttempt {
+                cycle: 2,
+                results: vec![release_notes],
+            },
+        ];
+        state
+            .pipeline_runs
+            .get_mut("NODE_123")
+            .unwrap()
+            .acceptance_attempts = attempts.clone();
+
+        let detail = build_issue_snapshot(&state, "my-repo#42", "/tmp/workspaces", None)
+            .await
+            .unwrap();
+
+        assert_eq!(detail.acceptance_attempts, attempts);
+    }
+
+    #[tokio::test]
+    async fn issue_snapshot_preserves_an_empty_acceptance_attempt_sequence() {
+        let mut state = build_test_state();
+        attach_pipeline_state(&mut state, "NODE_123");
+
+        let detail = build_issue_snapshot(&state, "my-repo#42", "/tmp/workspaces", None)
+            .await
+            .unwrap();
+
+        assert!(detail.acceptance_attempts.is_empty());
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/tests/openapi_spec.rs
+++ b/crates/ensemble-core/tests/openapi_spec.rs
@@ -142,6 +142,28 @@ fn openapi_documents_versioned_acceptance_evidence() {
 }
 
 #[test]
+fn openapi_documents_issue_detail_acceptance_attempts() {
+    let spec: serde_json::Value =
+        serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+    let issue_detail = &spec["components"]["schemas"]["IssueDetailSnapshot"];
+
+    assert_eq!(
+        issue_detail["properties"]["acceptance_attempts"]["items"]["$ref"],
+        "#/components/schemas/AcceptanceAttempt"
+    );
+    assert_eq!(
+        spec["components"]["schemas"]["AcceptanceResult"]["properties"]["evidence"]["$ref"],
+        "#/components/schemas/AcceptanceEvidence"
+    );
+    assert_eq!(
+        spec["components"]["schemas"]["AcceptanceEvidence"]["oneOf"]
+            .as_array()
+            .map(Vec::len),
+        Some(4)
+    );
+}
+
+#[test]
 #[ignore = "writes generated OpenAPI output for frontend codegen"]
 fn write_openapi_spec() {
     let spec = ApiDoc::openapi().to_pretty_json().unwrap();

--- a/crates/ensemble-ui/src-ui/src/components/AcceptanceEvidencePanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/AcceptanceEvidencePanel.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { AcceptanceAttempt } from "@/generated/models";
+import { AcceptanceEvidencePanel } from "./AcceptanceEvidencePanel";
+
+const attempts = [
+  {
+    cycle: 1,
+    results: [
+      {
+        version: 2,
+        name: "unit tests",
+        status: "passed",
+        summary: "tests passed",
+        timing: {
+          kind: "observed",
+          started_at: "2026-08-04T09:00:00Z",
+          completed_at: "2026-08-04T09:00:01Z",
+          duration_ms: 1000,
+        },
+        evidence: {
+          kind: "command",
+          exit_code: 0,
+          stdout: { tail: "tests passed", total_bytes: 12, truncated: false },
+          stderr: { tail: "", total_bytes: 0, truncated: false },
+        },
+      },
+      {
+        version: 2,
+        name: "release notes",
+        status: "failed",
+        summary: "release notes are missing",
+        timing: { kind: "unknown" },
+        evidence: {
+          kind: "file",
+          repo: "ensemble",
+          path: "docs/release.md",
+          observation: "missing",
+        },
+      },
+    ],
+  },
+  {
+    cycle: 2,
+    results: [
+      {
+        version: 2,
+        name: "handoff",
+        status: "timed_out",
+        summary: "handoff inspection timed out",
+        timing: { kind: "unknown" },
+        evidence: {
+          kind: "handoff",
+          step: "review",
+          output: { kind: "non_object", value_kind: "string" },
+          sections: [{ name: "summary", observation: "missing" }],
+        },
+      },
+      {
+        version: 2,
+        name: "pull request",
+        status: "unavailable",
+        summary: "pull request delivery is unavailable",
+        timing: { kind: "unknown" },
+        evidence: {
+          kind: "pull_request",
+          repo: "chrisbanes/ensemble",
+          delivery_phase: "blocked",
+          base_branch: "main",
+          head_branch: "feature/acceptance",
+          head_sha: "abc123",
+          pr_number: 419,
+          pr_url: "https://github.com/chrisbanes/ensemble/pull/419",
+        },
+      },
+    ],
+  },
+] satisfies AcceptanceAttempt[];
+
+describe("AcceptanceEvidencePanel", () => {
+  it("renders every persisted result in cycle and result order with typed evidence", () => {
+    render(<AcceptanceEvidencePanel attempts={attempts} />);
+
+    expect(screen.getAllByRole("heading", { level: 3 }).map((heading) => heading.textContent)).toEqual([
+      "Cycle 1",
+      "Cycle 2",
+    ]);
+    expect(screen.getAllByRole("heading", { level: 4 }).map((heading) => heading.textContent)).toEqual([
+      "unit tests",
+      "release notes",
+      "handoff",
+      "pull request",
+    ]);
+    expect(screen.getByText("passed")).toBeInTheDocument();
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.getByText("timed_out")).toBeInTheDocument();
+    expect(screen.getByText("unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Exit code: 0")).toBeInTheDocument();
+    expect(screen.getByText("stdout (12 bytes)")).toBeInTheDocument();
+    expect(screen.getAllByText("tests passed")).toHaveLength(2);
+    expect(screen.getByText("File observation: missing")).toBeInTheDocument();
+    expect(screen.getByText("Output observation: non_object (string)")).toBeInTheDocument();
+    expect(screen.getByText("summary: missing")).toBeInTheDocument();
+    expect(screen.getByText("Delivery phase: blocked")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "PR #419" })).toHaveAttribute(
+      "href",
+      "https://github.com/chrisbanes/ensemble/pull/419",
+    );
+    expect(screen.getByText("Observed: 1,000 ms")).toBeInTheDocument();
+    expect(screen.getAllByText("Timing unknown")).toHaveLength(3);
+  });
+
+  it("uses neutral copy for empty and partial persisted sequences", () => {
+    const { rerender } = render(<AcceptanceEvidencePanel attempts={[]} />);
+    expect(screen.getByText("No acceptance evidence has been recorded.")).toBeInTheDocument();
+    expect(screen.getByText(/No acceptance outcome is implied/)).toBeInTheDocument();
+
+    rerender(<AcceptanceEvidencePanel attempts={[{ cycle: 3, results: attempts[0]!.results.slice(0, 1) }]} />);
+    expect(screen.getByText(/Results are shown exactly as recorded/)).toBeInTheDocument();
+    expect(screen.getByText(/No outcome is inferred for checks that were not recorded/)).toBeInTheDocument();
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/components/AcceptanceEvidencePanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/AcceptanceEvidencePanel.tsx
@@ -1,0 +1,144 @@
+import type { AcceptanceAttempt, AcceptanceOutput, AcceptanceResult } from "@/generated/models";
+import { Badge } from "@/components/ui/badge";
+
+interface AcceptanceEvidencePanelProps {
+  attempts: AcceptanceAttempt[];
+}
+
+function safeExternalUrl(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+function Timing({ result }: { result: AcceptanceResult }) {
+  if (result.timing?.kind !== "observed") {
+    return <div className="text-xs text-muted-foreground">Timing unknown</div>;
+  }
+
+  return <div className="text-xs text-muted-foreground">Observed: {result.timing.duration_ms.toLocaleString()} ms</div>;
+}
+
+function CommandEvidence({ result }: { result: AcceptanceResult }) {
+  if (result.evidence.kind !== "command") return null;
+  const { exit_code, stderr, stdout } = result.evidence;
+  return (
+    <div className="space-y-2 text-sm">
+      <div>Exit code: {exit_code ?? "unavailable"}</div>
+      <OutputEvidence label="stdout" output={stdout} />
+      <OutputEvidence label="stderr" output={stderr} />
+    </div>
+  );
+}
+
+function OutputEvidence({
+  label,
+  output,
+}: {
+  label: string;
+  output: AcceptanceOutput;
+}) {
+  return (
+    <div>
+      <div className="text-xs text-muted-foreground">
+        {label} ({output.total_bytes.toLocaleString()} bytes){output.truncated ? ", truncated" : ""}
+      </div>
+      {output.tail ? <pre className="mt-1 max-h-40 overflow-auto rounded bg-muted/50 p-2 text-xs whitespace-pre-wrap">{output.tail}</pre> : null}
+    </div>
+  );
+}
+
+function Evidence({ result }: { result: AcceptanceResult }) {
+  switch (result.evidence.kind) {
+    case "command":
+      return <CommandEvidence result={result} />;
+    case "file":
+      return (
+        <div className="space-y-1 text-sm">
+          <div>{result.evidence.repo}: {result.evidence.path}</div>
+          <div>File observation: {result.evidence.observation}</div>
+        </div>
+      );
+    case "handoff":
+      return (
+        <div className="space-y-1 text-sm">
+          <div>Step: {result.evidence.step}</div>
+          <div>
+            Output observation: {result.evidence.output.kind}
+            {result.evidence.output.kind === "non_object" ? ` (${result.evidence.output.value_kind})` : ""}
+          </div>
+          {result.evidence.sections.map((section) => (
+            <div key={section.name}>{section.name}: {section.observation}</div>
+          ))}
+        </div>
+      );
+    case "pull_request": {
+      const url = safeExternalUrl(result.evidence.pr_url);
+      return (
+        <div className="space-y-1 text-sm">
+          <div>Repository: {result.evidence.repo}</div>
+          <div>Delivery phase: {result.evidence.delivery_phase}</div>
+          {result.evidence.base_branch ? <div>Base: {result.evidence.base_branch}</div> : null}
+          {result.evidence.head_branch ? <div>Head: {result.evidence.head_branch}</div> : null}
+          {result.evidence.head_sha ? <div>Head SHA: {result.evidence.head_sha}</div> : null}
+          {url && result.evidence.pr_number != null ? (
+            <a className="text-primary underline" href={url} target="_blank" rel="noreferrer">
+              PR #{result.evidence.pr_number}
+            </a>
+          ) : result.evidence.pr_number != null ? (
+            <div>PR #{result.evidence.pr_number}</div>
+          ) : null}
+        </div>
+      );
+    }
+  }
+}
+
+export function AcceptanceEvidencePanel({ attempts }: AcceptanceEvidencePanelProps) {
+  if (attempts.length === 0) {
+    return (
+      <div className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+        <p>No acceptance evidence has been recorded.</p>
+        <p className="mt-1">No acceptance outcome is implied.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Results are shown exactly as recorded. No outcome is inferred for checks that were not recorded.
+      </p>
+      {attempts.map((attempt) => (
+        <section key={attempt.cycle} className="space-y-3" aria-label={`Acceptance cycle ${attempt.cycle}`}>
+          <h3 className="font-semibold">Cycle {attempt.cycle}</h3>
+          {attempt.results.length === 0 ? (
+            <p className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+              No results were recorded for this cycle.
+            </p>
+          ) : (
+            attempt.results.map((result, index) => (
+              <article key={`${result.name}-${index}`} className="space-y-2 rounded-lg border p-3">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <h4 className="font-medium">{result.name}</h4>
+                    <p className="text-sm text-muted-foreground">{result.summary}</p>
+                  </div>
+                  <Badge variant={result.status === "failed" ? "destructive" : "outline"}>
+                    {result.status}
+                  </Badge>
+                </div>
+                <Timing result={result} />
+                <Evidence result={result} />
+              </article>
+            ))
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/hooks.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/hooks.test.tsx
@@ -102,6 +102,7 @@ function interaction(status: InteractionDetail["status"]): InteractionDetail {
 
 function issueDetail(finalizeStatus: string, approvalRequired = false): IssueDetailSnapshot {
   return {
+    acceptance_attempts: [],
     artifacts: null,
     attempts: { restart_count: 0, current_retry_attempt: null },
     current_interaction: null,

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
@@ -1164,6 +1164,7 @@ describe("useIssueRuntime lifecycle", () => {
     "prefers the last persisted transcript artifact when mounting a %s issue directly",
     async (status, terminalStepState) => {
       const terminalDetail = {
+        acceptance_attempts: [],
         issue_identifier: "todo-1",
         issue_id: "NODE_1",
         status,

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
@@ -80,6 +80,26 @@ const issue = {
   last_error: null,
   pending_input: null,
   current_interaction: null,
+  acceptance_attempts: [
+    {
+      cycle: 1,
+      results: [
+        {
+          version: 2,
+          name: "unit tests",
+          status: "passed",
+          summary: "tests passed",
+          timing: { kind: "unknown" },
+          evidence: {
+            kind: "command",
+            exit_code: 0,
+            stdout: { tail: "ok", total_bytes: 2, truncated: false },
+            stderr: { tail: "", total_bytes: 0, truncated: false },
+          },
+        },
+      ],
+    },
+  ],
 } satisfies IssueDetailSnapshot;
 
 const openInteraction = {
@@ -189,7 +209,7 @@ describe("IssueCommandPanel", () => {
       "aria-selected",
       "true",
     );
-    expect(screen.getAllByRole("tab")).toHaveLength(6);
+    expect(screen.getAllByRole("tab")).toHaveLength(7);
   });
 
   it("renders tabs in contract order and activates them with roving keyboard focus", async () => {
@@ -214,7 +234,15 @@ describe("IssueCommandPanel", () => {
     );
 
     const labels = screen.getAllByRole("tab").map((tab) => tab.textContent);
-    expect(labels).toEqual(["Overview", "Respond", "Steps", "Transcript", "Logs", "Artifacts"]);
+    expect(labels).toEqual([
+      "Overview",
+      "Respond",
+      "Steps",
+      "Transcript",
+      "Logs",
+      "Acceptance",
+      "Artifacts",
+    ]);
     const controlledPanelIds = screen
       .getAllByRole("tab")
       .map((tab) => tab.getAttribute("aria-controls"));
@@ -241,6 +269,8 @@ describe("IssueCommandPanel", () => {
     expect(screen.getByRole("tab", { name: "Overview" })).toHaveFocus();
     await user.keyboard("{ArrowLeft}");
     expect(screen.getByRole("tab", { name: "Artifacts" })).toHaveFocus();
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("tab", { name: "Acceptance" })).toHaveFocus();
   });
 
   it("notifies the parent when a tab is selected", async () => {
@@ -857,6 +887,17 @@ describe("IssueCommandPanel", () => {
     expect(screen.getByText("No run artifacts recorded.")).toBeInTheDocument();
     expect(screen.queryByText("Workspace")).not.toBeInTheDocument();
     expect(screen.getByText("Ship the command panel")).toBeInTheDocument();
+  });
+
+  it("renders generated acceptance attempts in the accessible Acceptance tab", () => {
+    renderPanel("acceptance");
+
+    expect(screen.getByRole("tab", { name: "Acceptance" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("unit tests")).toBeInTheDocument();
+    expect(screen.getByText("passed")).toBeInTheDocument();
   });
 
   it("reuses the artifact panel when run artifacts exist", () => {

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef, useState, type KeyboardEvent } from "react";
 import { X } from "lucide-react";
 import ArtifactsPanel from "@/components/ArtifactsPanel";
+import { AcceptanceEvidencePanel } from "@/components/AcceptanceEvidencePanel";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import FinalizeApprovalDialog from "@/components/FinalizeApprovalDialog";
 import EventTimeline from "@/components/EventTimeline";
@@ -19,6 +20,7 @@ export type IssueCommandPanelTab =
   | "steps"
   | "transcript"
   | "logs"
+  | "acceptance"
   | "artifacts";
 
 interface IssueCommandPanelProps {
@@ -34,6 +36,7 @@ const TABS: Array<{ id: IssueCommandPanelTab; label: string }> = [
   { id: "steps", label: "Steps" },
   { id: "transcript", label: "Transcript" },
   { id: "logs", label: "Logs" },
+  { id: "acceptance", label: "Acceptance" },
   { id: "artifacts", label: "Artifacts" },
 ];
 
@@ -396,6 +399,8 @@ function IssueCommandPanelContent({
             />
           </div>
         );
+      case "acceptance":
+        return <AcceptanceEvidencePanel attempts={data.acceptance_attempts} />;
       case "artifacts":
         return (
           <div className="space-y-3">

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
@@ -182,6 +182,7 @@ function mockMutation<T>(): T {
 
 function runtimeFixture(identifier: string): IssueRuntimeState {
   const data = {
+    acceptance_attempts: [],
     issue_identifier: identifier,
     issue_id: `id:${identifier}`,
     status: "running",
@@ -923,7 +924,7 @@ describe("Mission Control page", () => {
 
   it("restores valid preferences", async () => {
     window.localStorage.setItem(VIEW_MODE_KEY, "list");
-    window.localStorage.setItem(ACTIVE_TAB_KEY, "transcript");
+    window.localStorage.setItem(ACTIVE_TAB_KEY, "acceptance");
     window.localStorage.setItem(ATTENTION_ONLY_KEY, "true");
     const user = userEvent.setup();
     renderMissionControl(runtimeSnapshot());
@@ -935,7 +936,7 @@ describe("Mission Control page", () => {
         name: /Open\s*repo#2/i,
       }),
     );
-    expect(screen.getByRole("tab", { name: "Transcript" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Acceptance" })).toHaveAttribute("aria-selected", "true");
   });
 
   it("renders when localStorage access is unavailable", () => {

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
@@ -25,6 +25,7 @@ const PANEL_TABS: IssueCommandPanelTab[] = [
   "steps",
   "transcript",
   "logs",
+  "acceptance",
   "artifacts",
 ];
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2462,6 +2462,12 @@ Minimum endpoints:
     artifacts such as workspace path, repo branch/HEAD/change metadata, transcript metadata, and
     finalize output. These artifacts are independent of finalize mode; `finalize.mode: none` still
     records the workspace, repo, and transcript metadata.
+  - `acceptance_attempts` is an additive ordered array of the persisted version-2 acceptance
+    attempts. For an active or recovered run, the response copies the owning `PipelineRun` sequence;
+    a terminal history fallback copies the `HistoryRecord` sequence. Empty sequences and partial
+    result prefixes are returned unchanged. The API and Mission Control only present this stored
+    evidence: they do not re-evaluate acceptance, infer an outcome, inspect raw agent transcripts,
+    or consult current acceptance configuration or tracker state.
   - Suggested response shape:
 
     ```json


### PR DESCRIPTION
Closes #419

## Summary
- Project persisted acceptance attempts through live/recovered and history-backed issue-detail responses.
- Regenerate the typed client and present the evidence in Mission Control’s persisted Acceptance tab.
- Document ordered, copy-only evidence semantics.

## Validation
- `cargo test -p ensemble-core issue_snapshot_`
- `cargo test -p ensemble-core api::handlers::tests`
- `cargo test -p ensemble-core --test openapi_spec`
- `pnpm --dir crates/ensemble-ui/src-ui test`
- `pnpm --dir crates/ensemble-ui/src-ui run build`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`

The full Rust workspace suite is blocked locally by pre-existing parallel fixture failures in four delivery-recovery tests; the affected test passes in isolation. GitHub CI remains the merge gate.