### PR TITLE
Add live dogfood tracer bullet

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -3,11 +3,12 @@
 use serde_json::Value;
 use std::ffi::OsString;
 use std::fs;
-use std::io;
+use std::io::{self, Read};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 
 const ISSUE_ID: &str = "E2E-1";
@@ -677,4 +678,992 @@ fn section_contains_issue(markdown: &str, section: &str, issue_id: &str) -> bool
     }
 
     false
+}
+
+const LIVE_DOGFOOD_OPT_IN: &str = "ENSEMBLE_LIVE_DOGFOOD";
+const LIVE_DOGFOOD_PROJECT: &str = "ENSEMBLE_DOGFOOD_PROJECT_NUMBER";
+const LIVE_DOGFOOD_BAMBOON_PATH: &str = "ENSEMBLE_DOGFOOD_BAMBOON_PATH";
+const LIVE_DOGFOOD_AGENT: &str = "ENSEMBLE_DOGFOOD_AGENT";
+const LIVE_DOGFOOD_STATUSES: [&str; 4] = ["Ready to implement", "In progress", "In review", "Done"];
+static LIVE_DOGFOOD_SEQUENCE: AtomicU32 = AtomicU32::new(0);
+
+#[derive(Debug)]
+struct LiveDogfoodInputs {
+    project_number: u64,
+    bamboon_path: PathBuf,
+    agent: String,
+}
+
+impl LiveDogfoodInputs {
+    fn from_env() -> Result<Self, String> {
+        Self::from_values(
+            std::env::var(LIVE_DOGFOOD_OPT_IN).ok().as_deref(),
+            std::env::var(LIVE_DOGFOOD_PROJECT).ok().as_deref(),
+            std::env::var(LIVE_DOGFOOD_BAMBOON_PATH).ok().as_deref(),
+            std::env::var(LIVE_DOGFOOD_AGENT).ok().as_deref(),
+        )
+    }
+
+    fn from_values(
+        opt_in: Option<&str>,
+        project_number: Option<&str>,
+        bamboon_path: Option<&str>,
+        agent: Option<&str>,
+    ) -> Result<Self, String> {
+        if opt_in != Some("1") {
+            return Err(format!("{LIVE_DOGFOOD_OPT_IN} must be exactly 1"));
+        }
+        let project_number = project_number
+            .filter(|value| !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
+            .ok_or_else(|| format!("{LIVE_DOGFOOD_PROJECT} must be a positive decimal value"))?
+            .parse::<u64>()
+            .ok()
+            .filter(|number| *number > 0)
+            .ok_or_else(|| format!("{LIVE_DOGFOOD_PROJECT} must be a positive decimal value"))?;
+        let bamboon_path = PathBuf::from(
+            bamboon_path
+                .ok_or_else(|| format!("{LIVE_DOGFOOD_BAMBOON_PATH} must be an absolute path"))?,
+        );
+        if !bamboon_path.is_absolute() {
+            return Err(format!(
+                "{LIVE_DOGFOOD_BAMBOON_PATH} must be an absolute path"
+            ));
+        }
+
+        Ok(Self {
+            project_number,
+            bamboon_path,
+            agent: agent
+                .filter(|value| !value.is_empty())
+                .unwrap_or("codex")
+                .to_string(),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct LiveDogfoodRun {
+    marker: String,
+    root: PathBuf,
+}
+
+impl LiveDogfoodRun {
+    fn create() -> io::Result<Self> {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(io::Error::other)?
+            .as_nanos();
+        let marker = live_dogfood_marker(
+            timestamp,
+            std::process::id(),
+            LIVE_DOGFOOD_SEQUENCE.fetch_add(1, Ordering::Relaxed),
+        );
+        let root = std::env::temp_dir()
+            .join("ensemble-live-dogfood")
+            .join(&marker);
+        fs::create_dir_all(&root)?;
+        Ok(Self { marker, root })
+    }
+
+    fn expected_artifact(&self) -> ExpectedDogfoodArtifact {
+        ExpectedDogfoodArtifact {
+            path: PathBuf::from("docs/ensemble-dogfood").join(format!("{}.md", self.marker)),
+            content: format!("# Ensemble live dogfood\n\nMarker: `{}`\n", self.marker),
+            commit_message: format!("Add live dogfood artifact {}", self.marker),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ExpectedDogfoodArtifact {
+    path: PathBuf,
+    content: String,
+    commit_message: String,
+}
+
+fn live_dogfood_marker(timestamp_nanos: u128, process_id: u32, sequence: u32) -> String {
+    format!("live-dogfood-{timestamp_nanos:x}-{process_id:x}-{sequence:x}")
+}
+
+fn redact_live_dogfood(value: &str, inputs: &LiveDogfoodInputs, token: Option<&str>) -> String {
+    let mut redacted = value
+        .replace(&inputs.project_number.to_string(), "[REDACTED]")
+        .replace(&inputs.bamboon_path.display().to_string(), "[REDACTED]");
+    if let Some(token) = token.filter(|token| !token.is_empty()) {
+        redacted = redacted.replace(token, "[REDACTED]");
+    }
+    redacted
+}
+
+fn live_dogfood_config(inputs: &LiveDogfoodInputs, run: &LiveDogfoodRun) -> String {
+    let artifact = run.expected_artifact();
+    format!(
+        r#"tracker:
+  kind: github
+  repository: chrisbanes/bamboon
+  project_number: {}
+  active_states:
+    - Ready to implement
+  terminal_states:
+    - Done
+workspace:
+  root: {}
+repos:
+  - path: {}
+    branch: main
+    finalize:
+      mode: none
+agents:
+  builder:
+    acpx_agent: {}
+    prompt: >-
+      Work only on this issue. Create exactly {} with exactly this content:
+      {} Commit it with exactly this message: {}. Run a lightweight verification.
+      Do not push, create a pull request, or change any other tracked file. End with a JSON
+      step output declaring success and a concise summary.
+steps:
+  - name: implement
+    agent: builder
+    tracker_state: In progress
+on_success: Done
+on_failure: Done
+max_cycles: 1
+polling:
+  interval_ms: 1000
+concurrency:
+  max_concurrent_agents: 1
+  max_step_parallelism: 1
+agent:
+  turn_timeout_ms: 1800000
+"#,
+        inputs.project_number,
+        yaml_quote(&run.root.join("workspaces").display().to_string()),
+        yaml_quote(&inputs.bamboon_path.display().to_string()),
+        yaml_quote(&inputs.agent),
+        yaml_quote(&artifact.path.display().to_string()),
+        yaml_quote(&artifact.content),
+        yaml_quote(&artifact.commit_message),
+    )
+}
+
+struct LiveDogfoodProject {
+    id: String,
+    status_field_id: String,
+    ready_option_id: String,
+}
+
+struct LiveDogfoodResources {
+    issue_id: String,
+    issue_number: u64,
+    project_id: String,
+    project_item_id: String,
+    dispatch_started: bool,
+}
+
+fn run_live_command(
+    phase: &str,
+    mut command: Command,
+    inputs: &LiveDogfoodInputs,
+) -> Result<String, String> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("{phase}: could not start command: {error}"))?;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(50)),
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("{phase}: command timed out after 30 seconds"));
+            }
+            Err(error) => return Err(format!("{phase}: command wait failed: {error}")),
+        }
+    };
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        let _ = pipe.read_to_string(&mut stdout);
+    }
+    if let Some(mut pipe) = child.stderr.take() {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    if status.success() {
+        Ok(stdout)
+    } else {
+        let last_observation = redact_live_dogfood(&stderr, inputs, None);
+        Err(format!(
+            "{phase}: command exited {status}; last observation: {last_observation}"
+        ))
+    }
+}
+
+fn live_gh(
+    phase: &str,
+    arguments: impl IntoIterator<Item = String>,
+    inputs: &LiveDogfoodInputs,
+) -> Result<String, String> {
+    let mut command = Command::new("gh");
+    command.args(arguments);
+    run_live_command(phase, command, inputs)
+}
+
+fn live_git(
+    phase: &str,
+    path: &Path,
+    arguments: impl IntoIterator<Item = String>,
+    inputs: &LiveDogfoodInputs,
+) -> Result<String, String> {
+    let mut command = Command::new("git");
+    command.current_dir(path).args(arguments);
+    run_live_command(phase, command, inputs)
+}
+
+fn live_project_query(inputs: &LiveDogfoodInputs) -> Result<Value, String> {
+    const QUERY: &str = r#"query($owner: String!, $repo: String!, $projectNumber: Int!) {
+  repository(owner: $owner, name: $repo) {
+    projectV2(number: $projectNumber) {
+      id title viewerCanUpdate
+      fields(first: 100) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } }
+      items(first: 100) {
+        totalCount
+        nodes {
+          id
+          content { ... on Issue { id number } }
+          fieldValues(first: 20) {
+            nodes { ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2SingleSelectField { name } } } }
+          }
+        }
+      }
+      workflows(first: 100) { nodes { enabled } }
+    }
+  }
+}"#;
+    let output = live_gh(
+        "preflight project discovery",
+        [
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={QUERY}"),
+            "-F".to_string(),
+            "owner=chrisbanes".to_string(),
+            "-F".to_string(),
+            "repo=bamboon".to_string(),
+            "-F".to_string(),
+            format!("projectNumber={}", inputs.project_number),
+        ],
+        inputs,
+    )?;
+    serde_json::from_str(&output)
+        .map_err(|error| format!("preflight project discovery: invalid response: {error}"))
+}
+
+fn validate_live_project(inputs: &LiveDogfoodInputs) -> Result<LiveDogfoodProject, String> {
+    let response = live_project_query(inputs)?;
+    let project = &response["data"]["repository"]["projectV2"];
+    if project["title"] != "Ensemble Dogfood" || project["viewerCanUpdate"] != true {
+        return Err("preflight project discovery: Project title or write access did not match the fixture contract".to_string());
+    }
+    if project["items"]["totalCount"].as_u64() != Some(0) {
+        return Err(
+            "preflight project discovery: Project must have no items before dispatch".to_string(),
+        );
+    }
+    if project["workflows"]["nodes"]
+        .as_array()
+        .is_none_or(|workflows| workflows.iter().any(|workflow| workflow["enabled"] == true))
+    {
+        return Err(
+            "preflight project discovery: Project must not have enabled workflows".to_string(),
+        );
+    }
+    let status_fields = project["fields"]["nodes"]
+        .as_array()
+        .ok_or_else(|| "preflight project discovery: Project fields were unavailable".to_string())?
+        .iter()
+        .filter(|field| field["name"] == "Status")
+        .collect::<Vec<_>>();
+    if status_fields.len() != 1 {
+        return Err(
+            "preflight project discovery: Project must have exactly one Status field".to_string(),
+        );
+    }
+    let status_field = status_fields[0];
+    let status_names = status_field["options"]
+        .as_array()
+        .ok_or_else(|| "preflight project discovery: Status options were unavailable".to_string())?
+        .iter()
+        .filter_map(|option| option["name"].as_str())
+        .collect::<Vec<_>>();
+    if status_names != LIVE_DOGFOOD_STATUSES {
+        return Err(
+            "preflight project discovery: Status options did not match the fixture contract"
+                .to_string(),
+        );
+    }
+    Ok(LiveDogfoodProject {
+        id: project["id"]
+            .as_str()
+            .ok_or_else(|| "preflight project discovery: Project ID was unavailable".to_string())?
+            .to_string(),
+        status_field_id: status_field["id"]
+            .as_str()
+            .ok_or_else(|| {
+                "preflight project discovery: Status field ID was unavailable".to_string()
+            })?
+            .to_string(),
+        ready_option_id: status_field["options"]
+            .as_array()
+            .and_then(|options| options.first())
+            .and_then(|option| option["id"].as_str())
+            .ok_or_else(|| {
+                "preflight project discovery: Ready status ID was unavailable".to_string()
+            })?
+            .to_string(),
+    })
+}
+
+fn validate_live_bamboon_clone(inputs: &LiveDogfoodInputs) -> Result<(), String> {
+    let root = &inputs.bamboon_path;
+    if !root.is_dir() {
+        return Err("preflight Bamboon clone: configured path was not a directory".to_string());
+    }
+    let inside = live_git(
+        "preflight Bamboon clone",
+        root,
+        ["rev-parse".to_string(), "--is-inside-work-tree".to_string()],
+        inputs,
+    )?;
+    if inside.trim() != "true" {
+        return Err("preflight Bamboon clone: configured path was not a Git worktree".to_string());
+    }
+    let branch = live_git(
+        "preflight Bamboon branch",
+        root,
+        ["branch".to_string(), "--show-current".to_string()],
+        inputs,
+    )?;
+    if branch.trim() != "main" {
+        return Err("preflight Bamboon branch: checked-out branch must be main".to_string());
+    }
+    let remote = live_git(
+        "preflight Bamboon remote",
+        root,
+        [
+            "remote".to_string(),
+            "get-url".to_string(),
+            "origin".to_string(),
+        ],
+        inputs,
+    )?;
+    if !is_bamboon_remote(remote.trim()) {
+        return Err(
+            "preflight Bamboon remote: origin must identify chrisbanes/bamboon".to_string(),
+        );
+    }
+    let status = live_git(
+        "preflight Bamboon cleanliness",
+        root,
+        ["status".to_string(), "--porcelain".to_string()],
+        inputs,
+    )?;
+    if !status.is_empty() {
+        return Err(
+            "preflight Bamboon cleanliness: clone must have no tracked or untracked changes"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn is_bamboon_remote(remote: &str) -> bool {
+    matches!(
+        remote.strip_suffix(".git").unwrap_or(remote),
+        "git@github.com:chrisbanes/bamboon"
+            | "ssh://git@github.com/chrisbanes/bamboon"
+            | "https://github.com/chrisbanes/bamboon"
+    )
+}
+
+fn live_preflight(inputs: &LiveDogfoodInputs, run: &LiveDogfoodRun) -> Result<String, String> {
+    run_live_command("preflight gh", Command::new("gh"), inputs)?;
+    let mut acpx = Command::new("acpx");
+    acpx.arg("--version");
+    let acpx_version = run_live_command("preflight ACPX", acpx, inputs)?;
+    fs::write(run.root.join("acpx.version"), acpx_version)
+        .map_err(|error| format!("preflight ACPX: could not retain version metadata: {error}"))?;
+    validate_live_bamboon_clone(inputs)?;
+    live_gh(
+        "preflight GitHub access",
+        ["api".to_string(), "user".to_string()],
+        inputs,
+    )?;
+    validate_live_project(inputs)?;
+    let token = live_gh(
+        "preflight GitHub token",
+        ["auth".to_string(), "token".to_string()],
+        inputs,
+    )?;
+    if token.trim().is_empty() {
+        return Err("preflight GitHub token: gh returned an empty token".to_string());
+    }
+    Ok(token.trim().to_string())
+}
+
+fn live_project_item_status(
+    inputs: &LiveDogfoodInputs,
+    issue_id: &str,
+) -> Result<Option<String>, String> {
+    let response = live_project_query(inputs)?;
+    Ok(
+        response["data"]["repository"]["projectV2"]["items"]["nodes"]
+            .as_array()
+            .and_then(|items| {
+                items
+                    .iter()
+                    .find(|item| item["content"]["id"] == issue_id)
+                    .and_then(|item| item["fieldValues"]["nodes"].as_array())
+                    .and_then(|fields| {
+                        fields.iter().find_map(|field| {
+                            (field["field"]["name"] == "Status")
+                                .then(|| field["name"].as_str().map(ToString::to_string))
+                                .flatten()
+                        })
+                    })
+            }),
+    )
+}
+
+fn live_graphql_mutation(
+    phase: &str,
+    query: &str,
+    variables: impl IntoIterator<Item = (String, String)>,
+    inputs: &LiveDogfoodInputs,
+) -> Result<Value, String> {
+    let mut arguments = vec![
+        "api".to_string(),
+        "graphql".to_string(),
+        "-f".to_string(),
+        format!("query={query}"),
+    ];
+    for (name, value) in variables {
+        arguments.extend(["-F".to_string(), format!("{name}={value}")]);
+    }
+    let output = live_gh(phase, arguments, inputs)?;
+    serde_json::from_str(&output).map_err(|error| format!("{phase}: invalid response: {error}"))
+}
+
+fn rollback_pre_dispatch(resources: &LiveDogfoodResources, inputs: &LiveDogfoodInputs) {
+    const REMOVE_ITEM: &str = r#"mutation($projectId: ID!, $itemId: ID!) {
+  deleteProjectV2Item(input: {projectId: $projectId, itemId: $itemId}) { deletedItemId }
+}"#;
+    if !resources.project_item_id.is_empty() {
+        let _ = live_graphql_mutation(
+            "pre-dispatch rollback project item",
+            REMOVE_ITEM,
+            [
+                ("projectId".to_string(), resources.project_id.clone()),
+                ("itemId".to_string(), resources.project_item_id.clone()),
+            ],
+            inputs,
+        );
+    }
+    let _ = live_gh(
+        "pre-dispatch rollback issue",
+        [
+            "api".to_string(),
+            "--method".to_string(),
+            "PATCH".to_string(),
+            format!("repos/chrisbanes/bamboon/issues/{}", resources.issue_number),
+            "-f".to_string(),
+            "state=closed".to_string(),
+        ],
+        inputs,
+    );
+}
+
+fn create_live_resources(
+    inputs: &LiveDogfoodInputs,
+    run: &LiveDogfoodRun,
+    project: &LiveDogfoodProject,
+) -> Result<LiveDogfoodResources, String> {
+    let artifact = run.expected_artifact();
+    let issue = live_gh(
+        "create synthetic issue",
+        [
+            "api".to_string(),
+            "--method".to_string(),
+            "POST".to_string(),
+            "repos/chrisbanes/bamboon/issues".to_string(),
+            "-f".to_string(),
+            format!("title=Ensemble live dogfood {}", run.marker),
+            "-f".to_string(),
+            format!(
+                "body=Create exactly `{}` with exactly this content:\n\n```text\n{}\n```\n\nCommit with `{}`. Run a lightweight verification. Do not push or create a pull request.\n\nMarker: `{}`",
+                artifact.path.display(), artifact.content, artifact.commit_message, run.marker
+            ),
+        ],
+        inputs,
+    )?;
+    let issue: Value = serde_json::from_str(&issue)
+        .map_err(|error| format!("create synthetic issue: invalid response: {error}"))?;
+    let issue_id = issue["node_id"]
+        .as_str()
+        .ok_or_else(|| "create synthetic issue: missing node ID".to_string())?
+        .to_string();
+    let issue_number = issue["number"]
+        .as_u64()
+        .ok_or_else(|| "create synthetic issue: missing number".to_string())?;
+
+    const ADD_ITEM: &str = r#"mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) { item { id } }
+}"#;
+    let add_item = live_graphql_mutation(
+        "add synthetic issue to Project",
+        ADD_ITEM,
+        [
+            ("projectId".to_string(), project.id.clone()),
+            ("contentId".to_string(), issue_id.clone()),
+        ],
+        inputs,
+    );
+    let project_item_id = match add_item {
+        Ok(value) => match value["data"]["addProjectV2ItemById"]["item"]["id"].as_str() {
+            Some(id) => id.to_string(),
+            None => {
+                let resources = LiveDogfoodResources {
+                    issue_id,
+                    issue_number,
+                    project_id: project.id.clone(),
+                    project_item_id: String::new(),
+                    dispatch_started: false,
+                };
+                rollback_pre_dispatch(&resources, inputs);
+                return Err("add synthetic issue to Project: missing Project item ID".to_string());
+            }
+        },
+        Err(error) => {
+            let resources = LiveDogfoodResources {
+                issue_id,
+                issue_number,
+                project_id: project.id.clone(),
+                project_item_id: String::new(),
+                dispatch_started: false,
+            };
+            rollback_pre_dispatch(&resources, inputs);
+            return Err(error);
+        }
+    };
+    let mut resources = LiveDogfoodResources {
+        issue_id,
+        issue_number,
+        project_id: project.id.clone(),
+        project_item_id,
+        dispatch_started: false,
+    };
+
+    const SET_STATUS: &str = r#"mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {singleSelectOptionId: $optionId}}) { projectV2Item { id } }
+}"#;
+    if let Err(error) = live_graphql_mutation(
+        "make synthetic issue ready",
+        SET_STATUS,
+        [
+            ("projectId".to_string(), project.id.clone()),
+            ("itemId".to_string(), resources.project_item_id.clone()),
+            ("fieldId".to_string(), project.status_field_id.clone()),
+            ("optionId".to_string(), project.ready_option_id.clone()),
+        ],
+        inputs,
+    ) {
+        rollback_pre_dispatch(&resources, inputs);
+        return Err(error);
+    }
+    resources.dispatch_started = true;
+    Ok(resources)
+}
+
+fn spawn_live_host(
+    inputs: &LiveDogfoodInputs,
+    run: &LiveDogfoodRun,
+    token: &str,
+    port: u16,
+) -> Result<Child, String> {
+    fs::write(
+        run.root.join("config.yaml"),
+        live_dogfood_config(inputs, run),
+    )
+    .map_err(|error| format!("start host: could not write generated config: {error}"))?;
+    let stdout = fs::File::create(run.root.join("host.stdout.log"))
+        .map_err(|error| format!("start host: could not create stdout log: {error}"))?;
+    let stderr = fs::File::create(run.root.join("host.stderr.log"))
+        .map_err(|error| format!("start host: could not create stderr log: {error}"))?;
+    Command::new(env!("CARGO_BIN_EXE_ensemble"))
+        .arg("web")
+        .arg("--config-dir")
+        .arg(&run.root)
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("GITHUB_TOKEN", token)
+        .env("ENSEMBLE_LOG", "info")
+        .env("ENSEMBLE_LOG_FORMAT", "json")
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .map_err(|error| format!("start host: could not spawn ensemble web: {error}"))
+}
+
+async fn wait_for_live_project_status(
+    inputs: &LiveDogfoodInputs,
+    issue_id: &str,
+    target: &str,
+) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(90);
+    loop {
+        let last_observation = match live_project_item_status(inputs, issue_id) {
+            Ok(Some(status)) if status == target => return Ok(()),
+            Ok(status) => format!(
+                "observed status {}",
+                status.unwrap_or_else(|| "missing".to_string())
+            ),
+            Err(error) => error,
+        };
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "wait for Project status {target}: timed out; last observation: {}",
+                redact_live_dogfood(&last_observation, inputs, None)
+            ));
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn wait_for_live_completion(
+    client: &reqwest::Client,
+    base_url: &str,
+    issue_number: u64,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(30 * 60);
+    let url = format!("{base_url}/api/v1/chrisbanes%2Fbamboon%23{issue_number}");
+    loop {
+        let last_observation = match client.get(&url).send().await {
+            Ok(response) if response.status().is_success() => {
+                let detail = response
+                    .json::<Value>()
+                    .await
+                    .map_err(|error| error.to_string())?;
+                if detail["status"] == "completed_succeeded" {
+                    return Ok(detail);
+                }
+                detail["status"].as_str().unwrap_or("unknown").to_string()
+            }
+            Ok(response) => format!("issue detail returned {}", response.status()),
+            Err(error) => error.to_string(),
+        };
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "wait for terminal host state: timed out; last observation: {}",
+                last_observation
+            ));
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn wait_for_live_history(
+    client: &reqwest::Client,
+    base_url: &str,
+    issue_number: u64,
+) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let identifier = format!("chrisbanes/bamboon#{issue_number}");
+    loop {
+        let response = client
+            .get(format!(
+                "{base_url}/api/v1/history?outcome=succeeded&step=implement"
+            ))
+            .send()
+            .await
+            .map_err(|error| format!("wait for public history: {error}"))?;
+        let history = response
+            .json::<Value>()
+            .await
+            .map_err(|error| format!("wait for public history: invalid response: {error}"))?;
+        if history["records"].as_array().is_some_and(|records| {
+            records
+                .iter()
+                .any(|record| record["issue_identifier"] == identifier)
+        }) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "wait for public history: timed out; last observation: {history}"
+            ));
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+fn verify_live_artifact(
+    inputs: &LiveDogfoodInputs,
+    run: &LiveDogfoodRun,
+    resources: &LiveDogfoodResources,
+) -> Result<(String, String), String> {
+    let artifact = run.expected_artifact();
+    let repo_root = run.root.join("workspaces").join("bamboon");
+    let worktree = fs::read_dir(&repo_root)
+        .map_err(|error| format!("verify local commit: worktree root was unavailable: {error}"))?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.is_dir())
+        .ok_or_else(|| "verify local commit: no Bamboon issue worktree was found".to_string())?;
+    let actual_content = fs::read_to_string(worktree.join(&artifact.path))
+        .map_err(|error| format!("verify local commit: expected artifact was absent: {error}"))?;
+    if actual_content != artifact.content {
+        return Err("verify local commit: expected artifact content did not match".to_string());
+    }
+    let status = live_git(
+        "verify local worktree cleanliness",
+        &worktree,
+        ["status".to_string(), "--porcelain".to_string()],
+        inputs,
+    )?;
+    if !status.is_empty() {
+        return Err(
+            "verify local worktree cleanliness: worktree had uncommitted changes".to_string(),
+        );
+    }
+    let branch = live_git(
+        "verify generated branch",
+        &worktree,
+        ["branch".to_string(), "--show-current".to_string()],
+        inputs,
+    )?
+    .trim()
+    .to_string();
+    if !branch.starts_with("ensemble-") {
+        return Err("verify generated branch: branch was not Ensemble-generated".to_string());
+    }
+    let diff = live_git(
+        "verify expected-only diff",
+        &worktree,
+        [
+            "diff".to_string(),
+            "--name-only".to_string(),
+            "main...HEAD".to_string(),
+        ],
+        inputs,
+    )?;
+    if diff.lines().collect::<Vec<_>>() != [artifact.path.to_string_lossy()] {
+        return Err("verify expected-only diff: commit changed an unexpected path".to_string());
+    }
+    let commit = live_git(
+        "verify committed artifact",
+        &worktree,
+        [
+            "log".to_string(),
+            "-1".to_string(),
+            "--format=%H%x00%s".to_string(),
+        ],
+        inputs,
+    )?;
+    let (sha, message) = commit
+        .trim_end()
+        .split_once('\0')
+        .ok_or_else(|| "verify committed artifact: Git did not report a commit".to_string())?;
+    if message != artifact.commit_message {
+        return Err("verify committed artifact: commit message did not match".to_string());
+    }
+    let remote_branch = live_git(
+        "verify no remote branch",
+        &worktree,
+        [
+            "ls-remote".to_string(),
+            "--heads".to_string(),
+            "origin".to_string(),
+            branch.clone(),
+        ],
+        inputs,
+    )?;
+    if !remote_branch.is_empty() {
+        return Err("verify no remote branch: marker branch was published".to_string());
+    }
+    let pull_requests = live_gh(
+        "verify no pull request",
+        [
+            "pr".to_string(),
+            "list".to_string(),
+            "--repo".to_string(),
+            "chrisbanes/bamboon".to_string(),
+            "--head".to_string(),
+            branch.clone(),
+            "--json".to_string(),
+            "number".to_string(),
+        ],
+        inputs,
+    )?;
+    if pull_requests != "[]\n" {
+        return Err(
+            "verify no pull request: a pull request existed for the generated branch".to_string(),
+        );
+    }
+    let _ = resources;
+    Ok((branch, sha.to_string()))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires the explicitly provisioned private dogfood Project, clean Bamboon clone, ACPX, and model/network cost"]
+async fn live_bamboon_issue_commits_without_publication() {
+    let inputs = LiveDogfoodInputs::from_env().expect("live dogfood inputs");
+    let run = LiveDogfoodRun::create().expect("persistent live dogfood run directory");
+    let result = async {
+        let token = live_preflight(&inputs, &run)?;
+        let project = validate_live_project(&inputs)?;
+        let resources = create_live_resources(&inputs, &run, &project)?;
+        wait_for_live_project_status(&inputs, &resources.issue_id, "Ready to implement").await?;
+        let port = reserve_local_port().map_err(|error| format!("reserve host port: {error}"))?;
+        let mut host = spawn_live_host(&inputs, &run, &token, port)?;
+        let client = reqwest::Client::new();
+        let base_url = format!("http://127.0.0.1:{port}");
+        let completed = async {
+            wait_for_server(&client, &base_url)
+                .await
+                .map_err(|error| format!("wait for host: {error}"))?;
+            wait_for_live_project_status(&inputs, &resources.issue_id, "In progress").await?;
+            let detail =
+                wait_for_live_completion(&client, &base_url, resources.issue_number).await?;
+            wait_for_live_history(&client, &base_url, resources.issue_number).await?;
+            let (branch, sha) = verify_live_artifact(&inputs, &run, &resources)?;
+            Ok::<_, String>((detail, branch, sha))
+        }
+        .await;
+        let _ = host.kill();
+        let _ = host.wait();
+        let (detail, branch, sha) = completed?;
+        if detail["issue_identifier"] != format!("chrisbanes/bamboon#{}", resources.issue_number) {
+            return Err("verify public host detail: host reported an unexpected issue".to_string());
+        }
+        Ok((resources, branch, sha))
+    }
+    .await;
+
+    match result {
+        Ok((resources, branch, sha)) => eprintln!(
+            "live dogfood preserved marker={} issue={} branch={} sha={} run_directory={}",
+            run.marker,
+            resources.issue_number,
+            branch,
+            sha,
+            run.root.display()
+        ),
+        Err(error) => panic!(
+            "{error}\nlive dogfood dispatch-and-later artifacts are preserved: marker={} run_directory={}",
+            run.marker,
+            run.root.display()
+        ),
+    }
+}
+
+#[test]
+fn live_dogfood_inputs_require_the_exact_opt_in() {
+    let error = LiveDogfoodInputs::from_values(None, None, None, None).unwrap_err();
+    assert_eq!(error, "ENSEMBLE_LIVE_DOGFOOD must be exactly 1");
+}
+
+#[test]
+fn live_dogfood_inputs_require_safe_fixture_values() {
+    assert!(
+        LiveDogfoodInputs::from_values(Some("1"), Some("0"), Some("/tmp/bamboon"), None)
+            .unwrap_err()
+            .contains(LIVE_DOGFOOD_PROJECT)
+    );
+    assert!(
+        LiveDogfoodInputs::from_values(Some("1"), Some("+12"), Some("/tmp/bamboon"), None)
+            .unwrap_err()
+            .contains(LIVE_DOGFOOD_PROJECT)
+    );
+    assert!(
+        LiveDogfoodInputs::from_values(Some("1"), Some("12"), Some("relative"), None)
+            .unwrap_err()
+            .contains(LIVE_DOGFOOD_BAMBOON_PATH)
+    );
+
+    let inputs = LiveDogfoodInputs::from_values(
+        Some("1"),
+        Some("12"),
+        Some("/tmp/bamboon"),
+        Some("named-agent"),
+    )
+    .unwrap();
+    assert_eq!(inputs.agent, "named-agent");
+}
+
+#[test]
+fn live_dogfood_marker_artifact_and_config_are_run_scoped() {
+    let inputs =
+        LiveDogfoodInputs::from_values(Some("1"), Some("12"), Some("/tmp/bamboon"), None).unwrap();
+    let run = LiveDogfoodRun {
+        marker: live_dogfood_marker(42, 7, 1),
+        root: PathBuf::from("/tmp/ensemble-live-dogfood/live-dogfood-2a-7-1"),
+    };
+    let artifact = run.expected_artifact();
+    let config = live_dogfood_config(&inputs, &run);
+
+    assert_eq!(
+        artifact.path,
+        PathBuf::from("docs/ensemble-dogfood/live-dogfood-2a-7-1.md")
+    );
+    assert!(artifact.content.contains(&run.marker));
+    assert!(config.contains("project_number: 12"));
+    assert!(config.contains("acpx_agent: 'codex'"));
+    assert!(config.contains("tracker_state: In progress"));
+    assert!(config.contains("on_success: Done"));
+    assert!(config.contains("max_cycles: 1"));
+    assert!(config.contains("max_concurrent_agents: 1"));
+    assert!(config.contains("max_step_parallelism: 1"));
+    assert!(config.contains("mode: none"));
+    assert!(!config.contains("api_key:"));
+}
+
+#[test]
+fn live_dogfood_redaction_hides_private_inputs_and_tokens() {
+    let inputs =
+        LiveDogfoodInputs::from_values(Some("1"), Some("12"), Some("/tmp/private-bamboon"), None)
+            .unwrap();
+    let redacted = redact_live_dogfood(
+        "project 12 clone /tmp/private-bamboon token secret-token",
+        &inputs,
+        Some("secret-token"),
+    );
+    assert_eq!(
+        redacted,
+        "project [REDACTED] clone [REDACTED] token [REDACTED]"
+    );
+}
+
+#[test]
+fn live_dogfood_operator_contract_is_documented_without_fixture_values() {
+    let contributing = include_str!("../../../docs/contributing.md");
+    for required in [
+        "ENSEMBLE_LIVE_DOGFOOD=1",
+        "ENSEMBLE_DOGFOOD_PROJECT_NUMBER",
+        "ENSEMBLE_DOGFOOD_BAMBOON_PATH",
+        "ENSEMBLE_DOGFOOD_AGENT",
+        "gh auth token",
+        "finalization set to",
+        "`none`",
+        "never part of CI",
+    ] {
+        assert!(
+            contributing.contains(required),
+            "contributing guide must document {required}"
+        );
+    }
 }

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -1222,7 +1222,7 @@ fn create_live_resources(
     inputs: &LiveDogfoodInputs,
     run: &LiveDogfoodRun,
     project: &LiveDogfoodProject,
-) -> Result<LiveDogfoodResources, String> {
+) -> Result<PreDispatchResources, String> {
     let artifact = run.expected_artifact();
     let issue = live_gh(
         "create synthetic issue",
@@ -1312,10 +1312,7 @@ fn create_live_resources(
         rollback_pre_dispatch(&resources, inputs);
         return Err(error);
     }
-    Ok(LiveDogfoodResources {
-        issue_id: resources.issue_id,
-        issue_number: resources.issue_number,
-    })
+    Ok(resources)
 }
 
 fn spawn_live_host(
@@ -1521,8 +1518,31 @@ fn verify_live_artifact(
         ],
         inputs,
     )?;
-    if marker_owned_remote_branch(&remote_branch, &run.marker) {
+    if remote_branch_contains(&remote_branch, &branch)
+        || marker_owned_remote_branch(&remote_branch, &run.marker)
+    {
         return Err("verify no remote branch: marker branch was published".to_string());
+    }
+    let branch_pull_requests = live_gh(
+        "verify no pull request for generated branch",
+        [
+            "pr".to_string(),
+            "list".to_string(),
+            "--repo".to_string(),
+            "chrisbanes/bamboon".to_string(),
+            "--state".to_string(),
+            "all".to_string(),
+            "--head".to_string(),
+            branch.clone(),
+            "--json".to_string(),
+            "number".to_string(),
+        ],
+        inputs,
+    )?;
+    if branch_pull_requests != "[]\n" {
+        return Err(
+            "verify no pull request: a pull request existed for the generated branch".to_string(),
+        );
     }
     let pull_requests = live_gh(
         "verify no pull request",
@@ -1540,7 +1560,7 @@ fn verify_live_artifact(
         ],
         inputs,
     )?;
-    if marker_owned_pull_request(&pull_requests, &run.marker) {
+    if marker_owned_pull_request(&pull_requests, &run.marker)? {
         return Err(
             "verify no pull request: a pull request existed for the generated branch".to_string(),
         );
@@ -1552,18 +1572,21 @@ fn marker_owned_remote_branch(remote_heads: &str, marker: &str) -> bool {
     remote_heads.lines().any(|line| line.contains(marker))
 }
 
-fn marker_owned_pull_request(pull_requests: &str, marker: &str) -> bool {
-    serde_json::from_str::<Value>(pull_requests)
-        .ok()
-        .and_then(|value| value.as_array().cloned())
-        .is_some_and(|pull_requests| {
-            pull_requests.iter().any(|pull_request| {
-                ["title", "headRefName"]
-                    .iter()
-                    .filter_map(|field| pull_request[*field].as_str())
-                    .any(|value| value.contains(marker))
-            })
-        })
+fn remote_branch_contains(remote_heads: &str, branch: &str) -> bool {
+    remote_heads.lines().any(|line| {
+        line == format!("refs/heads/{branch}") || line.ends_with(&format!("\trefs/heads/{branch}"))
+    })
+}
+
+fn marker_owned_pull_request(pull_requests: &str, marker: &str) -> Result<bool, String> {
+    let pull_requests: Vec<Value> = serde_json::from_str(pull_requests)
+        .map_err(|error| format!("verify no pull request: invalid GitHub response: {error}"))?;
+    Ok(pull_requests.iter().any(|pull_request| {
+        ["title", "headRefName"]
+            .iter()
+            .filter_map(|field| pull_request[*field].as_str())
+            .any(|value| value.contains(marker))
+    }))
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1574,7 +1597,16 @@ async fn live_bamboon_issue_commits_without_publication() {
     let result = async {
         let (token, project) = live_preflight(&inputs, &run)?;
         let resources = create_live_resources(&inputs, &run, &project)?;
-        wait_for_live_project_status(&inputs, &resources.issue_id, "Ready to implement").await?;
+        if let Err(error) =
+            wait_for_live_project_status(&inputs, &resources.issue_id, "Ready to implement").await
+        {
+            rollback_pre_dispatch(&resources, &inputs);
+            return Err(error);
+        }
+        let resources = LiveDogfoodResources {
+            issue_id: resources.issue_id,
+            issue_number: resources.issue_number,
+        };
         let port = reserve_local_port().map_err(|error| format!("reserve host port: {error}"))?;
         let mut host = spawn_live_host(&inputs, &run, &token, port)?;
         let client = reqwest::Client::new();
@@ -1760,14 +1792,21 @@ fn live_dogfood_publication_observations_are_marker_scoped() {
         "deadbeef\trefs/heads/agent-live-dogfood-2a-7-1",
         marker
     ));
+    assert!(remote_branch_contains(
+        "deadbeef\trefs/heads/ensemble-20260805-e2e-1",
+        "ensemble-20260805-e2e-1"
+    ));
     assert!(marker_owned_pull_request(
         r#"[{"number":12,"title":"dogfood live-dogfood-2a-7-1","headRefName":"agent-branch"}]"#,
         marker,
-    ));
+    )
+    .unwrap());
     assert!(!marker_owned_pull_request(
         r#"[{"number":12,"title":"unrelated","headRefName":"agent-branch"}]"#,
         marker,
-    ));
+    )
+    .unwrap());
+    assert!(marker_owned_pull_request("not JSON", marker).is_err());
 }
 
 #[test]

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -797,6 +797,10 @@ fn redact_live_dogfood(value: &str, inputs: &LiveDogfoodInputs, token: Option<&s
 
 fn live_dogfood_config(inputs: &LiveDogfoodInputs, run: &LiveDogfoodRun) -> String {
     let artifact = run.expected_artifact();
+    let prompt = format!(
+        "Work only on this issue. Create exactly {} with exactly this content:\n{} Commit it with exactly this message: {}. Run a lightweight verification. Do not push, create a pull request, or change any other tracked file. End with a JSON step output declaring success and a concise summary.",
+        artifact.path.display(), artifact.content, artifact.commit_message,
+    );
     format!(
         r#"tracker:
   kind: github
@@ -816,11 +820,7 @@ repos:
 agents:
   builder:
     acpx_agent: {}
-    prompt: >-
-      Work only on this issue. Create exactly {} with exactly this content:
-      {} Commit it with exactly this message: {}. Run a lightweight verification.
-      Do not push, create a pull request, or change any other tracked file. End with a JSON
-      step output declaring success and a concise summary.
+    prompt: {}
 steps:
   - name: implement
     agent: builder
@@ -840,9 +840,17 @@ agent:
         yaml_quote(&run.root.join("workspaces").display().to_string()),
         yaml_quote(&inputs.bamboon_path.display().to_string()),
         yaml_quote(&inputs.agent),
-        yaml_quote(&artifact.path.display().to_string()),
-        yaml_quote(&artifact.content),
-        yaml_quote(&artifact.commit_message),
+        yaml_string(&prompt),
+    )
+}
+
+fn yaml_string(value: &str) -> String {
+    format!(
+        "\"{}\"",
+        value
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n")
     )
 }
 
@@ -1444,13 +1452,7 @@ fn verify_live_artifact(
     run: &LiveDogfoodRun,
 ) -> Result<(String, String), String> {
     let artifact = run.expected_artifact();
-    let repo_root = run.root.join("workspaces").join("bamboon");
-    let worktree = fs::read_dir(&repo_root)
-        .map_err(|error| format!("verify local commit: worktree root was unavailable: {error}"))?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .find(|path| path.is_dir())
-        .ok_or_else(|| "verify local commit: no Bamboon issue worktree was found".to_string())?;
+    let worktree = live_dogfood_worktree(&run.root.join("workspaces"))?;
     let actual_content = fs::read_to_string(worktree.join(&artifact.path))
         .map_err(|error| format!("verify local commit: expected artifact was absent: {error}"))?;
     if actual_content != artifact.content {
@@ -1566,6 +1568,30 @@ fn verify_live_artifact(
         );
     }
     Ok((branch, sha.to_string()))
+}
+
+fn live_dogfood_worktree(workspaces: &Path) -> Result<PathBuf, String> {
+    let workspace_entries = fs::read_dir(workspaces)
+        .map_err(|error| format!("verify local commit: workspace root was unavailable: {error}"))?;
+    let mut worktrees = Vec::new();
+    for entry in workspace_entries.filter_map(Result::ok) {
+        let repo_root = entry.path().join("bamboon");
+        let repo_entries = match fs::read_dir(&repo_root) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        worktrees.extend(
+            repo_entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|path| path.is_dir()),
+        );
+    }
+    match worktrees.as_slice() {
+        [worktree] => Ok(worktree.clone()),
+        [] => Err("verify local commit: no Bamboon issue worktree was found".to_string()),
+        _ => Err("verify local commit: multiple Bamboon issue worktrees were found".to_string()),
+    }
 }
 
 fn marker_owned_remote_branch(remote_heads: &str, marker: &str) -> bool {
@@ -1815,4 +1841,34 @@ fn live_dogfood_command_timeouts_keep_a_safe_last_observation() {
         live_command_timeout("preflight ACPX"),
         "preflight ACPX: command timed out after 30 seconds; last observation: command was still running"
     );
+}
+
+#[test]
+fn live_dogfood_config_parses_with_multiline_artifact_content() {
+    let inputs =
+        LiveDogfoodInputs::from_values(Some("1"), Some("12"), Some("/tmp/bamboon"), None).unwrap();
+    let run = LiveDogfoodRun {
+        marker: live_dogfood_marker(42, 7, 1),
+        root: PathBuf::from("/tmp/ensemble-live-dogfood/live-dogfood-2a-7-1"),
+    };
+
+    let config: serde_yaml::Value =
+        serde_yaml::from_str(&live_dogfood_config(&inputs, &run)).expect("live config must parse");
+    let prompt = config["agents"]["builder"]["prompt"]
+        .as_str()
+        .expect("live prompt must be a scalar");
+    assert!(prompt.contains("# Ensemble live dogfood\n\nMarker:"));
+}
+
+#[test]
+fn live_dogfood_worktree_discovery_includes_the_issue_key_directory() {
+    let temporary = tempfile::tempdir().unwrap();
+    let workspaces = temporary.path().join("workspaces");
+    let expected = workspaces
+        .join("I_live_dogfood--expected-key")
+        .join("bamboon")
+        .join("ensemble-2026-08-05-I-live-dogfood");
+    fs::create_dir_all(&expected).unwrap();
+
+    assert_eq!(live_dogfood_worktree(&workspaces).unwrap(), expected);
 }

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -846,18 +846,23 @@ agent:
     )
 }
 
