### PR TITLE
Update Project required check configuration

### DIFF
--- a/docs/agents/run-github-project.md
+++ b/docs/agents/run-github-project.md
@@ -57,7 +57,7 @@
 - Issue closure: `closing-keyword`
 - Required reviews: `none`
 - Required checks: `Check, Test, Clippy, Format`; `Frontend Test and Build`;
-  `Tauri PR (Linux)`; `Tauri PR (Mac)`
+  `Tauri PR (Linux)`; `Tauri PR (Mac)`; `MSRV (Rust 1.95.0)`
 - Done automation: `set-status`
 - Automation description: Enabled Project workflows `Item closed` and
   `Pull request merged`; verified that merged-and-closed issue #182 moved from


### PR DESCRIPTION
The active main ruleset now requires the MSRV (Rust 1.95.0) check, but the trusted GitHub Project binding still listed the previous four checks.

This updates the binding to match the live rule so Project execution can fail closed against the current merge policy.

Validation:
- Revalidated Project field and option IDs
- Revalidated role-label IDs and Done workflows
- Revalidated squash-only merge settings and active ruleset 14473440
- git diff --check
- Correctness, standards, reuse/clarity/efficiency, and over-engineering reviews: no findings