### PR TITLE
Document immutable artifact evaluation design

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,14 @@ _Avoid_: Run, session
 The structured result by which a step reports success, failure, concern, summary, and downstream data.
 _Avoid_: Verdict
 
+**Artifact snapshot**:
+An immutable identity for material exposed by one step to downstream evaluation, ensuring sibling evaluators assess the same subject.
+_Avoid_: Current workspace, live files
+
+**Assessment**:
+A structured judgment about whether an artifact snapshot satisfies declared criteria, distinct from whether the evaluating step completed successfully.
+_Avoid_: Step result, execution result
+
 **Interaction request**:
 A durable question, approval, or handoff that blocks a run until a human resolves it.
 _Avoid_: Prompt, comment

--- a/docs/adr/0017-evaluate-immutable-artifact-snapshots-with-generic-pipeline-primitives.md
+++ b/docs/adr/0017-evaluate-immutable-artifact-snapshots-with-generic-pipeline-primitives.md
@@ -1,0 +1,11 @@
+---
+status: proposed
+---
+
+# Evaluate immutable artifact snapshots with generic pipeline primitives
+
+Ensemble will support adversarial evaluation through generic pipeline primitives rather than a review-specific step kind or development method. A producing step exposes an explicit artifact snapshot, evaluating steps bind to that immutable identity, and the core verifies the declared material before and after each evaluation while runtime adapters restrict known mutation capabilities where possible; this preserves issue-level workspace reuse without creating a worktree per evaluator.
+
+Step completion and artifact assessment remain separate facts. When a step declares an output schema, every result must provide schema-valid output after at most one schema-aware repair turn; sibling assessments may then be synthesized, but every finding must receive an evidence-backed disposition and a deterministic gate fails upheld blocking findings and pauses for human judgment on unresolved findings.
+
+This design assumes trusted critics rather than hostile agent containment. Controlled mutation execution remains outside the runtime lifecycle until usage justifies exclusive ownership, journaling, restoration, and restart-recovery semantics; existing mutation tools may run through separately configured commands or their own disposable environments.


### PR DESCRIPTION
## Summary

- define Artifact snapshot and Assessment in the domain glossary
- record proposed ADR-0017 for generic immutable evaluation primitives
- separate Step completion from artifact assessment and document trusted-critic/mutation boundaries

## Why

This records the architectural decisions behind #477 before implementation, including shared Workspace reuse, schema-valid assessments, deterministic adjudication, and deferred controlled mutation.

## Impact

Documentation only. Runtime behavior is unchanged; ADR-0017 remains proposed until implementation lands.

## Validation

- `git diff --check origin/main...HEAD`
- `review-and-simplify-changes`
- `ponytail-review`

Related to #477.