### PR TITLE
Project delivered pull requests to review

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -808,6 +808,7 @@ fn live_dogfood_config(inputs: &LiveDogfoodInputs, run: &LiveDogfoodRun) -> Stri
   project_number: {}
   active_states:
     - Ready to implement
+    - In progress
   terminal_states:
     - Done
 workspace:
@@ -816,7 +817,9 @@ repos:
   - path: {}
     branch: main
     finalize:
-      mode: none
+      mode: push_and_pr
+      approval_required: false
+      review_state: In review
 agents:
   builder:
     acpx_agent: {}
@@ -1380,7 +1383,7 @@ async fn wait_for_live_project_status(
     }
 }
 
-async fn wait_for_live_completion(
+async fn wait_for_live_review_projection(
     client: &reqwest::Client,
     base_url: &str,
     issue_number: u64,
@@ -1394,7 +1397,19 @@ async fn wait_for_live_completion(
                     .json::<Value>()
                     .await
                     .map_err(|error| error.to_string())?;
-                if detail["status"] == "completed_succeeded" {
+                if detail["artifacts"]["repos"]
+                    .as_array()
+                    .is_some_and(|repositories| {
+                        repositories.iter().any(|repository| {
+                            repository["review_state"] == "In review"
+                                && repository["review_projection"] == "applied"
+                                && repository["pr_number"].as_u64().is_some()
+                                && repository["pr_url"]
+                                    .as_str()
+                                    .is_some_and(|url| !url.is_empty())
+                        })
+                    })
+                {
                     return Ok(detail);
                 }
                 detail["status"].as_str().unwrap_or("unknown").to_string()
@@ -1404,7 +1419,7 @@ async fn wait_for_live_completion(
         };
         if Instant::now() >= deadline {
             return Err(format!(
-                "wait for terminal host state: timed out; last observation: {}",
+                "wait for review-projected host state: timed out; last observation: {}",
                 last_observation
             ));
         }
@@ -1422,7 +1437,7 @@ async fn wait_for_live_history(
     loop {
         let response = client
             .get(format!(
-                "{base_url}/api/v1/history?outcome=succeeded&step=implement"
+                "{base_url}/api/v1/history?outcome=in_review&step=implement"
             ))
             .send()
             .await
@@ -1511,7 +1526,7 @@ fn verify_live_artifact(
         return Err("verify committed artifact: commit message did not match".to_string());
     }
     let remote_branch = live_git(
-        "verify no remote branch",
+        "verify published remote branch",
         &worktree,
         [
             "ls-remote".to_string(),
@@ -1520,51 +1535,51 @@ fn verify_live_artifact(
         ],
         inputs,
     )?;
-    if remote_branch_contains(&remote_branch, &branch)
-        || marker_owned_remote_branch(&remote_branch, &run.marker)
-    {
-        return Err("verify no remote branch: marker branch was published".to_string());
+    let expected_ref = format!("refs/heads/{branch}");
+    let matching_remote_heads: Vec<_> = remote_branch
+        .lines()
+        .filter_map(|line| line.split_once('\t'))
+        .filter(|(_, reference)| *reference == expected_ref)
+        .collect();
+    if matching_remote_heads.len() != 1 || matching_remote_heads[0].0 != sha {
+        return Err(
+            "verify published remote branch: expected exactly one branch at the local commit"
+                .to_string(),
+        );
     }
     let branch_pull_requests = live_gh(
-        "verify no pull request for generated branch",
+        "verify published pull request for generated branch",
         [
             "pr".to_string(),
             "list".to_string(),
             "--repo".to_string(),
             "chrisbanes/bamboon".to_string(),
             "--state".to_string(),
-            "all".to_string(),
+            "open".to_string(),
             "--head".to_string(),
             branch.clone(),
             "--json".to_string(),
-            "number".to_string(),
+            "number,url,headRefOid,baseRefName".to_string(),
         ],
         inputs,
     )?;
-    if branch_pull_requests != "[]\n" {
+    let pull_requests: Vec<Value> =
+        serde_json::from_str(&branch_pull_requests).map_err(|error| {
+            format!("verify published pull request: invalid GitHub response: {error}")
+        })?;
+    let [pull_request] = pull_requests.as_slice() else {
         return Err(
-            "verify no pull request: a pull request existed for the generated branch".to_string(),
+            "verify published pull request: expected exactly one open pull request".to_string(),
         );
-    }
-    let pull_requests = live_gh(
-        "verify no pull request",
-        [
-            "pr".to_string(),
-            "list".to_string(),
-            "--repo".to_string(),
-            "chrisbanes/bamboon".to_string(),
-            "--state".to_string(),
-            "all".to_string(),
-            "--search".to_string(),
-            run.marker.clone(),
-            "--json".to_string(),
-            "number,title,headRefName".to_string(),
-        ],
-        inputs,
-    )?;
-    if marker_owned_pull_request(&pull_requests, &run.marker)? {
+    };
+    if pull_request["headRefOid"] != sha
+        || pull_request["baseRefName"] != "main"
+        || pull_request["number"].as_u64().is_none()
+        || pull_request["url"].as_str().is_none_or(str::is_empty)
+    {
         return Err(
-            "verify no pull request: a pull request existed for the generated branch".to_string(),
+            "verify published pull request: branch, base, commit, or identity did not match"
+                .to_string(),
         );
     }
     Ok((branch, sha.to_string()))
@@ -1617,7 +1632,7 @@ fn marker_owned_pull_request(pull_requests: &str, marker: &str) -> Result<bool, 
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires the explicitly provisioned private dogfood Project, clean Bamboon clone, ACPX, and model/network cost"]
-async fn live_bamboon_issue_commits_without_publication() {
+async fn live_bamboon_issue_publishes_pull_request() {
     let inputs = LiveDogfoodInputs::from_env().expect("live dogfood inputs");
     let run = LiveDogfoodRun::create().expect("persistent live dogfood run directory");
     let result = async {
@@ -1643,7 +1658,8 @@ async fn live_bamboon_issue_commits_without_publication() {
                 .map_err(|error| format!("wait for host: {error}"))?;
             wait_for_live_project_status(&inputs, &resources.issue_id, "In progress").await?;
             let detail =
-                wait_for_live_completion(&client, &base_url, resources.issue_number).await?;
+                wait_for_live_review_projection(&client, &base_url, resources.issue_number).await?;
+            wait_for_live_project_status(&inputs, &resources.issue_id, "In review").await?;
             wait_for_live_history(&client, &base_url, resources.issue_number).await?;
             let (branch, sha) = verify_live_artifact(&inputs, &run)?;
             Ok::<_, String>((detail, branch, sha))
@@ -1729,11 +1745,14 @@ fn live_dogfood_marker_artifact_and_config_are_run_scoped() {
     assert!(config.contains("project_number: 12"));
     assert!(config.contains("acpx_agent: 'codex'"));
     assert!(config.contains("tracker_state: In progress"));
+    assert!(config.contains("    - In progress"));
     assert!(config.contains("on_success: Done"));
     assert!(config.contains("max_cycles: 1"));
     assert!(config.contains("max_concurrent_agents: 1"));
     assert!(config.contains("max_step_parallelism: 1"));
-    assert!(config.contains("mode: none"));
+    assert!(config.contains("mode: push_and_pr"));
+    assert!(config.contains("approval_required: false"));
+    assert!(config.contains("review_state: In review"));
     assert!(!config.contains("api_key:"));
 }
 
@@ -1762,8 +1781,8 @@ fn live_dogfood_operator_contract_is_documented_without_fixture_values() {
         "ENSEMBLE_DOGFOOD_BAMBOON_PATH",
         "ENSEMBLE_DOGFOOD_AGENT",
         "gh auth token",
-        "finalization set to",
-        "`none`",
+        "Ensemble alone pushes",
+        "`In review`",
         "never part of CI",
     ] {
         assert!(

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -311,6 +311,13 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
     use crate::error::PipelineError;
 
     match e {
+        PipelineError::InvalidFinalizeConfig { repo, reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("invalid repository finalization config for '{repo}': {reason}"),
+            section: "workflow".to_string(),
+            field: Some("finalize.review_state".to_string()),
+            path: Some(format!("repos.{repo}.finalize.review_state")),
+        },
         PipelineError::InvalidAcceptanceCommand { name, reason } => ValidationIssue {
             kind: ValidationIssueKind::Config,
             message: format!("invalid acceptance command '{}': {}", name, reason),

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -1045,6 +1045,66 @@ fn reject_legacy_agent_permission_policy(
 
 /// Validate the config for consistency: prompt config, agent references, step name uniqueness, etc.
 pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
+    let mut review_state: Option<&str> = None;
+    for (index, repo) in config.repos.iter().enumerate() {
+        let Some(target) = repo.finalize.review_state.as_deref() else {
+            continue;
+        };
+        let repo_key = repository_key(repo, index);
+        if target.trim().is_empty() {
+            return Err(PipelineError::InvalidFinalizeConfig {
+                repo: repo_key,
+                reason: "review_state must not be empty".to_string(),
+            });
+        }
+        if repo.finalize.mode != crate::workspace::finalize::FinalizeMode::PushAndPr {
+            return Err(PipelineError::InvalidFinalizeConfig {
+                repo: repo_key,
+                reason: "review_state is valid only with push_and_pr finalization".to_string(),
+            });
+        }
+        if target.eq_ignore_ascii_case(&config.on_success) {
+            return Err(PipelineError::InvalidFinalizeConfig {
+                repo: repo_key,
+                reason: "review_state must not equal on_success".to_string(),
+            });
+        }
+        if config
+            .tracker
+            .terminal_states
+            .iter()
+            .any(|state| target.eq_ignore_ascii_case(state))
+        {
+            return Err(PipelineError::InvalidFinalizeConfig {
+                repo: repo_key,
+                reason: "review_state must not be a configured terminal state".to_string(),
+            });
+        }
+        if let Some(existing) = review_state {
+            if !target.eq_ignore_ascii_case(existing) {
+                return Err(PipelineError::InvalidFinalizeConfig {
+                    repo: repo_key,
+                    reason: "all review_state values must use the same value".to_string(),
+                });
+            }
+        } else {
+            review_state = Some(target);
+        }
+    }
+    if review_state.is_some() {
+        for (index, repo) in config.repos.iter().enumerate() {
+            if repo.finalize.mode == crate::workspace::finalize::FinalizeMode::PushAndPr
+                && repo.finalize.review_state.is_none()
+            {
+                return Err(PipelineError::InvalidFinalizeConfig {
+                    repo: repository_key(repo, index),
+                    reason: "all push_and_pr repositories must opt in to the review_state"
+                        .to_string(),
+                });
+            }
+        }
+    }
+
     let mut acceptance_names = std::collections::HashSet::new();
     for command in &config.acceptance.commands {
         let display_name = if command.name.trim().is_empty() {
@@ -1471,6 +1531,46 @@ on_failure: Failed
             }]
         );
         assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn review_state_requires_one_non_terminal_push_and_pr_target() {
+        let valid = format!(
+            "{}\nrepos:\n  - path: /tmp/ensemble\n    branch: main\n    finalize:\n      mode: push_and_pr\n      review_state: In review\n",
+            minimal_yaml()
+        );
+        let config = parse_config(&valid).unwrap();
+        assert_eq!(
+            config.repos[0].finalize.review_state.as_deref(),
+            Some("In review")
+        );
+        assert!(validate_config(&config).is_ok());
+
+        let cases = [
+            ("blank", "mode: push_and_pr\n      review_state: '  '", "must not be empty"),
+            ("push", "mode: push\n      review_state: In review", "push_and_pr"),
+            ("success", "mode: push_and_pr\n      review_state: Done", "on_success"),
+            ("partial", "mode: push_and_pr\n      review_state: In review\n  - path: /tmp/other\n    branch: main\n    finalize:\n      mode: push_and_pr", "must opt in"),
+            ("conflict", "mode: push_and_pr\n      review_state: In review\n  - path: /tmp/other\n    branch: main\n    finalize:\n      mode: push_and_pr\n      review_state: Needs review", "same value"),
+        ];
+        for (label, finalize, expected) in cases {
+            let yaml = format!(
+                "{}\nrepos:\n  - path: /tmp/ensemble\n    branch: main\n    finalize:\n      {finalize}\n",
+                minimal_yaml()
+            );
+            let config = parse_config(&yaml).unwrap();
+            let error = validate_config(&config).expect_err(label);
+            assert!(error.to_string().contains(expected), "{label}: {error}");
+        }
+
+        let terminal = format!(
+            "{}\nrepos:\n  - path: /tmp/ensemble\n    branch: main\n    finalize:\n      mode: push_and_pr\n      review_state: Failed\n",
+            minimal_yaml()
+        );
+        let mut config = parse_config(&terminal).unwrap();
+        config.tracker.terminal_states.push("Failed".to_string());
+        let error = validate_config(&config).unwrap_err();
+        assert!(error.to_string().contains("terminal"));
     }
 
     #[test]

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -132,6 +132,8 @@ pub enum AgentError {
 
 #[derive(Debug, Error)]
 pub enum PipelineError {
+    #[error("invalid repository finalization config for {repo}: {reason}")]
+    InvalidFinalizeConfig { repo: String, reason: String },
     #[error("invalid acceptance command {name}: {reason}")]
     InvalidAcceptanceCommand { name: String, reason: String },
     #[error("invalid acceptance {kind} requirement {name}: {reason}")]

--- a/crates/ensemble-core/src/history/artifacts.rs
+++ b/crates/ensemble-core/src/history/artifacts.rs
@@ -22,7 +22,13 @@ pub struct RepoArtifact {
     pub finalize_mode: String,
     pub finalize_status: String,
     pub pushed_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
     pub pr_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_projection: Option<String>,
     pub last_error: Option<String>,
 }
 
@@ -66,7 +72,10 @@ pub async fn collect_repo_artifact(
         finalize_mode: finalize_mode_name(finalize_mode).to_string(),
         finalize_status: finalize_status.to_string(),
         pushed_ref: None,
+        pr_number: None,
         pr_url: None,
+        review_state: None,
+        review_projection: None,
         last_error: None,
     }
 }

--- a/crates/ensemble-core/src/history/writer.rs
+++ b/crates/ensemble-core/src/history/writer.rs
@@ -148,7 +148,10 @@ mod tests {
                 finalize_mode: "none".into(),
                 finalize_status: "not_required".into(),
                 pushed_ref: None,
+                pr_number: None,
                 pr_url: None,
+                review_state: None,
+                review_projection: None,
                 last_error: None,
             }],
             transcripts: vec![crate::history::artifacts::StepTranscriptArtifact {

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -457,7 +457,10 @@ mod tests {
                 finalize_mode: "push_and_pr".into(),
                 finalize_status: "succeeded".into(),
                 pushed_ref: Some("origin/ensemble/repo-1".into()),
+                pr_number: Some(12),
                 pr_url: Some("https://github.com/acme/repo/pull/12".into()),
+                review_state: None,
+                review_projection: None,
                 last_error: None,
             }],
             transcripts: vec![crate::history::artifacts::StepTranscriptArtifact {

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
 use tracing::warn;
@@ -10,6 +11,7 @@ use tracing::warn;
 use super::pipeline_journal::{PipelineTransitionInput, PipelineTransitionKind, TerminalOutcome};
 use super::state::{FinalizeStatus, IssueFinalizeState, RepoFinalizeState};
 use super::Orchestrator;
+use crate::history::model::HistoryRecord;
 use crate::pipeline::engine::{PipelineRun, PipelineRunSnapshot};
 use crate::workspace::finalize::FinalizeMode;
 
@@ -52,12 +54,41 @@ pub(crate) struct DeliveryRepository {
     pub retry_from: Option<DeliveryPhase>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct DeliveryRecord {
     pub issue_id: String,
     pub identifier: String,
     pub run_id: String,
     pub repositories: BTreeMap<String, DeliveryRepository>,
+    #[serde(default)]
+    pub review_projection: Option<ReviewProjection>,
+}
+
+/// The durable issue-level tracker projection owned by finalization delivery.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct ReviewProjection {
+    pub target: String,
+    /// Every configured pull-request repository that must have durable delivery identity.
+    #[serde(default)]
+    pub repositories: Vec<String>,
+    pub phase: ReviewProjectionPhase,
+    pub diagnostic: Option<String>,
+    pub last_observed_state: Option<String>,
+    /// The exact history record prepared before the tracker state is changed.
+    #[serde(default)]
+    pub history_record: Option<HistoryRecord>,
+    /// Whether the prepared record has been persisted to the history stores.
+    #[serde(default)]
+    pub history_persisted: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReviewProjectionPhase {
+    Pending,
+    InFlight,
+    Applied,
+    Blocked,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +101,13 @@ pub(crate) enum DeliveryAggregate {
 
 impl DeliveryRecord {
     pub(crate) fn aggregate(&self) -> DeliveryAggregate {
+        if self
+            .review_projection
+            .as_ref()
+            .is_some_and(|projection| projection.phase == ReviewProjectionPhase::Blocked)
+        {
+            return DeliveryAggregate::Blocked;
+        }
         if self
             .repositories
             .values()
@@ -92,6 +130,33 @@ impl DeliveryRecord {
         } else {
             DeliveryAggregate::Active
         }
+    }
+
+    fn review_ready(&self) -> bool {
+        let repositories = self
+            .review_projection
+            .as_ref()
+            .map(|projection| &projection.repositories);
+        let repository_keys = repositories
+            .filter(|keys| !keys.is_empty())
+            .cloned()
+            .unwrap_or_else(|| self.repositories.keys().cloned().collect());
+        !repository_keys.is_empty()
+            && repository_keys.iter().all(|repository_key| {
+                match self.repositories.get(repository_key) {
+                    Some(repository) => match repository.mode {
+                        DeliveryMode::Push => repository.phase == DeliveryPhase::Published,
+                        DeliveryMode::PushAndPr => {
+                            repository.phase == DeliveryPhase::Waiting
+                                && repository.observed_remote_sha.as_deref()
+                                    == Some(repository.local_sha.as_str())
+                                && repository.pr_number.is_some()
+                                && repository.pr_url.is_some()
+                        }
+                    },
+                    None => false,
+                }
+            })
     }
 }
 
@@ -568,6 +633,7 @@ impl Orchestrator {
             let delivery = self
                 .evaluate_post_final_acceptance(delivery, snapshot.as_ref())
                 .await;
+            let delivery = self.advance_review_projection(delivery).await;
             if delivery.aggregate() == DeliveryAggregate::Published {
                 self.complete_published_delivery(&delivery).await;
                 continue;
@@ -623,6 +689,282 @@ impl Orchestrator {
         }
     }
 
+    pub(super) async fn advance_review_projection(
+        &self,
+        delivery: DeliveryRecord,
+    ) -> DeliveryRecord {
+        let Some(projection) = delivery.review_projection.as_ref() else {
+            return delivery;
+        };
+        if projection.phase == ReviewProjectionPhase::Blocked
+            || (projection.phase == ReviewProjectionPhase::Applied && projection.history_persisted)
+            || !delivery.review_ready()
+        {
+            return delivery;
+        }
+
+        let mut candidate = delivery;
+        if candidate
+            .review_projection
+            .as_ref()
+            .is_some_and(|projection| projection.phase == ReviewProjectionPhase::Applied)
+        {
+            return self.persist_applied_review_history(candidate).await;
+        }
+        if candidate
+            .review_projection
+            .as_ref()
+            .is_some_and(|projection| projection.phase == ReviewProjectionPhase::Pending)
+        {
+            self.project_delivery_artifacts(&candidate.issue_id, &candidate)
+                .await;
+            self.refresh_review_history(&mut candidate, true).await;
+            candidate
+                .review_projection
+                .as_mut()
+                .expect("checked above")
+                .phase = ReviewProjectionPhase::InFlight;
+            if self
+                .persist_delivery_record(&candidate, None)
+                .await
+                .is_err()
+            {
+                return candidate;
+            }
+        }
+
+        let target = candidate
+            .review_projection
+            .as_ref()
+            .expect("review projection is retained")
+            .target
+            .clone();
+        let observed = self
+            .tracker
+            .fetch_issue_states_by_ids(std::slice::from_ref(&candidate.issue_id))
+            .await;
+        let observed = match observed {
+            Ok(mut issues) if issues.len() == 1 => issues.pop().expect("one issue"),
+            Ok(issues) => {
+                return self
+                    .block_review_projection(
+                        candidate,
+                        format!(
+                            "tracker reconciliation returned {} issues for delivery identity",
+                            issues.len()
+                        ),
+                    )
+                    .await;
+            }
+            Err(error) => {
+                return self
+                    .block_review_projection(
+                        candidate,
+                        format!("tracker reconciliation read failed: {error}"),
+                    )
+                    .await;
+            }
+        };
+        if observed.state.eq_ignore_ascii_case(&target) {
+            let projection = candidate.review_projection.as_mut().expect("retained");
+            projection.last_observed_state = Some(observed.state);
+            return self.persist_applied_review_history(candidate).await;
+        }
+
+        let config = self.config.read().await;
+        let terminal = config
+            .tracker
+            .terminal_states
+            .iter()
+            .any(|state| state.eq_ignore_ascii_case(&observed.state));
+        let active = config
+            .tracker
+            .active_states
+            .iter()
+            .any(|state| state.eq_ignore_ascii_case(&observed.state));
+        drop(config);
+        if terminal || !active {
+            return self
+                .block_review_projection(
+                    candidate,
+                    format!(
+                        "unexpected tracker state '{}' during review projection",
+                        observed.state
+                    ),
+                )
+                .await;
+        }
+
+        if let Err(error) = self
+            .tracker
+            .set_issue_state(&candidate.issue_id, &target)
+            .await
+        {
+            let projection = candidate.review_projection.as_mut().expect("retained");
+            projection.last_observed_state = Some(observed.state);
+            projection.diagnostic =
+                Some(format!("review-state write needs reconciliation: {error}"));
+            let _ = self.persist_delivery_record(&candidate, None).await;
+            return candidate;
+        }
+
+        let confirmed = self
+            .tracker
+            .fetch_issue_states_by_ids(std::slice::from_ref(&candidate.issue_id))
+            .await;
+        match confirmed {
+            Ok(mut issues) if issues.len() == 1 => {
+                let issue = issues.pop().expect("one issue");
+                let projection = candidate.review_projection.as_mut().expect("retained");
+                projection.last_observed_state = Some(issue.state.clone());
+                if issue.state.eq_ignore_ascii_case(&target) {
+                    self.persist_applied_review_history(candidate).await
+                } else if issue.state.eq_ignore_ascii_case(&observed.state) {
+                    projection.diagnostic = Some("review-state write not yet observed".to_string());
+                    let _ = self.persist_delivery_record(&candidate, None).await;
+                    candidate
+                } else {
+                    self.block_review_projection(
+                        candidate,
+                        format!(
+                            "unexpected tracker state '{}' after review-state write",
+                            issue.state
+                        ),
+                    )
+                    .await
+                }
+            }
+            Ok(issues) => {
+                self.block_review_projection(
+                    candidate,
+                    format!(
+                        "tracker reconciliation returned {} issues after review-state write",
+                        issues.len()
+                    ),
+                )
+                .await
+            }
+            Err(error) => {
+                self.block_review_projection(
+                    candidate,
+                    format!("tracker reconciliation read failed after review-state write: {error}"),
+                )
+                .await
+            }
+        }
+    }
+
+    async fn block_review_projection(
+        &self,
+        delivery: DeliveryRecord,
+        diagnostic: String,
+    ) -> DeliveryRecord {
+        let mut candidate = delivery.clone();
+        let projection = candidate
+            .review_projection
+            .as_mut()
+            .expect("review projection is retained");
+        projection.phase = ReviewProjectionPhase::Blocked;
+        projection.diagnostic = Some(diagnostic);
+        if self
+            .persist_delivery_record(&candidate, None)
+            .await
+            .is_err()
+        {
+            return delivery;
+        }
+        candidate
+    }
+
+    async fn persist_applied_review_history(&self, mut delivery: DeliveryRecord) -> DeliveryRecord {
+        {
+            let projection = delivery.review_projection.as_mut().expect("retained");
+            projection.phase = ReviewProjectionPhase::Applied;
+            projection.diagnostic = None;
+        }
+        if self.persist_delivery_record(&delivery, None).await.is_err() {
+            return delivery;
+        }
+        self.project_delivery_artifacts(&delivery.issue_id, &delivery)
+            .await;
+        if delivery
+            .review_projection
+            .as_ref()
+            .expect("retained")
+            .history_persisted
+        {
+            return delivery;
+        }
+        self.refresh_review_history(&mut delivery, false).await;
+        if self.persist_delivery_record(&delivery, None).await.is_err() {
+            return delivery;
+        }
+        let record = delivery
+            .review_projection
+            .as_ref()
+            .expect("retained")
+            .history_record
+            .clone();
+        let Some(record) = record else {
+            return self
+                .block_review_projection(
+                    delivery,
+                    "review projection is missing its prepared history record".to_string(),
+                )
+                .await;
+        };
+        if let Err(error) = self
+            .persist_history_record(Some(&delivery.run_id), &record)
+            .await
+        {
+            let projection = delivery.review_projection.as_mut().expect("retained");
+            projection.diagnostic = Some(format!(
+                "review state is confirmed but in-review history persistence needs reconciliation: {error}"
+            ));
+            let _ = self.persist_delivery_record(&delivery, None).await;
+            return delivery;
+        }
+        delivery
+            .review_projection
+            .as_mut()
+            .expect("retained")
+            .history_persisted = true;
+        if self.persist_delivery_record(&delivery, None).await.is_err() {
+            return delivery;
+        }
+        delivery
+    }
+
+    async fn refresh_review_history(
+        &self,
+        delivery: &mut DeliveryRecord,
+        refresh_completed_at: bool,
+    ) {
+        let artifacts = self
+            .state
+            .read()
+            .await
+            .artifacts
+            .get(&delivery.issue_id)
+            .cloned();
+        let Some(record) = delivery
+            .review_projection
+            .as_mut()
+            .and_then(|projection| projection.history_record.as_mut())
+        else {
+            return;
+        };
+        if refresh_completed_at {
+            record.completed_at = Utc::now();
+            record.duration_seconds = record
+                .completed_at
+                .signed_duration_since(record.started_at)
+                .num_seconds()
+                .max(0) as u64;
+        }
+        record.artifacts = artifacts;
+    }
+
     async fn complete_published_delivery(&self, delivery: &DeliveryRecord) {
         let config = self.config.read().await.clone();
         let finalize = Self::finalize_state_from_delivery(delivery);
@@ -671,6 +1013,20 @@ impl Orchestrator {
                 .as_ref()
                 .map(|_| format!("{}/{}", repository.remote, repository.head_branch));
             artifact.pr_url = repository.pr_url.clone();
+            artifact.pr_number = repository.pr_number;
+            artifact.review_state = delivery
+                .review_projection
+                .as_ref()
+                .map(|projection| projection.target.clone());
+            artifact.review_projection = delivery.review_projection.as_ref().map(|projection| {
+                match projection.phase {
+                    ReviewProjectionPhase::Pending => "pending",
+                    ReviewProjectionPhase::InFlight => "in_flight",
+                    ReviewProjectionPhase::Applied => "applied",
+                    ReviewProjectionPhase::Blocked => "blocked",
+                }
+                .to_string()
+            });
             artifact.last_error = repository.last_error.clone();
         }
     }
@@ -1235,7 +1591,7 @@ impl Orchestrator {
         workspace: &crate::workspace::manager::WorkspaceResult,
         repository_keys: &[String],
     ) -> Result<(DeliveryRecord, Option<PipelineRunSnapshot>), String> {
-        let (run_id, snapshot) = {
+        let (run_id, snapshot, review_history) = {
             let state = self.state.read().await;
             let run_id = state
                 .running
@@ -1246,7 +1602,21 @@ impl Orchestrator {
             let snapshot = state
                 .get_pipeline_run(issue_id)
                 .map(PipelineRun::to_snapshot);
-            (run_id, snapshot)
+            let review_history = state
+                .running
+                .get(issue_id)
+                .zip(state.get_pipeline_run(issue_id))
+                .map(|(running, run)| {
+                    self.build_history_record(super::RunningHistoryRecordInput {
+                        outcome: "in_review",
+                        last_error: None,
+                        running_entry: running,
+                        run,
+                        completed_at: Utc::now(),
+                        artifacts: state.artifacts.get(issue_id).cloned(),
+                    })
+                });
+            (run_id, snapshot, review_history)
         };
         let configured_repositories = self.workspace_mgr.repos();
         let mut repositories = std::collections::BTreeMap::new();
@@ -1281,12 +1651,37 @@ impl Orchestrator {
                 },
             );
         }
+        let review_state = repository_keys.iter().find_map(|repository_key| {
+            configured_repositories
+                .get(repository_key)
+                .and_then(|config| config.finalize.review_state.clone())
+        });
+        let mut review_repositories = configured_repositories
+            .iter()
+            .filter_map(|(repository_key, config)| {
+                (config.finalize.enabled && config.finalize.mode != FinalizeMode::None)
+                    .then_some(repository_key.clone())
+            })
+            .collect::<Vec<_>>();
+        review_repositories.sort();
+        if review_state.is_some() && review_history.is_none() {
+            return Err("review projection requires a live run history record".to_string());
+        }
         Ok((
             DeliveryRecord {
                 issue_id: issue_id.to_string(),
                 identifier: issue_identifier.to_string(),
                 run_id,
                 repositories,
+                review_projection: review_state.map(|target| ReviewProjection {
+                    target,
+                    repositories: review_repositories,
+                    phase: ReviewProjectionPhase::Pending,
+                    diagnostic: None,
+                    last_observed_state: None,
+                    history_record: review_history,
+                    history_persisted: false,
+                }),
             },
             snapshot,
         ))
@@ -1336,12 +1731,96 @@ mod tests {
             identifier: "ensemble#420".to_string(),
             run_id: "run-420".to_string(),
             repositories,
+            review_projection: None,
         };
 
         assert_eq!(record.aggregate(), DeliveryAggregate::Waiting);
         let json = serde_json::to_string(&record).unwrap();
         assert!(json.find("alpha").unwrap() < json.find("zeta").unwrap());
         assert!(!json.contains("aggregate"));
+    }
+
+    #[test]
+    fn review_projection_requires_durable_waiting_pr_identity() {
+        let mut repository = repository(DeliveryPhase::Waiting);
+        repository.observed_remote_sha = Some(repository.local_sha.clone());
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".into());
+        let record = DeliveryRecord {
+            issue_id: "issue-420".into(),
+            identifier: "ensemble#420".into(),
+            run_id: "run-420".into(),
+            repositories: BTreeMap::from([("primary".into(), repository)]),
+            review_projection: Some(ReviewProjection {
+                target: "In review".into(),
+                repositories: vec!["primary".into()],
+                phase: ReviewProjectionPhase::Pending,
+                diagnostic: None,
+                last_observed_state: None,
+                history_record: None,
+                history_persisted: false,
+            }),
+        };
+
+        assert!(record.review_ready());
+    }
+
+    #[test]
+    fn review_projection_waits_for_every_configured_pr_repository() {
+        let mut repository = repository(DeliveryPhase::Waiting);
+        repository.observed_remote_sha = Some(repository.local_sha.clone());
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".into());
+        let record = DeliveryRecord {
+            issue_id: "issue-420".into(),
+            identifier: "ensemble#420".into(),
+            run_id: "run-420".into(),
+            repositories: BTreeMap::from([("primary".into(), repository)]),
+            review_projection: Some(ReviewProjection {
+                target: "In review".into(),
+                repositories: vec!["primary".into(), "approval-gated".into()],
+                phase: ReviewProjectionPhase::Pending,
+                diagnostic: None,
+                last_observed_state: None,
+                history_record: None,
+                history_persisted: false,
+            }),
+        };
+
+        assert!(!record.review_ready());
+    }
+
+    #[test]
+    fn review_projection_waits_for_configured_push_repositories() {
+        let mut pull_request = repository(DeliveryPhase::Waiting);
+        pull_request.observed_remote_sha = Some(pull_request.local_sha.clone());
+        pull_request.pr_number = Some(420);
+        pull_request.pr_url = Some("https://github.com/example/project/pull/420".into());
+        let push = DeliveryRepository {
+            mode: DeliveryMode::Push,
+            phase: DeliveryPhase::Prepared,
+            ..pull_request.clone()
+        };
+        let record = DeliveryRecord {
+            issue_id: "issue-420".into(),
+            identifier: "ensemble#420".into(),
+            run_id: "run-420".into(),
+            repositories: BTreeMap::from([
+                ("pull-request".into(), pull_request),
+                ("push".into(), push),
+            ]),
+            review_projection: Some(ReviewProjection {
+                target: "In review".into(),
+                repositories: vec!["pull-request".into(), "push".into()],
+                phase: ReviewProjectionPhase::Pending,
+                diagnostic: None,
+                last_observed_state: None,
+                history_record: None,
+                history_persisted: false,
+            }),
+        };
+
+        assert!(!record.review_ready());
     }
 
     #[test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -456,7 +456,7 @@ pub struct OrchestratorRuntimeParts {
     pub workspace_root: std::path::PathBuf,
 }
 
-struct RunningHistoryRecordInput<'a> {
+pub(super) struct RunningHistoryRecordInput<'a> {
     outcome: &'a str,
     last_error: Option<String>,
     running_entry: &'a crate::tracker::model::RunningEntry,
@@ -3608,23 +3608,23 @@ impl Orchestrator {
                             {
                                 AcceptancePhaseOutcome::Passed => {}
                                 AcceptancePhaseOutcome::Failed { reason, owner } => {
-                                    self.schedule_acceptance_failure(
+                                    Box::pin(self.schedule_acceptance_failure(
                                         &acceptance_issue,
                                         &config_snapshot,
                                         &reason,
                                         &owner,
-                                    )
+                                    ))
                                     .await;
                                     return;
                                 }
                                 AcceptancePhaseOutcome::RetainedForRecovery => return,
                             }
-                            let finalize_state = self
-                                .finalize_and_stage_terminal_transition(
+                            let finalize_state =
+                                Box::pin(self.finalize_and_stage_terminal_transition(
                                     issue_id,
                                     &issue_identifier,
                                     &config_snapshot,
-                                )
+                                ))
                                 .await;
 
                             let (tracker_state, terminal_outcome, terminal_issue, history) = {
@@ -6446,9 +6446,10 @@ impl Orchestrator {
             let state = self.state.read().await;
             RunningAttemptIdentity::capture(&state, issue_id)
         };
-        let finalize_state = self
-            .run_finalize_phase(issue_id, issue_identifier, config)
-            .await;
+        // Finalization includes durable delivery reconciliation; heap-allocate its future so
+        // terminal failure handling does not inherit the full delivery state machine's stack use.
+        let finalize_state =
+            Box::pin(self.run_finalize_phase(issue_id, issue_identifier, config)).await;
         #[cfg(test)]
         self.wait_for_finalization_commit_test_barriers().await;
         if attempt.is_some() {
@@ -6635,6 +6636,7 @@ impl Orchestrator {
                     let delivery = self
                         .advance_delivery_record(delivery, workspace, snapshot.as_ref())
                         .await;
+                    let delivery = self.advance_review_projection(delivery).await;
                     repos.extend(Self::finalize_repositories_from_delivery(&delivery));
                     self.project_delivery_artifacts(issue_id, &delivery).await;
                 }
@@ -6825,9 +6827,13 @@ impl Orchestrator {
                     );
                     return;
                 }
+                let existing_projection = existing.review_projection.clone();
                 let mut repositories = existing.repositories;
                 repositories.extend(prepared.repositories);
                 prepared.repositories = repositories;
+                if existing_projection.is_some() {
+                    prepared.review_projection = existing_projection;
+                }
             }
             (prepared, snapshot)
         };
@@ -6863,6 +6869,7 @@ impl Orchestrator {
         let delivery = self
             .advance_delivery_record(delivery, &workspace, snapshot.as_ref())
             .await;
+        let delivery = self.advance_review_projection(delivery).await;
         self.project_delivery_artifacts(issue_id, &delivery).await;
 
         let (final_status, should_complete, last_error) = {
@@ -7011,7 +7018,10 @@ impl Orchestrator {
             .any(|step_state| matches!(step_state, StepState::Running { .. }))
     }
 
-    fn build_history_record(&self, input: RunningHistoryRecordInput<'_>) -> HistoryRecord {
+    pub(super) fn build_history_record(
+        &self,
+        input: RunningHistoryRecordInput<'_>,
+    ) -> HistoryRecord {
         let steps_traversed = input.run.traversed_steps_in_order();
 
         let duration_seconds = input
@@ -9548,6 +9558,7 @@ mod tests {
                     enabled: true,
                     mode: FinalizeMode::Push,
                     approval_required: true,
+                    review_state: None,
                 },
             },
         )
@@ -9649,6 +9660,7 @@ mod tests {
         let (repo_temp, mut repo_config) = create_finalize_repo().await;
         repo_config.finalize.mode = FinalizeMode::PushAndPr;
         repo_config.finalize.approval_required = false;
+        repo_config.finalize.review_state = Some("In review".to_string());
         let config = Arc::new(RwLock::new(make_config()));
         let issue = test_issue("1", "Todo");
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
@@ -9677,6 +9689,15 @@ mod tests {
             mutation_phases: std::sync::Mutex::new(Vec::new()),
         });
         orchestrator.delivery_remote = remote.clone();
+        let review_tracker = Arc::new(ReviewProjectionTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+            journal: orchestrator.pipeline_journal.clone(),
+            issue_id: issue.id.clone(),
+            writes: AtomicUsize::new(0),
+            saw_in_flight_before_write: AtomicBool::new(false),
+            fail_reads: false,
+        });
+        orchestrator.tracker = review_tracker.clone();
 
         {
             let cfg = config.read().await;
@@ -9707,10 +9728,20 @@ mod tests {
             crate::orchestrator::delivery::DeliveryPhase::Waiting
         );
         assert_eq!(delivery.repositories["source-repo"].pr_number, Some(420));
+        assert_eq!(
+            delivery.review_projection.as_ref().unwrap().phase,
+            crate::orchestrator::delivery::ReviewProjectionPhase::Applied
+        );
         assert!(!state.is_running(&issue.id));
         assert!(state.is_claimed(&issue.id));
+        assert!(!state.completed.contains_key(&issue.id));
         assert_eq!(live_worker_count(&orchestrator.cancellation_registry), 0);
         drop(state);
+
+        assert_eq!(review_tracker.writes.load(Ordering::SeqCst), 1);
+        assert!(review_tracker
+            .saw_in_flight_before_write
+            .load(Ordering::SeqCst));
 
         assert_eq!(
             *remote.mutation_phases.lock().unwrap(),
@@ -9752,6 +9783,93 @@ mod tests {
         pushes: AtomicUsize,
         creates: AtomicUsize,
         lists: AtomicUsize,
+    }
+
+    struct ReviewProjectionTracker {
+        issues: Arc<RwLock<Vec<Issue>>>,
+        journal: PipelineRunJournal,
+        issue_id: String,
+        writes: AtomicUsize,
+        saw_in_flight_before_write: AtomicBool,
+        fail_reads: bool,
+    }
+
+    #[async_trait]
+    impl IssueTracker for ReviewProjectionTracker {
+        async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, crate::tracker::TrackerError> {
+            Ok(self.issues.read().await.clone())
+        }
+
+        async fn fetch_issues_by_states(
+            &self,
+            states: &[String],
+        ) -> Result<Vec<Issue>, crate::tracker::TrackerError> {
+            let issues = self.issues.read().await;
+            Ok(issues
+                .iter()
+                .filter(|issue| {
+                    states
+                        .iter()
+                        .any(|state| state.eq_ignore_ascii_case(&issue.state))
+                })
+                .cloned()
+                .collect())
+        }
+
+        async fn fetch_issue_states_by_ids(
+            &self,
+            ids: &[String],
+        ) -> Result<Vec<Issue>, crate::tracker::TrackerError> {
+            if self.fail_reads {
+                return Err(crate::tracker::TrackerError::ApiRequestFailed {
+                    reason: "simulated tracker read failure".to_string(),
+                });
+            }
+            let issues = self.issues.read().await;
+            Ok(issues
+                .iter()
+                .filter(|issue| ids.contains(&issue.id))
+                .cloned()
+                .collect())
+        }
+
+        fn supports_writes(&self) -> bool {
+            true
+        }
+
+        async fn set_issue_state(
+            &self,
+            id: &str,
+            state: &str,
+        ) -> Result<(), crate::tracker::TrackerError> {
+            let latest = self
+                .journal
+                .latest_live_record_for_issue(&self.issue_id)
+                .await
+                .unwrap()
+                .unwrap();
+            self.saw_in_flight_before_write.store(
+                latest.delivery.as_ref().is_some_and(|delivery| {
+                    delivery
+                        .review_projection
+                        .as_ref()
+                        .is_some_and(|projection| {
+                            projection.phase
+                                == crate::orchestrator::delivery::ReviewProjectionPhase::InFlight
+                                && !projection.history_persisted
+                        })
+                }),
+                Ordering::SeqCst,
+            );
+            self.writes.fetch_add(1, Ordering::SeqCst);
+            let mut issues = self.issues.write().await;
+            issues
+                .iter_mut()
+                .find(|issue| issue.id == id)
+                .expect("tracker owns issue")
+                .state = state.to_string();
+            Ok(())
+        }
     }
 
     #[async_trait]
@@ -9863,12 +9981,212 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            review_projection: None,
         };
         orchestrator
             .persist_delivery_record(&delivery, None)
             .await
             .unwrap();
         (orchestrator, workspace_temp, repo_temp, delivery)
+    }
+
+    fn review_projection_history() -> HistoryRecord {
+        HistoryRecord {
+            issue_identifier: "repo#1".to_string(),
+            issue_id: "1".to_string(),
+            outcome: "in_review".to_string(),
+            steps_traversed: vec!["build".to_string()],
+            attempts: 1,
+            tokens: TokenTotals {
+                input_tokens: 0,
+                output_tokens: 0,
+                total_tokens: 0,
+            },
+            duration_seconds: 0,
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+            last_error: None,
+            verdict: Some("approved".to_string()),
+            workspace_path: "/tmp/ensemble-test".to_string(),
+            acceptance_attempts: Vec::new(),
+            artifacts: None,
+        }
+    }
+
+    fn review_ready_delivery(mut delivery: DeliveryRecord) -> DeliveryRecord {
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
+        repository.last_error = None;
+        delivery.review_projection = Some(crate::orchestrator::delivery::ReviewProjection {
+            target: "In review".to_string(),
+            repositories: vec!["source-repo".to_string()],
+            phase: crate::orchestrator::delivery::ReviewProjectionPhase::Pending,
+            diagnostic: None,
+            last_observed_state: None,
+            history_record: Some(review_projection_history()),
+            history_persisted: false,
+        });
+        delivery
+    }
+
+    #[tokio::test]
+    async fn review_projection_persists_in_flight_then_history_before_applied() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, workspace, _repo, delivery) =
+            recovery_test_orchestrator(remote).await;
+        let tracker = Arc::new(ReviewProjectionTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "In Progress")])),
+            journal: orchestrator.pipeline_journal.clone(),
+            issue_id: "1".to_string(),
+            writes: AtomicUsize::new(0),
+            saw_in_flight_before_write: AtomicBool::new(false),
+            fail_reads: false,
+        });
+        orchestrator.tracker = tracker.clone();
+        let delivery = review_ready_delivery(delivery);
+        orchestrator
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+
+        let applied = orchestrator.advance_review_projection(delivery).await;
+
+        assert_eq!(
+            applied.review_projection.as_ref().unwrap().phase,
+            crate::orchestrator::delivery::ReviewProjectionPhase::Applied
+        );
+        assert!(
+            applied
+                .review_projection
+                .as_ref()
+                .unwrap()
+                .history_persisted
+        );
+        assert_eq!(tracker.writes.load(Ordering::SeqCst), 1);
+        assert!(tracker.saw_in_flight_before_write.load(Ordering::SeqCst));
+        let history = tokio::fs::read_to_string(workspace.path().join("ensemble_history.jsonl"))
+            .await
+            .unwrap();
+        assert_eq!(history.lines().count(), 1);
+        assert_eq!(
+            serde_json::from_str::<HistoryRecord>(history.lines().next().unwrap())
+                .unwrap()
+                .outcome,
+            "in_review"
+        );
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        let in_flight = records
+            .iter()
+            .position(|record| {
+                record.delivery.as_ref().is_some_and(|delivery| {
+                    delivery
+                        .review_projection
+                        .as_ref()
+                        .is_some_and(|projection| {
+                            projection.phase
+                                == crate::orchestrator::delivery::ReviewProjectionPhase::InFlight
+                        })
+                })
+            })
+            .unwrap();
+        let applied = records
+            .iter()
+            .position(|record| {
+                record.delivery.as_ref().is_some_and(|delivery| {
+                    delivery
+                        .review_projection
+                        .as_ref()
+                        .is_some_and(|projection| {
+                            projection.phase
+                                == crate::orchestrator::delivery::ReviewProjectionPhase::Applied
+                                && projection.history_persisted
+                        })
+                })
+            })
+            .unwrap();
+        assert!(in_flight < applied);
+    }
+
+    #[tokio::test]
+    async fn review_projection_adopts_already_target_state_without_write() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, delivery) =
+            recovery_test_orchestrator(remote).await;
+        let tracker = Arc::new(ReviewProjectionTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "In review")])),
+            journal: orchestrator.pipeline_journal.clone(),
+            issue_id: "1".to_string(),
+            writes: AtomicUsize::new(0),
+            saw_in_flight_before_write: AtomicBool::new(false),
+            fail_reads: false,
+        });
+        orchestrator.tracker = tracker.clone();
+        let delivery = review_ready_delivery(delivery);
+        orchestrator
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+
+        let applied = orchestrator.advance_review_projection(delivery).await;
+
+        assert_eq!(
+            applied.review_projection.as_ref().unwrap().phase,
+            crate::orchestrator::delivery::ReviewProjectionPhase::Applied
+        );
+        assert_eq!(tracker.writes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn review_projection_retains_unreadable_and_unexpected_observations_as_blocked() {
+        for (state, fail_reads) in [("In Progress", true), ("Done", false)] {
+            let remote = Arc::new(RecoveryDeliveryRemote {
+                pull_requests: std::sync::Mutex::new(Vec::new()),
+                pushes: AtomicUsize::new(0),
+                creates: AtomicUsize::new(0),
+                lists: AtomicUsize::new(0),
+            });
+            let (mut orchestrator, _workspace, _repo, delivery) =
+                recovery_test_orchestrator(remote).await;
+            let tracker = Arc::new(ReviewProjectionTracker {
+                issues: Arc::new(RwLock::new(vec![test_issue("1", state)])),
+                journal: orchestrator.pipeline_journal.clone(),
+                issue_id: "1".to_string(),
+                writes: AtomicUsize::new(0),
+                saw_in_flight_before_write: AtomicBool::new(false),
+                fail_reads,
+            });
+            orchestrator.tracker = tracker.clone();
+            let delivery = review_ready_delivery(delivery);
+            orchestrator
+                .persist_delivery_record(&delivery, None)
+                .await
+                .unwrap();
+
+            let blocked = orchestrator.advance_review_projection(delivery).await;
+
+            assert_eq!(
+                blocked.review_projection.as_ref().unwrap().phase,
+                crate::orchestrator::delivery::ReviewProjectionPhase::Blocked
+            );
+            assert_eq!(tracker.writes.load(Ordering::SeqCst), 0);
+            assert_eq!(orchestrator.state.read().await.delivery["1"], blocked);
+        }
     }
 
     fn post_finalize_acceptance_snapshot(
@@ -10311,6 +10629,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            review_projection: None,
         }
     }
 

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -631,6 +631,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            review_projection: None,
         };
 
         journal

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -1467,6 +1467,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            review_projection: None,
         };
         state
             .write()

--- a/crates/ensemble-core/src/workspace/finalize.rs
+++ b/crates/ensemble-core/src/workspace/finalize.rs
@@ -26,6 +26,9 @@ pub struct RepoFinalizeConfig {
     pub mode: FinalizeMode,
     #[serde(default)]
     pub approval_required: bool,
+    /// Optional non-terminal tracker state projected after durable pull-request delivery.
+    #[serde(default)]
+    pub review_state: Option<String>,
 }
 
 impl Default for RepoFinalizeConfig {
@@ -34,6 +37,7 @@ impl Default for RepoFinalizeConfig {
             enabled: default_finalize_enabled(),
             mode: FinalizeMode::None,
             approval_required: false,
+            review_state: None,
         }
     }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -383,6 +383,12 @@ Pipeline run recovery:
   dispatches no pipeline work, and does not project a terminal tracker state. `blocked` is likewise
   retained for operator recovery. A fully `published` push-only delivery continues the existing
   durable terminal-transition protocol; it does not republish the branch.
+- An optional `push_and_pr` `review_state` is an issue-level retained projection, never a terminal
+  outcome. Its journal phase is `pending`, `in_flight`, `applied`, or `blocked`; Ensemble persists
+  `in_flight` before the tracker write and applies only after an exact target-state read. It writes
+  only after every configured repository is non-active and every pull request is uniquely durable
+  at its stored SHA. Read failures, terminal states, and unexpected states block the delivery while
+  retaining the claim, workspace, branch, SHA, pull request, and artifacts without redispatch.
 - Required pull-request checks run only after the retained delivery identity reaches `waiting` or
   `published`. Results form one ordered suffix batch per evaluation. Restart resumes a partial
   batch without push, creation, or discovery; an explicit finalize retry appends a complete new

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,7 @@ repos:
     finalize:
       mode: push_and_pr
       approval_required: true
+      review_state: In review
 
 agents:
   builder:
@@ -442,6 +443,7 @@ List of repositories for workspace setup. Paths can be absolute or relative to t
 | `finalize.enabled` | bool | `true` | Whether post-pipeline finalization is enabled for this repo |
 | `finalize.mode` | string | `none` | Finalization action: `none`, `push`, or `push_and_pr` |
 | `finalize.approval_required` | bool | `false` | Requires explicit approval from web/desktop UI before finalize runs |
+| `finalize.review_state` | string | none | Optional non-terminal tracker state projected after exact `push_and_pr` delivery |
 
 `finalize.mode` defaults to `none`, so Ensemble does not push branches or open pull requests unless
 you opt in per repo. Ensemble still records durable run artifacts for each completed issue,
@@ -454,6 +456,15 @@ before retrying, so an ambiguous push or pull request response cannot silently d
 publication. A `push_and_pr` repository remains claimed in a non-capacity-consuming waiting state
 after its uniquely matching pull request is found; merging or closing that pull request does not by
 itself project the issue to `on_success`.
+
+`finalize.review_state` is valid only with `push_and_pr`. It must be non-blank, must not be
+`on_success` or a configured terminal state, and every opt-in pull-request repository for one
+delivery must select the same target. Ensemble persists the issue-level projection as `pending`,
+`in_flight`, `applied`, or `blocked`. It persists `in_flight` before writing to the tracker and
+reconciles the exact target after every write. An unreadable, terminal, or unexpected observed
+state blocks the retained delivery; a confirmed active-state absence may retry on a later poll.
+The branch, SHA, pull-request identity, workspace, and claim remain retained throughout; this
+state consumes no agent capacity and never uses `on_success` or cleanup.
 
 **Headless behavior:** if `finalize.approval_required: true` and Ensemble is running headless, startup emits a warning and finalize is skipped for that repo.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -62,7 +62,7 @@ require GitHub, Notion, real ACP credentials, or non-localhost network access.
 
 ### Ignored live dogfood tracer bullet
 
-`live_bamboon_issue_commits_without_publication` is a deliberately expensive local-only
+`live_bamboon_issue_publishes_pull_request` is a deliberately expensive, explicitly opted-in
 tracer bullet. It is ignored, is never part of CI, and creates a real synthetic issue in the
 private, operator-provisioned **Ensemble Dogfood** Project. It launches a real ACPX agent against
 an issue-owned Bamboon worktree, so it can consume network access and model time.
@@ -77,7 +77,7 @@ ENSEMBLE_LIVE_DOGFOOD=1 \
   ENSEMBLE_DOGFOOD_BAMBOON_PATH=<absolute-clean-bamboon-clone> \
   SKIP_UI_BUILD=1 \
   cargo test -p ensemble-cli --features web-ui --test product_e2e \
-  live_bamboon_issue_commits_without_publication -- --ignored --nocapture
+  live_bamboon_issue_publishes_pull_request -- --ignored --nocapture
 ```
 
 `ENSEMBLE_LIVE_DOGFOOD=1` is the exact mutation opt-in. The harness validates the linked Project,
@@ -87,13 +87,14 @@ the `codex` named agent; set a non-empty `ENSEMBLE_DOGFOOD_AGENT` only for an ex
 override. The GitHub credential comes from `gh auth token` only after the opt-in gate, is passed to
 the child host in memory as `GITHUB_TOKEN`, and is not written into generated YAML or diagnostics.
 
-The tracer bullet creates one marker-owned Markdown artifact and commit, with finalization set to
-`none`: neither the agent nor Ensemble may push a branch or create a pull request. From the point
-the issue is made ready to implement onward, it preserves the run directory, host stdout/stderr,
-issue, Project item, workspace, and local branch for diagnosis. The test prints the redacted,
-run-scoped preservation location on success or failure. Do not perform routine cleanup or fixture
-repair from the harness; publication, restart recovery, and cleanup are intentionally outside this
-slice.
+The tracer bullet creates one marker-owned Markdown artifact and commit. The agent may not publish:
+after capturing that local commit, Ensemble alone pushes the generated branch and creates exactly
+one open pull request at the captured SHA. It projects the Project issue to `In review` only after
+the delivery record persists its remote branch and pull-request identity. From that point it
+preserves the run directory, host stdout/stderr, issue, Project item, workspace, branch, and pull
+request for diagnosis. The test prints the redacted, run-scoped preservation location on success
+or failure. Do not perform routine cleanup or fixture repair from the harness; merge/close,
+restart-recovery proof, and cleanup remain outside this slice.
 
 ## Project structure
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -247,6 +247,13 @@ retains their exact delivery and pull-request identity. An explicit finalize ret
 new suffix batch; a passing retry returns the delivery to `waiting`, while failure remains blocked.
 This path does not consume pipeline cycles or use `max_cycles`.
 
+When `repos[].finalize.review_state` is configured, review is a separate delivery-owned,
+non-terminal projection. Only after every repository has durable non-active publication evidence
+and each pull request is uniquely reconciled at its stored SHA may Ensemble write the configured
+review state. The journal records `pending`, then `in_flight` before the tracker write, and
+`applied` only after an exact tracker read. Ambiguous or unexpected reconciliation blocks the
+retained delivery without another branch, pull request, terminal transition, or agent dispatch.
+
 ## Retries and cycles
 
 When a step fails or an agent errors out, Ensemble can retry. The `max_cycles` setting controls how many times:


### PR DESCRIPTION
Fixes #465

Adds a durable non-terminal `repos[].finalize.review_state` projection for
`push_and_pr` delivery. Ensemble now waits for every enabled finalizing
repository's captured delivery evidence, records the tracker projection as a
recoverable protocol, and retains matched PR, branch, SHA, artifacts, and
history evidence while the issue is in review.

The projection writes `in_flight` before the tracker mutation, reconciles the
exact target state, fails closed on unreadable or unexpected observations, and
preserves approval-retry and mixed push/PR delivery gates. It also avoids a
worker-stack regression exposed by terminal acceptance failures.

Validation:

- Product E2E: 14 passed, 1 ignored.
- Focused review projection, readiness, configuration, and live finalization
  coverage passed.
- Web UI feature check, clippy with warnings denied, formatting, and diff
  checks passed.
- Final correctness, simplify, and ponytail reviews found no material issues.

The private ignored live dogfood test was not run; it requires the provisioned
Project, clean Bamboon checkout, ACPX, and model/network cost.
