### PR TITLE
Automate opted-in epic closure

### DIFF
--- a/.github/scripts/auto-close-epics.mjs
+++ b/.github/scripts/auto-close-epics.mjs
@@ -1,0 +1,160 @@
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const REQUIRED_LABEL_IDS = [
+  "LA_kwDORzdwYM8AAAACuWX7NA", // epic
+  "LA_kwDORzdwYM8AAAACu3F6Tg", // auto-close-epic
+];
+const CLOSE_COMMENT =
+  "All native sub-issues are closed and no native blocker remains open. " +
+  "Closing this opted-in epic automatically.";
+
+export class GhClient {
+  constructor(runGh) {
+    this.runGh = runGh;
+  }
+
+  async getParent({ repository, number }) {
+    let output;
+    try {
+      output = this.runGh([
+        "api",
+        `repos/${repository}/issues/${number}/parent`,
+      ]).trim();
+    } catch (error) {
+      try {
+        const response = JSON.parse(String(error.stdout));
+        if (
+          response.status === "404" &&
+          response.message === "No parent issue found"
+        ) {
+          return null;
+        }
+      } catch {
+        // The original GitHub CLI failure is more useful than a parse error.
+      }
+      throw error;
+    }
+    if (!output) return null;
+
+    return JSON.parse(output);
+  }
+
+  async closeIssue({ repository, number }) {
+    this.runGh([
+      "issue",
+      "close",
+      String(number),
+      "--repo",
+      repository,
+      "--reason",
+      "completed",
+      "--comment",
+      CLOSE_COMMENT,
+    ]);
+  }
+}
+
+function ineligibleReason(issue) {
+  const labelIds = new Set(issue.labels?.map(({ node_id }) => node_id) ?? []);
+  const subIssues = issue.sub_issues_summary;
+  const dependencies = issue.issue_dependencies_summary;
+
+  if (issue.state !== "open") return "parent is not open";
+  if (!REQUIRED_LABEL_IDS.every((labelId) => labelIds.has(labelId))) {
+    return "parent is not opted in";
+  }
+  if (
+    !Number.isInteger(subIssues?.total) ||
+    !Number.isInteger(subIssues?.completed) ||
+    !Number.isInteger(dependencies?.blocked_by)
+  ) {
+    return "GitHub omitted required completion metadata";
+  }
+  if (subIssues.total === 0) return "parent has no native sub-issues";
+  if (subIssues.completed !== subIssues.total) {
+    return `${subIssues.total - subIssues.completed} native sub-issue(s) remain open`;
+  }
+  if (dependencies.blocked_by > 0) {
+    return `${dependencies.blocked_by} native blocker(s) remain open`;
+  }
+  return null;
+}
+
+export function canAutoCloseEpic(issue) {
+  return ineligibleReason(issue) === null;
+}
+
+export async function closeEligibleAncestors({
+  repository,
+  issueNumber,
+  client,
+  logger = console,
+}) {
+  let current = { repository, number: issueNumber };
+
+  while (true) {
+    const issue = await client.getParent(current);
+    if (!issue) return;
+
+    const parent = {
+      repository: issue.repository?.full_name,
+      number: issue.number,
+    };
+    if (!parent.repository || !Number.isSafeInteger(parent.number)) {
+      throw new Error("GitHub returned incomplete parent identity metadata");
+    }
+    if (parent.repository !== repository) {
+      logger.warn(
+        `Skipping cross-repository parent ${parent.repository}#${parent.number}`,
+      );
+      return;
+    }
+    if (issue.state === "closed") {
+      current = parent;
+      continue;
+    }
+
+    const reason = ineligibleReason(issue);
+    if (reason) {
+      logger.info(`Leaving ${repository}#${parent.number} open: ${reason}`);
+      return;
+    }
+
+    await client.closeIssue(parent);
+    logger.info(`Closed ${repository}#${parent.number}`);
+    current = parent;
+  }
+}
+
+function runGh(args) {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+    timeout: 30_000,
+  });
+}
+
+export async function main(environment = process.env) {
+  const repository = environment.GITHUB_REPOSITORY;
+  const issueNumber = Number(environment.ISSUE_NUMBER);
+  if (!repository || !Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error("GITHUB_REPOSITORY and a positive ISSUE_NUMBER are required");
+  }
+
+  await closeEligibleAncestors({
+    repository,
+    issueNumber,
+    client: new GhClient(runGh),
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/auto-close-epics.test.mjs
+++ b/.github/scripts/auto-close-epics.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  GhClient,
+  canAutoCloseEpic,
+  closeEligibleAncestors,
+} from "./auto-close-epics.mjs";
+
+function eligibleIssue(overrides = {}) {
+  return {
+    number: 462,
+    state: "open",
+    repository: { full_name: "chrisbanes/ensemble" },
+    labels: [
+      { name: "epic", node_id: "LA_kwDORzdwYM8AAAACuWX7NA" },
+      {
+        name: "auto-close-epic",
+        node_id: "LA_kwDORzdwYM8AAAACu3F6Tg",
+      },
+    ],
+    sub_issues_summary: { total: 3, completed: 3 },
+    issue_dependencies_summary: { blocked_by: 0 },
+    ...overrides,
+  };
+}
+
+test("closes an opted-in epic when every child is closed and no blocker is open", () => {
+  assert.equal(canAutoCloseEpic(eligibleIssue()), true);
+});
+
+test("fails closed when GitHub omits completion metadata", () => {
+  const issue = eligibleIssue({
+    sub_issues_summary: undefined,
+    issue_dependencies_summary: undefined,
+  });
+
+  assert.equal(canAutoCloseEpic(issue), false);
+});
+
+test("does not transfer closure authority to recreated labels", () => {
+  const issue = eligibleIssue({
+    labels: [
+      { name: "epic", node_id: "new-epic" },
+      { name: "auto-close-epic", node_id: "new-auto-close-epic" },
+    ],
+  });
+
+  assert.equal(canAutoCloseEpic(issue), false);
+});
+
+for (const [name, override] of [
+  [
+    "the opt-in label is absent",
+    { labels: [{ name: "epic", node_id: "LA_kwDORzdwYM8AAAACuWX7NA" }] },
+  ],
+  ["the epic has no children", { sub_issues_summary: { total: 0, completed: 0 } }],
+  ["a child remains open", { sub_issues_summary: { total: 3, completed: 2 } }],
+  ["a blocker remains open", { issue_dependencies_summary: { blocked_by: 1 } }],
+]) {
+  test(`does not close when ${name}`, () => {
+    assert.equal(canAutoCloseEpic(eligibleIssue(override)), false);
+  });
+}
+
+test("closes an eligible parent after its final child closes", async () => {
+  const closed = [];
+  const client = {
+    async getParent({ number }) {
+      return number === 465
+        ? eligibleIssue({ sub_issues_summary: { total: 4, completed: 4 } })
+        : null;
+    },
+    async closeIssue(issue) {
+      closed.push(issue.number);
+    },
+  };
+
+  await closeEligibleAncestors({
+    repository: "chrisbanes/ensemble",
+    issueNumber: 465,
+    client,
+    logger: { info() {}, warn() {} },
+  });
+
+  assert.deepEqual(closed, [462]);
+});
+
+test("reads the native parent identity from GitHub CLI", async () => {
+  const calls = [];
+  const client = new GhClient((args) => {
+    calls.push(args);
+    return JSON.stringify(eligibleIssue());
+  });
+
+  const parent = await client.getParent({
+    repository: "chrisbanes/ensemble",
+    number: 465,
+  });
+
+  assert.deepEqual(parent, eligibleIssue());
+  assert.deepEqual(calls, [
+    ["api", "repos/chrisbanes/ensemble/issues/465/parent"],
+  ]);
+});
+
+test("treats GitHub's no-parent response as a root issue", async () => {
+  const client = new GhClient(() => {
+    const error = new Error("HTTP 404");
+    error.stdout = '{"message":"No parent issue found","status":"404"}';
+    throw error;
+  });
+
+  assert.equal(
+    await client.getParent({
+      repository: "chrisbanes/ensemble",
+      number: 462,
+    }),
+    null,
+  );
+});
+
+test("does not hide unrelated GitHub 404 failures", async () => {
+  const error = new Error("HTTP 404");
+  error.stdout = '{"message":"Not Found","status":"404"}';
+  const client = new GhClient(() => {
+    throw error;
+  });
+
+  await assert.rejects(
+    client.getParent({ repository: "chrisbanes/ensemble", number: 999 }),
+    error,
+  );
+});
+
+test("leaves a cross-repository parent open", async () => {
+  const closed = [];
+  const warnings = [];
+  const client = {
+    async getParent() {
+      return eligibleIssue({ repository: { full_name: "chrisbanes/other" } });
+    },
+    async closeIssue(issue) {
+      closed.push(issue.number);
+    },
+  };
+
+  await closeEligibleAncestors({
+    repository: "chrisbanes/ensemble",
+    issueNumber: 465,
+    client,
+    logger: { info() {}, warn(message) { warnings.push(message); } },
+  });
+
+  assert.deepEqual(closed, []);
+  assert.deepEqual(warnings, [
+    "Skipping cross-repository parent chrisbanes/other#462",
+  ]);
+});
+
+test("closes an eligible epic through GitHub CLI", async () => {
+  const calls = [];
+  const client = new GhClient((args) => {
+    calls.push(args);
+    return "";
+  });
+  const reference = { repository: "chrisbanes/ensemble", number: 304 };
+
+  await client.closeIssue(reference);
+
+  assert.deepEqual(calls[0].slice(0, 8), [
+    "issue",
+    "close",
+    "304",
+    "--repo",
+    "chrisbanes/ensemble",
+    "--reason",
+    "completed",
+    "--comment",
+  ]);
+  assert.match(calls[0][8], /all native sub-issues are closed/i);
+});

--- a/.github/workflows/auto-close-epics.yml
+++ b/.github/workflows/auto-close-epics.yml
@@ -1,0 +1,36 @@
+name: Auto-close epics
+
+on:
+  issues:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Closed issue whose ancestor chain should be reconciled
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: auto-close-epics
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.18.1
+
+      - name: Close eligible ancestor epics
+        run: node .github/scripts/auto-close-epics.mjs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: crates/ensemble-ui/src-ui/pnpm-lock.yaml
 
+      - name: Test repository automation
+        run: node --test .github/scripts/auto-close-epics.test.mjs
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Install frontend dependencies

--- a/docs/agents/run-github-project.md
+++ b/docs/agents/run-github-project.md
@@ -39,8 +39,23 @@
 
 - Epic label: `epic`
 - Epic label ID: `LA_kwDORzdwYM8AAAACuWX7NA`
+- Auto-close epic label: `auto-close-epic`
+- Auto-close epic label ID: `LA_kwDORzdwYM8AAAACu3F6Tg`
 - Human-work label: `ready-for-human`
 - Human-work label ID: `LA_kwDORzdwYM8AAAACuAxOsQ`
+
+Epics are not auto-closed by default. Applying `auto-close-epic` delegates
+closure authority to `.github/workflows/auto-close-epics.yml`. When an issue
+closes, that workflow walks its same-repository native parent chain and closes
+an open parent only when the parent also has `epic`, has at least one native
+sub-issue, every native sub-issue is closed, and no native blocker remains open.
+Missing metadata fails closed. The workflow then continues up the chain so
+opted-in nested epics can complete in one serialized run. Cross-repository
+parents are logged and left open because the repository workflow token does not
+have authority outside this repository.
+
+Do not apply `auto-close-epic` to coordination issues with completion gates that
+are not fully represented by native sub-issues and blockers.
 
 ## Priority
 
@@ -62,4 +77,6 @@
 - Automation description: Enabled Project workflows `Item closed` and
   `Pull request merged`; verified that merged-and-closed issue #182 moved from
   `In progress` to `Done` through `github-project-automation` and remained
-  unarchived.
+  unarchived. Repository workflow `Auto-close epics` closes explicitly opted-in
+  epic issues after their native sub-issues and blockers complete; `Item closed`
+  then projects the epic to `Done`.


### PR DESCRIPTION
## What changed

- add an `issues.closed` workflow that walks same-repository native parent issues
- close only epics carrying the immutable `epic` and `auto-close-epic` label identities
- require at least one child, every child closed, and zero open native blockers
- serialize reconciliation, cascade within one run, and bound both job and GitHub CLI calls
- add a manual reconciliation input, focused Node tests, CI coverage, and Project contract documentation

## Why

Closing the final child currently leaves coordination epics open until a maintainer notices. The opt-in label delegates that closure authority explicitly while keeping release gates such as #314 human-owned.

The repository's existing Project workflow will continue moving closed issues to Done.

## Live configuration

Created `auto-close-epic` and applied it to #217, #304, #328, and #462. #314 is deliberately excluded.

## Validation

- `node --test .github/scripts/auto-close-epics.test.mjs` (13 tests)
- `actionlint .github/workflows/auto-close-epics.yml .github/workflows/ci.yml`
- `git diff --check`
- live no-op smoke tests against root issue #90 and closed child #177; #217 remained open at 1/4 children complete
- final review-and-simplify and ponytail-review passes were clean