### PR TITLE
Repair MSRV dependency resolution

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[resolver]
+incompatible-rust-versions = "fallback"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "kstring"
-version = "2.0.4"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b609e7ca5ea38f093c20a4a102335b247221c9643b7a6bc3510f196f99499a9e"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
 dependencies = [
  "serde",
  "static_assertions",

--- a/docs/adr/0015-pin-the-primary-rust-toolchain-and-test-msrv-separately.md
+++ b/docs/adr/0015-pin-the-primary-rust-toolchain-and-test-msrv-separately.md
@@ -4,4 +4,4 @@ status: accepted
 
 # Pin the primary Rust toolchain and test MSRV separately
 
-Normal development, linting, packaging, and releases use the exact Rust version pinned in `rust-toolchain.toml`, while `Cargo.toml` declares an independently tested minimum supported Rust version with a dedicated CI job. Toolchain upgrades and compatibility changes therefore happen through explicit repository changes instead of an unreviewed moving `stable` channel.
+Normal development, linting, packaging, and releases use the exact Rust version pinned in `rust-toolchain.toml`, while `Cargo.toml` declares an independently tested minimum supported Rust version with a dedicated CI job. Cargo's resolver is configured to prefer dependencies compatible with that declared minimum during lockfile updates. Toolchain upgrades and compatibility changes therefore happen through explicit repository changes instead of an unreviewed moving `stable` channel.


### PR DESCRIPTION
## Summary

Repair the Rust 1.95 MSRV gate after the lockfile resolved `kstring 2.0.4`, which requires Rust 1.96.

- configure Cargo's resolver to prefer dependencies compatible with the workspace-declared MSRV during lockfile updates
- resolve `kstring` to Cargo-selected 2.0.2, the latest compatible with Rust 1.95
- document the lockfile-resolution safeguard alongside the MSRV policy

## Validation

- `SKIP_UI_BUILD=1 cargo +1.95.0 check --workspace --all-targets --quiet`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo test --workspace --exclude ensemble-desktop --quiet`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e --quiet`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`

The product E2E test was rerun outside the sandbox because sandboxed localhost port reservation is denied; it passed 3/3.