+#[derive(Debug)]
 struct LiveDogfoodProject {
     id: String,
     status_field_id: String,
     ready_option_id: String,
 }
 
-struct LiveDogfoodResources {
+struct PreDispatchResources {
     issue_id: String,
     issue_number: u64,
     project_id: String,
     project_item_id: String,
-    dispatch_started: bool,
+}
+
+struct LiveDogfoodResources {
+    issue_id: String,
+    issue_number: u64,
 }
 
 fn run_live_command(
@@ -877,7 +882,7 @@ fn run_live_command(
             Ok(None) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                return Err(format!("{phase}: command timed out after 30 seconds"));
+                return Err(live_command_timeout(phase));
             }
             Err(error) => return Err(format!("{phase}: command wait failed: {error}")),
         }
@@ -899,6 +904,12 @@ fn run_live_command(
             "{phase}: command exited {status}; last observation: {last_observation}"
         ))
     }
+}
+
+fn live_command_timeout(phase: &str) -> String {
+    format!(
+        "{phase}: command timed out after 30 seconds; last observation: command was still running"
+    )
 }
 
 fn live_gh(
@@ -964,6 +975,10 @@ fn live_project_query(inputs: &LiveDogfoodInputs) -> Result<Value, String> {
 
 fn validate_live_project(inputs: &LiveDogfoodInputs) -> Result<LiveDogfoodProject, String> {
     let response = live_project_query(inputs)?;
+    validate_live_project_response(&response)
+}
+
+fn validate_live_project_response(response: &Value) -> Result<LiveDogfoodProject, String> {
     let project = &response["data"]["repository"]["projectV2"];
     if project["title"] != "Ensemble Dogfood" || project["viewerCanUpdate"] != true {
         return Err("preflight project discovery: Project title or write access did not match the fixture contract".to_string());
@@ -1089,20 +1104,25 @@ fn is_bamboon_remote(remote: &str) -> bool {
     )
 }
 
-fn live_preflight(inputs: &LiveDogfoodInputs, run: &LiveDogfoodRun) -> Result<String, String> {
+fn live_preflight(
+    inputs: &LiveDogfoodInputs,
+    run: &LiveDogfoodRun,
+) -> Result<(String, LiveDogfoodProject), String> {
     run_live_command("preflight gh", Command::new("gh"), inputs)?;
     let mut acpx = Command::new("acpx");
     acpx.arg("--version");
     let acpx_version = run_live_command("preflight ACPX", acpx, inputs)?;
     fs::write(run.root.join("acpx.version"), acpx_version)
         .map_err(|error| format!("preflight ACPX: could not retain version metadata: {error}"))?;
+    fs::write(run.root.join("agent.txt"), &inputs.agent)
+        .map_err(|error| format!("preflight ACPX: could not retain agent metadata: {error}"))?;
     validate_live_bamboon_clone(inputs)?;
     live_gh(
         "preflight GitHub access",
         ["api".to_string(), "user".to_string()],
         inputs,
     )?;
-    validate_live_project(inputs)?;
+    let project = validate_live_project(inputs)?;
     let token = live_gh(
         "preflight GitHub token",
         ["auth".to_string(), "token".to_string()],
@@ -1111,7 +1131,7 @@ fn live_preflight(inputs: &LiveDogfoodInputs, run: &LiveDogfoodRun) -> Result<St
     if token.trim().is_empty() {
         return Err("preflight GitHub token: gh returned an empty token".to_string());
     }
-    Ok(token.trim().to_string())
+    Ok((token.trim().to_string(), project))
 }
 
 fn live_project_item_status(
@@ -1154,10 +1174,22 @@ fn live_graphql_mutation(
         arguments.extend(["-F".to_string(), format!("{name}={value}")]);
     }
     let output = live_gh(phase, arguments, inputs)?;
-    serde_json::from_str(&output).map_err(|error| format!("{phase}: invalid response: {error}"))
+    parse_live_graphql_response(phase, &output)
 }
 
-fn rollback_pre_dispatch(resources: &LiveDogfoodResources, inputs: &LiveDogfoodInputs) {
+fn parse_live_graphql_response(phase: &str, output: &str) -> Result<Value, String> {
+    let response: Value = serde_json::from_str(output)
+        .map_err(|error| format!("{phase}: invalid response: {error}"))?;
+    if response["errors"]
+        .as_array()
+        .is_some_and(|errors| !errors.is_empty())
+    {
+        return Err(format!("{phase}: GraphQL returned errors"));
+    }
+    Ok(response)
+}
+
+fn rollback_pre_dispatch(resources: &PreDispatchResources, inputs: &LiveDogfoodInputs) {
     const REMOVE_ITEM: &str = r#"mutation($projectId: ID!, $itemId: ID!) {
   deleteProjectV2Item(input: {projectId: $projectId, itemId: $itemId}) { deletedItemId }
 }"#;
@@ -1235,35 +1267,32 @@ fn create_live_resources(
         Ok(value) => match value["data"]["addProjectV2ItemById"]["item"]["id"].as_str() {
             Some(id) => id.to_string(),
             None => {
-                let resources = LiveDogfoodResources {
+                let resources = PreDispatchResources {
                     issue_id,
                     issue_number,
                     project_id: project.id.clone(),
                     project_item_id: String::new(),
-                    dispatch_started: false,
                 };
                 rollback_pre_dispatch(&resources, inputs);
                 return Err("add synthetic issue to Project: missing Project item ID".to_string());
             }
         },
         Err(error) => {
-            let resources = LiveDogfoodResources {
+            let resources = PreDispatchResources {
                 issue_id,
                 issue_number,
                 project_id: project.id.clone(),
                 project_item_id: String::new(),
-                dispatch_started: false,
             };
             rollback_pre_dispatch(&resources, inputs);
             return Err(error);
         }
     };
-    let mut resources = LiveDogfoodResources {
+    let resources = PreDispatchResources {
         issue_id,
         issue_number,
         project_id: project.id.clone(),
         project_item_id,
-        dispatch_started: false,
     };
 
     const SET_STATUS: &str = r#"mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
@@ -1283,8 +1312,10 @@ fn create_live_resources(
         rollback_pre_dispatch(&resources, inputs);
         return Err(error);
     }
-    resources.dispatch_started = true;
-    Ok(resources)
+    Ok(LiveDogfoodResources {
+        issue_id: resources.issue_id,
+        issue_number: resources.issue_number,
+    })
 }
 
 fn spawn_live_host(
@@ -1414,7 +1445,6 @@ async fn wait_for_live_history(
 fn verify_live_artifact(
     inputs: &LiveDogfoodInputs,
     run: &LiveDogfoodRun,
-    resources: &LiveDogfoodResources,
 ) -> Result<(String, String), String> {
     let artifact = run.expected_artifact();
     let repo_root = run.root.join("workspaces").join("bamboon");
@@ -1488,11 +1518,10 @@ fn verify_live_artifact(
             "ls-remote".to_string(),
             "--heads".to_string(),
             "origin".to_string(),
-            branch.clone(),
         ],
         inputs,
     )?;
-    if !remote_branch.is_empty() {
+    if marker_owned_remote_branch(&remote_branch, &run.marker) {
         return Err("verify no remote branch: marker branch was published".to_string());
     }
     let pull_requests = live_gh(
@@ -1502,20 +1531,39 @@ fn verify_live_artifact(
             "list".to_string(),
             "--repo".to_string(),
             "chrisbanes/bamboon".to_string(),
-            "--head".to_string(),
-            branch.clone(),
+            "--state".to_string(),
+            "all".to_string(),
+            "--search".to_string(),
+            run.marker.clone(),
             "--json".to_string(),
-            "number".to_string(),
+            "number,title,headRefName".to_string(),
         ],
         inputs,
     )?;
-    if pull_requests != "[]\n" {
+    if marker_owned_pull_request(&pull_requests, &run.marker) {
         return Err(
             "verify no pull request: a pull request existed for the generated branch".to_string(),
         );
     }
-    let _ = resources;
     Ok((branch, sha.to_string()))
+}
+
+fn marker_owned_remote_branch(remote_heads: &str, marker: &str) -> bool {
+    remote_heads.lines().any(|line| line.contains(marker))
+}
+
+fn marker_owned_pull_request(pull_requests: &str, marker: &str) -> bool {
+    serde_json::from_str::<Value>(pull_requests)
+        .ok()
+        .and_then(|value| value.as_array().cloned())
+        .is_some_and(|pull_requests| {
+            pull_requests.iter().any(|pull_request| {
+                ["title", "headRefName"]
+                    .iter()
+                    .filter_map(|field| pull_request[*field].as_str())
+                    .any(|value| value.contains(marker))
+            })
+        })
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1524,8 +1572,7 @@ async fn live_bamboon_issue_commits_without_publication() {
     let inputs = LiveDogfoodInputs::from_env().expect("live dogfood inputs");
     let run = LiveDogfoodRun::create().expect("persistent live dogfood run directory");
     let result = async {
-        let token = live_preflight(&inputs, &run)?;
-        let project = validate_live_project(&inputs)?;
+        let (token, project) = live_preflight(&inputs, &run)?;
         let resources = create_live_resources(&inputs, &run, &project)?;
         wait_for_live_project_status(&inputs, &resources.issue_id, "Ready to implement").await?;
         let port = reserve_local_port().map_err(|error| format!("reserve host port: {error}"))?;
@@ -1540,7 +1587,7 @@ async fn live_bamboon_issue_commits_without_publication() {
             let detail =
                 wait_for_live_completion(&client, &base_url, resources.issue_number).await?;
             wait_for_live_history(&client, &base_url, resources.issue_number).await?;
-            let (branch, sha) = verify_live_artifact(&inputs, &run, &resources)?;
+            let (branch, sha) = verify_live_artifact(&inputs, &run)?;
             Ok::<_, String>((detail, branch, sha))
         }
         .await;
@@ -1666,4 +1713,67 @@ fn live_dogfood_operator_contract_is_documented_without_fixture_values() {
             "contributing guide must document {required}"
         );
     }
+}
+
+#[test]
+fn live_dogfood_rejects_graphql_errors_before_dispatch() {
+    let error = parse_live_graphql_response(
+        "make synthetic issue ready",
+        r#"{"errors":[{"message":"fixture drift"}]}"#,
+    )
+    .unwrap_err();
+
+    assert_eq!(error, "make synthetic issue ready: GraphQL returned errors");
+}
+
+#[test]
+fn live_dogfood_preflight_rejects_project_fixture_drift() {
+    let response = serde_json::json!({
+        "data": {"repository": {"projectV2": {
+            "id": "project-id",
+            "title": "Wrong Project",
+            "viewerCanUpdate": true,
+            "items": {"totalCount": 0},
+            "workflows": {"nodes": []},
+            "fields": {"nodes": [{
+                "id": "status-id",
+                "name": "Status",
+                "options": [
+                    {"id": "ready", "name": "Ready to implement"},
+                    {"id": "progress", "name": "In progress"},
+                    {"id": "review", "name": "In review"},
+                    {"id": "done", "name": "Done"}
+                ]
+            }]}
+        }}}
+    });
+
+    assert!(validate_live_project_response(&response)
+        .unwrap_err()
+        .contains("Project title or write access"));
+}
+
+#[test]
+fn live_dogfood_publication_observations_are_marker_scoped() {
+    let marker = "live-dogfood-2a-7-1";
+    assert!(marker_owned_remote_branch(
+        "deadbeef\trefs/heads/agent-live-dogfood-2a-7-1",
+        marker
+    ));
+    assert!(marker_owned_pull_request(
+        r#"[{"number":12,"title":"dogfood live-dogfood-2a-7-1","headRefName":"agent-branch"}]"#,
+        marker,
+    ));
+    assert!(!marker_owned_pull_request(
+        r#"[{"number":12,"title":"unrelated","headRefName":"agent-branch"}]"#,
+        marker,
+    ));
+}
+
+#[test]
+fn live_dogfood_command_timeouts_keep_a_safe_last_observation() {
+    assert_eq!(
+        live_command_timeout("preflight ACPX"),
+        "preflight ACPX: command timed out after 30 seconds; last observation: command was still running"
+    );
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -60,6 +60,41 @@ The test starts a real `ensemble web` server on localhost with a temporary
 config directory, a todo-file tracker fixture, and mock `acpx`. It does not
 require GitHub, Notion, real ACP credentials, or non-localhost network access.
 
+### Ignored live dogfood tracer bullet
+
+`live_bamboon_issue_commits_without_publication` is a deliberately expensive local-only
+tracer bullet. It is ignored, is never part of CI, and creates a real synthetic issue in the
+private, operator-provisioned **Ensemble Dogfood** Project. It launches a real ACPX agent against
+an issue-owned Bamboon worktree, so it can consume network access and model time.
+
+Run it only when you have the dedicated fixture and a clean Bamboon clone. The project number and
+clone path are private local setup values: do not put either in shell history, documentation,
+issues, or logs.
+
+```sh
+ENSEMBLE_LIVE_DOGFOOD=1 \
+  ENSEMBLE_DOGFOOD_PROJECT_NUMBER=<local-project-number> \
+  ENSEMBLE_DOGFOOD_BAMBOON_PATH=<absolute-clean-bamboon-clone> \
+  SKIP_UI_BUILD=1 \
+  cargo test -p ensemble-cli --features web-ui --test product_e2e \
+  live_bamboon_issue_commits_without_publication -- --ignored --nocapture
+```
+
+`ENSEMBLE_LIVE_DOGFOOD=1` is the exact mutation opt-in. The harness validates the linked Project,
+its empty fixture state and status mapping, GitHub/ACPX access, Bamboon identity, `main`, origin,
+and clone cleanliness before creating an issue; it never repairs fixture drift. ACPX defaults to
+the `codex` named agent; set a non-empty `ENSEMBLE_DOGFOOD_AGENT` only for an explicit local
+override. The GitHub credential comes from `gh auth token` only after the opt-in gate, is passed to
+the child host in memory as `GITHUB_TOKEN`, and is not written into generated YAML or diagnostics.
+
+The tracer bullet creates one marker-owned Markdown artifact and commit, with finalization set to
+`none`: neither the agent nor Ensemble may push a branch or create a pull request. From the point
+the issue is made ready to implement onward, it preserves the run directory, host stdout/stderr,
+issue, Project item, workspace, and local branch for diagnosis. The test prints the redacted,
+run-scoped preservation location on success or failure. Do not perform routine cleanup or fixture
+repair from the harness; publication, restart recovery, and cleanup are intentionally outside this
+slice.
+
 ## Project structure
 
 ```


### PR DESCRIPTION
Fixes #464

## Rationale

Adds the first explicitly opt-in, ignored live dogfood E2E profile without changing runtime APIs or configuration schema. It validates the provisioned fixture before mutation, drives one marker-owned Bamboon issue through the public host, and preserves dispatch-and-later evidence while asserting no branch publication or pull request.

## Validation

- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture` (8 passed, 1 live test ignored)
- `cargo test -p ensemble-core tracker::github::tests::project_mode_write_targets_configured_project_item`
- `cargo test -p ensemble-core history::artifacts::tests::collect_repo_artifact_records_none_mode_repo_state`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Residual risk

The private fixture inputs were not available in this environment, so the ignored live run was not executed. It remains fail-closed unless the exact opt-in, private Project number, and clean absolute Bamboon clone are supplied.