### PR TITLE
Make live dogfood runs safely repeatable

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 use serde_json::Value;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::{self, Read, Write};
 use std::net::TcpListener;
@@ -708,6 +708,17 @@ impl LiveDogfoodMode {
             )),
         }
     }
+
+    fn from_os_input(value: Option<&OsStr>) -> Result<Self, String> {
+        let value = value
+            .map(|value| {
+                value
+                    .to_str()
+                    .ok_or_else(|| format!("{LIVE_DOGFOOD_PRESERVE} must contain valid UTF-8"))
+            })
+            .transpose()?;
+        Self::from_input(value)
+    }
 }
 
 #[derive(Debug)]
@@ -720,12 +731,14 @@ struct LiveDogfoodInputs {
 
 impl LiveDogfoodInputs {
     fn from_env() -> Result<Self, String> {
-        Self::from_values_with_preserve(
+        let mode =
+            LiveDogfoodMode::from_os_input(std::env::var_os(LIVE_DOGFOOD_PRESERVE).as_deref())?;
+        Self::from_values_with_mode(
             std::env::var(LIVE_DOGFOOD_OPT_IN).ok().as_deref(),
             std::env::var(LIVE_DOGFOOD_PROJECT).ok().as_deref(),
             std::env::var(LIVE_DOGFOOD_BAMBOON_PATH).ok().as_deref(),
             std::env::var(LIVE_DOGFOOD_AGENT).ok().as_deref(),
-            std::env::var(LIVE_DOGFOOD_PRESERVE).ok().as_deref(),
+            mode,
         )
     }
 
@@ -744,6 +757,22 @@ impl LiveDogfoodInputs {
         bamboon_path: Option<&str>,
         agent: Option<&str>,
         preserve: Option<&str>,
+    ) -> Result<Self, String> {
+        Self::from_values_with_mode(
+            opt_in,
+            project_number,
+            bamboon_path,
+            agent,
+            LiveDogfoodMode::from_input(preserve)?,
+        )
+    }
+
+    fn from_values_with_mode(
+        opt_in: Option<&str>,
+        project_number: Option<&str>,
+        bamboon_path: Option<&str>,
+        agent: Option<&str>,
+        mode: LiveDogfoodMode,
     ) -> Result<Self, String> {
         if opt_in != Some("1") {
             return Err(format!("{LIVE_DOGFOOD_OPT_IN} must be exactly 1"));
@@ -772,7 +801,7 @@ impl LiveDogfoodInputs {
                 .filter(|value| !value.is_empty())
                 .unwrap_or("codex")
                 .to_string(),
-            mode: LiveDogfoodMode::from_input(preserve)?,
+            mode,
         })
     }
 }
@@ -2471,6 +2500,17 @@ fn stop_and_reap_live_host(host: &mut Child) -> Result<(), String> {
     Ok(())
 }
 
+fn run_live_preserve_completion(
+    host: &mut Child,
+    evidence: &mut LiveDogfoodEvidenceV1,
+    run: &LiveDogfoodRun,
+) -> Result<(), String> {
+    stop_and_reap_live_host(host)?;
+    evidence.append_transition("preserve_stop_and_reap_host", "succeeded");
+    evidence.preserve_certification();
+    write_live_dogfood_evidence_v1(&run.root, evidence)
+}
+
 fn finalize_live_restarted_run_failure(
     host: &mut Child,
     evidence: &mut LiveDogfoodEvidenceV1,
@@ -2494,12 +2534,21 @@ fn finalize_live_restarted_run_failure(
         .unwrap_or(error)
 }
 
+fn canonical_live_worktree_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| {
+        path.parent()
+            .and_then(|parent| fs::canonicalize(parent).ok())
+            .and_then(|parent| path.file_name().map(|name| parent.join(name)))
+            .unwrap_or_else(|| path.to_path_buf())
+    })
+}
+
 fn worktree_is_registered(listing: &str, worktree: &Path) -> bool {
-    let expected = worktree.to_string_lossy();
+    let expected = canonical_live_worktree_path(worktree);
     listing
         .lines()
         .filter_map(|line| line.strip_prefix("worktree "))
-        .any(|path| path == expected)
+        .any(|path| canonical_live_worktree_path(Path::new(path)) == expected)
 }
 
 fn live_public_issue_released(detail: &Value) -> bool {
@@ -2651,16 +2700,11 @@ fn delete_live_remote_ref(
     plan: &LiveDogfoodCleanupPlan,
 ) -> Result<(), String> {
     revalidate_live_remote_ref(inputs, &inputs.bamboon_path, plan)?;
-    live_git(
-        "cleanup delete generated ref",
-        &inputs.bamboon_path,
-        [
-            "push".to_string(),
-            "origin".to_string(),
-            "--delete".to_string(),
-            plan.branch.clone(),
-        ],
+    delete_live_remote_ref_at_sha(
         inputs,
+        &inputs.bamboon_path,
+        &plan.branch,
+        &plan.expected_sha,
     )?;
     let remaining = live_git(
         "cleanup verify generated ref absence",
@@ -2677,6 +2721,27 @@ fn delete_live_remote_ref(
         return Err("cleanup delete generated ref: ref remained present".to_string());
     }
     Ok(())
+}
+
+fn delete_live_remote_ref_at_sha(
+    inputs: &LiveDogfoodInputs,
+    worktree: &Path,
+    branch: &str,
+    expected_sha: &str,
+) -> Result<(), String> {
+    live_git(
+        "cleanup delete generated ref",
+        worktree,
+        [
+            "push".to_string(),
+            format!("--force-with-lease=refs/heads/{branch}:{expected_sha}"),
+            "--delete".to_string(),
+            "origin".to_string(),
+            branch.to_string(),
+        ],
+        inputs,
+    )
+    .map(|_| ())
 }
 
 fn validate_live_final_absence(observations: [bool; 6]) -> Result<(), String> {
@@ -2780,8 +2845,72 @@ fn persist_live_cleanup_transition(
     step: LiveDogfoodCleanupStep,
     result: Result<(), String>,
 ) -> Result<(), String> {
-    record_live_cleanup_step(cleanup, evidence, step, result)?;
-    write_live_dogfood_evidence_v1(&run.root, evidence)
+    match record_live_cleanup_step(cleanup, evidence, step, result) {
+        Ok(()) => write_live_dogfood_evidence_v1(&run.root, evidence),
+        Err(error) => {
+            write_live_dogfood_evidence_v1(&run.root, evidence)
+                .map_err(|write_error| format!("{error}; {write_error}"))?;
+            Err(error)
+        }
+    }
+}
+
+trait LiveDogfoodCleanupActions {
+    async fn execute(&mut self, step: LiveDogfoodCleanupStep) -> Result<(), String>;
+}
+
+struct LiveDogfoodRoutineCleanupActions<'a> {
+    client: &'a reqwest::Client,
+    base_url: &'a str,
+    inputs: &'a LiveDogfoodInputs,
+    host: &'a mut Child,
+    worktree: &'a Path,
+    plan: &'a LiveDogfoodCleanupPlan,
+}
+
+impl LiveDogfoodCleanupActions for LiveDogfoodRoutineCleanupActions<'_> {
+    async fn execute(&mut self, step: LiveDogfoodCleanupStep) -> Result<(), String> {
+        match step {
+            LiveDogfoodCleanupStep::ClosePullRequest => {
+                close_live_pull_request(self.inputs, self.plan)
+            }
+            LiveDogfoodCleanupStep::ProjectDone => set_live_project_done(self.inputs, self.plan),
+            LiveDogfoodCleanupStep::WaitForHostRelease => {
+                wait_for_live_host_release(
+                    self.client,
+                    self.base_url,
+                    self.inputs,
+                    self.plan.issue_number,
+                    self.worktree,
+                )
+                .await
+            }
+            LiveDogfoodCleanupStep::StopAndReapHost => stop_and_reap_live_host(self.host),
+            LiveDogfoodCleanupStep::CloseIssue => close_live_issue(self.inputs, self.plan),
+            LiveDogfoodCleanupStep::RemoveProjectItem => {
+                remove_live_project_item(self.inputs, self.plan)
+            }
+            LiveDogfoodCleanupStep::DeleteGeneratedRef => {
+                delete_live_remote_ref(self.inputs, self.plan)
+            }
+            LiveDogfoodCleanupStep::VerifyFinalAbsence => {
+                verify_live_final_absence(self.inputs, self.host, self.worktree, self.plan)
+            }
+        }
+    }
+}
+
+async fn execute_live_cleanup_sequence(
+    actions: &mut impl LiveDogfoodCleanupActions,
+    cleanup: &mut LiveDogfoodCleanupRecorder,
+    evidence: &mut LiveDogfoodEvidenceV1,
+    run: &LiveDogfoodRun,
+) -> Result<(), String> {
+    for step in LIVE_DOGFOOD_CLEANUP_ORDER {
+        let result = actions.execute(step).await;
+        persist_live_cleanup_transition(cleanup, evidence, run, step, result)?;
+    }
+    Ok(())
 }
 
 async fn run_live_routine_cleanup(
@@ -2814,80 +2943,15 @@ async fn run_live_routine_cleanup(
         }
     };
     let mut cleanup = LiveDogfoodCleanupRecorder::new(&plan)?;
-
-    let result = close_live_pull_request(inputs, &plan);
-    persist_live_cleanup_transition(
-        &mut cleanup,
-        evidence,
-        run,
-        LiveDogfoodCleanupStep::ClosePullRequest,
-        result,
-    )?;
-
-    let result = set_live_project_done(inputs, &plan);
-    persist_live_cleanup_transition(
-        &mut cleanup,
-        evidence,
-        run,
-        LiveDogfoodCleanupStep::ProjectDone,
-        result,
-    )?;
-
-    let result =
-        wait_for_live_host_release(client, base_url, inputs, resources.issue_number, worktree)
-            .await;
-    persist_live_cleanup_transition(
-        &mut cleanup,
-        evidence,
-        run,
-        LiveDogfoodCleanupStep::WaitForHostRelease,
-        result,
-    )?;
-
-    let result = stop_and_reap_live_host(host);
-    persist_live_cleanup_transition(
-        &mut cleanup,
-        evidence,
-        run,
-        LiveDogfoodCleanupStep::StopAndReapHost,
-        result,
-    )?;
-
-    let result = close_live_issue(inputs, &plan);
-    persist_live_cleanup_transition(
-        &mut cleanup,
-        evidence,
-        run,
-        LiveDogfoodCleanupStep::CloseIssue,
-        result,
-    )?;
-
-    let result = remove_live_project_item(inputs, &plan);
-    persist_live_cleanup_transition(
-        &mut cleanup,
-        evidence,
-        run,
-        LiveDogfoodCleanupStep::RemoveProjectItem,
-        result,
-    )?;
-
-    let result = delete_live_remote_ref(inputs, &plan);
-    persist_live_cleanup_transition(
-        &mut cleanup,
-        evidence,
-        run,
-        LiveDogfoodCleanupStep::DeleteGeneratedRef,
-        result,
-    )?;
-
-    let result = verify_live_final_absence(inputs, host, worktree, &plan);
-    persist_live_cleanup_transition(
-        &mut cleanup,
-        evidence,
-        run,
-        LiveDogfoodCleanupStep::VerifyFinalAbsence,
-        result,
-    )?;
+    let mut actions = LiveDogfoodRoutineCleanupActions {
+        client,
+        base_url,
+        inputs,
+        host,
+        worktree,
+        plan: &plan,
+    };
+    execute_live_cleanup_sequence(&mut actions, &mut cleanup, evidence, run).await?;
     if !cleanup.is_complete() {
         return Err("cleanup final absence: transition plan was incomplete".to_string());
     }
@@ -2993,8 +3057,29 @@ fn rollback_pre_dispatch_after_error(
     error: String,
 ) -> String {
     match rollback_pre_dispatch(resources, inputs) {
-        Ok(()) => error,
-        Err(rollback_error) => format!("{error}; {rollback_error}"),
+        Ok(()) => format!(
+            "{error}; pre-dispatch rollback completed for synthetic issue #{}",
+            resources.issue_number
+        ),
+        Err(rollback_error) => format!(
+            "{error}; pre-dispatch rollback for synthetic issue #{} failed: {rollback_error}",
+            resources.issue_number
+        ),
+    }
+}
+
+fn start_live_pre_dispatch_host<H>(
+    resources: &PreDispatchResources,
+    reserve_port: impl FnOnce() -> Result<u16, String>,
+    spawn_host: impl FnOnce(u16) -> Result<H, String>,
+    rollback_after_error: impl FnOnce(&PreDispatchResources, String) -> String,
+) -> Result<(u16, H), String> {
+    match reserve_port() {
+        Err(error) => Err(rollback_after_error(resources, error)),
+        Ok(port) => match spawn_host(port) {
+            Ok(host) => Ok((port, host)),
+            Err(error) => Err(rollback_after_error(resources, error)),
+        },
     }
 }
 
@@ -3740,6 +3825,12 @@ async fn live_bamboon_issue_publishes_pull_request() {
                 &resources, &inputs, error,
             ));
         }
+        let (port, mut host) = start_live_pre_dispatch_host(
+            &resources,
+            || reserve_local_port().map_err(|error| format!("reserve host port: {error}")),
+            |port| spawn_live_host(&inputs, &run, &token, port, LiveDogfoodHostLifetime::First),
+            |resources, error| rollback_pre_dispatch_after_error(resources, &inputs, error),
+        )?;
         let resources = LiveDogfoodResources {
             issue_id: resources.issue_id,
             issue_number: resources.issue_number,
@@ -3752,21 +3843,6 @@ async fn live_bamboon_issue_publishes_pull_request() {
             inputs.mode,
         );
         let mut pre_publication_captured = false;
-        let port = reserve_local_port().map_err(|error| format!("reserve host port: {error}"))?;
-        let mut host =
-            match spawn_live_host(&inputs, &run, &token, port, LiveDogfoodHostLifetime::First) {
-                Ok(host) => host,
-                Err(error) => {
-                    let failure = persist_live_dogfood_failure(
-                        &mut evidence,
-                        &run,
-                        &inputs,
-                        pre_publication_captured,
-                        &error,
-                    );
-                    return Err(failure.err().unwrap_or(error));
-                }
-            };
         let client = reqwest::Client::new();
         let base_url = format!("http://127.0.0.1:{port}");
         let completed = async {
@@ -3946,7 +4022,9 @@ async fn live_bamboon_issue_publishes_pull_request() {
         }
         match inputs.mode {
             LiveDogfoodMode::Preserve => {
-                if let Err(error) = stop_and_reap_live_host(&mut restarted_host) {
+                if let Err(error) =
+                    run_live_preserve_completion(&mut restarted_host, &mut evidence, &run)
+                {
                     return Err(finalize_live_restarted_run_failure(
                         &mut restarted_host,
                         &mut evidence,
@@ -3956,9 +4034,6 @@ async fn live_bamboon_issue_publishes_pull_request() {
                         error,
                     ));
                 }
-                evidence.append_transition("preserve_stop_and_reap_host", "succeeded");
-                evidence.preserve_certification();
-                write_live_dogfood_evidence_v1(&run.root, &evidence)?;
             }
             LiveDogfoodMode::Routine => {
                 if let Err(error) = run_live_routine_cleanup(
@@ -4001,7 +4076,7 @@ async fn live_bamboon_issue_publishes_pull_request() {
             run.root.display()
         ),
         Err(error) => panic!(
-            "{error}\nlive dogfood artifacts are preserved: marker={} run_directory={}\ndeliberate cleanup procedure: inspect run_directory/evidence-v1.json and follow docs/contributing.md#ignored-live-dogfood-tracer-bullet; revalidate every stored identity before mutation",
+            "{error}\nlive dogfood artifacts are preserved: marker={} run_directory={}\ndeliberate cleanup procedure: inspect run_directory and evidence-v1.json when present, then follow docs/contributing.md#ignored-live-dogfood-tracer-bullet; revalidate every stored identity before mutation",
             run.marker,
             run.root.display()
         ),
@@ -4466,6 +4541,7 @@ fn live_dogfood_operator_contract_is_documented_without_fixture_values() {
         "host-2.stderr.log",
         "two configured polling intervals",
         "unchanged config",
+        "not exist before dispatch",
     ] {
         assert!(
             contributing.contains(required),
@@ -4574,6 +4650,25 @@ fn live_dogfood_worktree_discovery_includes_the_issue_key_directory() {
     assert_eq!(live_dogfood_worktree(&workspaces).unwrap(), expected);
 }
 
+#[cfg(unix)]
+#[test]
+fn live_dogfood_worktree_registration_canonicalizes_symlinked_prefixes() {
+    use std::os::unix::fs::symlink;
+
+    let temporary = tempfile::tempdir().unwrap();
+    let canonical_root = temporary.path().join("canonical");
+    let canonical_worktree = canonical_root.join("issue-worktree");
+    let aliased_root = temporary.path().join("alias");
+    let aliased_worktree = aliased_root.join("issue-worktree");
+    fs::create_dir_all(&canonical_worktree).unwrap();
+    symlink(&canonical_root, &aliased_root).unwrap();
+    let listing = format!("worktree {}\n", canonical_worktree.display());
+
+    assert!(worktree_is_registered(&listing, &aliased_worktree));
+    fs::remove_dir(&canonical_worktree).unwrap();
+    assert!(worktree_is_registered(&listing, &aliased_worktree));
+}
+
 #[test]
 fn live_dogfood_preserve_input_is_exact_and_defaults_to_routine_cleanup() {
     assert_eq!(
@@ -4591,6 +4686,14 @@ fn live_dogfood_preserve_input_is_exact_and_defaults_to_routine_cleanup() {
     assert!(LiveDogfoodMode::from_input(Some("true")).is_err());
 }
 
+#[cfg(unix)]
+#[test]
+fn live_dogfood_preserve_input_rejects_non_utf8_values() {
+    use std::os::unix::ffi::OsStrExt;
+
+    assert!(LiveDogfoodMode::from_os_input(Some(std::ffi::OsStr::from_bytes(&[0xff]))).is_err());
+}
+
 #[test]
 fn live_dogfood_evidence_records_the_selected_cleanup_mode() {
     let run = LiveDogfoodRun {
@@ -4602,6 +4705,35 @@ fn live_dogfood_evidence_records_the_selected_cleanup_mode() {
 
     let value = serde_json::to_value(evidence).unwrap();
     assert_eq!(value["mode"], "preserve");
+}
+
+#[test]
+fn live_dogfood_preserve_completion_only_reaps_and_records_preservation() {
+    let temporary = tempfile::tempdir().unwrap();
+    let run = LiveDogfoodRun {
+        marker: "live-dogfood-preserve-execution".to_string(),
+        root: temporary.path().to_path_buf(),
+    };
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#47", LiveDogfoodMode::Preserve);
+    let mut child = Command::new("sh").args(["-c", "sleep 30"]).spawn().unwrap();
+
+    run_live_preserve_completion(&mut child, &mut evidence, &run).unwrap();
+
+    assert!(child.try_wait().unwrap().is_some());
+    let value: Value = serde_json::from_str(
+        &fs::read_to_string(temporary.path().join("evidence-v1.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(value["outcome"], "preserved_certification");
+    assert_eq!(
+        value["transitions"],
+        serde_json::json!([{"phase": "preserve_stop_and_reap_host", "result": "succeeded"}])
+    );
+    assert_eq!(
+        value["final_state"]["absent"],
+        serde_json::json!(["active_child"])
+    );
 }
 
 #[test]
@@ -4674,6 +4806,66 @@ fn live_dogfood_pull_request_revalidation_requires_the_stored_identity() {
 }
 
 #[test]
+fn live_dogfood_remote_ref_deletion_rejects_a_replacement_sha() {
+    let temporary = tempfile::tempdir().unwrap();
+    let remote = temporary.path().join("remote.git");
+    let source = temporary.path().join("source");
+    init_git_repo(&source).unwrap();
+    let inputs =
+        LiveDogfoodInputs::from_values(Some("1"), Some("12"), source.to_str(), None).unwrap();
+    let git = |phase: &str, arguments: &[&str]| {
+        live_git(
+            phase,
+            &source,
+            arguments.iter().map(|argument| (*argument).to_string()),
+            &inputs,
+        )
+        .unwrap()
+    };
+    git(
+        "test initialize bare remote",
+        &["init", "--bare", remote.to_str().unwrap()],
+    );
+    git(
+        "test add remote",
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git(
+        "test publish expected ref",
+        &["push", "-u", "origin", "main"],
+    );
+    let expected_sha = git("test read expected SHA", &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    fs::write(source.join("README.md"), "replacement\n").unwrap();
+    git(
+        "test commit replacement",
+        &[
+            "-c",
+            "user.name=Ensemble E2E",
+            "-c",
+            "user.email=ensemble-e2e@example.invalid",
+            "commit",
+            "-am",
+            "replacement",
+        ],
+    );
+    git("test publish replacement ref", &["push", "origin", "main"]);
+    let replacement_sha = git("test read replacement SHA", &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+
+    assert!(delete_live_remote_ref_at_sha(&inputs, &source, "main", &expected_sha).is_err());
+    assert_eq!(
+        git(
+            "test observe replacement ref",
+            &["ls-remote", "--heads", "origin", "refs/heads/main"],
+        ),
+        format!("{replacement_sha}\trefs/heads/main\n")
+    );
+}
+
+#[test]
 fn live_dogfood_cleanup_stops_after_a_failed_revalidation() {
     let plan = LiveDogfoodCleanupPlan::for_test();
     let mut cleanup = LiveDogfoodCleanupRecorder::new(&plan).unwrap();
@@ -4695,6 +4887,64 @@ fn live_dogfood_cleanup_stops_after_a_failed_revalidation() {
             ("close_pull_request", "succeeded"),
             ("project_done", "preserved_failure"),
         ]
+    );
+}
+
+struct FailingLiveDogfoodCleanupActions {
+    attempted: Vec<LiveDogfoodCleanupStep>,
+    fail_at: LiveDogfoodCleanupStep,
+}
+
+impl LiveDogfoodCleanupActions for FailingLiveDogfoodCleanupActions {
+    async fn execute(&mut self, step: LiveDogfoodCleanupStep) -> Result<(), String> {
+        self.attempted.push(step);
+        if step == self.fail_at {
+            Err(format!("{} helper failed", step.name()))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[tokio::test]
+async fn live_dogfood_cleanup_execution_stops_after_a_helper_failure() {
+    let temporary = tempfile::tempdir().unwrap();
+    let run = LiveDogfoodRun {
+        marker: "live-dogfood-execution-stop".to_string(),
+        root: temporary.path().to_path_buf(),
+    };
+    let plan = LiveDogfoodCleanupPlan::for_test();
+    let mut cleanup = LiveDogfoodCleanupRecorder::new(&plan).unwrap();
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#47", LiveDogfoodMode::Routine);
+    let mut actions = FailingLiveDogfoodCleanupActions {
+        attempted: Vec::new(),
+        fail_at: LiveDogfoodCleanupStep::ProjectDone,
+    };
+
+    assert!(
+        execute_live_cleanup_sequence(&mut actions, &mut cleanup, &mut evidence, &run,)
+            .await
+            .is_err()
+    );
+
+    assert_eq!(
+        actions.attempted,
+        [
+            LiveDogfoodCleanupStep::ClosePullRequest,
+            LiveDogfoodCleanupStep::ProjectDone,
+        ]
+    );
+    let persisted: Value = serde_json::from_str(
+        &fs::read_to_string(temporary.path().join("evidence-v1.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        persisted["transitions"],
+        serde_json::json!([
+            {"phase": "close_pull_request", "result": "succeeded"},
+            {"phase": "project_done", "result": "preserved_failure"}
+        ])
     );
 }
 
@@ -4786,4 +5036,52 @@ fn live_dogfood_pre_dispatch_rollback_requires_exact_issue_and_item_ownership() 
         &resources,
     )
     .is_err());
+}
+
+#[test]
+fn live_dogfood_host_setup_failures_run_pre_dispatch_rollback() {
+    use std::cell::RefCell;
+
+    let resources = PreDispatchResources {
+        issue_id: "issue-node".to_string(),
+        issue_number: 47,
+        project_id: "project-node".to_string(),
+        project_item_id: "item-node".to_string(),
+    };
+    let actions = RefCell::new(Vec::new());
+    let reservation_error = start_live_pre_dispatch_host(
+        &resources,
+        || Err("reserve host port: unavailable".to_string()),
+        |_| {
+            actions.borrow_mut().push("spawn");
+            Ok(())
+        },
+        |_, error| {
+            actions.borrow_mut().push("rollback");
+            format!("{error}; rolled back")
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        reservation_error,
+        "reserve host port: unavailable; rolled back"
+    );
+    assert_eq!(*actions.borrow(), ["rollback"]);
+
+    actions.borrow_mut().clear();
+    let spawn_error = start_live_pre_dispatch_host(
+        &resources,
+        || Ok(42),
+        |_| {
+            actions.borrow_mut().push("spawn");
+            Err::<(), _>("start first host: unavailable".to_string())
+        },
+        |_, error| {
+            actions.borrow_mut().push("rollback");
+            format!("{error}; rolled back")
+        },
+    )
+    .unwrap_err();
+    assert_eq!(spawn_error, "start first host: unavailable; rolled back");
+    assert_eq!(*actions.borrow(), ["spawn", "rollback"]);
 }

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -157,7 +157,7 @@ async fn acceptance_failure_dominates_successful_agent_and_exhausts_the_issue() 
         .env("PATH", fixture.path_with_mock_bin())
         .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::inherit());
     let child = command.spawn().expect("spawn ensemble web");
     let _guard = ChildGuard::new(child);
     let client = reqwest::Client::new();
@@ -212,7 +212,7 @@ async fn missing_file_and_handoff_are_durable_acceptance_failures() {
         .env("ENSEMBLE_E2E_SKIP_REQUIRED_FILE", "1")
         .env("ENSEMBLE_E2E_MISSING_HANDOFF", "1")
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::inherit());
     let child = command.spawn().expect("spawn ensemble web");
     let _guard = ChildGuard::new(child);
     let client = reqwest::Client::new();

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -2502,6 +2502,14 @@ fn worktree_is_registered(listing: &str, worktree: &Path) -> bool {
         .any(|path| path == expected)
 }
 
+fn live_public_issue_released(detail: &Value) -> bool {
+    detail.get("running").is_some_and(Value::is_null)
+        && detail
+            .get("status")
+            .and_then(Value::as_str)
+            .is_some_and(|status| status == "Done" || status.starts_with("completed_"))
+}
+
 async fn wait_for_live_host_release(
     client: &reqwest::Client,
     base_url: &str,
@@ -2517,7 +2525,7 @@ async fn wait_for_live_host_release(
             Ok(response) if response.status().is_success() => response
                 .json::<Value>()
                 .await
-                .is_ok_and(|detail| detail["running"].is_null() && detail["status"] == "Done"),
+                .is_ok_and(|detail| live_public_issue_released(&detail)),
             _ => false,
         };
         let capacity_released = match client.get(format!("{base_url}/api/v1/state")).send().await {
@@ -4351,6 +4359,22 @@ fn live_dogfood_restart_rejects_ambiguous_public_agent_capacity() {
     ] {
         assert!(validate_live_public_agent_capacity(&state).is_err());
     }
+}
+
+#[test]
+fn live_dogfood_completed_history_snapshot_counts_as_released() {
+    assert!(live_public_issue_released(&serde_json::json!({
+        "running": null,
+        "status": "completed_succeeded",
+    })));
+    assert!(!live_public_issue_released(&serde_json::json!({
+        "running": {"step": "implement"},
+        "status": "completed_succeeded",
+    })));
+    assert!(!live_public_issue_released(&serde_json::json!({
+        "running": null,
+        "status": "In review",
+    })));
 }
 
 #[test]

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -685,25 +685,47 @@ const LIVE_DOGFOOD_OPT_IN: &str = "ENSEMBLE_LIVE_DOGFOOD";
 const LIVE_DOGFOOD_PROJECT: &str = "ENSEMBLE_DOGFOOD_PROJECT_NUMBER";
 const LIVE_DOGFOOD_BAMBOON_PATH: &str = "ENSEMBLE_DOGFOOD_BAMBOON_PATH";
 const LIVE_DOGFOOD_AGENT: &str = "ENSEMBLE_DOGFOOD_AGENT";
+const LIVE_DOGFOOD_PRESERVE: &str = "ENSEMBLE_LIVE_DOGFOOD_PRESERVE";
 const LIVE_DOGFOOD_STATUSES: [&str; 4] = ["Ready to implement", "In progress", "In review", "Done"];
 const LIVE_DOGFOOD_POLL_INTERVAL_MS: u64 = 1_000;
 const LIVE_DOGFOOD_RESTART_STABLE_POLLS: usize = 2;
 static LIVE_DOGFOOD_SEQUENCE: AtomicU32 = AtomicU32::new(0);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum LiveDogfoodMode {
+    Routine,
+    Preserve,
+}
+
+impl LiveDogfoodMode {
+    fn from_input(value: Option<&str>) -> Result<Self, String> {
+        match value {
+            None | Some("") => Ok(Self::Routine),
+            Some("1") => Ok(Self::Preserve),
+            Some(_) => Err(format!(
+                "{LIVE_DOGFOOD_PRESERVE} must be exactly 1 when set"
+            )),
+        }
+    }
+}
 
 #[derive(Debug)]
 struct LiveDogfoodInputs {
     project_number: u64,
     bamboon_path: PathBuf,
     agent: String,
+    mode: LiveDogfoodMode,
 }
 
 impl LiveDogfoodInputs {
     fn from_env() -> Result<Self, String> {
-        Self::from_values(
+        Self::from_values_with_preserve(
             std::env::var(LIVE_DOGFOOD_OPT_IN).ok().as_deref(),
             std::env::var(LIVE_DOGFOOD_PROJECT).ok().as_deref(),
             std::env::var(LIVE_DOGFOOD_BAMBOON_PATH).ok().as_deref(),
             std::env::var(LIVE_DOGFOOD_AGENT).ok().as_deref(),
+            std::env::var(LIVE_DOGFOOD_PRESERVE).ok().as_deref(),
         )
     }
 
@@ -712,6 +734,16 @@ impl LiveDogfoodInputs {
         project_number: Option<&str>,
         bamboon_path: Option<&str>,
         agent: Option<&str>,
+    ) -> Result<Self, String> {
+        Self::from_values_with_preserve(opt_in, project_number, bamboon_path, agent, None)
+    }
+
+    fn from_values_with_preserve(
+        opt_in: Option<&str>,
+        project_number: Option<&str>,
+        bamboon_path: Option<&str>,
+        agent: Option<&str>,
+        preserve: Option<&str>,
     ) -> Result<Self, String> {
         if opt_in != Some("1") {
             return Err(format!("{LIVE_DOGFOOD_OPT_IN} must be exactly 1"));
@@ -740,7 +772,264 @@ impl LiveDogfoodInputs {
                 .filter(|value| !value.is_empty())
                 .unwrap_or("codex")
                 .to_string(),
+            mode: LiveDogfoodMode::from_input(preserve)?,
         })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LiveDogfoodCleanupPlan {
+    issue_id: String,
+    issue_number: u64,
+    project_id: String,
+    project_item_id: String,
+    status_field_id: String,
+    done_option_id: String,
+    pull_request: LiveDogfoodPullRequestIdentity,
+    branch: String,
+    expected_sha: String,
+    worktree_identity: String,
+}
+
+impl LiveDogfoodCleanupPlan {
+    fn validate(&self) -> Result<(), String> {
+        for (name, value) in [
+            ("issue ID", &self.issue_id),
+            ("Project ID", &self.project_id),
+            ("Project item ID", &self.project_item_id),
+            ("Status field ID", &self.status_field_id),
+            ("Done option ID", &self.done_option_id),
+            ("pull-request ID", &self.pull_request.id),
+            ("pull-request URL", &self.pull_request.url),
+            ("generated branch", &self.branch),
+            ("expected SHA", &self.expected_sha),
+            ("worktree identity", &self.worktree_identity),
+        ] {
+            if value.is_empty() {
+                return Err(format!("cleanup plan: stored {name} was missing"));
+            }
+        }
+        if self.issue_number == 0 || self.pull_request.number == 0 {
+            return Err("cleanup plan: numeric identity was missing".to_string());
+        }
+        if self.pull_request.head != self.branch
+            || self.pull_request.sha != self.expected_sha
+            || self.pull_request.base != "main"
+        {
+            return Err(
+                "cleanup plan: pull request did not match the stored ref identity".to_string(),
+            );
+        }
+        if Path::new(&self.worktree_identity).is_absolute()
+            || self.worktree_identity.starts_with("../")
+        {
+            return Err("cleanup plan: worktree was not run-owned".to_string());
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn for_test() -> Self {
+        Self {
+            issue_id: "issue-node".to_string(),
+            issue_number: 47,
+            project_id: "project-node".to_string(),
+            project_item_id: "item-node".to_string(),
+            status_field_id: "status-node".to_string(),
+            done_option_id: "done-option".to_string(),
+            pull_request: LiveDogfoodPullRequestIdentity {
+                id: "pr-node".to_string(),
+                number: 48,
+                url: "https://github.com/chrisbanes/bamboon/pull/48".to_string(),
+                state: "OPEN".to_string(),
+                head: "ensemble-live-dogfood".to_string(),
+                sha: "expected-sha".to_string(),
+                base: "main".to_string(),
+            },
+            branch: "ensemble-live-dogfood".to_string(),
+            expected_sha: "expected-sha".to_string(),
+            worktree_identity: "issue/bamboon/ensemble-live-dogfood".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_pull_request_sha(mut self, value: &str) -> Self {
+        self.pull_request.sha = value.to_string();
+        self
+    }
+    #[cfg(test)]
+    fn with_pull_request_base(mut self, value: &str) -> Self {
+        self.pull_request.base = value.to_string();
+        self
+    }
+    #[cfg(test)]
+    fn with_issue_id(mut self, value: &str) -> Self {
+        self.issue_id = value.to_string();
+        self
+    }
+    #[cfg(test)]
+    fn with_worktree(mut self, value: &str) -> Self {
+        self.worktree_identity = value.to_string();
+        self
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LiveDogfoodCleanupStep {
+    ClosePullRequest,
+    ProjectDone,
+    WaitForHostRelease,
+    StopAndReapHost,
+    CloseIssue,
+    RemoveProjectItem,
+    DeleteGeneratedRef,
+    VerifyFinalAbsence,
+}
+
+const LIVE_DOGFOOD_CLEANUP_ORDER: [LiveDogfoodCleanupStep; 8] = [
+    LiveDogfoodCleanupStep::ClosePullRequest,
+    LiveDogfoodCleanupStep::ProjectDone,
+    LiveDogfoodCleanupStep::WaitForHostRelease,
+    LiveDogfoodCleanupStep::StopAndReapHost,
+    LiveDogfoodCleanupStep::CloseIssue,
+    LiveDogfoodCleanupStep::RemoveProjectItem,
+    LiveDogfoodCleanupStep::DeleteGeneratedRef,
+    LiveDogfoodCleanupStep::VerifyFinalAbsence,
+];
+
+impl LiveDogfoodCleanupStep {
+    fn name(self) -> &'static str {
+        match self {
+            Self::ClosePullRequest => "close_pull_request",
+            Self::ProjectDone => "project_done",
+            Self::WaitForHostRelease => "wait_for_host_release",
+            Self::StopAndReapHost => "stop_and_reap_host",
+            Self::CloseIssue => "close_issue",
+            Self::RemoveProjectItem => "remove_project_item",
+            Self::DeleteGeneratedRef => "delete_generated_ref",
+            Self::VerifyFinalAbsence => "verify_final_absence",
+        }
+    }
+
+    fn ordinal(self) -> usize {
+        LIVE_DOGFOOD_CLEANUP_ORDER
+            .iter()
+            .position(|candidate| *candidate == self)
+            .expect("every cleanup step must appear in the cleanup order")
+    }
+}
+
+struct LiveDogfoodCleanupRecorder {
+    next_step: usize,
+    failed: bool,
+    transitions: Vec<(&'static str, &'static str)>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LiveDogfoodPullRequestIdentity {
+    id: String,
+    number: u64,
+    url: String,
+    state: String,
+    head: String,
+    sha: String,
+    base: String,
+}
+
+impl LiveDogfoodPullRequestIdentity {
+    fn validate_against(
+        &self,
+        plan: &LiveDogfoodCleanupPlan,
+        expected_state: &str,
+    ) -> Result<(), String> {
+        if self.id != plan.pull_request.id
+            || self.number != plan.pull_request.number
+            || self.url != plan.pull_request.url
+            || self.state != expected_state
+            || self.head != plan.branch
+            || self.sha != plan.expected_sha
+            || self.base != "main"
+        {
+            return Err(
+                "cleanup pull request revalidation: stored identity no longer matched".to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
+impl LiveDogfoodCleanupPlan {
+    fn from_live(
+        resources: &LiveDogfoodResources,
+        run: &LiveDogfoodRun,
+        worktree: &Path,
+        branch: &str,
+        sha: &str,
+        pull_request: &LiveDogfoodPullRequestIdentity,
+    ) -> Result<Self, String> {
+        let worktree_identity = worktree
+            .strip_prefix(run.root.join("workspaces"))
+            .map_err(|_| "cleanup plan: captured worktree was outside the run root".to_string())?
+            .to_string_lossy()
+            .replace('\\', "/");
+        let plan = Self {
+            issue_id: resources.issue_id.clone(),
+            issue_number: resources.issue_number,
+            project_id: resources.project.id.clone(),
+            project_item_id: resources.project_item_id.clone(),
+            status_field_id: resources.project.status_field_id.clone(),
+            done_option_id: resources.project.done_option_id.clone(),
+            pull_request: pull_request.clone(),
+            branch: branch.to_string(),
+            expected_sha: sha.to_string(),
+            worktree_identity,
+        };
+        plan.validate()?;
+        Ok(plan)
+    }
+}
+
+impl LiveDogfoodCleanupRecorder {
+    fn new(plan: &LiveDogfoodCleanupPlan) -> Result<Self, String> {
+        plan.validate()?;
+        Ok(Self {
+            next_step: 0,
+            failed: false,
+            transitions: Vec::new(),
+        })
+    }
+
+    fn attempt(
+        &mut self,
+        step: LiveDogfoodCleanupStep,
+        result: Result<(), &str>,
+    ) -> Result<(), String> {
+        if self.failed || step.ordinal() != self.next_step {
+            return Err(
+                "cleanup plan: later mutation was unreachable after a failed or out-of-order step"
+                    .to_string(),
+            );
+        }
+        let name = step.name();
+        match result {
+            Ok(()) => {
+                self.transitions.push((name, "succeeded"));
+                self.next_step += 1;
+                Ok(())
+            }
+            Err(error) => {
+                self.transitions.push((name, "preserved_failure"));
+                self.failed = true;
+                Err(format!("cleanup plan: {name} failed revalidation: {error}"))
+            }
+        }
+    }
+
+    fn transitions(&self) -> Vec<(&'static str, &'static str)> {
+        self.transitions.clone()
+    }
+    fn is_complete(&self) -> bool {
+        !self.failed && self.next_step == LIVE_DOGFOOD_CLEANUP_ORDER.len()
     }
 }
 
@@ -803,9 +1092,12 @@ struct LiveDogfoodEvidenceV1 {
     format: &'static str,
     schema_version: u8,
     run: LiveDogfoodEvidenceRun,
+    mode: LiveDogfoodMode,
     outcome: LiveDogfoodEvidenceOutcome,
     retained_logs: Vec<&'static str>,
     snapshots: Vec<LiveDogfoodEvidenceSnapshot>,
+    transitions: Vec<LiveDogfoodEvidenceTransition>,
+    final_state: LiveDogfoodEvidenceFinalState,
 }
 
 #[derive(Debug, Serialize)]
@@ -820,6 +1112,20 @@ struct LiveDogfoodEvidenceRun {
 enum LiveDogfoodEvidenceOutcome {
     InReview,
     PreservedFailure,
+    PreservedCertification,
+    RoutineCleaned,
+}
+
+#[derive(Debug, Serialize)]
+struct LiveDogfoodEvidenceTransition {
+    phase: &'static str,
+    result: &'static str,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct LiveDogfoodEvidenceFinalState {
+    absent: Vec<&'static str>,
+    retained: Vec<&'static str>,
 }
 
 #[derive(Debug, Serialize)]
@@ -875,7 +1181,11 @@ struct LiveDogfoodEvidencePullRequest {
 }
 
 impl LiveDogfoodEvidenceV1 {
-    fn new(run: &LiveDogfoodRun, issue_identifier: impl Into<String>) -> Self {
+    fn new(
+        run: &LiveDogfoodRun,
+        issue_identifier: impl Into<String>,
+        mode: LiveDogfoodMode,
+    ) -> Self {
         Self {
             format: "ensemble.live-dogfood-evidence",
             schema_version: 1,
@@ -884,9 +1194,12 @@ impl LiveDogfoodEvidenceV1 {
                 issue_identifier: issue_identifier.into(),
                 workspace_identifier: format!("run/{}", run.marker),
             },
+            mode,
             outcome: LiveDogfoodEvidenceOutcome::InReview,
             retained_logs: LiveDogfoodHostLifetime::all_log_names().to_vec(),
             snapshots: Vec::new(),
+            transitions: Vec::new(),
+            final_state: LiveDogfoodEvidenceFinalState::default(),
         }
     }
 
@@ -939,6 +1252,100 @@ impl LiveDogfoodEvidenceV1 {
                 assertions_not_reached,
             });
         Ok(())
+    }
+
+    fn append_transition(&mut self, phase: &'static str, result: &'static str) {
+        self.transitions
+            .push(LiveDogfoodEvidenceTransition { phase, result });
+    }
+
+    fn preserve_certification(&mut self) {
+        self.outcome = LiveDogfoodEvidenceOutcome::PreservedCertification;
+        self.final_state.absent = vec!["active_child"];
+        self.final_state.retained = vec![
+            "synthetic_issue",
+            "project_item",
+            "generated_ref",
+            "pull_request",
+            "generated_config",
+            "workspace_worktree",
+            "host_logs",
+            "evidence",
+        ];
+    }
+
+    fn preserve_after_transitions(&mut self) {
+        self.outcome = LiveDogfoodEvidenceOutcome::PreservedFailure;
+        self.final_state.absent.clear();
+        self.final_state.retained.clear();
+
+        for (transition, absent, retained) in [
+            ("close_pull_request", "open_pull_request", "pull_request"),
+            ("close_issue", "open_synthetic_issue", "synthetic_issue"),
+            ("remove_project_item", "project_item", "project_item"),
+            ("delete_generated_ref", "generated_ref", "generated_ref"),
+            (
+                "wait_for_host_release",
+                "workspace_worktree",
+                "workspace_worktree",
+            ),
+        ] {
+            if self.transition_succeeded(transition) {
+                self.final_state.absent.push(absent);
+            } else {
+                self.final_state.retained.push(retained);
+            }
+        }
+        if self.transition_succeeded("stop_and_reap_host")
+            || self.transition_succeeded("failure_host_reap")
+            || self.transition_succeeded("failure_child_absence")
+        {
+            self.final_state.absent.push("active_child");
+        } else {
+            self.final_state.retained.push("active_child");
+        }
+        self.final_state
+            .retained
+            .extend(["generated_config", "host_logs", "evidence"]);
+    }
+
+    fn preserve_discovered_artifacts(&mut self) {
+        self.outcome = LiveDogfoodEvidenceOutcome::PreservedFailure;
+        self.final_state.absent = vec!["active_child"];
+        self.final_state.retained = vec![
+            "synthetic_issue",
+            "project_item",
+            "generated_config",
+            "host_logs",
+            "evidence",
+        ];
+        if !self.snapshots.is_empty() {
+            self.final_state.retained.push("workspace_worktree");
+        }
+        if self.has_post_delivery() {
+            self.final_state
+                .retained
+                .extend(["generated_ref", "pull_request"]);
+        }
+    }
+
+    fn transition_succeeded(&self, phase: &str) -> bool {
+        self.transitions
+            .iter()
+            .any(|transition| transition.phase == phase && transition.result == "succeeded")
+    }
+
+    fn routine_cleaned(&mut self) {
+        self.outcome = LiveDogfoodEvidenceOutcome::RoutineCleaned;
+        self.final_state.absent = vec![
+            "open_synthetic_issue",
+            "project_item",
+            "generated_ref",
+            "open_pull_request",
+            "workspace_worktree",
+            "active_child",
+        ];
+        self.final_state.retained = vec!["generated_config", "host_logs", "evidence"];
     }
 
     fn append_post_delivery(
@@ -1062,6 +1469,12 @@ impl LiveDogfoodEvidenceV1 {
         self.snapshots
             .iter()
             .any(|snapshot| matches!(snapshot, LiveDogfoodEvidenceSnapshot::PostDelivery { .. }))
+    }
+
+    fn has_post_restart(&self) -> bool {
+        self.snapshots
+            .iter()
+            .any(|snapshot| matches!(snapshot, LiveDogfoodEvidenceSnapshot::PostRestart { .. }))
     }
 }
 
@@ -1324,7 +1737,12 @@ fn persist_live_dogfood_failure(
     pre_publication_captured: bool,
     error: &str,
 ) -> Result<(), String> {
-    let assertions_not_reached = if evidence.has_post_delivery() {
+    if evidence.final_state.absent.is_empty() && evidence.final_state.retained.is_empty() {
+        evidence.preserve_discovered_artifacts();
+    }
+    let assertions_not_reached = if evidence.has_post_restart() {
+        ["cleanup_completion"].as_slice()
+    } else if evidence.has_post_delivery() {
         ["post_restart"].as_slice()
     } else if pre_publication_captured {
         ["post_delivery"].as_slice()
@@ -1469,6 +1887,7 @@ struct LiveDogfoodProject {
     id: String,
     status_field_id: String,
     ready_option_id: String,
+    done_option_id: String,
 }
 
 struct PreDispatchResources {
@@ -1481,6 +1900,8 @@ struct PreDispatchResources {
 struct LiveDogfoodResources {
     issue_id: String,
     issue_number: u64,
+    project: LiveDogfoodProject,
+    project_item_id: String,
 }
 
 fn run_live_command(
@@ -1657,6 +2078,14 @@ fn validate_live_project_response(response: &Value) -> Result<LiveDogfoodProject
                 "preflight project discovery: Ready status ID was unavailable".to_string()
             })?
             .to_string(),
+        done_option_id: status_field["options"]
+            .as_array()
+            .and_then(|options| options.last())
+            .and_then(|option| option["id"].as_str())
+            .ok_or_else(|| {
+                "preflight project discovery: Done status ID was unavailable".to_string()
+            })?
+            .to_string(),
     })
 }
 
@@ -1776,6 +2205,688 @@ fn live_project_item_status(
     )
 }
 
+fn revalidate_live_project_item(
+    inputs: &LiveDogfoodInputs,
+    plan: &LiveDogfoodCleanupPlan,
+) -> Result<String, String> {
+    let response = live_project_query(inputs)?;
+    let item = validate_live_project_item_identity(
+        &response,
+        &plan.project_id,
+        &plan.project_item_id,
+        &plan.issue_id,
+        plan.issue_number,
+        "cleanup Project item",
+    )?;
+    item["fieldValues"]["nodes"]
+        .as_array()
+        .and_then(|fields| {
+            fields.iter().find_map(|field| {
+                (field["field"]["name"] == "Status")
+                    .then(|| field["name"].as_str().map(ToString::to_string))
+                    .flatten()
+            })
+        })
+        .ok_or_else(|| {
+            "cleanup Project item: stored Status observation was unavailable".to_string()
+        })
+}
+
+fn validate_live_project_item_identity<'a>(
+    response: &'a Value,
+    project_id: &str,
+    project_item_id: &str,
+    issue_id: &str,
+    issue_number: u64,
+    phase: &str,
+) -> Result<&'a Value, String> {
+    let project = &response["data"]["repository"]["projectV2"];
+    if project["id"].as_str() != Some(project_id) {
+        return Err(format!(
+            "{phase}: stored Project identity no longer matched"
+        ));
+    }
+    let matching = project["items"]["nodes"]
+        .as_array()
+        .ok_or_else(|| format!("{phase}: Project items were unavailable"))?
+        .iter()
+        .filter(|item| item["id"].as_str() == Some(project_item_id))
+        .collect::<Vec<_>>();
+    let [item] = matching.as_slice() else {
+        return Err(format!("{phase}: stored item was missing or ambiguous"));
+    };
+    if item["content"]["id"].as_str() != Some(issue_id)
+        || item["content"]["number"].as_u64() != Some(issue_number)
+    {
+        return Err(format!("{phase}: stored item ownership no longer matched"));
+    }
+    Ok(item)
+}
+
+fn capture_live_pull_request_identity(
+    inputs: &LiveDogfoodInputs,
+    number: u64,
+    expected_state: &str,
+) -> Result<LiveDogfoodPullRequestIdentity, String> {
+    let output = live_gh(
+        "cleanup pull request revalidation",
+        [
+            "pr".to_string(),
+            "view".to_string(),
+            number.to_string(),
+            "--repo".to_string(),
+            "chrisbanes/bamboon".to_string(),
+            "--json".to_string(),
+            "id,number,url,state,headRefName,headRefOid,baseRefName".to_string(),
+        ],
+        inputs,
+    )?;
+    let value: Value = serde_json::from_str(&output)
+        .map_err(|_| "cleanup pull request revalidation: invalid GitHub response".to_string())?;
+    let identity = LiveDogfoodPullRequestIdentity {
+        id: value["id"]
+            .as_str()
+            .ok_or_else(|| {
+                "cleanup pull request revalidation: node ID was unavailable".to_string()
+            })?
+            .to_string(),
+        number: value["number"].as_u64().ok_or_else(|| {
+            "cleanup pull request revalidation: number was unavailable".to_string()
+        })?,
+        url: value["url"]
+            .as_str()
+            .ok_or_else(|| "cleanup pull request revalidation: URL was unavailable".to_string())?
+            .to_string(),
+        state: value["state"]
+            .as_str()
+            .ok_or_else(|| "cleanup pull request revalidation: state was unavailable".to_string())?
+            .to_string(),
+        head: value["headRefName"]
+            .as_str()
+            .ok_or_else(|| {
+                "cleanup pull request revalidation: head ref was unavailable".to_string()
+            })?
+            .to_string(),
+        sha: value["headRefOid"]
+            .as_str()
+            .ok_or_else(|| {
+                "cleanup pull request revalidation: head SHA was unavailable".to_string()
+            })?
+            .to_string(),
+        base: value["baseRefName"]
+            .as_str()
+            .ok_or_else(|| {
+                "cleanup pull request revalidation: base ref was unavailable".to_string()
+            })?
+            .to_string(),
+    };
+    if identity.state != expected_state {
+        return Err("cleanup pull request revalidation: state no longer matched".to_string());
+    }
+    Ok(identity)
+}
+
+fn revalidate_live_issue(
+    inputs: &LiveDogfoodInputs,
+    plan: &LiveDogfoodCleanupPlan,
+    expected_state: &str,
+) -> Result<(), String> {
+    revalidate_live_issue_identity(
+        inputs,
+        &plan.issue_id,
+        plan.issue_number,
+        expected_state,
+        "cleanup issue",
+    )
+}
+
+fn revalidate_live_issue_identity(
+    inputs: &LiveDogfoodInputs,
+    issue_id: &str,
+    issue_number: u64,
+    expected_state: &str,
+    phase: &str,
+) -> Result<(), String> {
+    let output = live_gh(
+        &format!("{phase} revalidation"),
+        [
+            "api".to_string(),
+            format!("repos/chrisbanes/bamboon/issues/{issue_number}"),
+        ],
+        inputs,
+    )?;
+    let issue: Value = serde_json::from_str(&output)
+        .map_err(|_| format!("{phase} revalidation: invalid GitHub response"))?;
+    validate_live_issue_identity(&issue, issue_id, issue_number, expected_state, phase)
+}
+
+fn validate_live_issue_identity(
+    issue: &Value,
+    issue_id: &str,
+    issue_number: u64,
+    expected_state: &str,
+    phase: &str,
+) -> Result<(), String> {
+    if issue["node_id"].as_str() != Some(issue_id)
+        || issue["number"].as_u64() != Some(issue_number)
+        || issue["state"].as_str() != Some(expected_state)
+    {
+        return Err(format!(
+            "{phase} revalidation: stored issue identity or state no longer matched"
+        ));
+    }
+    Ok(())
+}
+
+fn revalidate_live_remote_ref(
+    inputs: &LiveDogfoodInputs,
+    worktree: &Path,
+    plan: &LiveDogfoodCleanupPlan,
+) -> Result<(), String> {
+    let remote = live_git(
+        "cleanup generated ref revalidation",
+        worktree,
+        [
+            "ls-remote".to_string(),
+            "--heads".to_string(),
+            "origin".to_string(),
+            format!("refs/heads/{}", plan.branch),
+        ],
+        inputs,
+    )?;
+    let expected = format!("{}\trefs/heads/{}", plan.expected_sha, plan.branch);
+    if remote.lines().collect::<Vec<_>>() != [expected] {
+        return Err("cleanup generated ref revalidation: stored ref no longer matched".to_string());
+    }
+    Ok(())
+}
+
+fn revalidate_live_pull_request(
+    inputs: &LiveDogfoodInputs,
+    plan: &LiveDogfoodCleanupPlan,
+    expected_state: &str,
+) -> Result<(), String> {
+    capture_live_pull_request_identity(inputs, plan.pull_request.number, expected_state)?
+        .validate_against(plan, expected_state)
+}
+
+fn close_live_pull_request(
+    inputs: &LiveDogfoodInputs,
+    plan: &LiveDogfoodCleanupPlan,
+) -> Result<(), String> {
+    revalidate_live_pull_request(inputs, plan, "OPEN")?;
+    live_gh(
+        "cleanup close pull request",
+        [
+            "pr".to_string(),
+            "close".to_string(),
+            plan.pull_request.number.to_string(),
+            "--repo".to_string(),
+            "chrisbanes/bamboon".to_string(),
+        ],
+        inputs,
+    )?;
+    revalidate_live_pull_request(inputs, plan, "CLOSED")
+}
+
+fn set_live_project_done(
+    inputs: &LiveDogfoodInputs,
+    plan: &LiveDogfoodCleanupPlan,
+) -> Result<(), String> {
+    if revalidate_live_project_item(inputs, plan)? != "In review" {
+        return Err("cleanup Project item: expected In review before Done".to_string());
+    }
+    set_live_project_item_status(
+        "cleanup project Done",
+        inputs,
+        &plan.project_id,
+        &plan.project_item_id,
+        &plan.status_field_id,
+        &plan.done_option_id,
+    )?;
+    if revalidate_live_project_item(inputs, plan)? != "Done" {
+        return Err("cleanup Project item: Done mutation was not observed".to_string());
+    }
+    Ok(())
+}
+
+fn stop_and_reap_live_host(host: &mut Child) -> Result<(), String> {
+    if host
+        .try_wait()
+        .map_err(|error| format!("cleanup stop host: status unavailable: {error}"))?
+        .is_none()
+    {
+        host.kill()
+            .map_err(|error| format!("cleanup stop host: kill failed: {error}"))?;
+        host.wait()
+            .map_err(|error| format!("cleanup stop host: reap failed: {error}"))?;
+    }
+    if host
+        .try_wait()
+        .map_err(|error| format!("cleanup stop host: final status unavailable: {error}"))?
+        .is_none()
+    {
+        return Err("cleanup stop host: child was not reaped".to_string());
+    }
+    Ok(())
+}
+
+fn finalize_live_restarted_run_failure(
+    host: &mut Child,
+    evidence: &mut LiveDogfoodEvidenceV1,
+    run: &LiveDogfoodRun,
+    inputs: &LiveDogfoodInputs,
+    pre_publication_captured: bool,
+    mut error: String,
+) -> String {
+    let child_was_active = host.try_wait().map_or(true, |status| status.is_none());
+    match stop_and_reap_live_host(host) {
+        Ok(()) if child_was_active => evidence.append_transition("failure_host_reap", "succeeded"),
+        Ok(()) => evidence.append_transition("failure_child_absence", "succeeded"),
+        Err(reap_error) => {
+            error = format!("{error}; {reap_error}");
+            evidence.append_transition("failure_host_reap", "preserved_failure");
+        }
+    }
+    evidence.preserve_after_transitions();
+    persist_live_dogfood_failure(evidence, run, inputs, pre_publication_captured, &error)
+        .err()
+        .unwrap_or(error)
+}
+
+fn worktree_is_registered(listing: &str, worktree: &Path) -> bool {
+    let expected = worktree.to_string_lossy();
+    listing
+        .lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .any(|path| path == expected)
+}
+
+async fn wait_for_live_host_release(
+    client: &reqwest::Client,
+    base_url: &str,
+    inputs: &LiveDogfoodInputs,
+    issue_number: u64,
+    worktree: &Path,
+) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(90);
+    let detail_url = format!("{base_url}/api/v1/chrisbanes%2Fbamboon%23{issue_number}");
+    loop {
+        let public_released = match client.get(&detail_url).send().await {
+            Ok(response) if response.status() == reqwest::StatusCode::NOT_FOUND => true,
+            Ok(response) if response.status().is_success() => response
+                .json::<Value>()
+                .await
+                .is_ok_and(|detail| detail["running"].is_null() && detail["status"] == "Done"),
+            _ => false,
+        };
+        let capacity_released = match client.get(format!("{base_url}/api/v1/state")).send().await {
+            Ok(response) if response.status().is_success() => response
+                .json::<Value>()
+                .await
+                .is_ok_and(|state| validate_live_public_agent_capacity(&state).is_ok()),
+            _ => false,
+        };
+        let worktree_absent = !worktree.exists();
+        let worktree_unregistered = live_git(
+            "cleanup worktree release observation",
+            &inputs.bamboon_path,
+            [
+                "worktree".to_string(),
+                "list".to_string(),
+                "--porcelain".to_string(),
+            ],
+            inputs,
+        )
+        .is_ok_and(|listing| !worktree_is_registered(&listing, worktree));
+        if public_released && capacity_released && worktree_absent && worktree_unregistered {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "cleanup wait for host release: timed out; last observation: public_released={public_released}, capacity_released={capacity_released}, worktree_absent={worktree_absent}, worktree_unregistered={worktree_unregistered}"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(LIVE_DOGFOOD_POLL_INTERVAL_MS)).await;
+    }
+}
+
+fn close_live_issue(
+    inputs: &LiveDogfoodInputs,
+    plan: &LiveDogfoodCleanupPlan,
+) -> Result<(), String> {
+    close_live_issue_identity(inputs, &plan.issue_id, plan.issue_number, "cleanup issue")
+}
+
+fn close_live_issue_identity(
+    inputs: &LiveDogfoodInputs,
+    issue_id: &str,
+    issue_number: u64,
+    phase: &str,
+) -> Result<(), String> {
+    revalidate_live_issue_identity(inputs, issue_id, issue_number, "open", phase)?;
+    live_gh(
+        &format!("{phase} close"),
+        [
+            "api".to_string(),
+            "--method".to_string(),
+            "PATCH".to_string(),
+            format!("repos/chrisbanes/bamboon/issues/{issue_number}"),
+            "-f".to_string(),
+            "state=closed".to_string(),
+        ],
+        inputs,
+    )?;
+    revalidate_live_issue_identity(inputs, issue_id, issue_number, "closed", phase)
+}
+
+fn remove_live_project_item(
+    inputs: &LiveDogfoodInputs,
+    plan: &LiveDogfoodCleanupPlan,
+) -> Result<(), String> {
+    if revalidate_live_project_item(inputs, plan)? != "Done" {
+        return Err("cleanup remove Project item: expected Done item".to_string());
+    }
+    delete_live_project_item(
+        inputs,
+        &plan.project_id,
+        &plan.project_item_id,
+        "cleanup remove Project item",
+    )
+}
+
+fn delete_live_project_item(
+    inputs: &LiveDogfoodInputs,
+    project_id: &str,
+    project_item_id: &str,
+    phase: &str,
+) -> Result<(), String> {
+    const REMOVE_ITEM: &str = r#"mutation($projectId: ID!, $itemId: ID!) {
+  deleteProjectV2Item(input: {projectId: $projectId, itemId: $itemId}) { deletedItemId }
+}"#;
+    live_graphql_mutation(
+        phase,
+        REMOVE_ITEM,
+        [
+            ("projectId".to_string(), project_id.to_string()),
+            ("itemId".to_string(), project_item_id.to_string()),
+        ],
+        inputs,
+    )?;
+    let response = live_project_query(inputs)?;
+    validate_live_project_item_absence(&response, project_id, project_item_id)
+}
+
+fn validate_live_project_item_absence(
+    response: &Value,
+    project_id: &str,
+    project_item_id: &str,
+) -> Result<(), String> {
+    let project = &response["data"]["repository"]["projectV2"];
+    if project["id"].as_str() != Some(project_id) {
+        return Err("cleanup Project item absence: Project identity did not match".to_string());
+    }
+    let items = project["items"]["nodes"]
+        .as_array()
+        .ok_or_else(|| "cleanup Project item absence: items were unavailable".to_string())?;
+    if items
+        .iter()
+        .any(|item| item["id"].as_str() == Some(project_item_id))
+    {
+        return Err("cleanup Project item absence: item remained present".to_string());
+    }
+    Ok(())
+}
+
+fn delete_live_remote_ref(
+    inputs: &LiveDogfoodInputs,
+    plan: &LiveDogfoodCleanupPlan,
+) -> Result<(), String> {
+    revalidate_live_remote_ref(inputs, &inputs.bamboon_path, plan)?;
+    live_git(
+        "cleanup delete generated ref",
+        &inputs.bamboon_path,
+        [
+            "push".to_string(),
+            "origin".to_string(),
+            "--delete".to_string(),
+            plan.branch.clone(),
+        ],
+        inputs,
+    )?;
+    let remaining = live_git(
+        "cleanup verify generated ref absence",
+        &inputs.bamboon_path,
+        [
+            "ls-remote".to_string(),
+            "--heads".to_string(),
+            "origin".to_string(),
+            format!("refs/heads/{}", plan.branch),
+        ],
+        inputs,
+    )?;
+    if !remaining.trim().is_empty() {
+        return Err("cleanup delete generated ref: ref remained present".to_string());
+    }
+    Ok(())
+}
+
+fn validate_live_final_absence(observations: [bool; 6]) -> Result<(), String> {
+    let names = [
+        "pull request closed",
+        "issue closed",
+        "Project item absent",
+        "generated ref absent",
+        "workspace worktree absent",
+        "active child absent",
+    ];
+    let missing = observations
+        .into_iter()
+        .zip(names)
+        .filter_map(|(satisfied, name)| (!satisfied).then_some(name))
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "cleanup final absence: required observations failed: {}",
+            missing.join(", ")
+        ))
+    }
+}
+
+fn verify_live_final_absence(
+    inputs: &LiveDogfoodInputs,
+    host: &mut Child,
+    worktree: &Path,
+    plan: &LiveDogfoodCleanupPlan,
+) -> Result<(), String> {
+    let pull_request_closed = revalidate_live_pull_request(inputs, plan, "CLOSED").is_ok();
+    let issue_closed = revalidate_live_issue(inputs, plan, "closed").is_ok();
+    let project_item_absent = live_project_query(inputs).is_ok_and(|response| {
+        validate_live_project_item_absence(&response, &plan.project_id, &plan.project_item_id)
+            .is_ok()
+    });
+    let generated_ref_absent = live_git(
+        "cleanup final generated ref observation",
+        &inputs.bamboon_path,
+        [
+            "ls-remote".to_string(),
+            "--heads".to_string(),
+            "origin".to_string(),
+            format!("refs/heads/{}", plan.branch),
+        ],
+        inputs,
+    )
+    .is_ok_and(|output| output.trim().is_empty());
+    let workspace_worktree_absent = !worktree.exists()
+        && live_git(
+            "cleanup final worktree observation",
+            &inputs.bamboon_path,
+            [
+                "worktree".to_string(),
+                "list".to_string(),
+                "--porcelain".to_string(),
+            ],
+            inputs,
+        )
+        .is_ok_and(|listing| !worktree_is_registered(&listing, worktree));
+    let active_child_absent = host.try_wait().is_ok_and(|status| status.is_some());
+
+    validate_live_final_absence([
+        pull_request_closed,
+        issue_closed,
+        project_item_absent,
+        generated_ref_absent,
+        workspace_worktree_absent,
+        active_child_absent,
+    ])
+}
+
+fn record_live_cleanup_step(
+    cleanup: &mut LiveDogfoodCleanupRecorder,
+    evidence: &mut LiveDogfoodEvidenceV1,
+    step: LiveDogfoodCleanupStep,
+    result: Result<(), String>,
+) -> Result<(), String> {
+    match result {
+        Ok(()) => {
+            cleanup.attempt(step, Ok(()))?;
+            evidence.append_transition(step.name(), "succeeded");
+            Ok(())
+        }
+        Err(error) => {
+            cleanup
+                .attempt(step, Err(error.as_str()))
+                .expect_err("failed cleanup step must stop the recorder");
+            evidence.append_transition(step.name(), "preserved_failure");
+            Err(error)
+        }
+    }
+}
+
+fn persist_live_cleanup_transition(
+    cleanup: &mut LiveDogfoodCleanupRecorder,
+    evidence: &mut LiveDogfoodEvidenceV1,
+    run: &LiveDogfoodRun,
+    step: LiveDogfoodCleanupStep,
+    result: Result<(), String>,
+) -> Result<(), String> {
+    record_live_cleanup_step(cleanup, evidence, step, result)?;
+    write_live_dogfood_evidence_v1(&run.root, evidence)
+}
+
+async fn run_live_routine_cleanup(
+    client: &reqwest::Client,
+    base_url: &str,
+    inputs: &LiveDogfoodInputs,
+    run: &LiveDogfoodRun,
+    resources: &LiveDogfoodResources,
+    host: &mut Child,
+    worktree: &Path,
+    branch: &str,
+    sha: &str,
+    pull_request_number: u64,
+    evidence: &mut LiveDogfoodEvidenceV1,
+) -> Result<(), String> {
+    let plan = (|| {
+        let pull_request = capture_live_pull_request_identity(inputs, pull_request_number, "OPEN")?;
+        LiveDogfoodCleanupPlan::from_live(resources, run, worktree, branch, sha, &pull_request)
+    })();
+    let plan = match plan {
+        Ok(plan) => {
+            evidence.append_transition("prepare_cleanup", "succeeded");
+            write_live_dogfood_evidence_v1(&run.root, evidence)?;
+            plan
+        }
+        Err(error) => {
+            evidence.append_transition("prepare_cleanup", "preserved_failure");
+            write_live_dogfood_evidence_v1(&run.root, evidence)?;
+            return Err(error);
+        }
+    };
+    let mut cleanup = LiveDogfoodCleanupRecorder::new(&plan)?;
+
+    let result = close_live_pull_request(inputs, &plan);
+    persist_live_cleanup_transition(
+        &mut cleanup,
+        evidence,
+        run,
+        LiveDogfoodCleanupStep::ClosePullRequest,
+        result,
+    )?;
+
+    let result = set_live_project_done(inputs, &plan);
+    persist_live_cleanup_transition(
+        &mut cleanup,
+        evidence,
+        run,
+        LiveDogfoodCleanupStep::ProjectDone,
+        result,
+    )?;
+
+    let result =
+        wait_for_live_host_release(client, base_url, inputs, resources.issue_number, worktree)
+            .await;
+    persist_live_cleanup_transition(
+        &mut cleanup,
+        evidence,
+        run,
+        LiveDogfoodCleanupStep::WaitForHostRelease,
+        result,
+    )?;
+
+    let result = stop_and_reap_live_host(host);
+    persist_live_cleanup_transition(
+        &mut cleanup,
+        evidence,
+        run,
+        LiveDogfoodCleanupStep::StopAndReapHost,
+        result,
+    )?;
+
+    let result = close_live_issue(inputs, &plan);
+    persist_live_cleanup_transition(
+        &mut cleanup,
+        evidence,
+        run,
+        LiveDogfoodCleanupStep::CloseIssue,
+        result,
+    )?;
+
+    let result = remove_live_project_item(inputs, &plan);
+    persist_live_cleanup_transition(
+        &mut cleanup,
+        evidence,
+        run,
+        LiveDogfoodCleanupStep::RemoveProjectItem,
+        result,
+    )?;
+
+    let result = delete_live_remote_ref(inputs, &plan);
+    persist_live_cleanup_transition(
+        &mut cleanup,
+        evidence,
+        run,
+        LiveDogfoodCleanupStep::DeleteGeneratedRef,
+        result,
+    )?;
+
+    let result = verify_live_final_absence(inputs, host, worktree, &plan);
+    persist_live_cleanup_transition(
+        &mut cleanup,
+        evidence,
+        run,
+        LiveDogfoodCleanupStep::VerifyFinalAbsence,
+        result,
+    )?;
+    if !cleanup.is_complete() {
+        return Err("cleanup final absence: transition plan was incomplete".to_string());
+    }
+    evidence.routine_cleaned();
+    write_live_dogfood_evidence_v1(&run.root, evidence)
+}
+
 fn live_graphql_mutation(
     phase: &str,
     query: &str,
@@ -1795,6 +2906,30 @@ fn live_graphql_mutation(
     parse_live_graphql_response(phase, &output)
 }
 
+fn set_live_project_item_status(
+    phase: &str,
+    inputs: &LiveDogfoodInputs,
+    project_id: &str,
+    item_id: &str,
+    field_id: &str,
+    option_id: &str,
+) -> Result<Value, String> {
+    const SET_STATUS: &str = r#"mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {singleSelectOptionId: $optionId}}) { projectV2Item { id } }
+}"#;
+    live_graphql_mutation(
+        phase,
+        SET_STATUS,
+        [
+            ("projectId".to_string(), project_id.to_string()),
+            ("itemId".to_string(), item_id.to_string()),
+            ("fieldId".to_string(), field_id.to_string()),
+            ("optionId".to_string(), option_id.to_string()),
+        ],
+        inputs,
+    )
+}
+
 fn parse_live_graphql_response(phase: &str, output: &str) -> Result<Value, String> {
     let response: Value = serde_json::from_str(output)
         .map_err(|error| format!("{phase}: invalid response: {error}"))?;
@@ -1807,33 +2942,52 @@ fn parse_live_graphql_response(phase: &str, output: &str) -> Result<Value, Strin
     Ok(response)
 }
 
-fn rollback_pre_dispatch(resources: &PreDispatchResources, inputs: &LiveDogfoodInputs) {
-    const REMOVE_ITEM: &str = r#"mutation($projectId: ID!, $itemId: ID!) {
-  deleteProjectV2Item(input: {projectId: $projectId, itemId: $itemId}) { deletedItemId }
-}"#;
+fn validate_pre_dispatch_project_item_identity(
+    response: &Value,
+    resources: &PreDispatchResources,
+) -> Result<(), String> {
+    validate_live_project_item_identity(
+        response,
+        &resources.project_id,
+        &resources.project_item_id,
+        &resources.issue_id,
+        resources.issue_number,
+        "pre-dispatch rollback Project item",
+    )
+    .map(|_| ())
+}
+
+fn rollback_pre_dispatch(
+    resources: &PreDispatchResources,
+    inputs: &LiveDogfoodInputs,
+) -> Result<(), String> {
     if !resources.project_item_id.is_empty() {
-        let _ = live_graphql_mutation(
-            "pre-dispatch rollback project item",
-            REMOVE_ITEM,
-            [
-                ("projectId".to_string(), resources.project_id.clone()),
-                ("itemId".to_string(), resources.project_item_id.clone()),
-            ],
+        let before = live_project_query(inputs)?;
+        validate_pre_dispatch_project_item_identity(&before, resources)?;
+        delete_live_project_item(
             inputs,
-        );
+            &resources.project_id,
+            &resources.project_item_id,
+            "pre-dispatch rollback project item",
+        )?;
     }
-    let _ = live_gh(
-        "pre-dispatch rollback issue",
-        [
-            "api".to_string(),
-            "--method".to_string(),
-            "PATCH".to_string(),
-            format!("repos/chrisbanes/bamboon/issues/{}", resources.issue_number),
-            "-f".to_string(),
-            "state=closed".to_string(),
-        ],
+    close_live_issue_identity(
         inputs,
-    );
+        &resources.issue_id,
+        resources.issue_number,
+        "pre-dispatch rollback issue",
+    )
+}
+
+fn rollback_pre_dispatch_after_error(
+    resources: &PreDispatchResources,
+    inputs: &LiveDogfoodInputs,
+    error: String,
+) -> String {
+    match rollback_pre_dispatch(resources, inputs) {
+        Ok(()) => error,
+        Err(rollback_error) => format!("{error}; {rollback_error}"),
+    }
 }
 
 fn create_live_resources(
@@ -1885,25 +3039,15 @@ fn create_live_resources(
         Ok(value) => match value["data"]["addProjectV2ItemById"]["item"]["id"].as_str() {
             Some(id) => id.to_string(),
             None => {
-                let resources = PreDispatchResources {
-                    issue_id,
-                    issue_number,
-                    project_id: project.id.clone(),
-                    project_item_id: String::new(),
-                };
-                rollback_pre_dispatch(&resources, inputs);
-                return Err("add synthetic issue to Project: missing Project item ID".to_string());
+                return Err(format!(
+                    "add synthetic issue to Project: missing Project item ID; synthetic issue #{issue_number} is retained because Project-item ownership is ambiguous"
+                ));
             }
         },
         Err(error) => {
-            let resources = PreDispatchResources {
-                issue_id,
-                issue_number,
-                project_id: project.id.clone(),
-                project_item_id: String::new(),
-            };
-            rollback_pre_dispatch(&resources, inputs);
-            return Err(error);
+            return Err(format!(
+                "{error}; synthetic issue #{issue_number} is retained because Project-item creation is ambiguous"
+            ));
         }
     };
     let resources = PreDispatchResources {
@@ -1913,22 +3057,15 @@ fn create_live_resources(
         project_item_id,
     };
 
-    const SET_STATUS: &str = r#"mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-  updateProjectV2ItemFieldValue(input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {singleSelectOptionId: $optionId}}) { projectV2Item { id } }
-}"#;
-    if let Err(error) = live_graphql_mutation(
+    if let Err(error) = set_live_project_item_status(
         "make synthetic issue ready",
-        SET_STATUS,
-        [
-            ("projectId".to_string(), project.id.clone()),
-            ("itemId".to_string(), resources.project_item_id.clone()),
-            ("fieldId".to_string(), project.status_field_id.clone()),
-            ("optionId".to_string(), project.ready_option_id.clone()),
-        ],
         inputs,
+        &project.id,
+        &resources.project_item_id,
+        &project.status_field_id,
+        &project.ready_option_id,
     ) {
-        rollback_pre_dispatch(&resources, inputs);
-        return Err(error);
+        return Err(rollback_pre_dispatch_after_error(&resources, inputs, error));
     }
     Ok(resources)
 }
@@ -2591,16 +3728,20 @@ async fn live_bamboon_issue_publishes_pull_request() {
         if let Err(error) =
             wait_for_live_project_status(&inputs, &resources.issue_id, "Ready to implement").await
         {
-            rollback_pre_dispatch(&resources, &inputs);
-            return Err(error);
+            return Err(rollback_pre_dispatch_after_error(
+                &resources, &inputs, error,
+            ));
         }
         let resources = LiveDogfoodResources {
             issue_id: resources.issue_id,
             issue_number: resources.issue_number,
+            project,
+            project_item_id: resources.project_item_id,
         };
         let mut evidence = LiveDogfoodEvidenceV1::new(
             &run,
             format!("chrisbanes/bamboon#{}", resources.issue_number),
+            inputs.mode,
         );
         let mut pre_publication_captured = false;
         let port = reserve_local_port().map_err(|error| format!("reserve host port: {error}"))?;
@@ -2678,13 +3819,32 @@ async fn live_bamboon_issue_publishes_pull_request() {
             ))
         }
         .await;
-        let _ = host.kill();
-        let _ = host.wait();
+        let first_host_stopped = stop_and_reap_live_host(&mut host);
         let (worktree, branch, sha, pull_request_number, pull_request_url, baseline) =
             match completed {
-                Ok(completed) => completed,
-                Err(error) if error.starts_with("evidence-v1:") => return Err(error),
-                Err(error) => {
+                Ok(completed) => {
+                    if let Err(error) = first_host_stopped {
+                        evidence.preserve_discovered_artifacts();
+                        evidence.final_state.absent.clear();
+                        evidence.final_state.retained.push("active_child");
+                        let failure = persist_live_dogfood_failure(
+                            &mut evidence,
+                            &run,
+                            &inputs,
+                            pre_publication_captured,
+                            &error,
+                        );
+                        return Err(failure.err().unwrap_or(error));
+                    }
+                    completed
+                }
+                Err(mut error) => {
+                    if let Err(reap_error) = first_host_stopped {
+                        evidence.preserve_discovered_artifacts();
+                        evidence.final_state.absent.clear();
+                        evidence.final_state.retained.push("active_child");
+                        error = format!("{error}; {reap_error}");
+                    }
                     let failure = persist_live_dogfood_failure(
                         &mut evidence,
                         &run,
@@ -2746,30 +3906,86 @@ async fn live_bamboon_issue_publishes_pull_request() {
             &baseline,
         )
         .await;
-        let _ = restarted_host.kill();
-        let _ = restarted_host.wait();
         if let Err(error) = restarted {
-            let failure = persist_live_dogfood_failure(
+            return Err(finalize_live_restarted_run_failure(
+                &mut restarted_host,
                 &mut evidence,
                 &run,
                 &inputs,
                 pre_publication_captured,
-                &error,
-            );
-            return Err(failure.err().unwrap_or(error));
+                error,
+            ));
         }
-        evidence.append_post_restart(&baseline)?;
-        write_live_dogfood_evidence_v1(&run.root, &evidence)?;
-        if evidence.snapshots.len() != 3 {
-            return Err("verify evidence-v1: post-restart snapshot was not retained".to_string());
+        let post_restart_evidence = (|| {
+            evidence.append_post_restart(&baseline)?;
+            write_live_dogfood_evidence_v1(&run.root, &evidence)?;
+            if evidence.snapshots.len() != 3 {
+                return Err(
+                    "verify evidence-v1: post-restart snapshot was not retained".to_string()
+                );
+            }
+            Ok::<(), String>(())
+        })();
+        if let Err(error) = post_restart_evidence {
+            return Err(finalize_live_restarted_run_failure(
+                &mut restarted_host,
+                &mut evidence,
+                &run,
+                &inputs,
+                pre_publication_captured,
+                error,
+            ));
         }
-        Ok((resources, branch, sha))
+        match inputs.mode {
+            LiveDogfoodMode::Preserve => {
+                if let Err(error) = stop_and_reap_live_host(&mut restarted_host) {
+                    return Err(finalize_live_restarted_run_failure(
+                        &mut restarted_host,
+                        &mut evidence,
+                        &run,
+                        &inputs,
+                        pre_publication_captured,
+                        error,
+                    ));
+                }
+                evidence.append_transition("preserve_stop_and_reap_host", "succeeded");
+                evidence.preserve_certification();
+                write_live_dogfood_evidence_v1(&run.root, &evidence)?;
+            }
+            LiveDogfoodMode::Routine => {
+                if let Err(error) = run_live_routine_cleanup(
+                    &client,
+                    &restart_base_url,
+                    &inputs,
+                    &run,
+                    &resources,
+                    &mut restarted_host,
+                    &worktree,
+                    &branch,
+                    &sha,
+                    pull_request_number,
+                    &mut evidence,
+                )
+                .await
+                {
+                    return Err(finalize_live_restarted_run_failure(
+                        &mut restarted_host,
+                        &mut evidence,
+                        &run,
+                        &inputs,
+                        pre_publication_captured,
+                        error,
+                    ));
+                }
+            }
+        }
+        Ok((resources, branch, sha, inputs.mode))
     }
     .await;
 
     match result {
-        Ok((resources, branch, sha)) => eprintln!(
-            "live dogfood preserved marker={} issue={} branch={} sha={} run_directory={}",
+        Ok((resources, branch, sha, mode)) => eprintln!(
+            "live dogfood completed mode={mode:?} marker={} issue={} branch={} sha={} run_directory={}",
             run.marker,
             resources.issue_number,
             branch,
@@ -2777,7 +3993,7 @@ async fn live_bamboon_issue_publishes_pull_request() {
             run.root.display()
         ),
         Err(error) => panic!(
-            "{error}\nlive dogfood dispatch-and-later artifacts are preserved: marker={} run_directory={}",
+            "{error}\nlive dogfood artifacts are preserved: marker={} run_directory={}\ndeliberate cleanup procedure: inspect run_directory/evidence-v1.json and follow docs/contributing.md#ignored-live-dogfood-tracer-bullet; revalidate every stored identity before mutation",
             run.marker,
             run.root.display()
         ),
@@ -2873,7 +4089,8 @@ fn live_dogfood_evidence_v1_schema_and_redaction_are_stable() {
         marker: "live-dogfood-evidence".to_string(),
         root: PathBuf::from("/tmp/private-run-root"),
     };
-    let mut evidence = LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#34");
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#34", LiveDogfoodMode::Routine);
     evidence
         .append_pre_publication(
             "docs/ensemble-dogfood/live-dogfood-evidence.md",
@@ -2919,7 +4136,8 @@ fn live_dogfood_evidence_v1_atomic_write_replaces_only_complete_documents() {
         marker: "live-dogfood-atomic".to_string(),
         root: temporary.path().to_path_buf(),
     };
-    let mut evidence = LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#35");
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#35", LiveDogfoodMode::Routine);
     evidence
         .append_pre_publication(
             "docs/ensemble-dogfood/live-dogfood-atomic.md",
@@ -2953,7 +4171,8 @@ fn live_dogfood_evidence_v1_failed_replacement_retains_prior_document() {
         marker: "live-dogfood-retention".to_string(),
         root: temporary.path().to_path_buf(),
     };
-    let mut evidence = LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#36");
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#36", LiveDogfoodMode::Routine);
     evidence
         .append_pre_publication(
             "docs/ensemble-dogfood/live-dogfood-retention.md",
@@ -2987,7 +4206,8 @@ fn live_dogfood_evidence_v1_snapshots_are_cumulative_and_ordered() {
         marker: "live-dogfood-order".to_string(),
         root: PathBuf::from("/tmp/run-root-not-serialized"),
     };
-    let mut evidence = LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#37");
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#37", LiveDogfoodMode::Routine);
     evidence
         .append_pre_publication(
             "docs/ensemble-dogfood/live-dogfood-order.md",
@@ -3021,7 +4241,8 @@ fn live_dogfood_post_restart_evidence_is_ordered_and_redacted() {
         marker: "live-dogfood-restart-order".to_string(),
         root: PathBuf::from("/tmp/private-run-root"),
     };
-    let mut evidence = LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#39");
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#39", LiveDogfoodMode::Routine);
     evidence
         .append_pre_publication(
             "docs/ensemble-dogfood/live-dogfood-restart-order.md",
@@ -3199,10 +4420,18 @@ fn live_dogfood_operator_contract_is_documented_without_fixture_values() {
         "ENSEMBLE_DOGFOOD_PROJECT_NUMBER",
         "ENSEMBLE_DOGFOOD_BAMBOON_PATH",
         "ENSEMBLE_DOGFOOD_AGENT",
+        "ENSEMBLE_LIVE_DOGFOOD_PRESERVE=1",
         "gh auth token",
         "Ensemble alone pushes",
         "`In review`",
         "never part of CI",
+        "default routine mode",
+        "network and model cost",
+        "close the exact pull request",
+        "while the second host remains running",
+        "deliberate cleanup procedure",
+        "revalidate each stored identity",
+        "does not close the MVP release gate",
         "evidence-v1.json",
         "pre-publication",
         "post-delivery",
@@ -3319,4 +4548,218 @@ fn live_dogfood_worktree_discovery_includes_the_issue_key_directory() {
     fs::create_dir_all(&expected).unwrap();
 
     assert_eq!(live_dogfood_worktree(&workspaces).unwrap(), expected);
+}
+
+#[test]
+fn live_dogfood_preserve_input_is_exact_and_defaults_to_routine_cleanup() {
+    assert_eq!(
+        LiveDogfoodMode::from_input(None).unwrap(),
+        LiveDogfoodMode::Routine
+    );
+    assert_eq!(
+        LiveDogfoodMode::from_input(Some("")).unwrap(),
+        LiveDogfoodMode::Routine
+    );
+    assert_eq!(
+        LiveDogfoodMode::from_input(Some("1")).unwrap(),
+        LiveDogfoodMode::Preserve
+    );
+    assert!(LiveDogfoodMode::from_input(Some("true")).is_err());
+}
+
+#[test]
+fn live_dogfood_evidence_records_the_selected_cleanup_mode() {
+    let run = LiveDogfoodRun {
+        marker: "live-dogfood-mode".to_string(),
+        root: PathBuf::from("/tmp/ensemble-live-dogfood/live-dogfood-mode"),
+    };
+    let evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#47", LiveDogfoodMode::Preserve);
+
+    let value = serde_json::to_value(evidence).unwrap();
+    assert_eq!(value["mode"], "preserve");
+}
+
+#[test]
+fn live_dogfood_partial_cleanup_evidence_distinguishes_absent_and_retained_state() {
+    let run = LiveDogfoodRun {
+        marker: "live-dogfood-partial".to_string(),
+        root: PathBuf::from("/tmp/ensemble-live-dogfood/live-dogfood-partial"),
+    };
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#47", LiveDogfoodMode::Routine);
+    evidence.append_transition("close_pull_request", "succeeded");
+    evidence.append_transition("project_done", "preserved_failure");
+    evidence.preserve_after_transitions();
+
+    let value = serde_json::to_value(evidence).unwrap();
+    assert_eq!(value["outcome"], "preserved_failure");
+    assert_eq!(
+        value["final_state"]["absent"],
+        serde_json::json!(["open_pull_request"])
+    );
+    assert!(value["final_state"]["retained"]
+        .as_array()
+        .unwrap()
+        .contains(&serde_json::json!("project_item")));
+}
+
+#[test]
+fn live_dogfood_cleanup_plan_requires_exact_consistent_run_owned_identities() {
+    let plan = LiveDogfoodCleanupPlan::for_test();
+    assert!(plan.validate().is_ok());
+    assert!(plan
+        .clone()
+        .with_pull_request_sha("other")
+        .validate()
+        .is_err());
+    assert!(plan
+        .clone()
+        .with_pull_request_base("release")
+        .validate()
+        .is_err());
+    assert!(plan.clone().with_issue_id("").validate().is_err());
+    assert!(plan
+        .clone()
+        .with_worktree("/tmp/not-run-owned")
+        .validate()
+        .is_err());
+}
+
+#[test]
+fn live_dogfood_pull_request_revalidation_requires_the_stored_identity() {
+    let plan = LiveDogfoodCleanupPlan::for_test();
+    let identity = LiveDogfoodPullRequestIdentity {
+        id: plan.pull_request.id.clone(),
+        number: plan.pull_request.number,
+        url: plan.pull_request.url.clone(),
+        state: "OPEN".to_string(),
+        head: plan.branch.clone(),
+        sha: plan.expected_sha.clone(),
+        base: "main".to_string(),
+    };
+
+    assert!(identity.validate_against(&plan, "OPEN").is_ok());
+    assert!(identity.validate_against(&plan, "CLOSED").is_err());
+    assert!(LiveDogfoodPullRequestIdentity {
+        sha: "replacement-sha".to_string(),
+        ..identity
+    }
+    .validate_against(&plan, "OPEN")
+    .is_err());
+}
+
+#[test]
+fn live_dogfood_cleanup_stops_after_a_failed_revalidation() {
+    let plan = LiveDogfoodCleanupPlan::for_test();
+    let mut cleanup = LiveDogfoodCleanupRecorder::new(&plan).unwrap();
+    cleanup
+        .attempt(LiveDogfoodCleanupStep::ClosePullRequest, Ok(()))
+        .unwrap();
+    assert!(cleanup
+        .attempt(
+            LiveDogfoodCleanupStep::ProjectDone,
+            Err("stored Project item no longer matched"),
+        )
+        .is_err());
+    assert!(cleanup
+        .attempt(LiveDogfoodCleanupStep::WaitForHostRelease, Ok(()))
+        .is_err());
+    assert_eq!(
+        cleanup.transitions(),
+        [
+            ("close_pull_request", "succeeded"),
+            ("project_done", "preserved_failure"),
+        ]
+    );
+}
+
+#[test]
+fn live_dogfood_cleanup_order_keeps_the_host_alive_until_public_release() {
+    let plan = LiveDogfoodCleanupPlan::for_test();
+    let mut cleanup = LiveDogfoodCleanupRecorder::new(&plan).unwrap();
+    for step in LIVE_DOGFOOD_CLEANUP_ORDER {
+        cleanup.attempt(step, Ok(())).unwrap();
+    }
+    assert!(cleanup.is_complete());
+}
+
+#[test]
+fn live_dogfood_final_absence_requires_every_run_owned_artifact() {
+    assert!(validate_live_final_absence([true; 6]).is_ok());
+
+    for missing in 0..6 {
+        let mut observations = [true; 6];
+        observations[missing] = false;
+        assert!(validate_live_final_absence(observations).is_err());
+    }
+}
+
+#[test]
+fn live_dogfood_pre_dispatch_rollback_requires_exact_issue_and_item_ownership() {
+    let resources = PreDispatchResources {
+        issue_id: "issue-node".to_string(),
+        issue_number: 47,
+        project_id: "project-node".to_string(),
+        project_item_id: "item-node".to_string(),
+    };
+    let issue = serde_json::json!({
+        "node_id": "issue-node",
+        "number": 47,
+        "state": "open",
+    });
+    let project = serde_json::json!({
+        "data": {"repository": {"projectV2": {
+            "id": "project-node",
+            "items": {"nodes": [{
+                "id": "item-node",
+                "content": {"id": "issue-node", "number": 47}
+            }]}
+        }}}
+    });
+
+    assert!(validate_live_issue_identity(
+        &issue,
+        &resources.issue_id,
+        resources.issue_number,
+        "open",
+        "pre-dispatch rollback issue",
+    )
+    .is_ok());
+    assert!(validate_pre_dispatch_project_item_identity(&project, &resources).is_ok());
+    assert!(validate_live_project_item_absence(
+        &serde_json::json!({
+            "data": {"repository": {"projectV2": {
+                "id": "project-node",
+                "items": {"nodes": []}
+            }}}
+        }),
+        "project-node",
+        "item-node",
+    )
+    .is_ok());
+    assert!(validate_live_project_item_absence(
+        &serde_json::json!({
+            "data": {"repository": {"projectV2": {
+                "id": "project-node",
+                "items": null
+            }}}
+        }),
+        "project-node",
+        "item-node",
+    )
+    .is_err());
+    assert!(validate_pre_dispatch_project_item_identity(
+        &serde_json::json!({
+            "data": {"repository": {"projectV2": {
+                "id": "project-node",
+                "items": {"nodes": [{
+                    "id": "item-node",
+                    "content": {"id": "other-issue", "number": 47}
+                }]}
+            }}}
+        }),
+        &resources,
+    )
+    .is_err());
 }

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -1349,12 +1349,11 @@ impl LiveDogfoodEvidenceV1 {
             "evidence",
         ];
         if !self.snapshots.is_empty() {
-            self.final_state.retained.push("workspace_worktree");
-        }
-        if self.has_post_delivery() {
-            self.final_state
-                .retained
-                .extend(["generated_ref", "pull_request"]);
+            self.final_state.retained.extend([
+                "workspace_worktree",
+                "generated_ref",
+                "pull_request",
+            ]);
         }
     }
 
@@ -4484,6 +4483,32 @@ fn live_dogfood_failure_evidence_keeps_the_safe_failure_phase() {
 }
 
 #[test]
+fn live_dogfood_pre_delivery_failure_conservatively_reports_remote_residue() {
+    let run = LiveDogfoodRun {
+        marker: "live-dogfood-pre-delivery-failure".to_string(),
+        root: PathBuf::from("/tmp/ensemble-live-dogfood/live-dogfood-pre-delivery-failure"),
+    };
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#47", LiveDogfoodMode::Routine);
+    evidence
+        .append_pre_publication(
+            "docs/ensemble-dogfood/live-dogfood-pre-delivery-failure.md",
+            "ensemble-live-dogfood-pre-delivery-failure",
+            "local-sha",
+        )
+        .unwrap();
+
+    evidence.preserve_discovered_artifacts();
+
+    let retained = serde_json::to_value(evidence).unwrap()["final_state"]["retained"]
+        .as_array()
+        .unwrap()
+        .clone();
+    assert!(retained.contains(&serde_json::json!("generated_ref")));
+    assert!(retained.contains(&serde_json::json!("pull_request")));
+}
+
+#[test]
 fn live_dogfood_post_delivery_requires_matching_host_pull_request() {
     let detail = serde_json::json!({
         "issue_identifier": "chrisbanes/bamboon#38",
@@ -4542,6 +4567,8 @@ fn live_dogfood_operator_contract_is_documented_without_fixture_values() {
         "two configured polling intervals",
         "unchanged config",
         "not exist before dispatch",
+        "conservatively lists the generated ref",
+        "pull request until fresh observations",
     ] {
         assert!(
             contributing.contains(required),

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -2534,12 +2534,21 @@ fn finalize_live_restarted_run_failure(
 }
 
 fn canonical_live_worktree_path(path: &Path) -> PathBuf {
-    fs::canonicalize(path).unwrap_or_else(|_| {
-        path.parent()
-            .and_then(|parent| fs::canonicalize(parent).ok())
-            .and_then(|parent| path.file_name().map(|name| parent.join(name)))
-            .unwrap_or_else(|| path.to_path_buf())
-    })
+    let mut existing = path;
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        let (Some(parent), Some(file_name)) = (existing.parent(), existing.file_name()) else {
+            return path.to_path_buf();
+        };
+        missing.push(file_name.to_os_string());
+        existing = parent;
+    }
+
+    let mut canonical = fs::canonicalize(existing).unwrap_or_else(|_| existing.to_path_buf());
+    for component in missing.into_iter().rev() {
+        canonical.push(component);
+    }
+    canonical
 }
 
 fn worktree_is_registered(listing: &str, worktree: &Path) -> bool {
@@ -4684,15 +4693,15 @@ fn live_dogfood_worktree_registration_canonicalizes_symlinked_prefixes() {
 
     let temporary = tempfile::tempdir().unwrap();
     let canonical_root = temporary.path().join("canonical");
-    let canonical_worktree = canonical_root.join("issue-worktree");
+    let canonical_worktree = canonical_root.join("run-root").join("issue-worktree");
     let aliased_root = temporary.path().join("alias");
-    let aliased_worktree = aliased_root.join("issue-worktree");
+    let aliased_worktree = aliased_root.join("run-root").join("issue-worktree");
     fs::create_dir_all(&canonical_worktree).unwrap();
     symlink(&canonical_root, &aliased_root).unwrap();
     let listing = format!("worktree {}\n", canonical_worktree.display());
 
     assert!(worktree_is_registered(&listing, &aliased_worktree));
-    fs::remove_dir(&canonical_worktree).unwrap();
+    fs::remove_dir_all(canonical_root.join("run-root")).unwrap();
     assert!(worktree_is_registered(&listing, &aliased_worktree));
 }
 

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -1755,7 +1755,11 @@ fn write_live_dogfood_evidence_v1_with_replace(
     file.sync_all()
         .map_err(|_| "evidence-v1: could not flush temporary document")?;
     drop(file);
-    replace(&temporary, &target).map_err(|_| "evidence-v1: atomic replacement failed".to_string())
+    replace(&temporary, &target)
+        .map_err(|_| "evidence-v1: atomic replacement failed".to_string())?;
+    fs::File::open(run_root)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| "evidence-v1: could not flush run directory".to_string())
 }
 
 fn persist_live_dogfood_failure(
@@ -1876,6 +1880,7 @@ repos:
 agents:
   builder:
     acpx_agent: {}
+    permission_mode: approve_reads
     prompt: {}
 steps:
   - name: implement
@@ -1890,6 +1895,8 @@ concurrency:
   max_concurrent_agents: 1
   max_step_parallelism: 1
 agent:
+  permission_request_policy:
+    mode: reject_all
   turn_timeout_ms: 1800000
 "#,
         inputs.project_number,
@@ -2140,21 +2147,7 @@ fn validate_live_bamboon_clone(inputs: &LiveDogfoodInputs) -> Result<(), String>
     if branch.trim() != "main" {
         return Err("preflight Bamboon branch: checked-out branch must be main".to_string());
     }
-    let remote = live_git(
-        "preflight Bamboon remote",
-        root,
-        [
-            "remote".to_string(),
-            "get-url".to_string(),
-            "origin".to_string(),
-        ],
-        inputs,
-    )?;
-    if !is_bamboon_remote(remote.trim()) {
-        return Err(
-            "preflight Bamboon remote: origin must identify chrisbanes/bamboon".to_string(),
-        );
-    }
+    validated_live_bamboon_remote(inputs, root, "preflight Bamboon remote")?;
     let status = live_git(
         "preflight Bamboon cleanliness",
         root,
@@ -2177,6 +2170,28 @@ fn is_bamboon_remote(remote: &str) -> bool {
             | "ssh://git@github.com/chrisbanes/bamboon"
             | "https://github.com/chrisbanes/bamboon"
     )
+}
+
+fn validated_live_bamboon_remote(
+    inputs: &LiveDogfoodInputs,
+    worktree: &Path,
+    phase: &str,
+) -> Result<String, String> {
+    let remote = live_git(
+        phase,
+        worktree,
+        [
+            "remote".to_string(),
+            "get-url".to_string(),
+            "origin".to_string(),
+        ],
+        inputs,
+    )?;
+    let remote = remote.trim();
+    if !is_bamboon_remote(remote) {
+        return Err(format!("{phase}: origin must identify chrisbanes/bamboon"));
+    }
+    Ok(remote.to_string())
 }
 
 fn live_preflight(
@@ -2410,20 +2425,21 @@ fn revalidate_live_remote_ref(
     inputs: &LiveDogfoodInputs,
     worktree: &Path,
     plan: &LiveDogfoodCleanupPlan,
+    remote_url: &str,
 ) -> Result<(), String> {
-    let remote = live_git(
+    let remote_refs = live_git(
         "cleanup generated ref revalidation",
         worktree,
         [
             "ls-remote".to_string(),
             "--heads".to_string(),
-            "origin".to_string(),
+            remote_url.to_string(),
             format!("refs/heads/{}", plan.branch),
         ],
         inputs,
     )?;
     let expected = format!("{}\trefs/heads/{}", plan.expected_sha, plan.branch);
-    if remote.lines().collect::<Vec<_>>() != [expected] {
+    if remote_refs.lines().collect::<Vec<_>>() != [expected] {
         return Err("cleanup generated ref revalidation: stored ref no longer matched".to_string());
     }
     Ok(())
@@ -2707,10 +2723,16 @@ fn delete_live_remote_ref(
     inputs: &LiveDogfoodInputs,
     plan: &LiveDogfoodCleanupPlan,
 ) -> Result<(), String> {
-    revalidate_live_remote_ref(inputs, &inputs.bamboon_path, plan)?;
+    let remote = validated_live_bamboon_remote(
+        inputs,
+        &inputs.bamboon_path,
+        "cleanup generated ref origin revalidation",
+    )?;
+    revalidate_live_remote_ref(inputs, &inputs.bamboon_path, plan, &remote)?;
     delete_live_remote_ref_at_sha(
         inputs,
         &inputs.bamboon_path,
+        &remote,
         &plan.branch,
         &plan.expected_sha,
     )?;
@@ -2720,7 +2742,7 @@ fn delete_live_remote_ref(
         [
             "ls-remote".to_string(),
             "--heads".to_string(),
-            "origin".to_string(),
+            remote,
             format!("refs/heads/{}", plan.branch),
         ],
         inputs,
@@ -2734,6 +2756,7 @@ fn delete_live_remote_ref(
 fn delete_live_remote_ref_at_sha(
     inputs: &LiveDogfoodInputs,
     worktree: &Path,
+    remote: &str,
     branch: &str,
     expected_sha: &str,
 ) -> Result<(), String> {
@@ -2744,7 +2767,7 @@ fn delete_live_remote_ref_at_sha(
             "push".to_string(),
             format!("--force-with-lease=refs/heads/{branch}:{expected_sha}"),
             "--delete".to_string(),
-            "origin".to_string(),
+            remote.to_string(),
             branch.to_string(),
         ],
         inputs,
@@ -2846,17 +2869,18 @@ fn record_live_cleanup_step(
     }
 }
 
-fn persist_live_cleanup_transition(
+fn persist_live_cleanup_result(
     cleanup: &mut LiveDogfoodCleanupRecorder,
     evidence: &mut LiveDogfoodEvidenceV1,
     run: &LiveDogfoodRun,
     step: LiveDogfoodCleanupStep,
     result: Result<(), String>,
+    persist: &mut impl FnMut(&Path, &LiveDogfoodEvidenceV1) -> Result<(), String>,
 ) -> Result<(), String> {
     match record_live_cleanup_step(cleanup, evidence, step, result) {
-        Ok(()) => write_live_dogfood_evidence_v1(&run.root, evidence),
+        Ok(()) => persist(&run.root, evidence),
         Err(error) => {
-            write_live_dogfood_evidence_v1(&run.root, evidence)
+            persist(&run.root, evidence)
                 .map_err(|write_error| format!("{error}; {write_error}"))?;
             Err(error)
         }
@@ -2914,9 +2938,28 @@ async fn execute_live_cleanup_sequence(
     evidence: &mut LiveDogfoodEvidenceV1,
     run: &LiveDogfoodRun,
 ) -> Result<(), String> {
+    execute_live_cleanup_sequence_with_writer(
+        actions,
+        cleanup,
+        evidence,
+        run,
+        write_live_dogfood_evidence_v1,
+    )
+    .await
+}
+
+async fn execute_live_cleanup_sequence_with_writer(
+    actions: &mut impl LiveDogfoodCleanupActions,
+    cleanup: &mut LiveDogfoodCleanupRecorder,
+    evidence: &mut LiveDogfoodEvidenceV1,
+    run: &LiveDogfoodRun,
+    mut persist: impl FnMut(&Path, &LiveDogfoodEvidenceV1) -> Result<(), String>,
+) -> Result<(), String> {
     for step in LIVE_DOGFOOD_CLEANUP_ORDER {
+        evidence.append_transition(step.name(), "attempting");
+        persist(&run.root, evidence)?;
         let result = actions.execute(step).await;
-        persist_live_cleanup_transition(cleanup, evidence, run, step, result)?;
+        persist_live_cleanup_result(cleanup, evidence, run, step, result, &mut persist)?;
     }
     Ok(())
 }
@@ -4671,6 +4714,14 @@ fn live_dogfood_config_parses_with_multiline_artifact_content() {
         .as_str()
         .expect("live prompt must be a scalar");
     assert!(prompt.contains("# Ensemble live dogfood\n\nMarker:"));
+    assert_eq!(
+        config["agents"]["builder"]["permission_mode"],
+        "approve_reads"
+    );
+    assert_eq!(
+        config["agent"]["permission_request_policy"]["mode"],
+        "reject_all"
+    );
 }
 
 #[test]
@@ -4891,7 +4942,14 @@ fn live_dogfood_remote_ref_deletion_rejects_a_replacement_sha() {
         .trim()
         .to_string();
 
-    assert!(delete_live_remote_ref_at_sha(&inputs, &source, "main", &expected_sha).is_err());
+    assert!(delete_live_remote_ref_at_sha(
+        &inputs,
+        &source,
+        remote.to_str().unwrap(),
+        "main",
+        &expected_sha,
+    )
+    .is_err());
     assert_eq!(
         git(
             "test observe replacement ref",
@@ -4899,6 +4957,47 @@ fn live_dogfood_remote_ref_deletion_rejects_a_replacement_sha() {
         ),
         format!("{replacement_sha}\trefs/heads/main\n")
     );
+}
+
+#[test]
+fn live_dogfood_remote_ref_cleanup_rejects_a_replacement_origin() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let replacement = temporary.path().join("replacement.git");
+    init_git_repo(&source).unwrap();
+    let inputs =
+        LiveDogfoodInputs::from_values(Some("1"), Some("12"), source.to_str(), None).unwrap();
+    live_git(
+        "test initialize replacement remote",
+        &source,
+        [
+            "init".to_string(),
+            "--bare".to_string(),
+            replacement.display().to_string(),
+        ],
+        &inputs,
+    )
+    .unwrap();
+    live_git(
+        "test install replacement origin",
+        &source,
+        [
+            "remote".to_string(),
+            "add".to_string(),
+            "origin".to_string(),
+            replacement.display().to_string(),
+        ],
+        &inputs,
+    )
+    .unwrap();
+
+    assert!(validated_live_bamboon_remote(
+        &inputs,
+        &source,
+        "cleanup generated ref origin revalidation",
+    )
+    .unwrap_err()
+    .contains("origin must identify chrisbanes/bamboon"));
 }
 
 #[test]
@@ -4978,8 +5077,61 @@ async fn live_dogfood_cleanup_execution_stops_after_a_helper_failure() {
     assert_eq!(
         persisted["transitions"],
         serde_json::json!([
+            {"phase": "close_pull_request", "result": "attempting"},
             {"phase": "close_pull_request", "result": "succeeded"},
+            {"phase": "project_done", "result": "attempting"},
             {"phase": "project_done", "result": "preserved_failure"}
+        ])
+    );
+}
+
+#[tokio::test]
+async fn live_dogfood_cleanup_retains_intent_when_result_persistence_fails() {
+    let temporary = tempfile::tempdir().unwrap();
+    let run = LiveDogfoodRun {
+        marker: "live-dogfood-evidence-write-failure".to_string(),
+        root: temporary.path().to_path_buf(),
+    };
+    let plan = LiveDogfoodCleanupPlan::for_test();
+    let mut cleanup = LiveDogfoodCleanupRecorder::new(&plan).unwrap();
+    let mut evidence =
+        LiveDogfoodEvidenceV1::new(&run, "chrisbanes/bamboon#47", LiveDogfoodMode::Routine);
+    let mut actions = FailingLiveDogfoodCleanupActions {
+        attempted: Vec::new(),
+        fail_at: LiveDogfoodCleanupStep::VerifyFinalAbsence,
+    };
+    let mut writes = 0;
+
+    let error = execute_live_cleanup_sequence_with_writer(
+        &mut actions,
+        &mut cleanup,
+        &mut evidence,
+        &run,
+        |root, evidence| {
+            writes += 1;
+            if writes == 2 {
+                Err("injected evidence write failure".to_string())
+            } else {
+                write_live_dogfood_evidence_v1(root, evidence)
+            }
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, "injected evidence write failure");
+    assert_eq!(
+        actions.attempted,
+        [LiveDogfoodCleanupStep::ClosePullRequest]
+    );
+    let persisted: Value = serde_json::from_str(
+        &fs::read_to_string(temporary.path().join("evidence-v1.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        persisted["transitions"],
+        serde_json::json!([
+            {"phase": "close_pull_request", "result": "attempting"}
         ])
     );
 }

--- a/crates/ensemble-core/src/agent/acp_client.rs
+++ b/crates/ensemble-core/src/agent/acp_client.rs
@@ -33,10 +33,10 @@ use super::ResolvedCommand;
 /// Build an `AcpAgent` from a structured `ResolvedCommand`. The SDK's
 /// `McpServerStdio` spawns the child via `async_process::Command`.
 /// Because `McpServerStdio` has no working-directory field, we wrap the
-/// command with `sh -c 'cd "$1" && shift && exec "$@"'` and pass the
-/// workspace path as `$1` — the child process starts with the correct CWD
-/// while all agent args arrive as separate `argv` entries (no shell escaping
-/// needed for either the path or the args).
+/// command with a shell that removes the host's GitHub token, changes to the
+/// workspace passed as `$1`, and then executes the agent. All agent args arrive
+/// as separate `argv` entries, so neither paths nor arguments need shell
+/// escaping.
 fn build_acp_agent(cmd: &ResolvedCommand, workspace_path: &Path) -> AcpAgent {
     let name = cmd
         .program
@@ -45,7 +45,7 @@ fn build_acp_agent(cmd: &ResolvedCommand, workspace_path: &Path) -> AcpAgent {
         .unwrap_or_else(|| "agent".to_string());
     let mut args = vec![
         "-c".to_string(),
-        r#"cd "$1" && shift && exec "$@""#.to_string(),
+        r#"unset GITHUB_TOKEN; cd "$1" && shift && exec "$@""#.to_string(),
         name.clone(),
         workspace_path.to_string_lossy().to_string(),
         cmd.program.to_string_lossy().to_string(),
@@ -1124,7 +1124,7 @@ mod tests {
             config.arguments(),
             [
                 "-c",
-                r#"cd "$1" && shift && exec "$@""#,
+                r#"unset GITHUB_TOKEN; cd "$1" && shift && exec "$@""#,
                 "agent binary",
                 "/tmp/work space",
                 "/opt/agent binary",
@@ -1136,6 +1136,29 @@ mod tests {
             config.environment().get("AGENT_TOKEN").map(String::as_str),
             Some("secret")
         );
+    }
+
+    #[test]
+    fn build_acp_agent_removes_host_github_token_from_child() {
+        let command = ResolvedCommand {
+            program: PathBuf::from("sh"),
+            args: vec![
+                "-c".to_string(),
+                r#"printf '%s' "${GITHUB_TOKEN-unset}""#.to_string(),
+            ],
+            env: Vec::new(),
+        };
+        let agent = build_acp_agent(&command, Path::new("/tmp"));
+        let config = agent.config();
+        let output = std::process::Command::new(config.command())
+            .args(config.arguments())
+            .envs(config.environment())
+            .env("GITHUB_TOKEN", "host-secret")
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), "unset");
     }
 
     #[test]

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -9,6 +9,7 @@ use crate::observability::events::EventBus;
 use crate::orchestrator::retry::ManualStepRetryError;
 use crate::orchestrator::state::OrchestratorState;
 use crate::orchestrator::{
+    FinalizeApprovalCommand, FinalizeApprovalError, FinalizeRetryCommand, FinalizeRetryError,
     ManualStepRetryCommand, ManualWholeIssueRetryCommand, Orchestrator, OrchestratorCommand,
     OrchestratorRuntimeParts, QuiescingLatch,
 };
@@ -110,6 +111,40 @@ impl RegisteredOrchestrator {
         result
             .await
             .map_err(|_| ManualStepRetryError::RuntimeUnavailable)?
+    }
+
+    pub(crate) async fn approve_finalize(
+        &self,
+        command: FinalizeApprovalCommand,
+    ) -> Result<(), FinalizeApprovalError> {
+        let Some(command_tx) = self.command_sender() else {
+            return Err(FinalizeApprovalError::RuntimeUnavailable);
+        };
+        let (response, result) = tokio::sync::oneshot::channel();
+        command_tx
+            .send(OrchestratorCommand::ApproveFinalize { command, response })
+            .await
+            .map_err(|_| FinalizeApprovalError::RuntimeUnavailable)?;
+        result
+            .await
+            .map_err(|_| FinalizeApprovalError::RuntimeUnavailable)?
+    }
+
+    pub(crate) async fn retry_finalize(
+        &self,
+        command: FinalizeRetryCommand,
+    ) -> Result<(), FinalizeRetryError> {
+        let Some(command_tx) = self.command_sender() else {
+            return Err(FinalizeRetryError::RuntimeUnavailable);
+        };
+        let (response, result) = tokio::sync::oneshot::channel();
+        command_tx
+            .send(OrchestratorCommand::RetryFinalize { command, response })
+            .await
+            .map_err(|_| FinalizeRetryError::RuntimeUnavailable)?;
+        result
+            .await
+            .map_err(|_| FinalizeRetryError::RuntimeUnavailable)?
     }
 
     fn command_sender(&self) -> Option<mpsc::Sender<OrchestratorCommand>> {

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -116,7 +116,7 @@ impl RegisteredOrchestrator {
     pub(crate) async fn approve_finalize(
         &self,
         command: FinalizeApprovalCommand,
-    ) -> Result<(), FinalizeApprovalError> {
+    ) -> Result<bool, FinalizeApprovalError> {
         let Some(command_tx) = self.command_sender() else {
             return Err(FinalizeApprovalError::RuntimeUnavailable);
         };

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -546,9 +546,9 @@ pub async fn post_retry(
     operation_id = "postFinalizeApprove",
     params(("identifier" = String, Path, description = "Issue identifier")),
     responses(
-        (status = 200, description = "Finalize approved", body = FinalizeApproveResponse),
+        (status = 200, description = "Finalize approved or an earlier approval confirmed", body = FinalizeApproveResponse),
         (status = 404, description = "Issue not found", body = ApiError),
-        (status = 409, description = "Issue is not awaiting finalize approval", body = ApiError)
+        (status = 409, description = "Issue has no approval-gated delivery", body = ApiError)
     ),
     tag = "controls"
 )]
@@ -577,7 +577,7 @@ pub async fn post_finalize_approve(
 
     drop(lock);
 
-    match state
+    let newly_approved = match state
         .orchestrator_runtime
         .approve_finalize(FinalizeApprovalCommand {
             issue_id,
@@ -585,7 +585,7 @@ pub async fn post_finalize_approve(
         })
         .await
     {
-        Ok(()) => {}
+        Ok(newly_approved) => newly_approved,
         Err(FinalizeApprovalError::RuntimeUnavailable) => {
             return issue_error_response(
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -607,7 +607,7 @@ pub async fn post_finalize_approve(
                 format!("failed to persist finalization approval: {error}"),
             );
         }
-    }
+    };
 
     state.refresh_requested.notify_one();
 
@@ -616,7 +616,12 @@ pub async fn post_finalize_approve(
         Json(FinalizeApproveResponse {
             approved: true,
             issue_identifier: identifier,
-            message: "finalize approved".to_string(),
+            message: if newly_approved {
+                "finalize approved"
+            } else {
+                "finalize was already approved"
+            }
+            .to_string(),
         }),
     )
         .into_response()
@@ -1206,6 +1211,10 @@ mod tests {
     }
 
     fn install_test_finalize_runtime(state: &AppState) {
+        install_test_finalize_runtime_with_approval_result(state, true);
+    }
+
+    fn install_test_finalize_runtime_with_approval_result(state: &AppState, newly_approved: bool) {
         let (command_tx, mut command_rx) = tokio::sync::mpsc::channel(1);
         state
             .orchestrator_runtime
@@ -1219,7 +1228,7 @@ mod tests {
                         let finalize = state.get_finalize_state_mut(&command.issue_id).unwrap();
                         finalize.status = FinalizeStatus::InProgress;
                         finalize.repos[0].status = FinalizeStatus::InProgress;
-                        let _ = response.send(Ok(()));
+                        let _ = response.send(Ok(newly_approved));
                     }
                     OrchestratorCommand::RetryFinalize { command, response } => {
                         let mut state = orchestrator_state.write().await;
@@ -1316,6 +1325,19 @@ mod tests {
         assert_eq!(finalize.status, FinalizeStatus::InProgress);
         assert_eq!(finalize.repos[0].status, FinalizeStatus::InProgress);
         assert!(!lock.completed.contains_key("NODE_888"));
+    }
+
+    #[tokio::test]
+    async fn test_finalize_approve_reports_idempotent_replay() {
+        let state = build_app_state_with_finalize_pending();
+        install_test_finalize_runtime_with_approval_result(&state, false);
+
+        let response = post_finalize_approve(State(state), Path("my-repo#888".to_string())).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["approved"], true);
+        assert_eq!(body["message"], "finalize was already approved");
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -548,7 +548,9 @@ pub async fn post_retry(
     responses(
         (status = 200, description = "Finalize approved or an earlier approval confirmed", body = FinalizeApproveResponse),
         (status = 404, description = "Issue not found", body = ApiError),
-        (status = 409, description = "Issue has no approval-gated delivery", body = ApiError)
+        (status = 409, description = "Issue has no approval-gated delivery", body = ApiError),
+        (status = 500, description = "Finalize approval could not be persisted", body = ApiError),
+        (status = 503, description = "Orchestrator runtime unavailable", body = ApiError)
     ),
     tag = "controls"
 )]
@@ -636,7 +638,9 @@ pub async fn post_finalize_approve(
     responses(
         (status = 200, description = "Finalize retried", body = FinalizeRetryResponse),
         (status = 404, description = "Issue not found", body = ApiError),
-        (status = 409, description = "Issue has no failed finalize state", body = ApiError)
+        (status = 409, description = "Issue has no failed finalize state", body = ApiError),
+        (status = 500, description = "Finalize retry could not be persisted", body = ApiError),
+        (status = 503, description = "Orchestrator runtime unavailable", body = ApiError)
     ),
     tag = "controls"
 )]

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -4,8 +4,11 @@ use crate::api::router::AppState;
 use crate::interaction::{InteractionStatus, InteractionStore};
 use crate::orchestrator::pipeline_journal::PipelineRunJournal;
 use crate::orchestrator::retry::ManualStepRetryError;
-use crate::orchestrator::state::{FinalizeStatus, OrchestratorState};
-use crate::orchestrator::{ManualStepRetryCommand, ManualWholeIssueRetryCommand};
+use crate::orchestrator::state::OrchestratorState;
+use crate::orchestrator::{
+    FinalizeApprovalCommand, FinalizeApprovalError, FinalizeRetryCommand, FinalizeRetryError,
+    ManualStepRetryCommand, ManualWholeIssueRetryCommand,
+};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -553,7 +556,7 @@ pub async fn post_finalize_approve(
     State(state): State<AppState>,
     Path(identifier): Path<String>,
 ) -> impl IntoResponse {
-    let mut lock = state.orchestrator_state.write().await;
+    let lock = state.orchestrator_state.read().await;
     let issue_id = match find_issue_presence(&lock, &identifier) {
         IssuePresence::Finalizing(issue_id) => issue_id,
         IssuePresence::Running(_) | IssuePresence::Retrying(_) => {
@@ -572,46 +575,39 @@ pub async fn post_finalize_approve(
         }
     };
 
-    let Some(finalize) = lock.get_finalize_state_mut(&issue_id) else {
-        return issue_error_response(
-            StatusCode::CONFLICT,
-            "not_awaiting_finalize_approval",
-            format!("issue '{}' has no finalize state", identifier),
-        );
-    };
+    drop(lock);
 
-    let mut changed = false;
-    for repo in &mut finalize.repos {
-        if repo.status == FinalizeStatus::PendingApproval {
-            repo.last_error = None;
-            repo.status = FinalizeStatus::InProgress;
-            changed = true;
+    match state
+        .orchestrator_runtime
+        .approve_finalize(FinalizeApprovalCommand {
+            issue_id,
+            identifier: identifier.clone(),
+        })
+        .await
+    {
+        Ok(()) => {}
+        Err(FinalizeApprovalError::RuntimeUnavailable) => {
+            return issue_error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "orchestrator_unavailable",
+                "the orchestrator runtime is not available to approve finalization",
+            );
+        }
+        Err(FinalizeApprovalError::NotAwaitingApproval) => {
+            return issue_error_response(
+                StatusCode::CONFLICT,
+                "not_awaiting_finalize_approval",
+                format!("issue '{}' has no repos awaiting approval", identifier),
+            );
+        }
+        Err(FinalizeApprovalError::Persistence(error)) => {
+            return issue_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "finalize_approval_failed",
+                format!("failed to persist finalization approval: {error}"),
+            );
         }
     }
-
-    if !changed {
-        return issue_error_response(
-            StatusCode::CONFLICT,
-            "not_awaiting_finalize_approval",
-            format!("issue '{}' has no repos awaiting approval", identifier),
-        );
-    }
-
-    finalize.status = if finalize
-        .repos
-        .iter()
-        .all(|repo| repo.status == FinalizeStatus::Succeeded)
-    {
-        FinalizeStatus::Succeeded
-    } else if finalize
-        .repos
-        .iter()
-        .any(|repo| repo.status == FinalizeStatus::InProgress)
-    {
-        FinalizeStatus::InProgress
-    } else {
-        FinalizeStatus::PendingApproval
-    };
 
     state.refresh_requested.notify_one();
 
@@ -643,7 +639,7 @@ pub async fn post_finalize_retry(
     State(state): State<AppState>,
     Path(identifier): Path<String>,
 ) -> impl IntoResponse {
-    let mut lock = state.orchestrator_state.write().await;
+    let lock = state.orchestrator_state.read().await;
     let issue_id = match find_issue_presence(&lock, &identifier) {
         IssuePresence::Finalizing(issue_id) => issue_id,
         IssuePresence::Running(_) | IssuePresence::Retrying(_) => {
@@ -662,50 +658,39 @@ pub async fn post_finalize_retry(
         }
     };
 
-    let Some(finalize) = lock.get_finalize_state_mut(&issue_id) else {
-        return issue_error_response(
-            StatusCode::CONFLICT,
-            "not_finalize_failed",
-            format!("issue '{}' has no finalize state", identifier),
-        );
-    };
+    drop(lock);
 
-    let mut changed = false;
-    for repo in &mut finalize.repos {
-        if repo.status == FinalizeStatus::Failed {
-            repo.last_error = None;
-            repo.status = if repo.approval_required {
-                FinalizeStatus::PendingApproval
-            } else {
-                FinalizeStatus::InProgress
-            };
-            changed = true;
+    match state
+        .orchestrator_runtime
+        .retry_finalize(FinalizeRetryCommand {
+            issue_id,
+            identifier: identifier.clone(),
+        })
+        .await
+    {
+        Ok(()) => {}
+        Err(FinalizeRetryError::RuntimeUnavailable) => {
+            return issue_error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "orchestrator_unavailable",
+                "the orchestrator runtime is not available to retry finalization",
+            );
+        }
+        Err(FinalizeRetryError::NotFailed) => {
+            return issue_error_response(
+                StatusCode::CONFLICT,
+                "not_finalize_failed",
+                format!("issue '{}' has no failed finalize repos", identifier),
+            );
+        }
+        Err(FinalizeRetryError::Persistence(error)) => {
+            return issue_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "finalize_retry_failed",
+                format!("failed to persist finalization retry: {error}"),
+            );
         }
     }
-
-    if !changed {
-        return issue_error_response(
-            StatusCode::CONFLICT,
-            "not_finalize_failed",
-            format!("issue '{}' has no failed finalize repos", identifier),
-        );
-    }
-
-    finalize.status = if finalize
-        .repos
-        .iter()
-        .all(|repo| repo.status == FinalizeStatus::Succeeded)
-    {
-        FinalizeStatus::Succeeded
-    } else if finalize
-        .repos
-        .iter()
-        .any(|repo| repo.status == FinalizeStatus::InProgress)
-    {
-        FinalizeStatus::InProgress
-    } else {
-        FinalizeStatus::PendingApproval
-    };
 
     state.refresh_requested.notify_one();
 
@@ -1209,6 +1194,47 @@ mod tests {
                         .await;
                         let _ = response.send(result);
                     }
+                    OrchestratorCommand::ApproveFinalize { response, .. } => {
+                        let _ = response.send(Err(FinalizeApprovalError::NotAwaitingApproval));
+                    }
+                    OrchestratorCommand::RetryFinalize { response, .. } => {
+                        let _ = response.send(Err(FinalizeRetryError::RuntimeUnavailable));
+                    }
+                }
+            }
+        });
+    }
+
+    fn install_test_finalize_runtime(state: &AppState) {
+        let (command_tx, mut command_rx) = tokio::sync::mpsc::channel(1);
+        state
+            .orchestrator_runtime
+            .install_test_command_sender(command_tx);
+        let orchestrator_state = Arc::clone(&state.orchestrator_state);
+        tokio::spawn(async move {
+            if let Some(command) = command_rx.recv().await {
+                match command {
+                    OrchestratorCommand::ApproveFinalize { command, response } => {
+                        let mut state = orchestrator_state.write().await;
+                        let finalize = state.get_finalize_state_mut(&command.issue_id).unwrap();
+                        finalize.status = FinalizeStatus::InProgress;
+                        finalize.repos[0].status = FinalizeStatus::InProgress;
+                        let _ = response.send(Ok(()));
+                    }
+                    OrchestratorCommand::RetryFinalize { command, response } => {
+                        let mut state = orchestrator_state.write().await;
+                        let finalize = state.get_finalize_state_mut(&command.issue_id).unwrap();
+                        finalize.status = FinalizeStatus::InProgress;
+                        finalize.repos[0].status = FinalizeStatus::InProgress;
+                        finalize.repos[0].last_error = None;
+                        let _ = response.send(Ok(()));
+                    }
+                    OrchestratorCommand::QueueManualStepRetry { response, .. } => {
+                        let _ = response.send(Err(ManualStepRetryError::RuntimeUnavailable));
+                    }
+                    OrchestratorCommand::QueueManualWholeIssueRetry { response, .. } => {
+                        let _ = response.send(Err(ManualStepRetryError::RuntimeUnavailable));
+                    }
                 }
             }
         });
@@ -1279,6 +1305,7 @@ mod tests {
     #[tokio::test]
     async fn test_finalize_approve_transitions_pending_to_in_progress() {
         let state = build_app_state_with_finalize_pending();
+        install_test_finalize_runtime(&state);
         let response =
             post_finalize_approve(State(state.clone()), Path("my-repo#888".to_string())).await;
         let response = response.into_response();
@@ -1294,6 +1321,7 @@ mod tests {
     #[tokio::test]
     async fn test_finalize_retry_sets_repo_to_in_progress() {
         let state = build_app_state_with_finalize_failed();
+        install_test_finalize_runtime(&state);
         let response =
             post_finalize_retry(State(state.clone()), Path("my-repo#999".to_string())).await;
         let response = response.into_response();

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -65,6 +66,14 @@ pub enum WorkspaceError {
         path: String,
         expected_issue_id: String,
         actual_issue_id: String,
+    },
+    #[error(
+        "workspace repository configuration mismatch at {path}: expected {expected_repositories:?}, found {actual_repositories:?}"
+    )]
+    RepositoryConfigurationMismatch {
+        path: String,
+        expected_repositories: BTreeMap<String, String>,
+        actual_repositories: BTreeMap<String, String>,
     },
     #[error("hook failed: {hook} — {reason}")]
     HookFailed { hook: String, reason: String },

--- a/crates/ensemble-core/src/history/writer.rs
+++ b/crates/ensemble-core/src/history/writer.rs
@@ -18,6 +18,17 @@ impl HistoryWriter {
         &self.path
     }
 
+    async fn sync_parent(&self) -> Result<(), std::io::Error> {
+        if let Some(parent) = self
+            .path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            File::open(parent).await?.sync_all().await?;
+        }
+        Ok(())
+    }
+
     pub async fn append(&self, record: &HistoryRecord) -> Result<(), std::io::Error> {
         let mut line = serde_json::to_string(record)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
@@ -41,13 +52,7 @@ impl HistoryWriter {
         file.flush().await?;
         file.sync_data().await?;
         if created {
-            if let Some(parent) = self
-                .path
-                .parent()
-                .filter(|parent| !parent.as_os_str().is_empty())
-            {
-                File::open(parent).await?.sync_all().await?;
-            }
+            self.sync_parent().await?;
         }
         Ok(())
     }
@@ -64,6 +69,13 @@ impl HistoryWriter {
                 if serde_json::from_str::<HistoryRecord>(&line)
                     .is_ok_and(|existing| existing == *record)
                 {
+                    OpenOptions::new()
+                        .read(true)
+                        .open(&self.path)
+                        .await?
+                        .sync_data()
+                        .await?;
+                    self.sync_parent().await?;
                     return Ok(());
                 }
             }

--- a/crates/ensemble-core/src/history/writer.rs
+++ b/crates/ensemble-core/src/history/writer.rs
@@ -23,14 +23,32 @@ impl HistoryWriter {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         line.push('\n');
 
-        let mut file = OpenOptions::new()
-            .create(true)
+        let (mut file, created) = match OpenOptions::new()
+            .create_new(true)
             .append(true)
             .open(&self.path)
-            .await?;
+            .await
+        {
+            Ok(file) => (file, true),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => (
+                OpenOptions::new().append(true).open(&self.path).await?,
+                false,
+            ),
+            Err(error) => return Err(error),
+        };
 
         file.write_all(line.as_bytes()).await?;
         file.flush().await?;
+        file.sync_data().await?;
+        if created {
+            if let Some(parent) = self
+                .path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                File::open(parent).await?.sync_all().await?;
+            }
+        }
         Ok(())
     }
 

--- a/crates/ensemble-core/src/history/writer.rs
+++ b/crates/ensemble-core/src/history/writer.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use tokio::fs::{File, OpenOptions};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader};
 
 use super::model::HistoryRecord;
 
@@ -29,7 +29,59 @@ impl HistoryWriter {
         Ok(())
     }
 
+    async fn repair_trailing_record(&self) -> Result<(), std::io::Error> {
+        let mut file = match OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&self.path)
+            .await
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        let len = file.metadata().await?.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        const TAIL_SCAN_CHUNK_BYTES: u64 = 8 * 1024;
+        let mut cursor = len;
+        let mut tail_start = 0;
+        while cursor > 0 {
+            let chunk_start = cursor.saturating_sub(TAIL_SCAN_CHUNK_BYTES);
+            let mut chunk = vec![0; (cursor - chunk_start) as usize];
+            file.seek(std::io::SeekFrom::Start(chunk_start)).await?;
+            file.read_exact(&mut chunk).await?;
+            if let Some(position) = chunk.iter().rposition(|byte| *byte == b'\n') {
+                tail_start = chunk_start + position as u64 + 1;
+                break;
+            }
+            cursor = chunk_start;
+        }
+        if tail_start == len {
+            return Ok(());
+        }
+
+        let mut tail = vec![0; (len - tail_start) as usize];
+        file.seek(std::io::SeekFrom::Start(tail_start)).await?;
+        file.read_exact(&mut tail).await?;
+        if serde_json::from_slice::<HistoryRecord>(&tail).is_ok() {
+            file.seek(std::io::SeekFrom::End(0)).await?;
+            file.write_all(b"\n").await?;
+        } else {
+            file.set_len(tail_start).await?;
+        }
+        file.flush().await?;
+        file.sync_data().await
+    }
+
     pub async fn append(&self, record: &HistoryRecord) -> Result<(), std::io::Error> {
+        self.repair_trailing_record().await?;
+        self.append_repaired(record).await
+    }
+
+    async fn append_repaired(&self, record: &HistoryRecord) -> Result<(), std::io::Error> {
         let mut line = serde_json::to_string(record)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         line.push('\n');
@@ -58,6 +110,7 @@ impl HistoryWriter {
     }
 
     pub async fn append_if_absent(&self, record: &HistoryRecord) -> Result<(), std::io::Error> {
+        self.repair_trailing_record().await?;
         let file = match File::open(&self.path).await {
             Ok(file) => Some(file),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
@@ -81,7 +134,7 @@ impl HistoryWriter {
             }
         }
 
-        self.append(record).await
+        self.append_repaired(record).await
     }
 }
 
@@ -156,6 +209,30 @@ mod tests {
 
         let contents = tokio::fs::read_to_string(&path).await.unwrap();
         assert_eq!(contents.lines().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn append_if_absent_repairs_a_torn_trailing_record() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        let first = sample_record();
+        let mut second = sample_record();
+        second.issue_identifier = "MT-649".into();
+        let contents = format!(
+            "{}\n{{\"issue_identifier\":",
+            serde_json::to_string(&first).unwrap()
+        );
+        tokio::fs::write(&path, contents).await.unwrap();
+        let writer = HistoryWriter::new(path.clone());
+
+        writer.append_if_absent(&second).await.unwrap();
+
+        let contents = tokio::fs::read_to_string(&path).await.unwrap();
+        let records = contents
+            .lines()
+            .map(|line| serde_json::from_str::<HistoryRecord>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(records, [first, second]);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -739,7 +739,7 @@ impl Orchestrator {
                 .get(&delivery.issue_id)
                 .cloned()
                 .or_else(|| history_record.artifacts.clone());
-            self.begin_terminal_transition_for_identity(
+            self.begin_confirmed_terminal_transition_for_identity(
                 &delivery.issue_id,
                 &delivery.identifier,
                 Some(issue.clone()),

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -724,6 +724,15 @@ impl Orchestrator {
             repository.last_error = None;
             changed = true;
         }
+        if let Some(projection) = candidate
+            .review_projection
+            .as_mut()
+            .filter(|projection| projection.phase == ReviewProjectionPhase::Blocked)
+        {
+            projection.phase = ReviewProjectionPhase::Pending;
+            projection.diagnostic = None;
+            changed = true;
+        }
         if !changed {
             return Err(FinalizeRetryError::NotFailed);
         }
@@ -898,7 +907,7 @@ impl Orchestrator {
                 .signed_duration_since(history_record.started_at)
                 .num_seconds()
                 .max(0) as u64;
-            history_record.artifacts = self
+            let mut artifacts = self
                 .state
                 .read()
                 .await
@@ -906,6 +915,10 @@ impl Orchestrator {
                 .get(&delivery.issue_id)
                 .cloned()
                 .or_else(|| history_record.artifacts.clone());
+            if let Some(artifacts) = artifacts.as_mut() {
+                Self::apply_delivery_artifacts(artifacts, delivery);
+            }
+            history_record.artifacts = artifacts;
             self.begin_confirmed_terminal_transition_for_identity(
                 &delivery.issue_id,
                 &delivery.identifier,
@@ -1323,6 +1336,13 @@ impl Orchestrator {
         let Some(artifacts) = state.artifacts.get_mut(issue_id) else {
             return;
         };
+        Self::apply_delivery_artifacts(artifacts, delivery);
+    }
+
+    fn apply_delivery_artifacts(
+        artifacts: &mut crate::history::artifacts::RunArtifacts,
+        delivery: &DeliveryRecord,
+    ) {
         for artifact in &mut artifacts.repos {
             let Some(repository) = delivery.repositories.get(&artifact.repo) else {
                 continue;

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -11,7 +11,8 @@ use tracing::warn;
 use super::pipeline_journal::{PipelineTransitionInput, PipelineTransitionKind, TerminalOutcome};
 use super::state::{FinalizeStatus, IssueFinalizeState, RepoFinalizeState};
 use super::{
-    Orchestrator, HISTORY_OUTCOME_FAILED, HISTORY_OUTCOME_STOPPED, HISTORY_OUTCOME_SUCCEEDED,
+    FinalizeApprovalError, FinalizeRetryError, Orchestrator, HISTORY_OUTCOME_FAILED,
+    HISTORY_OUTCOME_STOPPED, HISTORY_OUTCOME_SUCCEEDED,
 };
 use crate::history::model::HistoryRecord;
 use crate::pipeline::engine::{PipelineRun, PipelineRunSnapshot};
@@ -30,6 +31,7 @@ pub(crate) enum DeliveryMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum DeliveryPhase {
+    AwaitingApproval,
     Prepared,
     PushInFlight,
     ReconcilingPush,
@@ -44,6 +46,8 @@ pub(crate) enum DeliveryPhase {
 pub(crate) struct DeliveryRepository {
     pub mode: DeliveryMode,
     pub phase: DeliveryPhase,
+    #[serde(default)]
+    pub approval_required: bool,
     pub remote: String,
     pub base_branch: String,
     pub head_branch: String,
@@ -160,6 +164,20 @@ impl DeliveryRecord {
                     },
                     None => false,
                 }
+            })
+    }
+
+    fn is_parked_for_approval(&self) -> bool {
+        self.repositories
+            .values()
+            .any(|repository| repository.phase == DeliveryPhase::AwaitingApproval)
+            && self.repositories.values().all(|repository| {
+                matches!(
+                    repository.phase,
+                    DeliveryPhase::AwaitingApproval
+                        | DeliveryPhase::Waiting
+                        | DeliveryPhase::Published
+                )
             })
     }
 }
@@ -508,6 +526,7 @@ fn pull_request_delivery_phase(
 ) -> crate::acceptance::PullRequestDeliveryPhase {
     use crate::acceptance::PullRequestDeliveryPhase as EvidencePhase;
     match phase {
+        DeliveryPhase::AwaitingApproval => EvidencePhase::Prepared,
         DeliveryPhase::Prepared => EvidencePhase::Prepared,
         DeliveryPhase::PushInFlight => EvidencePhase::PushInFlight,
         DeliveryPhase::ReconcilingPush => EvidencePhase::ReconcilingPush,
@@ -580,6 +599,140 @@ fn evaluate_pull_request_requirement(
 }
 
 impl Orchestrator {
+    pub(super) async fn approve_finalize_delivery(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+    ) -> Result<(), FinalizeApprovalError> {
+        let current = self
+            .state
+            .read()
+            .await
+            .delivery
+            .get(issue_id)
+            .filter(|delivery| delivery.identifier == identifier)
+            .cloned()
+            .ok_or(FinalizeApprovalError::NotAwaitingApproval)?;
+        if current.repositories.values().any(|repository| {
+            repository.approval_required && repository.phase == DeliveryPhase::Blocked
+        }) {
+            return Err(FinalizeApprovalError::NotAwaitingApproval);
+        }
+        let mut candidate = current.clone();
+        let mut approval_required = false;
+        let mut changed = false;
+        for repository in candidate.repositories.values_mut() {
+            if !repository.approval_required {
+                continue;
+            }
+            approval_required = true;
+            if repository.phase == DeliveryPhase::AwaitingApproval {
+                let retry_from = repository.retry_from.unwrap_or(DeliveryPhase::Prepared);
+                repository.phase = retry_from;
+                if retry_from != DeliveryPhase::Waiting {
+                    repository.retry_from = None;
+                }
+                repository.last_error = None;
+                changed = true;
+            }
+        }
+        if !approval_required {
+            return Err(FinalizeApprovalError::NotAwaitingApproval);
+        }
+        let authoritative = if changed {
+            self.persist_delivery_record(&candidate, None)
+                .await
+                .map_err(FinalizeApprovalError::Persistence)?;
+            candidate
+        } else {
+            current
+        };
+        self.project_delivery_artifacts(issue_id, &authoritative)
+            .await;
+        self.state
+            .write()
+            .await
+            .set_finalize_state(issue_id, Self::finalize_state_from_delivery(&authoritative));
+        Ok(())
+    }
+
+    pub(super) async fn retry_finalize_delivery(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+    ) -> Result<(), FinalizeRetryError> {
+        let current = self
+            .state
+            .read()
+            .await
+            .delivery
+            .get(issue_id)
+            .filter(|delivery| delivery.identifier == identifier)
+            .cloned();
+        let Some(current) = current else {
+            let mut state = self.state.write().await;
+            let finalize = state
+                .get_finalize_state_mut(issue_id)
+                .ok_or(FinalizeRetryError::NotFailed)?;
+            let mut changed = false;
+            for repository in &mut finalize.repos {
+                if repository.status == FinalizeStatus::Failed {
+                    repository.last_error = None;
+                    repository.status = if repository.approval_required {
+                        FinalizeStatus::PendingApproval
+                    } else {
+                        FinalizeStatus::InProgress
+                    };
+                    changed = true;
+                }
+            }
+            if !changed {
+                return Err(FinalizeRetryError::NotFailed);
+            }
+            finalize.status = if finalize
+                .repos
+                .iter()
+                .any(|repository| repository.status == FinalizeStatus::InProgress)
+            {
+                FinalizeStatus::InProgress
+            } else {
+                FinalizeStatus::PendingApproval
+            };
+            return Ok(());
+        };
+
+        let mut candidate = current;
+        let mut changed = false;
+        for repository in candidate.repositories.values_mut() {
+            if repository.phase != DeliveryPhase::Blocked {
+                continue;
+            }
+            if repository.approval_required {
+                repository.phase = DeliveryPhase::AwaitingApproval;
+            } else {
+                let retry_from = repository.retry_from.unwrap_or(DeliveryPhase::Prepared);
+                repository.phase = retry_from;
+                if retry_from != DeliveryPhase::Waiting {
+                    repository.retry_from = None;
+                }
+            }
+            repository.last_error = None;
+            changed = true;
+        }
+        if !changed {
+            return Err(FinalizeRetryError::NotFailed);
+        }
+        self.persist_delivery_record(&candidate, None)
+            .await
+            .map_err(FinalizeRetryError::Persistence)?;
+        self.project_delivery_artifacts(issue_id, &candidate).await;
+        self.state
+            .write()
+            .await
+            .set_finalize_state(issue_id, Self::finalize_state_from_delivery(&candidate));
+        Ok(())
+    }
+
     pub(super) async fn reconcile_and_recover_deliveries(&self) {
         let recoverable_issue_ids = self.reconcile_terminal_delivery_owners().await;
         if recoverable_issue_ids.is_empty() {
@@ -775,6 +928,9 @@ impl Orchestrator {
         };
 
         for delivery in deliveries {
+            if delivery.is_parked_for_approval() {
+                continue;
+            }
             let snapshot = match self.load_delivery_snapshot(&delivery).await {
                 Ok(snapshot) => snapshot,
                 Err(error) => {
@@ -1157,11 +1313,10 @@ impl Orchestrator {
             let Some(repository) = delivery.repositories.get(&artifact.repo) else {
                 continue;
             };
-            artifact.finalize_status = match repository.phase {
-                DeliveryPhase::Waiting => "waiting",
-                DeliveryPhase::Published => "succeeded",
-                DeliveryPhase::Blocked => "failed",
-                _ => "in_progress",
+            artifact.finalize_status = if repository.phase == DeliveryPhase::Waiting {
+                "waiting"
+            } else {
+                Self::finalize_status_name(&Self::finalize_status_from_delivery(repository))
             }
             .to_string();
             artifact.pushed_ref = repository
@@ -1187,13 +1342,22 @@ impl Orchestrator {
         }
     }
     pub(super) fn finalize_state_from_delivery(delivery: &DeliveryRecord) -> IssueFinalizeState {
+        let aggregate = delivery.aggregate();
         IssueFinalizeState {
             issue_identifier: delivery.identifier.clone(),
-            status: match delivery.aggregate() {
-                DeliveryAggregate::Published => FinalizeStatus::Succeeded,
+            status: match aggregate {
                 DeliveryAggregate::Blocked => FinalizeStatus::Failed,
+                DeliveryAggregate::Published => FinalizeStatus::Succeeded,
                 DeliveryAggregate::Active | DeliveryAggregate::Waiting => {
-                    FinalizeStatus::InProgress
+                    if delivery
+                        .repositories
+                        .values()
+                        .any(|repository| repository.phase == DeliveryPhase::AwaitingApproval)
+                    {
+                        FinalizeStatus::PendingApproval
+                    } else {
+                        FinalizeStatus::InProgress
+                    }
                 }
             },
             repos: Self::finalize_repositories_from_delivery(delivery),
@@ -1212,15 +1376,20 @@ impl Orchestrator {
                     DeliveryMode::PushAndPr => "push_and_pr",
                 }
                 .to_string(),
-                approval_required: false,
-                status: match repository.phase {
-                    DeliveryPhase::Published => FinalizeStatus::Succeeded,
-                    DeliveryPhase::Blocked => FinalizeStatus::Failed,
-                    _ => FinalizeStatus::InProgress,
-                },
+                approval_required: repository.approval_required,
+                status: Self::finalize_status_from_delivery(repository),
                 last_error: repository.last_error.clone(),
             })
             .collect()
+    }
+
+    pub(super) fn finalize_status_from_delivery(repository: &DeliveryRepository) -> FinalizeStatus {
+        match repository.phase {
+            DeliveryPhase::AwaitingApproval => FinalizeStatus::PendingApproval,
+            DeliveryPhase::Published => FinalizeStatus::Succeeded,
+            DeliveryPhase::Blocked => FinalizeStatus::Failed,
+            _ => FinalizeStatus::InProgress,
+        }
     }
     pub(super) async fn advance_delivery_record(
         &self,
@@ -1252,6 +1421,7 @@ impl Orchestrator {
                 let mut created_this_iteration = false;
                 let phase = delivery.repositories[&repository_key].phase;
                 delivery = match phase {
+                    DeliveryPhase::AwaitingApproval => break,
                     DeliveryPhase::Prepared
                     | DeliveryPhase::PushInFlight
                     | DeliveryPhase::ReconcilingPush => {
@@ -1786,7 +1956,12 @@ impl Orchestrator {
                 repository_key.clone(),
                 DeliveryRepository {
                     mode,
-                    phase: DeliveryPhase::Prepared,
+                    phase: if config.finalize.approval_required {
+                        DeliveryPhase::AwaitingApproval
+                    } else {
+                        DeliveryPhase::Prepared
+                    },
+                    approval_required: config.finalize.approval_required,
                     remote: config.git_remote.clone(),
                     base_branch: config.branch.clone(),
                     head_branch: identity.head_branch,
@@ -1850,6 +2025,7 @@ mod tests {
         DeliveryRepository {
             mode: DeliveryMode::PushAndPr,
             phase,
+            approval_required: false,
             remote: "origin".to_string(),
             base_branch: "main".to_string(),
             head_branch: "ensemble/issue-420".to_string(),

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -577,12 +577,10 @@ fn evaluate_pull_request_requirement(
 
 impl Orchestrator {
     pub(super) async fn reconcile_and_recover_deliveries(&self) {
-        if self.state.read().await.delivery.is_empty() {
+        let recoverable_issue_ids = self.reconcile_terminal_delivery_owners().await;
+        if recoverable_issue_ids.is_empty() {
             return;
         }
-        let Some(recoverable_issue_ids) = self.reconcile_terminal_delivery_owners().await else {
-            return;
-        };
 
         // Remote delivery recovery is another large state machine. Poll it only after terminal
         // ownership reconciliation has finished and released its future.
@@ -613,13 +611,13 @@ impl Orchestrator {
         Ok(record.snapshot)
     }
 
-    pub(super) async fn reconcile_terminal_delivery_owners(&self) -> Option<BTreeSet<String>> {
+    pub(super) async fn reconcile_terminal_delivery_owners(&self) -> BTreeSet<String> {
         let deliveries = {
             let state = self.state.read().await;
             state.delivery.values().cloned().collect::<Vec<_>>()
         };
         if deliveries.is_empty() {
-            return Some(BTreeSet::new());
+            return BTreeSet::new();
         }
 
         let issue_ids = deliveries
@@ -627,19 +625,36 @@ impl Orchestrator {
             .map(|delivery| delivery.issue_id.clone())
             .collect::<Vec<_>>();
         let observed_issues = match self.tracker.fetch_issue_states_by_ids(&issue_ids).await {
-            Ok(issues) => issues
-                .into_iter()
-                .map(|issue| (issue.id.clone(), issue))
-                .collect::<BTreeMap<_, _>>(),
+            Ok(issues) => issues,
             Err(error) => {
                 warn!(
                     error = %error,
                     "delivery recovery could not refresh tracker ownership"
                 );
-                return None;
+                let mut observed = Vec::new();
+                if issue_ids.len() > 1 {
+                    for issue_id in &issue_ids {
+                        match self
+                            .tracker
+                            .fetch_issue_states_by_ids(std::slice::from_ref(issue_id))
+                            .await
+                        {
+                            Ok(issues) => observed.extend(issues),
+                            Err(error) => warn!(
+                                issue_id = %issue_id,
+                                error = %error,
+                                "delivery recovery could not refresh one tracker owner"
+                            ),
+                        }
+                    }
+                }
+                observed
             }
-        };
-        let (terminal_states, failure_state) = {
+        }
+        .into_iter()
+        .map(|issue| (issue.id.clone(), issue))
+        .collect::<BTreeMap<_, _>>();
+        let (terminal_states, success_state) = {
             let config = self.config.read().await;
             (
                 config
@@ -648,7 +663,7 @@ impl Orchestrator {
                     .iter()
                     .map(|state| state.to_lowercase())
                     .collect::<Vec<_>>(),
-                config.on_failure.clone(),
+                config.on_success.clone(),
             )
         };
 
@@ -662,10 +677,10 @@ impl Orchestrator {
                 continue;
             };
             if terminal_states.contains(&issue.state.to_lowercase()) {
-                let outcome = if issue.state.eq_ignore_ascii_case(&failure_state) {
-                    TerminalOutcome::Failed
-                } else {
+                let outcome = if issue.state.eq_ignore_ascii_case(&success_state) {
                     TerminalOutcome::Succeeded
+                } else {
+                    TerminalOutcome::Failed
                 };
                 Box::pin(self.begin_terminal_transition_for_identity(
                     &delivery.issue_id,
@@ -680,7 +695,7 @@ impl Orchestrator {
                 recoverable_issue_ids.insert(delivery.issue_id);
             }
         }
-        Some(recoverable_issue_ids)
+        recoverable_issue_ids
     }
 
     pub(super) async fn process_delivery_recovery(

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -887,48 +887,59 @@ impl Orchestrator {
         history_outcome: &'static str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
         Box::pin(async move {
-            let mut history_record = delivery.terminal_history.as_deref().cloned().or_else(|| {
-                delivery
-                    .review_projection
-                    .as_ref()
-                    .and_then(|projection| projection.history_record.clone())
-            });
-            let Some(history_record) = history_record.as_mut() else {
+            let Some(history_record) = self
+                .projected_terminal_history(delivery, history_outcome)
+                .await
+            else {
                 warn!(
                     issue_id = %delivery.issue_id,
                     "terminal delivery has no durable completion history"
                 );
                 return;
             };
-            history_record.outcome = history_outcome.to_string();
-            history_record.completed_at = Utc::now();
-            history_record.duration_seconds = history_record
-                .completed_at
-                .signed_duration_since(history_record.started_at)
-                .num_seconds()
-                .max(0) as u64;
-            let mut artifacts = self
-                .state
-                .read()
-                .await
-                .artifacts
-                .get(&delivery.issue_id)
-                .cloned()
-                .or_else(|| history_record.artifacts.clone());
-            if let Some(artifacts) = artifacts.as_mut() {
-                Self::apply_delivery_artifacts(artifacts, delivery);
-            }
-            history_record.artifacts = artifacts;
             self.begin_confirmed_terminal_transition_for_identity(
                 &delivery.issue_id,
                 &delivery.identifier,
                 Some(issue.clone()),
                 outcome,
                 issue.state.clone(),
-                Some(history_record.clone()),
+                Some(history_record),
             )
             .await;
         })
+    }
+
+    async fn projected_terminal_history(
+        &self,
+        delivery: &DeliveryRecord,
+        outcome: &'static str,
+    ) -> Option<HistoryRecord> {
+        let mut record = delivery.terminal_history.as_deref().cloned().or_else(|| {
+            delivery
+                .review_projection
+                .as_ref()
+                .and_then(|projection| projection.history_record.clone())
+        })?;
+        let mut artifacts = self
+            .state
+            .read()
+            .await
+            .artifacts
+            .get(&delivery.issue_id)
+            .cloned()
+            .or_else(|| record.artifacts.clone());
+        if let Some(artifacts) = artifacts.as_mut() {
+            Self::apply_delivery_artifacts(artifacts, delivery);
+        }
+        record.outcome = outcome.to_string();
+        record.completed_at = Utc::now();
+        record.duration_seconds = record
+            .completed_at
+            .signed_duration_since(record.started_at)
+            .num_seconds()
+            .max(0) as u64;
+        record.artifacts = artifacts;
+        Some(record)
     }
 
     pub(super) async fn process_delivery_recovery(
@@ -1305,6 +1316,16 @@ impl Orchestrator {
     }
 
     async fn complete_published_delivery(&self, delivery: &DeliveryRecord) {
+        let Some(history_record) = self
+            .projected_terminal_history(delivery, HISTORY_OUTCOME_SUCCEEDED)
+            .await
+        else {
+            warn!(
+                issue_id = %delivery.issue_id,
+                "published delivery has no durable completion history"
+            );
+            return;
+        };
         let config = self.config.read().await.clone();
         let finalize = Self::finalize_state_from_delivery(delivery);
         self.state
@@ -1323,7 +1344,7 @@ impl Orchestrator {
             issue,
             TerminalOutcome::Succeeded,
             config.on_success,
-            None,
+            Some(history_record),
         )
         .await;
     }

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -938,6 +938,21 @@ impl Orchestrator {
             .signed_duration_since(record.started_at)
             .num_seconds()
             .max(0) as u64;
+        if let Some(diagnostic) = delivery
+            .repositories
+            .values()
+            .filter(|repository| repository.phase == DeliveryPhase::Blocked)
+            .find_map(|repository| repository.last_error.clone())
+            .or_else(|| {
+                delivery
+                    .review_projection
+                    .as_ref()
+                    .filter(|projection| projection.phase == ReviewProjectionPhase::Blocked)
+                    .and_then(|projection| projection.diagnostic.clone())
+            })
+        {
+            record.last_error = Some(diagnostic);
+        }
         record.artifacts = artifacts;
         Some(record)
     }

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -897,7 +897,7 @@ impl Orchestrator {
         })
     }
 
-    async fn projected_terminal_history(
+    pub(super) async fn projected_terminal_history(
         &self,
         delivery: &DeliveryRecord,
         outcome: &'static str,

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -1957,6 +1957,7 @@ impl Orchestrator {
         state
             .delivery
             .insert(delivery.issue_id.clone(), delivery.clone());
+        state.finalize_terminal_history.remove(&delivery.issue_id);
         if let Some(snapshot) = persisted_snapshot
             .as_ref()
             .filter(|snapshot| snapshot.issue_id == delivery.issue_id)
@@ -1986,13 +1987,15 @@ impl Orchestrator {
             let snapshot = state
                 .get_pipeline_run(issue_id)
                 .map(PipelineRun::to_snapshot);
-            let terminal_history = self.build_owned_history_record(
-                &state,
-                issue_id,
-                HISTORY_OUTCOME_SUCCEEDED,
-                None,
-                Utc::now(),
-            );
+            let terminal_history = self
+                .build_owned_history_record(
+                    &state,
+                    issue_id,
+                    HISTORY_OUTCOME_SUCCEEDED,
+                    None,
+                    Utc::now(),
+                )
+                .or_else(|| state.finalize_terminal_history.get(issue_id).cloned());
             (run_id, snapshot, terminal_history)
         };
         let configured_repositories = self.workspace_mgr.repos();

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -600,6 +600,75 @@ impl Orchestrator {
         Ok(record.snapshot)
     }
 
+    pub(super) async fn reconcile_terminal_delivery_owners(&self) -> bool {
+        let deliveries = {
+            let state = self.state.read().await;
+            state.delivery.values().cloned().collect::<Vec<_>>()
+        };
+        if deliveries.is_empty() {
+            return true;
+        }
+
+        let issue_ids = deliveries
+            .iter()
+            .map(|delivery| delivery.issue_id.clone())
+            .collect::<Vec<_>>();
+        let observed_issues = match self.tracker.fetch_issue_states_by_ids(&issue_ids).await {
+            Ok(issues) => issues
+                .into_iter()
+                .map(|issue| (issue.id.clone(), issue))
+                .collect::<BTreeMap<_, _>>(),
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "delivery recovery could not refresh tracker ownership"
+                );
+                return false;
+            }
+        };
+        let (terminal_states, failure_state) = {
+            let config = self.config.read().await;
+            (
+                config
+                    .tracker
+                    .terminal_states
+                    .iter()
+                    .map(|state| state.to_lowercase())
+                    .collect::<Vec<_>>(),
+                config.on_failure.clone(),
+            )
+        };
+
+        let mut observed_all = true;
+        for delivery in deliveries {
+            let Some(issue) = observed_issues.get(&delivery.issue_id) else {
+                warn!(
+                    issue_id = %delivery.issue_id,
+                    "delivery recovery did not observe its tracker issue"
+                );
+                observed_all = false;
+                continue;
+            };
+            if terminal_states.contains(&issue.state.to_lowercase()) {
+                let outcome = if issue.state.eq_ignore_ascii_case(&failure_state) {
+                    TerminalOutcome::Failed
+                } else {
+                    TerminalOutcome::Succeeded
+                };
+                Box::pin(self.begin_terminal_transition_for_identity(
+                    &delivery.issue_id,
+                    &delivery.identifier,
+                    Some(issue.clone()),
+                    outcome,
+                    issue.state.clone(),
+                    None,
+                ))
+                .await;
+            }
+        }
+        observed_all
+    }
+
     pub(super) async fn process_delivery_recovery(&self) {
         let deliveries = {
             let state = self.state.read().await;

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -604,15 +604,17 @@ impl Orchestrator {
         issue_id: &str,
         identifier: &str,
     ) -> Result<bool, FinalizeApprovalError> {
-        let current = self
-            .state
-            .read()
-            .await
+        let state = self.state.read().await;
+        if state.pending_terminal_transitions.contains_key(issue_id) {
+            return Err(FinalizeApprovalError::NotAwaitingApproval);
+        }
+        let current = state
             .delivery
             .get(issue_id)
             .filter(|delivery| delivery.identifier == identifier)
             .cloned()
             .ok_or(FinalizeApprovalError::NotAwaitingApproval)?;
+        drop(state);
         if current.repositories.values().any(|repository| {
             repository.approval_required && repository.phase == DeliveryPhase::Blocked
         }) {
@@ -661,14 +663,17 @@ impl Orchestrator {
         issue_id: &str,
         identifier: &str,
     ) -> Result<(), FinalizeRetryError> {
-        let current = self
-            .state
-            .read()
-            .await
-            .delivery
-            .get(issue_id)
-            .filter(|delivery| delivery.identifier == identifier)
-            .cloned();
+        let current = {
+            let state = self.state.read().await;
+            if state.pending_terminal_transitions.contains_key(issue_id) {
+                return Err(FinalizeRetryError::NotFailed);
+            }
+            state
+                .delivery
+                .get(issue_id)
+                .filter(|delivery| delivery.identifier == identifier)
+                .cloned()
+        };
         let Some(current) = current else {
             let mut state = self.state.write().await;
             let finalize = state

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -771,7 +771,16 @@ impl Orchestrator {
     pub(super) async fn reconcile_terminal_delivery_owners(&self) -> BTreeSet<String> {
         let deliveries = {
             let state = self.state.read().await;
-            state.delivery.values().cloned().collect::<Vec<_>>()
+            state
+                .delivery
+                .values()
+                .filter(|delivery| {
+                    !state
+                        .pending_terminal_transitions
+                        .contains_key(&delivery.issue_id)
+                })
+                .cloned()
+                .collect::<Vec<_>>()
         };
         if deliveries.is_empty() {
             return BTreeSet::new();

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::time::Duration;
 
@@ -600,13 +600,13 @@ impl Orchestrator {
         Ok(record.snapshot)
     }
 
-    pub(super) async fn reconcile_terminal_delivery_owners(&self) -> bool {
+    pub(super) async fn reconcile_terminal_delivery_owners(&self) -> Option<BTreeSet<String>> {
         let deliveries = {
             let state = self.state.read().await;
             state.delivery.values().cloned().collect::<Vec<_>>()
         };
         if deliveries.is_empty() {
-            return true;
+            return Some(BTreeSet::new());
         }
 
         let issue_ids = deliveries
@@ -623,7 +623,7 @@ impl Orchestrator {
                     error = %error,
                     "delivery recovery could not refresh tracker ownership"
                 );
-                return false;
+                return None;
             }
         };
         let (terminal_states, failure_state) = {
@@ -639,14 +639,13 @@ impl Orchestrator {
             )
         };
 
-        let mut observed_all = true;
+        let observed_issue_ids = observed_issues.keys().cloned().collect();
         for delivery in deliveries {
             let Some(issue) = observed_issues.get(&delivery.issue_id) else {
                 warn!(
                     issue_id = %delivery.issue_id,
                     "delivery recovery did not observe its tracker issue"
                 );
-                observed_all = false;
                 continue;
             };
             if terminal_states.contains(&issue.state.to_lowercase()) {
@@ -666,22 +665,27 @@ impl Orchestrator {
                 .await;
             }
         }
-        observed_all
+        Some(observed_issue_ids)
     }
 
-    pub(super) async fn process_delivery_recovery(&self) {
+    pub(super) async fn process_delivery_recovery(
+        &self,
+        observed_issue_ids: Option<&BTreeSet<String>>,
+    ) {
         let deliveries = {
             let state = self.state.read().await;
             state
                 .delivery
                 .values()
                 .filter(|delivery| {
-                    matches!(
-                        delivery.aggregate(),
-                        DeliveryAggregate::Active
-                            | DeliveryAggregate::Waiting
-                            | DeliveryAggregate::Published
-                    )
+                    observed_issue_ids
+                        .is_none_or(|issue_ids| issue_ids.contains(&delivery.issue_id))
+                        && matches!(
+                            delivery.aggregate(),
+                            DeliveryAggregate::Active
+                                | DeliveryAggregate::Waiting
+                                | DeliveryAggregate::Published
+                        )
                 })
                 .cloned()
                 .collect::<Vec<_>>()

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -603,7 +603,7 @@ impl Orchestrator {
         &self,
         issue_id: &str,
         identifier: &str,
-    ) -> Result<(), FinalizeApprovalError> {
+    ) -> Result<bool, FinalizeApprovalError> {
         let current = self
             .state
             .read()
@@ -653,7 +653,7 @@ impl Orchestrator {
             .write()
             .await
             .set_finalize_state(issue_id, Self::finalize_state_from_delivery(&authoritative));
-        Ok(())
+        Ok(changed)
     }
 
     pub(super) async fn retry_finalize_delivery(

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -576,6 +576,19 @@ fn evaluate_pull_request_requirement(
 }
 
 impl Orchestrator {
+    pub(super) async fn reconcile_and_recover_deliveries(&self) {
+        if self.state.read().await.delivery.is_empty() {
+            return;
+        }
+        let Some(recoverable_issue_ids) = self.reconcile_terminal_delivery_owners().await else {
+            return;
+        };
+
+        // Remote delivery recovery is another large state machine. Poll it only after terminal
+        // ownership reconciliation has finished and released its future.
+        Box::pin(self.process_delivery_recovery(Some(&recoverable_issue_ids))).await;
+    }
+
     pub(super) async fn load_delivery_snapshot(
         &self,
         delivery: &DeliveryRecord,
@@ -639,7 +652,7 @@ impl Orchestrator {
             )
         };
 
-        let observed_issue_ids = observed_issues.keys().cloned().collect();
+        let mut recoverable_issue_ids = BTreeSet::new();
         for delivery in deliveries {
             let Some(issue) = observed_issues.get(&delivery.issue_id) else {
                 warn!(
@@ -663,9 +676,11 @@ impl Orchestrator {
                     None,
                 ))
                 .await;
+            } else {
+                recoverable_issue_ids.insert(delivery.issue_id);
             }
         }
-        Some(observed_issue_ids)
+        Some(recoverable_issue_ids)
     }
 
     pub(super) async fn process_delivery_recovery(

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -10,7 +10,9 @@ use tracing::warn;
 
 use super::pipeline_journal::{PipelineTransitionInput, PipelineTransitionKind, TerminalOutcome};
 use super::state::{FinalizeStatus, IssueFinalizeState, RepoFinalizeState};
-use super::Orchestrator;
+use super::{
+    Orchestrator, HISTORY_OUTCOME_FAILED, HISTORY_OUTCOME_STOPPED, HISTORY_OUTCOME_SUCCEEDED,
+};
 use crate::history::model::HistoryRecord;
 use crate::pipeline::engine::{PipelineRun, PipelineRunSnapshot};
 use crate::workspace::finalize::FinalizeMode;
@@ -60,6 +62,8 @@ pub(crate) struct DeliveryRecord {
     pub identifier: String,
     pub run_id: String,
     pub repositories: BTreeMap<String, DeliveryRepository>,
+    #[serde(default)]
+    pub terminal_history: Option<Box<HistoryRecord>>,
     #[serde(default)]
     pub review_projection: Option<ReviewProjection>,
 }
@@ -654,7 +658,7 @@ impl Orchestrator {
         .into_iter()
         .map(|issue| (issue.id.clone(), issue))
         .collect::<BTreeMap<_, _>>();
-        let (terminal_states, success_state) = {
+        let (terminal_states, success_state, failure_state) = {
             let config = self.config.read().await;
             (
                 config
@@ -664,6 +668,7 @@ impl Orchestrator {
                     .map(|state| state.to_lowercase())
                     .collect::<Vec<_>>(),
                 config.on_success.clone(),
+                config.on_failure.clone(),
             )
         };
 
@@ -682,20 +687,68 @@ impl Orchestrator {
                 } else {
                     TerminalOutcome::Failed
                 };
-                Box::pin(self.begin_terminal_transition_for_identity(
-                    &delivery.issue_id,
-                    &delivery.identifier,
-                    Some(issue.clone()),
-                    outcome,
-                    issue.state.clone(),
-                    None,
-                ))
-                .await;
+                let history_outcome = if issue.state.eq_ignore_ascii_case(&success_state) {
+                    HISTORY_OUTCOME_SUCCEEDED
+                } else if issue.state.eq_ignore_ascii_case(&failure_state) {
+                    HISTORY_OUTCOME_FAILED
+                } else {
+                    HISTORY_OUTCOME_STOPPED
+                };
+                self.reconcile_terminal_delivery_owner(&delivery, issue, outcome, history_outcome)
+                    .await;
             } else {
                 recoverable_issue_ids.insert(delivery.issue_id);
             }
         }
         recoverable_issue_ids
+    }
+
+    fn reconcile_terminal_delivery_owner<'a>(
+        &'a self,
+        delivery: &'a DeliveryRecord,
+        issue: &'a crate::tracker::model::Issue,
+        outcome: TerminalOutcome,
+        history_outcome: &'static str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            let mut history_record = delivery.terminal_history.as_deref().cloned().or_else(|| {
+                delivery
+                    .review_projection
+                    .as_ref()
+                    .and_then(|projection| projection.history_record.clone())
+            });
+            let Some(history_record) = history_record.as_mut() else {
+                warn!(
+                    issue_id = %delivery.issue_id,
+                    "terminal delivery has no durable completion history"
+                );
+                return;
+            };
+            history_record.outcome = history_outcome.to_string();
+            history_record.completed_at = Utc::now();
+            history_record.duration_seconds = history_record
+                .completed_at
+                .signed_duration_since(history_record.started_at)
+                .num_seconds()
+                .max(0) as u64;
+            history_record.artifacts = self
+                .state
+                .read()
+                .await
+                .artifacts
+                .get(&delivery.issue_id)
+                .cloned()
+                .or_else(|| history_record.artifacts.clone());
+            self.begin_terminal_transition_for_identity(
+                &delivery.issue_id,
+                &delivery.identifier,
+                Some(issue.clone()),
+                outcome,
+                issue.state.clone(),
+                Some(history_record.clone()),
+            )
+            .await;
+        })
     }
 
     pub(super) async fn process_delivery_recovery(
@@ -1694,7 +1747,7 @@ impl Orchestrator {
         workspace: &crate::workspace::manager::WorkspaceResult,
         repository_keys: &[String],
     ) -> Result<(DeliveryRecord, Option<PipelineRunSnapshot>), String> {
-        let (run_id, snapshot, review_history) = {
+        let (run_id, snapshot, terminal_history) = {
             let state = self.state.read().await;
             let run_id = state
                 .running
@@ -1705,21 +1758,14 @@ impl Orchestrator {
             let snapshot = state
                 .get_pipeline_run(issue_id)
                 .map(PipelineRun::to_snapshot);
-            let review_history = state
-                .running
-                .get(issue_id)
-                .zip(state.get_pipeline_run(issue_id))
-                .map(|(running, run)| {
-                    self.build_history_record(super::RunningHistoryRecordInput {
-                        outcome: "in_review",
-                        last_error: None,
-                        running_entry: running,
-                        run,
-                        completed_at: Utc::now(),
-                        artifacts: state.artifacts.get(issue_id).cloned(),
-                    })
-                });
-            (run_id, snapshot, review_history)
+            let terminal_history = self.build_owned_history_record(
+                &state,
+                issue_id,
+                HISTORY_OUTCOME_SUCCEEDED,
+                None,
+                Utc::now(),
+            );
+            (run_id, snapshot, terminal_history)
         };
         let configured_repositories = self.workspace_mgr.repos();
         let mut repositories = std::collections::BTreeMap::new();
@@ -1767,6 +1813,10 @@ impl Orchestrator {
             })
             .collect::<Vec<_>>();
         review_repositories.sort();
+        let review_history = terminal_history.clone().map(|mut record| {
+            record.outcome = "in_review".to_string();
+            record
+        });
         if review_state.is_some() && review_history.is_none() {
             return Err("review projection requires a live run history record".to_string());
         }
@@ -1776,6 +1826,7 @@ impl Orchestrator {
                 identifier: issue_identifier.to_string(),
                 run_id,
                 repositories,
+                terminal_history: terminal_history.map(Box::new),
                 review_projection: review_state.map(|target| ReviewProjection {
                     target,
                     repositories: review_repositories,
@@ -1834,6 +1885,7 @@ mod tests {
             identifier: "ensemble#420".to_string(),
             run_id: "run-420".to_string(),
             repositories,
+            terminal_history: None,
             review_projection: None,
         };
 
@@ -1854,6 +1906,7 @@ mod tests {
             identifier: "ensemble#420".into(),
             run_id: "run-420".into(),
             repositories: BTreeMap::from([("primary".into(), repository)]),
+            terminal_history: None,
             review_projection: Some(ReviewProjection {
                 target: "In review".into(),
                 repositories: vec!["primary".into()],
@@ -1879,6 +1932,7 @@ mod tests {
             identifier: "ensemble#420".into(),
             run_id: "run-420".into(),
             repositories: BTreeMap::from([("primary".into(), repository)]),
+            terminal_history: None,
             review_projection: Some(ReviewProjection {
                 target: "In review".into(),
                 repositories: vec!["primary".into(), "approval-gated".into()],
@@ -1912,6 +1966,7 @@ mod tests {
                 ("pull-request".into(), pull_request),
                 ("push".into(), push),
             ]),
+            terminal_history: None,
             review_projection: Some(ReviewProjection {
                 target: "In review".into(),
                 repositories: vec!["pull-request".into(), "push".into()],

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -683,26 +683,14 @@ impl Orchestrator {
             for repository in &mut finalize.repos {
                 if repository.status == FinalizeStatus::Failed {
                     repository.last_error = None;
-                    repository.status = if repository.approval_required {
-                        FinalizeStatus::PendingApproval
-                    } else {
-                        FinalizeStatus::InProgress
-                    };
+                    repository.status = FinalizeStatus::InProgress;
                     changed = true;
                 }
             }
             if !changed {
                 return Err(FinalizeRetryError::NotFailed);
             }
-            finalize.status = if finalize
-                .repos
-                .iter()
-                .any(|repository| repository.status == FinalizeStatus::InProgress)
-            {
-                FinalizeStatus::InProgress
-            } else {
-                FinalizeStatus::PendingApproval
-            };
+            finalize.status = FinalizeStatus::InProgress;
             return Ok(());
         };
 

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6555,39 +6555,16 @@ impl Orchestrator {
 
         let history_record = {
             let state = self.state.read().await;
-            state.get_pipeline_run(issue_id).and_then(|run| {
-                state
-                    .running
-                    .get(issue_id)
-                    .map(|entry| {
-                        self.build_history_record(RunningHistoryRecordInput {
-                            outcome: match outcome {
-                                TerminalOutcome::Succeeded => HISTORY_OUTCOME_SUCCEEDED,
-                                TerminalOutcome::Failed => HISTORY_OUTCOME_FAILED,
-                            },
-                            last_error: last_error.clone(),
-                            running_entry: entry,
-                            run,
-                            completed_at,
-                            artifacts: state.artifacts.get(issue_id).cloned(),
-                        })
-                    })
-                    .or_else(|| {
-                        state.waiting_on_human.get(issue_id).map(|entry| {
-                            self.build_history_record_from_waiting(WaitingHistoryRecordInput {
-                                outcome: match outcome {
-                                    TerminalOutcome::Succeeded => HISTORY_OUTCOME_SUCCEEDED,
-                                    TerminalOutcome::Failed => HISTORY_OUTCOME_FAILED,
-                                },
-                                last_error: last_error.clone(),
-                                waiting_entry: entry,
-                                run,
-                                completed_at,
-                                artifacts: state.artifacts.get(issue_id).cloned(),
-                            })
-                        })
-                    })
-            })
+            self.build_owned_history_record(
+                &state,
+                issue_id,
+                match outcome {
+                    TerminalOutcome::Succeeded => HISTORY_OUTCOME_SUCCEEDED,
+                    TerminalOutcome::Failed => HISTORY_OUTCOME_FAILED,
+                },
+                last_error,
+                completed_at,
+            )
         };
 
         let _ = self
@@ -7117,6 +7094,43 @@ impl Orchestrator {
             acceptance_attempts: input.run.acceptance_attempts.clone(),
             artifacts: input.artifacts,
         }
+    }
+
+    pub(super) fn build_owned_history_record(
+        &self,
+        state: &OrchestratorState,
+        issue_id: &str,
+        outcome: &str,
+        last_error: Option<String>,
+        completed_at: chrono::DateTime<Utc>,
+    ) -> Option<HistoryRecord> {
+        state.get_pipeline_run(issue_id).and_then(|run| {
+            state
+                .running
+                .get(issue_id)
+                .map(|entry| {
+                    self.build_history_record(RunningHistoryRecordInput {
+                        outcome,
+                        last_error: last_error.clone(),
+                        running_entry: entry,
+                        run,
+                        completed_at,
+                        artifacts: state.artifacts.get(issue_id).cloned(),
+                    })
+                })
+                .or_else(|| {
+                    state.waiting_on_human.get(issue_id).map(|entry| {
+                        self.build_history_record_from_waiting(WaitingHistoryRecordInput {
+                            outcome,
+                            last_error,
+                            waiting_entry: entry,
+                            run,
+                            completed_at,
+                            artifacts: state.artifacts.get(issue_id).cloned(),
+                        })
+                    })
+                })
+        })
     }
 
     fn build_history_record_from_waiting(
@@ -9789,6 +9803,7 @@ mod tests {
             crate::orchestrator::delivery::DeliveryPhase::Waiting
         );
         assert_eq!(delivery.repositories["source-repo"].pr_number, Some(420));
+        assert!(delivery.terminal_history.is_some());
         assert_eq!(
             delivery.review_projection.as_ref().unwrap().phase,
             crate::orchestrator::delivery::ReviewProjectionPhase::Applied
@@ -10042,6 +10057,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            terminal_history: Some(Box::new(review_projection_history())),
             review_projection: None,
         };
         orchestrator
@@ -10065,6 +10081,10 @@ mod tests {
         observed_delivery.issue_id = "2".to_string();
         observed_delivery.identifier = "repo#2".to_string();
         observed_delivery.run_id = "run-2".to_string();
+        if let Some(history) = observed_delivery.terminal_history.as_deref_mut() {
+            history.issue_id = "2".to_string();
+            history.issue_identifier = "repo#2".to_string();
+        }
         observed_delivery
             .repositories
             .get_mut("source-repo")
@@ -10783,6 +10803,16 @@ mod tests {
 
         let state = orchestrator.state.read().await;
         assert_eq!(state.completed["1"].status, "completed_failed");
+        drop(state);
+        let history = orchestrator
+            .history_store
+            .as_ref()
+            .unwrap()
+            .read_history(&crate::history::reader::HistoryQuery::default())
+            .await
+            .unwrap();
+        assert_eq!(history.total, 1);
+        assert_eq!(history.records[0].outcome, HISTORY_OUTCOME_STOPPED);
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
@@ -10954,6 +10984,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            terminal_history: Some(Box::new(review_projection_history())),
             review_projection: None,
         }
     }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -10646,6 +10646,52 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn finalize_retry_requeues_a_blocked_review_projection() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, delivery) =
+            recovery_test_orchestrator(remote).await;
+        orchestrator.tracker = Arc::new(ReviewProjectionTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "In Progress")])),
+            journal: orchestrator.pipeline_journal.clone(),
+            issue_id: "1".to_string(),
+            writes: AtomicUsize::new(0),
+            saw_in_flight_before_write: AtomicBool::new(false),
+            fail_reads: true,
+        });
+        let delivery = review_ready_delivery(delivery);
+        orchestrator
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+        let blocked = orchestrator.advance_review_projection(delivery).await;
+        assert_eq!(
+            blocked.review_projection.as_ref().unwrap().phase,
+            crate::orchestrator::delivery::ReviewProjectionPhase::Blocked
+        );
+
+        assert_eq!(
+            orchestrator
+                .retry_finalize_delivery("1", &blocked.identifier)
+                .await,
+            Ok(())
+        );
+
+        let state = orchestrator.state.read().await;
+        let projection = state.delivery["1"].review_projection.as_ref().unwrap();
+        assert_eq!(
+            projection.phase,
+            crate::orchestrator::delivery::ReviewProjectionPhase::Pending
+        );
+        assert!(projection.diagnostic.is_none());
+        assert_eq!(state.finalize["1"].status, FinalizeStatus::InProgress);
+    }
+
     fn post_finalize_acceptance_snapshot(
         rule_names: &[&str],
         results: Vec<crate::acceptance::AcceptanceResult>,
@@ -11051,6 +11097,16 @@ mod tests {
         repository.pr_number = Some(420);
         repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
         repository.last_error = None;
+        delivery.terminal_history.as_deref_mut().unwrap().artifacts = Some(RunArtifacts {
+            run_id: delivery.run_id.clone(),
+            workspace_path: "/tmp/ensemble-test".to_string(),
+            repos: vec![crate::history::artifacts::RepoArtifact {
+                repo: "source-repo".to_string(),
+                finalize_status: "pending".to_string(),
+                ..Default::default()
+            }],
+            transcripts: Vec::new(),
+        });
         let snapshot = {
             let config = orchestrator.config.read().await;
             let dag = build_dag(&config.steps).unwrap();
@@ -11105,6 +11161,24 @@ mod tests {
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+        let history = orchestrator
+            .history_store
+            .as_ref()
+            .unwrap()
+            .read_history(&crate::history::reader::HistoryQuery::default())
+            .await
+            .unwrap();
+        let artifact = &history.records[0].artifacts.as_ref().unwrap().repos[0];
+        assert_eq!(artifact.finalize_status, "waiting");
+        assert_eq!(
+            artifact.pushed_ref.as_deref(),
+            Some("origin/ensemble/repo-1")
+        );
+        assert_eq!(artifact.pr_number, Some(420));
+        assert_eq!(
+            artifact.pr_url.as_deref(),
+            Some("https://github.com/example/project/pull/420")
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -11256,7 +11256,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancelled_delivery_does_not_report_success() {
+    async fn cancelled_delivery_preserves_blocked_diagnostic_without_reporting_success() {
         let remote = Arc::new(RecoveryDeliveryRemote {
             pull_requests: std::sync::Mutex::new(Vec::new()),
             pushes: AtomicUsize::new(0),
@@ -11270,6 +11270,15 @@ mod tests {
         repository.pr_number = Some(420);
         repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
         repository.last_error = None;
+        delivery.review_projection = Some(crate::orchestrator::delivery::ReviewProjection {
+            target: "In review".to_string(),
+            repositories: vec!["source-repo".to_string()],
+            phase: crate::orchestrator::delivery::ReviewProjectionPhase::Blocked,
+            diagnostic: Some("review state could not be confirmed".to_string()),
+            last_observed_state: Some("In progress".to_string()),
+            history_record: None,
+            history_persisted: false,
+        });
         let snapshot = {
             let config = orchestrator.config.read().await;
             let dag = build_dag(&config.steps).unwrap();
@@ -11311,6 +11320,10 @@ mod tests {
             .unwrap();
         assert_eq!(history.total, 1);
         assert_eq!(history.records[0].outcome, HISTORY_OUTCOME_STOPPED);
+        assert_eq!(
+            history.records[0].last_error.as_deref(),
+            Some("review state could not be confirmed")
+        );
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -11282,6 +11282,18 @@ mod tests {
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+        let first_transition = latest.terminal_transition.unwrap();
+
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(
+            state.pending_terminal_transitions["1"].transition,
+            first_transition
+        );
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
     }
 
     fn delivery_restart_orchestrator(

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -7060,6 +7060,7 @@ impl Orchestrator {
             .advance_delivery_record(delivery, &workspace, snapshot.as_ref())
             .await;
         let delivery = self.advance_review_projection(delivery).await;
+        let terminal_history = delivery.terminal_history.as_deref().cloned();
         self.project_delivery_artifacts(issue_id, &delivery).await;
 
         let (final_status, should_complete, last_error) = {
@@ -7154,7 +7155,7 @@ impl Orchestrator {
                 issue,
                 outcome,
                 target_state,
-                None,
+                terminal_history,
             )
             .await;
         } else if let Some(error) = last_error {
@@ -11234,6 +11235,78 @@ mod tests {
         let repository = &state.delivery["1"].repositories["source-repo"];
         assert_eq!(repository.phase, DeliveryPhase::Waiting);
         assert_eq!(repository.local_sha, "stored-delivery-sha");
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn operator_retry_carries_delivery_history_into_terminal_cleanup() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.mode = DeliveryMode::Push;
+        repository.phase = DeliveryPhase::Blocked;
+        repository.retry_from = Some(DeliveryPhase::ReconcilingPush);
+        repository.last_error = Some("remote observation failed".to_string());
+        repository.pr_number = None;
+        repository.pr_url = None;
+        delivery.terminal_history.as_deref_mut().unwrap().outcome =
+            HISTORY_OUTCOME_SUCCEEDED.to_string();
+        let snapshot = {
+            let config = orchestrator.config.read().await;
+            let dag = build_dag(&config.steps).unwrap();
+            let run = PipelineRun::new(delivery.issue_id.clone(), 1, dag);
+            run.start();
+            run.to_snapshot()
+        };
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        orchestrator.tracker = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Done")])),
+        });
+        {
+            let mut state = orchestrator.state.write().await;
+            state.set_finalize_state(
+                "1",
+                IssueFinalizeState {
+                    issue_identifier: "repo#1".to_string(),
+                    status: FinalizeStatus::InProgress,
+                    repos: vec![RepoFinalizeState {
+                        repo: "source-repo".to_string(),
+                        mode: "push".to_string(),
+                        approval_required: false,
+                        status: FinalizeStatus::InProgress,
+                        last_error: None,
+                    }],
+                },
+            );
+        }
+
+        orchestrator.process_finalize_retries().await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.delivery.contains_key("1"));
+        assert!(!state.is_claimed("1"));
+        assert!(state.completed.contains_key("1"));
+        drop(state);
+        let history = orchestrator
+            .history_store
+            .as_ref()
+            .unwrap()
+            .read_history(&crate::history::reader::HistoryQuery::default())
+            .await
+            .unwrap();
+        assert_eq!(history.total, 1);
+        assert_eq!(history.records[0].issue_id, delivery.issue_id);
+        assert_eq!(history.records[0].outcome, HISTORY_OUTCOME_SUCCEEDED);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
     }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6927,6 +6927,7 @@ impl Orchestrator {
             })
             .cloned()
             .collect::<Vec<_>>();
+        let newly_prepared_repo_names = missing_repo_names.iter().cloned().collect::<HashSet<_>>();
         let (mut delivery, snapshot) = if missing_repo_names.is_empty() {
             let Some(existing) = existing else {
                 return;
@@ -6991,6 +6992,9 @@ impl Orchestrator {
                 continue;
             };
             if repository.phase == DeliveryPhase::AwaitingApproval {
+                if newly_prepared_repo_names.contains(repo_name) {
+                    continue;
+                }
                 repository.phase = DeliveryPhase::Prepared;
                 repository.last_error = None;
             } else if repository.phase == DeliveryPhase::Blocked {
@@ -10690,6 +10694,86 @@ mod tests {
         );
         assert!(projection.diagnostic.is_none());
         assert_eq!(state.finalize["1"].status, FinalizeStatus::InProgress);
+    }
+
+    #[tokio::test]
+    async fn finalize_retry_reconstructs_pre_delivery_approval_failure() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (repo_temp, mut repo_config) = create_finalize_repo().await;
+        repo_config.finalize.mode = FinalizeMode::PushAndPr;
+        repo_config.finalize.approval_required = true;
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(CountingRunner {
+            runs: Arc::new(AtomicUsize::new(0)),
+        });
+        let workspace_temp = tempfile::TempDir::new().unwrap();
+        let workspace_mgr =
+            WorkspaceManager::new(workspace_temp.path(), Some(vec![repo_config])).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            workspace_temp.path(),
+            shutdown_rx,
+        );
+        orchestrator.delivery_remote = remote.clone();
+        {
+            let mut state = orchestrator.state.write().await;
+            state.claimed.insert("1".to_string());
+            state
+                .issue_run_ids
+                .insert("1".to_string(), "run-1".to_string());
+            state.set_finalize_state(
+                "1",
+                IssueFinalizeState {
+                    issue_identifier: "repo#1".to_string(),
+                    status: FinalizeStatus::Failed,
+                    repos: vec![RepoFinalizeState {
+                        repo: "source-repo".to_string(),
+                        mode: "push_and_pr".to_string(),
+                        approval_required: true,
+                        status: FinalizeStatus::Failed,
+                        last_error: Some("initial delivery persistence failed".to_string()),
+                    }],
+                },
+            );
+        }
+
+        orchestrator
+            .retry_finalize_delivery("1", "repo#1")
+            .await
+            .unwrap();
+        assert_eq!(
+            orchestrator.state.read().await.finalize["1"].status,
+            FinalizeStatus::InProgress
+        );
+
+        orchestrator.process_finalize_retries().await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(state.finalize["1"].status, FinalizeStatus::PendingApproval);
+        assert_eq!(
+            state.delivery["1"].repositories["source-repo"].phase,
+            DeliveryPhase::AwaitingApproval
+        );
+        drop(state);
+        assert_eq!(
+            orchestrator.approve_finalize_delivery("1", "repo#1").await,
+            Ok(true)
+        );
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+
+        drop(repo_temp);
     }
 
     fn post_finalize_acceptance_snapshot(

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -5895,13 +5895,14 @@ impl Orchestrator {
         .await;
     }
 
-    async fn persist_terminal_transition_intent(
+    async fn persist_terminal_transition(
         &self,
         issue_id: &str,
         identifier: &str,
         outcome: TerminalOutcome,
         target_state: String,
         history_record: Option<HistoryRecord>,
+        tracker_write_confirmed: bool,
     ) -> Option<PendingTerminalTransition> {
         let existing_record = self
             .pipeline_journal
@@ -5962,8 +5963,15 @@ impl Orchestrator {
         if history_record.is_some() {
             transition.history_record = history_record;
         }
+        if tracker_write_confirmed {
+            transition.confirm_tracker_write();
+        }
         let input = PipelineTransitionInput {
-            kind: PipelineTransitionKind::PendingTerminalTransition,
+            kind: if transition.tracker_write_confirmed {
+                PipelineTransitionKind::TerminalTransitionApplied
+            } else {
+                PipelineTransitionKind::PendingTerminalTransition
+            },
             issue_id: issue_id.to_string(),
             identifier: identifier.to_string(),
             run_id,
@@ -5997,18 +6005,57 @@ impl Orchestrator {
         history_record: Option<HistoryRecord>,
     ) {
         let Some(transition) = self
-            .persist_terminal_transition_intent(
+            .persist_terminal_transition(
                 issue_id,
                 identifier,
                 outcome,
                 target_state,
                 history_record,
+                false,
             )
             .await
         else {
             return;
         };
 
+        self.begin_persisted_terminal_transition(issue_id, identifier, issue, transition)
+            .await;
+    }
+
+    async fn begin_confirmed_terminal_transition_for_identity(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+        issue: Option<Issue>,
+        outcome: TerminalOutcome,
+        target_state: String,
+        history_record: Option<HistoryRecord>,
+    ) {
+        let Some(transition) = self
+            .persist_terminal_transition(
+                issue_id,
+                identifier,
+                outcome,
+                target_state,
+                history_record,
+                true,
+            )
+            .await
+        else {
+            return;
+        };
+
+        self.begin_persisted_terminal_transition(issue_id, identifier, issue, transition)
+            .await;
+    }
+
+    async fn begin_persisted_terminal_transition(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+        issue: Option<Issue>,
+        transition: PendingTerminalTransition,
+    ) {
         let issue = Some(issue.unwrap_or_else(|| {
             Self::terminal_issue_placeholder(issue_id, identifier, &transition.target_state)
         }));
@@ -6568,12 +6615,13 @@ impl Orchestrator {
         };
 
         let _ = self
-            .persist_terminal_transition_intent(
+            .persist_terminal_transition(
                 issue_id,
                 issue_identifier,
                 outcome,
                 target_state,
                 history_record,
+                false,
             )
             .await;
     }
@@ -10731,8 +10779,10 @@ mod tests {
             .await
             .unwrap();
         assert!(workspace.base_path.exists());
-        orchestrator.tracker = Arc::new(MockTracker {
+        let tracker_writes = Arc::new(RwLock::new(Vec::new()));
+        orchestrator.tracker = Arc::new(RecordingTracker {
             issues: Arc::new(RwLock::new(vec![test_issue("1", "Done")])),
+            state_writes: Arc::clone(&tracker_writes),
         });
 
         Box::pin(orchestrator.handle_tick()).await;
@@ -10752,6 +10802,17 @@ mod tests {
             records.last().map(|record| record.kind),
             Some(PipelineTransitionKind::Released)
         );
+        assert!(records.iter().any(|record| {
+            record.kind == PipelineTransitionKind::TerminalTransitionApplied
+                && record
+                    .terminal_transition
+                    .as_ref()
+                    .is_some_and(|transition| transition.tracker_write_confirmed)
+        }));
+        assert!(!records
+            .iter()
+            .any(|record| { record.kind == PipelineTransitionKind::PendingTerminalTransition }));
+        assert!(tracker_writes.read().await.is_empty());
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -887,7 +887,10 @@ impl Orchestrator {
         self.reconcile_pending_terminal_transitions().await;
         self.hydrate_waiting_on_human_from_store().await;
         self.process_interaction_thread_commands().await;
-        Box::pin(self.reconcile_and_recover_deliveries()).await;
+        let has_delivery = !self.state.read().await.delivery.is_empty();
+        if has_delivery {
+            Box::pin(self.reconcile_and_recover_deliveries()).await;
+        }
         self.process_finalize_retries().await;
 
         // Pre-compute lowercase state lists once per tick
@@ -10048,6 +10051,45 @@ mod tests {
         (orchestrator, workspace_temp, repo_temp, delivery)
     }
 
+    async fn two_delivery_recovery_test_orchestrator(
+        remote: Arc<RecoveryDeliveryRemote>,
+    ) -> (
+        Orchestrator,
+        tempfile::TempDir,
+        tempfile::TempDir,
+        DeliveryRecord,
+    ) {
+        let (orchestrator, workspace, repo, missing_delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let mut observed_delivery = missing_delivery.clone();
+        observed_delivery.issue_id = "2".to_string();
+        observed_delivery.identifier = "repo#2".to_string();
+        observed_delivery.run_id = "run-2".to_string();
+        observed_delivery
+            .repositories
+            .get_mut("source-repo")
+            .unwrap()
+            .marker = canonical_marker("run-2", "2", "source-repo");
+        remote.pull_requests.lock().unwrap().push(
+            crate::orchestrator::delivery::RemotePullRequest {
+                repository_key: "source-repo".to_string(),
+                head_branch: observed_delivery.repositories["source-repo"]
+                    .head_branch
+                    .clone(),
+                base_branch: "main".to_string(),
+                head_sha: "0123456789abcdef".to_string(),
+                body: observed_delivery.repositories["source-repo"].marker.clone(),
+                number: 421,
+                url: "https://github.com/example/project/pull/421".to_string(),
+            },
+        );
+        orchestrator
+            .persist_delivery_record(&observed_delivery, None)
+            .await
+            .unwrap();
+        (orchestrator, workspace, repo, missing_delivery)
+    }
+
     fn review_projection_history() -> HistoryRecord {
         HistoryRecord {
             issue_identifier: "repo#1".to_string(),
@@ -10696,6 +10738,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_delivery_does_not_report_success() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
+        repository.last_error = None;
+        let snapshot = {
+            let config = orchestrator.config.read().await;
+            let dag = build_dag(&config.steps).unwrap();
+            let run = PipelineRun::new(delivery.issue_id.clone(), 1, dag);
+            run.start();
+            run.to_snapshot()
+        };
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        orchestrator
+            .workspace_mgr
+            .prepare_workspace(&delivery.issue_id, &delivery.identifier)
+            .await
+            .unwrap();
+        orchestrator
+            .config
+            .write()
+            .await
+            .tracker
+            .terminal_states
+            .push("Cancelled".to_string());
+        orchestrator.tracker = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Cancelled")])),
+        });
+
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(state.completed["1"].status, "completed_failed");
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn missing_tracker_issue_does_not_block_other_delivery_recovery() {
         let remote = Arc::new(RecoveryDeliveryRemote {
             pull_requests: std::sync::Mutex::new(Vec::new()),
@@ -10704,35 +10797,37 @@ mod tests {
             lists: AtomicUsize::new(0),
         });
         let (mut orchestrator, _workspace, _repo, missing_delivery) =
-            recovery_test_orchestrator(Arc::clone(&remote)).await;
-        let mut observed_delivery = missing_delivery.clone();
-        observed_delivery.issue_id = "2".to_string();
-        observed_delivery.identifier = "repo#2".to_string();
-        observed_delivery.run_id = "run-2".to_string();
-        observed_delivery
-            .repositories
-            .get_mut("source-repo")
-            .unwrap()
-            .marker = canonical_marker("run-2", "2", "source-repo");
-        remote.pull_requests.lock().unwrap().push(
-            crate::orchestrator::delivery::RemotePullRequest {
-                repository_key: "source-repo".to_string(),
-                head_branch: observed_delivery.repositories["source-repo"]
-                    .head_branch
-                    .clone(),
-                base_branch: "main".to_string(),
-                head_sha: "0123456789abcdef".to_string(),
-                body: observed_delivery.repositories["source-repo"].marker.clone(),
-                number: 421,
-                url: "https://github.com/example/project/pull/421".to_string(),
-            },
-        );
-        orchestrator
-            .persist_delivery_record(&observed_delivery, None)
-            .await
-            .unwrap();
+            two_delivery_recovery_test_orchestrator(Arc::clone(&remote)).await;
         orchestrator.tracker = Arc::new(MockTracker {
             issues: Arc::new(RwLock::new(vec![test_issue("2", "Todo")])),
+        });
+
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(state.delivery.get("1"), Some(&missing_delivery));
+        assert_eq!(
+            state.delivery["2"].repositories["source-repo"].phase,
+            DeliveryPhase::Waiting
+        );
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 1);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn tracker_refresh_failure_does_not_block_other_delivery_recovery() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, missing_delivery) =
+            two_delivery_recovery_test_orchestrator(Arc::clone(&remote)).await;
+        orchestrator.tracker = Arc::new(FailingWorkflowStateTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("2", "Todo")])),
+            id_fetch_failures_remaining: AtomicUsize::new(2),
         });
 
         Box::pin(orchestrator.handle_tick()).await;

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6,8 +6,10 @@ pub mod scheduler;
 pub mod state;
 
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
+use std::pin::Pin;
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -6210,118 +6212,115 @@ impl Orchestrator {
             .await;
     }
 
-    async fn complete_pending_terminal_transition(
-        &self,
-        issue_id: &str,
+    // Box this lifecycle boundary so the already-large tick future does not embed workspace
+    // cleanup's state machine and overflow Tokio's worker stack on terminal failure paths.
+    fn complete_pending_terminal_transition<'a>(
+        &'a self,
+        issue_id: &'a str,
         expected_run_id: Option<String>,
-    ) {
-        let pending = {
-            let state = self.state.read().await;
-            let Some(pending) = state.pending_terminal_transitions.get(issue_id).cloned() else {
-                return;
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            let pending = {
+                let state = self.state.read().await;
+                let Some(pending) = state.pending_terminal_transitions.get(issue_id).cloned()
+                else {
+                    return;
+                };
+                if pending.run_id != expected_run_id {
+                    return;
+                }
+                if !pending.transition.tracker_write_confirmed {
+                    return;
+                }
+                pending
             };
-            if pending.run_id != expected_run_id {
-                return;
-            }
-            if !pending.transition.tracker_write_confirmed {
-                return;
-            }
-            pending
-        };
 
-        if let Err(error) = self
-            .clear_terminal_interaction_waiting_state(issue_id)
-            .await
-        {
-            warn!(
-                issue_id = %issue_id,
-                error = %error,
-                "failed to clear terminal interaction waiting state"
-            );
-            return;
-        }
-
-        if let Some(record) = pending.transition.history_record.as_ref() {
             if let Err(error) = self
-                .persist_history_record(pending.run_id.as_deref(), record)
+                .clear_terminal_interaction_waiting_state(issue_id)
                 .await
             {
                 warn!(
                     issue_id = %issue_id,
                     error = %error,
-                    "failed to persist terminal run history before release"
+                    "failed to clear terminal interaction waiting state"
                 );
                 return;
             }
-        }
 
-        if let Err(error) = self.workspace_mgr.remove_workspace(issue_id).await {
-            self.record_pending_terminal_transition_failure(issue_id, &pending, error.to_string())
+            if let Some(record) = pending.transition.history_record.as_ref() {
+                if let Err(error) = self
+                    .persist_history_record(pending.run_id.as_deref(), record)
+                    .await
+                {
+                    warn!(
+                        issue_id = %issue_id,
+                        error = %error,
+                        "failed to persist terminal run history before release"
+                    );
+                    return;
+                }
+            }
+
+            if let Err(error) = self.workspace_mgr.remove_workspace(issue_id).await {
+                self.record_pending_terminal_transition_failure(
+                    issue_id,
+                    &pending,
+                    error.to_string(),
+                )
                 .await;
-            warn!(
-                issue_id = %issue_id,
-                identifier = %pending.identifier,
-                error = %error,
-                "failed to clean terminal workspace before release"
-            );
-            return;
-        }
-
-        let pipeline_journal = self.pipeline_journal.clone();
-        let release_issue_id = issue_id.to_string();
-        let release_identifier = pending.identifier.clone();
-        let release_run_id = pending.run_id.clone();
-        let runtime = tokio::runtime::Handle::current();
-        // Keep the journal append off the Tokio worker stack: after workspace cleanup, this
-        // terminal transition chain is deep enough to exhaust that stack when appended inline.
-        let release_result = tokio::task::spawn_blocking(move || {
-            runtime.block_on(pipeline_journal.append_released(
-                &release_issue_id,
-                &release_identifier,
-                release_run_id,
-                "terminal tracker transition reconciled",
-            ))
-        })
-        .await;
-        let release_error = match release_result {
-            Ok(Ok(_)) => None,
-            Ok(Err(error)) => Some(error.to_string()),
-            Err(error) => Some(format!("pipeline release task failed: {error}")),
-        };
-        if let Some(error) = release_error {
-            warn!(
-                issue_id = %issue_id,
-                error,
-                "failed to persist pipeline release after terminal tracker transition"
-            );
-            return;
-        }
-
-        {
-            let mut state = self.state.write().await;
-            let Some(current) = state.pending_terminal_transitions.get(issue_id) else {
-                return;
-            };
-            if current.run_id != pending.run_id
-                || current.transition.target_state != pending.transition.target_state
-                || current.transition.outcome != pending.transition.outcome
-            {
+                warn!(
+                    issue_id = %issue_id,
+                    identifier = %pending.identifier,
+                    error = %error,
+                    "failed to clean terminal workspace before release"
+                );
                 return;
             }
 
-            let status = match pending.transition.outcome {
-                TerminalOutcome::Succeeded => "completed_succeeded",
-                TerminalOutcome::Failed => "completed_failed",
-            };
-            state.add_completed(
-                issue_id.to_string(),
-                pending.identifier.clone(),
-                status.to_string(),
-            );
-            state.release_claim(issue_id);
-            state.remove_pipeline_run(issue_id);
-            state.clear_finalize_state(issue_id);
-        }
+            if let Err(error) = self
+                .pipeline_journal
+                .append_released(
+                    issue_id,
+                    &pending.identifier,
+                    pending.run_id.clone(),
+                    "terminal tracker transition reconciled",
+                )
+                .await
+            {
+                warn!(
+                    issue_id = %issue_id,
+                    error = %error,
+                    "failed to persist pipeline release after terminal tracker transition"
+                );
+                return;
+            }
+
+            {
+                let mut state = self.state.write().await;
+                let Some(current) = state.pending_terminal_transitions.get(issue_id) else {
+                    return;
+                };
+                if current.run_id != pending.run_id
+                    || current.transition.target_state != pending.transition.target_state
+                    || current.transition.outcome != pending.transition.outcome
+                {
+                    return;
+                }
+
+                let status = match pending.transition.outcome {
+                    TerminalOutcome::Succeeded => "completed_succeeded",
+                    TerminalOutcome::Failed => "completed_failed",
+                };
+                state.add_completed(
+                    issue_id.to_string(),
+                    pending.identifier.clone(),
+                    status.to_string(),
+                );
+                state.release_claim(issue_id);
+                state.remove_pipeline_run(issue_id);
+                state.clear_finalize_state(issue_id);
+            }
+        })
     }
 
     async fn record_pending_terminal_transition_failure(

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6044,7 +6044,7 @@ impl Orchestrator {
                 error = %error,
                 "failed to persist terminal transition intent"
             );
-            return Some(transition);
+            return (!tracker_write_confirmed).then_some(transition);
         }
         Some(transition)
     }
@@ -11101,6 +11101,70 @@ mod tests {
         assert!(!records
             .iter()
             .any(|record| { record.kind == PipelineTransitionKind::PendingTerminalTransition }));
+        assert!(tracker_writes.read().await.is_empty());
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn confirmed_terminal_transition_append_failure_preserves_delivery_workspace() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
+        repository.last_error = None;
+        let snapshot = {
+            let config = orchestrator.config.read().await;
+            let dag = build_dag(&config.steps).unwrap();
+            let run = PipelineRun::new(delivery.issue_id.clone(), 1, dag);
+            run.start();
+            run.to_snapshot()
+        };
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        let workspace = orchestrator
+            .workspace_mgr
+            .prepare_workspace(&delivery.issue_id, &delivery.identifier)
+            .await
+            .unwrap();
+        let tracker_writes = Arc::new(RwLock::new(Vec::new()));
+        orchestrator.tracker = Arc::new(RecordingTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Done")])),
+            state_writes: Arc::clone(&tracker_writes),
+        });
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 1));
+
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.delivery.contains_key("1"));
+        assert!(state.is_claimed("1"));
+        assert!(!state.completed.contains_key("1"));
+        assert!(!state.pending_terminal_transitions.contains_key("1"));
+        drop(state);
+        assert!(workspace.base_path.exists());
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        assert_eq!(
+            records.last().map(|record| record.kind),
+            Some(PipelineTransitionKind::DeliveryOwned)
+        );
         assert!(tracker_writes.read().await.is_empty());
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -761,7 +761,8 @@ impl Orchestrator {
 
         // Immediate first tick
         if !self.quiescing.is_requested() {
-            self.handle_tick().await;
+            // Keep the large tick state machine out of the long-lived orchestrator future.
+            Box::pin(self.handle_tick()).await;
         }
 
         // Main event loop
@@ -802,7 +803,7 @@ impl Orchestrator {
                 _ = sleep(poll_interval) => {
                     if !self.quiescing.is_requested() {
                         debug!("poll tick");
-                        self.handle_tick().await;
+                        Box::pin(self.handle_tick()).await;
                     }
                 }
 
@@ -810,7 +811,7 @@ impl Orchestrator {
                 _ = self.refresh_requested.notified() => {
                     if !self.quiescing.is_requested() {
                         debug!("manual refresh tick");
-                        self.handle_tick().await;
+                        Box::pin(self.handle_tick()).await;
                     }
                 }
 
@@ -886,7 +887,12 @@ impl Orchestrator {
         self.reconcile_pending_terminal_transitions().await;
         self.hydrate_waiting_on_human_from_store().await;
         self.process_interaction_thread_commands().await;
-        self.process_delivery_recovery().await;
+        let has_delivery = !self.state.read().await.delivery.is_empty();
+        if has_delivery && Box::pin(self.reconcile_terminal_delivery_owners()).await {
+            // Remote delivery recovery is another large state machine. Poll it only after terminal
+            // ownership reconciliation has finished and released its future.
+            Box::pin(self.process_delivery_recovery()).await;
+        }
         self.process_finalize_retries().await;
 
         // Pre-compute lowercase state lists once per tick
@@ -10632,6 +10638,64 @@ mod tests {
         assert!(!state.is_claimed("1"));
         assert!(state.completed.contains_key("1"));
         drop(state);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn waiting_delivery_releases_when_tracker_becomes_terminal() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
+        repository.last_error = None;
+        let snapshot = {
+            let config = orchestrator.config.read().await;
+            let dag = build_dag(&config.steps).unwrap();
+            let run = PipelineRun::new(delivery.issue_id.clone(), 1, dag);
+            run.start();
+            run.to_snapshot()
+        };
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        let workspace = orchestrator
+            .workspace_mgr
+            .prepare_workspace(&delivery.issue_id, &delivery.identifier)
+            .await
+            .unwrap();
+        assert!(workspace.base_path.exists());
+        orchestrator.tracker = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Done")])),
+        });
+
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.delivery.contains_key("1"));
+        assert!(!state.is_claimed("1"));
+        assert!(state.completed.contains_key("1"));
+        drop(state);
+        assert!(!workspace.base_path.exists());
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        assert_eq!(
+            records.last().map(|record| record.kind),
+            Some(PipelineTransitionKind::Released)
+        );
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
     }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -11044,7 +11044,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn push_only_published_recovery_continues_terminal_transition() {
+    async fn push_only_published_recovery_persists_history_before_release() {
         let remote = Arc::new(RecoveryDeliveryRemote {
             pull_requests: std::sync::Mutex::new(Vec::new()),
             pushes: AtomicUsize::new(0),
@@ -11080,6 +11080,16 @@ mod tests {
         drop(state);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+        let history = orchestrator
+            .history_store
+            .as_ref()
+            .unwrap()
+            .read_history(&crate::history::reader::HistoryQuery::default())
+            .await
+            .unwrap();
+        assert_eq!(history.total, 1);
+        assert_eq!(history.records[0].issue_id, delivery.issue_id);
+        assert_eq!(history.records[0].outcome, HISTORY_OUTCOME_SUCCEEDED);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -7350,21 +7350,17 @@ impl Orchestrator {
         run_id: Option<&str>,
         record: &HistoryRecord,
     ) -> Result<(), std::io::Error> {
-        if let (Some(run_id), Some(store)) = (run_id, &self.history_store) {
-            if let Err(error) = store.append_history_record(run_id, record).await {
-                warn!(
-                    run_id = %run_id,
-                    issue_id = %record.issue_id,
-                    error = %error,
-                    "failed to append history record to sqlite"
-                );
-            }
-        }
+        let sqlite_result = if let (Some(run_id), Some(store)) = (run_id, &self.history_store) {
+            store.append_history_record(run_id, record).await
+        } else {
+            Ok(())
+        };
 
         let history_path = self.workspace_mgr.root().join("ensemble_history.jsonl");
         let _guard = self.history_write_lock.lock().await;
         let writer = HistoryWriter::new(history_path);
-        writer.append_if_absent(record).await
+        let jsonl_result = writer.append_if_absent(record).await;
+        sqlite_result.and(jsonl_result)
     }
 
     async fn append_history_record(&self, run_id: Option<&str>, record: HistoryRecord) {
@@ -11382,6 +11378,72 @@ mod tests {
             artifact.pr_url.as_deref(),
             Some("https://github.com/example/project/pull/420")
         );
+    }
+
+    #[tokio::test]
+    async fn terminal_history_store_failure_preserves_delivery_workspace() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
+        repository.last_error = None;
+        let snapshot = {
+            let config = orchestrator.config.read().await;
+            let dag = build_dag(&config.steps).unwrap();
+            let run = PipelineRun::new(delivery.issue_id.clone(), 1, dag);
+            run.start();
+            run.to_snapshot()
+        };
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        let workspace = orchestrator
+            .workspace_mgr
+            .prepare_workspace(&delivery.issue_id, &delivery.identifier)
+            .await
+            .unwrap();
+        orchestrator.tracker = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Done")])),
+        });
+        let history_path = orchestrator
+            .history_store
+            .as_ref()
+            .unwrap()
+            .db_path()
+            .clone();
+        std::fs::remove_file(&history_path).unwrap();
+        std::fs::create_dir(&history_path).unwrap();
+
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.delivery.contains_key("1"));
+        assert!(state.is_claimed("1"));
+        assert!(!state.completed.contains_key("1"));
+        assert!(state.pending_terminal_transitions.contains_key("1"));
+        drop(state);
+        assert!(workspace.base_path.exists());
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        assert_eq!(
+            records.last().map(|record| record.kind),
+            Some(PipelineTransitionKind::TerminalTransitionApplied)
+        );
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6761,6 +6761,20 @@ impl Orchestrator {
             let Some(workspace) = prepared_workspace.as_ref() else {
                 unreachable!("publication repositories require a prepared workspace");
             };
+            {
+                let mut state = self.state.write().await;
+                if let Some(history) = self.build_owned_history_record(
+                    &state,
+                    issue_id,
+                    HISTORY_OUTCOME_SUCCEEDED,
+                    None,
+                    Utc::now(),
+                ) {
+                    state
+                        .finalize_terminal_history
+                        .insert(issue_id.to_string(), history);
+                }
+            }
             let prepared = self
                 .prepare_delivery_record(
                     issue_id,
@@ -10215,6 +10229,11 @@ mod tests {
         lists: AtomicUsize,
     }
 
+    struct FailOnceIdentityRemote {
+        inner: RecoveryDeliveryRemote,
+        identity_failures: AtomicUsize,
+    }
+
     struct ReviewProjectionTracker {
         issues: Arc<RwLock<Vec<Issue>>>,
         journal: PipelineRunJournal,
@@ -10353,6 +10372,70 @@ mod tests {
         ) -> Result<(), String> {
             self.creates.fetch_add(1, Ordering::SeqCst);
             Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl crate::orchestrator::delivery::DeliveryRemote for FailOnceIdentityRemote {
+        async fn local_identity(
+            &self,
+            repository_path: &Path,
+        ) -> Result<crate::orchestrator::delivery::LocalRepositoryIdentity, String> {
+            if self
+                .identity_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err("simulated local identity failure".to_string());
+            }
+            self.inner.local_identity(repository_path).await
+        }
+
+        async fn remote_head(
+            &self,
+            repository_path: &Path,
+            remote: &str,
+            head_branch: &str,
+        ) -> Result<Option<String>, String> {
+            self.inner
+                .remote_head(repository_path, remote, head_branch)
+                .await
+        }
+
+        async fn push(
+            &self,
+            repository_path: &Path,
+            remote: &str,
+            head_branch: &str,
+            local_sha: &str,
+        ) -> Result<(), String> {
+            self.inner
+                .push(repository_path, remote, head_branch, local_sha)
+                .await
+        }
+
+        async fn list_pull_requests(
+            &self,
+            repository_path: &Path,
+            repository_key: &str,
+        ) -> Result<Vec<crate::orchestrator::delivery::RemotePullRequest>, String> {
+            self.inner
+                .list_pull_requests(repository_path, repository_key)
+                .await
+        }
+
+        async fn create_pull_request(
+            &self,
+            repository_path: &Path,
+            base_branch: &str,
+            head_branch: &str,
+            marker: &str,
+        ) -> Result<(), String> {
+            self.inner
+                .create_pull_request(repository_path, base_branch, head_branch, marker)
+                .await
         }
     }
 
@@ -10712,11 +10795,14 @@ mod tests {
 
     #[tokio::test]
     async fn finalize_retry_reconstructs_pre_delivery_approval_failure() {
-        let remote = Arc::new(RecoveryDeliveryRemote {
-            pull_requests: std::sync::Mutex::new(Vec::new()),
-            pushes: AtomicUsize::new(0),
-            creates: AtomicUsize::new(0),
-            lists: AtomicUsize::new(0),
+        let remote = Arc::new(FailOnceIdentityRemote {
+            inner: RecoveryDeliveryRemote {
+                pull_requests: std::sync::Mutex::new(Vec::new()),
+                pushes: AtomicUsize::new(0),
+                creates: AtomicUsize::new(0),
+                lists: AtomicUsize::new(0),
+            },
+            identity_failures: AtomicUsize::new(1),
         });
         let (repo_temp, mut repo_config) = create_finalize_repo().await;
         repo_config.finalize.mode = FinalizeMode::PushAndPr;
@@ -10752,9 +10838,6 @@ mod tests {
             state.add_running(&test_issue("1", "Todo"), None);
             state.insert_pipeline_run("1", run, Arc::new(cfg.clone()));
         }
-        orchestrator
-            .pipeline_journal
-            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 1));
         let config_snapshot = config.read().await.clone();
         let finalize = orchestrator
             .run_finalize_phase("1", "repo#1", &config_snapshot)
@@ -10766,9 +10849,6 @@ mod tests {
             .await
             .finalize_terminal_history
             .contains_key("1"));
-        orchestrator
-            .pipeline_journal
-            .transaction_append_error_on_call = None;
         {
             let mut state = orchestrator.state.write().await;
             state.remove_running("1");
@@ -10800,7 +10880,7 @@ mod tests {
             orchestrator.approve_finalize_delivery("1", "repo#1").await,
             Ok(true)
         );
-        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.inner.pushes.load(Ordering::SeqCst), 0);
 
         drop(repo_temp);
     }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6271,17 +6271,16 @@ impl Orchestrator {
         let release_issue_id = issue_id.to_string();
         let release_identifier = pending.identifier.clone();
         let release_run_id = pending.run_id.clone();
-        // Keep the journal append on a fresh poll stack: after workspace cleanup, this terminal
-        // transition chain is deep enough to exhaust a Tokio worker stack when appended inline.
-        let release_result = tokio::spawn(async move {
-            pipeline_journal
-                .append_released(
-                    &release_issue_id,
-                    &release_identifier,
-                    release_run_id,
-                    "terminal tracker transition reconciled",
-                )
-                .await
+        let runtime = tokio::runtime::Handle::current();
+        // Keep the journal append off the Tokio worker stack: after workspace cleanup, this
+        // terminal transition chain is deep enough to exhaust that stack when appended inline.
+        let release_result = tokio::task::spawn_blocking(move || {
+            runtime.block_on(pipeline_journal.append_released(
+                &release_issue_id,
+                &release_identifier,
+                release_run_id,
+                "terminal tracker transition reconciled",
+            ))
         })
         .await;
         let release_error = match release_result {

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -887,16 +887,7 @@ impl Orchestrator {
         self.reconcile_pending_terminal_transitions().await;
         self.hydrate_waiting_on_human_from_store().await;
         self.process_interaction_thread_commands().await;
-        let has_delivery = !self.state.read().await.delivery.is_empty();
-        if has_delivery {
-            if let Some(observed_issue_ids) =
-                Box::pin(self.reconcile_terminal_delivery_owners()).await
-            {
-                // Remote delivery recovery is another large state machine. Poll it only after
-                // terminal ownership reconciliation has finished and released its future.
-                Box::pin(self.process_delivery_recovery(Some(&observed_issue_ids))).await;
-            }
-        }
+        Box::pin(self.reconcile_and_recover_deliveries()).await;
         self.process_finalize_retries().await;
 
         // Pre-compute lowercase state lists once per tick
@@ -10753,6 +10744,67 @@ mod tests {
             DeliveryPhase::Waiting
         );
         assert_eq!(remote.lists.load(Ordering::SeqCst), 1);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn failed_terminal_cleanup_does_not_resume_delivery_recovery() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let snapshot = {
+            let config = orchestrator.config.read().await;
+            let dag = build_dag(&config.steps).unwrap();
+            let run = PipelineRun::new(delivery.issue_id.clone(), 1, dag);
+            run.start();
+            run.to_snapshot()
+        };
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        orchestrator
+            .workspace_mgr
+            .prepare_workspace(&delivery.issue_id, &delivery.identifier)
+            .await
+            .unwrap();
+        std::fs::write(
+            orchestrator
+                .workspace_mgr
+                .metadata_path_for_test(&delivery.issue_id),
+            "{not-json",
+        )
+        .unwrap();
+        orchestrator.tracker = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Done")])),
+        });
+
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.pending_terminal_transitions.contains_key("1"));
+        assert_eq!(
+            state.delivery["1"].repositories["source-repo"].phase,
+            DeliveryPhase::PrCreateInFlight
+        );
+        drop(state);
+        let latest = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue("1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            latest.kind,
+            PipelineTransitionKind::PendingTerminalTransition
+        );
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
     }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -888,10 +888,14 @@ impl Orchestrator {
         self.hydrate_waiting_on_human_from_store().await;
         self.process_interaction_thread_commands().await;
         let has_delivery = !self.state.read().await.delivery.is_empty();
-        if has_delivery && Box::pin(self.reconcile_terminal_delivery_owners()).await {
-            // Remote delivery recovery is another large state machine. Poll it only after terminal
-            // ownership reconciliation has finished and released its future.
-            Box::pin(self.process_delivery_recovery()).await;
+        if has_delivery {
+            if let Some(observed_issue_ids) =
+                Box::pin(self.reconcile_terminal_delivery_owners()).await
+            {
+                // Remote delivery recovery is another large state machine. Poll it only after
+                // terminal ownership reconciliation has finished and released its future.
+                Box::pin(self.process_delivery_recovery(Some(&observed_issue_ids))).await;
+            }
         }
         self.process_finalize_retries().await;
 
@@ -10470,7 +10474,7 @@ mod tests {
             .unwrap_err();
         assert!(error.contains("missing durable delivery owner"));
 
-        orchestrator.process_delivery_recovery().await;
+        orchestrator.process_delivery_recovery(None).await;
 
         let state = orchestrator.state.read().await;
         assert_eq!(state.delivery.get("1"), Some(&delivery));
@@ -10502,7 +10506,7 @@ mod tests {
             },
         );
 
-        orchestrator.process_delivery_recovery().await;
+        orchestrator.process_delivery_recovery(None).await;
 
         let state = orchestrator.state.read().await;
         assert_eq!(
@@ -10534,7 +10538,7 @@ mod tests {
         };
         *remote.pull_requests.lock().unwrap() = vec![exact.clone(), exact];
 
-        orchestrator.process_delivery_recovery().await;
+        orchestrator.process_delivery_recovery(None).await;
 
         let state = orchestrator.state.read().await;
         let repository = &state.delivery["1"].repositories["source-repo"];
@@ -10631,7 +10635,7 @@ mod tests {
             .await
             .unwrap();
 
-        orchestrator.process_delivery_recovery().await;
+        orchestrator.process_delivery_recovery(None).await;
 
         let state = orchestrator.state.read().await;
         assert!(!state.delivery.contains_key("1"));
@@ -10696,6 +10700,59 @@ mod tests {
             Some(PipelineTransitionKind::Released)
         );
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_tracker_issue_does_not_block_other_delivery_recovery() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, missing_delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let mut observed_delivery = missing_delivery.clone();
+        observed_delivery.issue_id = "2".to_string();
+        observed_delivery.identifier = "repo#2".to_string();
+        observed_delivery.run_id = "run-2".to_string();
+        observed_delivery
+            .repositories
+            .get_mut("source-repo")
+            .unwrap()
+            .marker = canonical_marker("run-2", "2", "source-repo");
+        remote.pull_requests.lock().unwrap().push(
+            crate::orchestrator::delivery::RemotePullRequest {
+                repository_key: "source-repo".to_string(),
+                head_branch: observed_delivery.repositories["source-repo"]
+                    .head_branch
+                    .clone(),
+                base_branch: "main".to_string(),
+                head_sha: "0123456789abcdef".to_string(),
+                body: observed_delivery.repositories["source-repo"].marker.clone(),
+                number: 421,
+                url: "https://github.com/example/project/pull/421".to_string(),
+            },
+        );
+        orchestrator
+            .persist_delivery_record(&observed_delivery, None)
+            .await
+            .unwrap();
+        orchestrator.tracker = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("2", "Todo")])),
+        });
+
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(state.delivery.get("1"), Some(&missing_delivery));
+        assert_eq!(
+            state.delivery["2"].repositories["source-repo"].phase,
+            DeliveryPhase::Waiting
+        );
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 1);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
     }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -239,6 +239,32 @@ pub(crate) struct ManualWholeIssueRetryCommand {
     pub identifier: String,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct FinalizeApprovalCommand {
+    pub issue_id: String,
+    pub identifier: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FinalizeApprovalError {
+    RuntimeUnavailable,
+    NotAwaitingApproval,
+    Persistence(String),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FinalizeRetryCommand {
+    pub issue_id: String,
+    pub identifier: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FinalizeRetryError {
+    RuntimeUnavailable,
+    NotFailed,
+    Persistence(String),
+}
+
 pub(crate) enum OrchestratorCommand {
     QueueManualStepRetry {
         command: ManualStepRetryCommand,
@@ -247,6 +273,14 @@ pub(crate) enum OrchestratorCommand {
     QueueManualWholeIssueRetry {
         command: ManualWholeIssueRetryCommand,
         response: tokio::sync::oneshot::Sender<Result<(), ManualStepRetryError>>,
+    },
+    ApproveFinalize {
+        command: FinalizeApprovalCommand,
+        response: tokio::sync::oneshot::Sender<Result<(), FinalizeApprovalError>>,
+    },
+    RetryFinalize {
+        command: FinalizeRetryCommand,
+        response: tokio::sync::oneshot::Sender<Result<(), FinalizeRetryError>>,
     },
 }
 
@@ -705,6 +739,26 @@ impl Orchestrator {
                     },
                 )
                 .await;
+                let _ = response.send(result);
+            }
+            OrchestratorCommand::ApproveFinalize { command, response } => {
+                if self.quiescing.is_requested() {
+                    let _ = response.send(Err(FinalizeApprovalError::RuntimeUnavailable));
+                    return;
+                }
+                let result = self
+                    .approve_finalize_delivery(&command.issue_id, &command.identifier)
+                    .await;
+                let _ = response.send(result);
+            }
+            OrchestratorCommand::RetryFinalize { command, response } => {
+                if self.quiescing.is_requested() {
+                    let _ = response.send(Err(FinalizeRetryError::RuntimeUnavailable));
+                    return;
+                }
+                let result = self
+                    .retry_finalize_delivery(&command.issue_id, &command.identifier)
+                    .await;
                 let _ = response.send(result);
             }
         }
@@ -6678,12 +6732,8 @@ impl Orchestrator {
 
             let mode_name = finalize_mode_name(&repo_config.finalize.mode).to_string();
 
-            if repo_config.finalize.approval_required {
-                let status = if headless {
-                    FinalizeStatus::SkippedHeadless
-                } else {
-                    FinalizeStatus::PendingApproval
-                };
+            if repo_config.finalize.approval_required && headless {
+                let status = FinalizeStatus::SkippedHeadless;
                 repos.push(RepoFinalizeState {
                     repo: repo_name.clone(),
                     mode: mode_name,
@@ -6694,6 +6744,15 @@ impl Orchestrator {
                 self.update_repo_artifact_finalize_status(issue_id, repo_name, status, None)
                     .await;
                 continue;
+            }
+            if repo_config.finalize.approval_required {
+                self.update_repo_artifact_finalize_status(
+                    issue_id,
+                    repo_name,
+                    FinalizeStatus::PendingApproval,
+                    None,
+                )
+                .await;
             }
             delivery_repo_names.push(repo_name.clone());
         }
@@ -6732,7 +6791,7 @@ impl Orchestrator {
                         repos.push(RepoFinalizeState {
                             repo: repo_name.clone(),
                             mode: finalize_mode_name(&repo_config.finalize.mode).to_string(),
-                            approval_required: false,
+                            approval_required: repo_config.finalize.approval_required,
                             status: FinalizeStatus::Failed,
                             last_error: Some(error.clone()),
                         });
@@ -6791,7 +6850,11 @@ impl Orchestrator {
                                     .repositories
                                     .get(&repo.repo)
                                     .is_none_or(|repository| {
-                                        repository.phase == DeliveryPhase::Blocked
+                                        matches!(
+                                            repository.phase,
+                                            DeliveryPhase::AwaitingApproval
+                                                | DeliveryPhase::Blocked
+                                        )
                                     })
                             })
                     })
@@ -6927,7 +6990,10 @@ impl Orchestrator {
             let Some(repository) = delivery.repositories.get_mut(repo_name) else {
                 continue;
             };
-            if repository.phase == DeliveryPhase::Blocked {
+            if repository.phase == DeliveryPhase::AwaitingApproval {
+                repository.phase = DeliveryPhase::Prepared;
+                repository.last_error = None;
+            } else if repository.phase == DeliveryPhase::Blocked {
                 let retry_from = repository.retry_from.unwrap_or(DeliveryPhase::Prepared);
                 repository.phase = retry_from;
                 if retry_from != DeliveryPhase::Waiting {
@@ -6968,11 +7034,7 @@ impl Orchestrator {
                     let Some(repository) = delivery.repositories.get(&repo.repo) else {
                         continue;
                     };
-                    repo.status = match repository.phase {
-                        DeliveryPhase::Published => FinalizeStatus::Succeeded,
-                        DeliveryPhase::Blocked => FinalizeStatus::Failed,
-                        _ => FinalizeStatus::InProgress,
-                    };
+                    repo.status = Self::finalize_status_from_delivery(repository);
                     repo.last_error = repository.last_error.clone();
                 }
 
@@ -9844,6 +9906,8 @@ mod tests {
             )
             .await;
 
+        orchestrator.reconcile_and_recover_deliveries().await;
+
         let state = orchestrator.state.read().await;
         let delivery = state.delivery.get(&issue.id).expect("delivery owner");
         assert_eq!(
@@ -9898,6 +9962,230 @@ mod tests {
             })
             .expect("push in flight record");
         assert!(prepared < first_mutation);
+
+        drop(repo_temp);
+    }
+
+    #[tokio::test]
+    async fn approval_required_delivery_preserves_terminal_history_before_approval() {
+        let (repo_temp, mut repo_config) = create_finalize_repo().await;
+        repo_config.finalize.mode = FinalizeMode::PushAndPr;
+        repo_config.finalize.approval_required = true;
+        let config = Arc::new(RwLock::new(make_config()));
+        let issue = test_issue("1", "Todo");
+        let tracker_issues = Arc::new(RwLock::new(vec![issue.clone()]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::clone(&tracker_issues),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(CountingRunner {
+            runs: Arc::new(AtomicUsize::new(0)),
+        });
+        let workspace_temp = tempfile::TempDir::new().unwrap();
+        let workspace_mgr =
+            WorkspaceManager::new(workspace_temp.path(), Some(vec![repo_config])).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            workspace_temp.path(),
+            shutdown_rx,
+        );
+        let remote = Arc::new(SuccessfulDeliveryRemote {
+            journal: orchestrator.pipeline_journal.clone(),
+            issue_id: issue.id.clone(),
+            remote_sha: std::sync::Mutex::new(None),
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            mutation_phases: std::sync::Mutex::new(Vec::new()),
+        });
+        orchestrator.delivery_remote = remote.clone();
+
+        {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
+            run.start();
+            run.mark_running("build", "session-1".to_string());
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, None);
+            state.insert_pipeline_run(&issue.id, run, Arc::new(cfg.clone()));
+        }
+
+        orchestrator
+            .handle_worker_exit(
+                &issue.id,
+                "build",
+                WorkerResult::Success {
+                    output: succeeded_step_output(),
+                    approval_request: None,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        let delivery = state.delivery.get(&issue.id).expect("delivery owner");
+        assert!(delivery.terminal_history.is_some());
+        assert_eq!(
+            delivery.repositories["source-repo"].phase,
+            DeliveryPhase::AwaitingApproval
+        );
+        assert!(delivery.repositories["source-repo"].approval_required);
+        assert_eq!(
+            state.finalize[&issue.id].status,
+            FinalizeStatus::PendingApproval
+        );
+        assert!(remote.mutation_phases.lock().unwrap().is_empty());
+        drop(state);
+        let durable = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue(&issue.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(durable.snapshot.is_some());
+        assert!(durable
+            .delivery
+            .as_ref()
+            .is_some_and(|delivery| delivery.terminal_history.is_some()));
+
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 1));
+        let (response, result) = tokio::sync::oneshot::channel();
+        orchestrator
+            .handle_command(OrchestratorCommand::ApproveFinalize {
+                command: FinalizeApprovalCommand {
+                    issue_id: issue.id.clone(),
+                    identifier: issue.identifier.clone(),
+                },
+                response,
+            })
+            .await;
+        assert!(matches!(
+            result.await.unwrap(),
+            Err(FinalizeApprovalError::Persistence(_))
+        ));
+        assert_eq!(
+            orchestrator.state.read().await.delivery[&issue.id].repositories["source-repo"].phase,
+            DeliveryPhase::AwaitingApproval
+        );
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = None;
+        let mut blocked = orchestrator.state.read().await.delivery[&issue.id].clone();
+        let repository = blocked.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Blocked;
+        repository.retry_from = Some(DeliveryPhase::Prepared);
+        repository.last_error = Some("push failed".to_string());
+        orchestrator
+            .persist_delivery_record(&blocked, None)
+            .await
+            .unwrap();
+
+        let (response, result) = tokio::sync::oneshot::channel();
+        orchestrator
+            .handle_command(OrchestratorCommand::ApproveFinalize {
+                command: FinalizeApprovalCommand {
+                    issue_id: issue.id.clone(),
+                    identifier: issue.identifier.clone(),
+                },
+                response,
+            })
+            .await;
+        assert_eq!(
+            result.await.unwrap(),
+            Err(FinalizeApprovalError::NotAwaitingApproval)
+        );
+
+        let (response, result) = tokio::sync::oneshot::channel();
+        orchestrator
+            .handle_command(OrchestratorCommand::RetryFinalize {
+                command: FinalizeRetryCommand {
+                    issue_id: issue.id.clone(),
+                    identifier: issue.identifier.clone(),
+                },
+                response,
+            })
+            .await;
+        assert_eq!(result.await.unwrap(), Ok(()));
+        assert_eq!(
+            orchestrator.state.read().await.delivery[&issue.id].repositories["source-repo"].phase,
+            DeliveryPhase::AwaitingApproval
+        );
+        assert_eq!(
+            orchestrator.state.read().await.delivery[&issue.id].repositories["source-repo"]
+                .retry_from,
+            Some(DeliveryPhase::Prepared)
+        );
+
+        orchestrator.pipeline_journal.transaction_append_late_error = true;
+        for _ in 0..2 {
+            let (response, result) = tokio::sync::oneshot::channel();
+            orchestrator
+                .handle_command(OrchestratorCommand::ApproveFinalize {
+                    command: FinalizeApprovalCommand {
+                        issue_id: issue.id.clone(),
+                        identifier: issue.identifier.clone(),
+                    },
+                    response,
+                })
+                .await;
+            assert_eq!(result.await.unwrap(), Ok(()));
+        }
+        orchestrator.pipeline_journal.transaction_append_late_error = false;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(
+            state.delivery[&issue.id].repositories["source-repo"].phase,
+            DeliveryPhase::Prepared
+        );
+        assert_eq!(state.finalize[&issue.id].status, FinalizeStatus::InProgress);
+        assert!(remote.mutation_phases.lock().unwrap().is_empty());
+        drop(state);
+        let durable = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue(&issue.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            durable.delivery.unwrap().repositories["source-repo"].phase,
+            DeliveryPhase::Prepared
+        );
+
+        orchestrator.reconcile_and_recover_deliveries().await;
+
+        let state = orchestrator.state.read().await;
+        let delivery = state.delivery.get(&issue.id).expect("delivery owner");
+        assert!(delivery.terminal_history.is_some());
+        assert_eq!(
+            delivery.repositories["source-repo"].phase,
+            DeliveryPhase::Waiting
+        );
+        drop(state);
+        assert_eq!(
+            *remote.mutation_phases.lock().unwrap(),
+            vec![DeliveryPhase::PushInFlight, DeliveryPhase::PrCreateInFlight,]
+        );
+
+        tracker_issues.write().await[0].state = "Done".to_string();
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.delivery.contains_key(&issue.id));
+        assert!(!state.is_claimed(&issue.id));
+        assert!(state.completed.contains_key(&issue.id));
+        drop(state);
+        let history = orchestrator
+            .history_store
+            .as_ref()
+            .unwrap()
+            .read_history(&crate::history::reader::HistoryQuery::default())
+            .await
+            .unwrap();
+        assert_eq!(history.total, 1);
+        assert_eq!(history.records[0].outcome, HISTORY_OUTCOME_SUCCEEDED);
 
         drop(repo_temp);
     }
@@ -10091,6 +10379,7 @@ mod tests {
                 DeliveryRepository {
                     mode: DeliveryMode::PushAndPr,
                     phase: DeliveryPhase::PrCreateInFlight,
+                    approval_required: false,
                     remote: "origin".to_string(),
                     base_branch: "main".to_string(),
                     head_branch: "ensemble/repo-1".to_string(),
@@ -11031,6 +11320,7 @@ mod tests {
                 DeliveryRepository {
                     mode: DeliveryMode::PushAndPr,
                     phase: DeliveryPhase::PrCreateInFlight,
+                    approval_required: false,
                     remote: "origin".to_string(),
                     base_branch: "main".to_string(),
                     head_branch: "ensemble/repo-1".to_string(),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6267,19 +6267,32 @@ impl Orchestrator {
             return;
         }
 
-        if let Err(error) = self
-            .pipeline_journal
-            .append_released(
-                issue_id,
-                &pending.identifier,
-                pending.run_id.clone(),
-                "terminal tracker transition reconciled",
-            )
-            .await
-        {
+        let pipeline_journal = self.pipeline_journal.clone();
+        let release_issue_id = issue_id.to_string();
+        let release_identifier = pending.identifier.clone();
+        let release_run_id = pending.run_id.clone();
+        // Keep the journal append on a fresh poll stack: after workspace cleanup, this terminal
+        // transition chain is deep enough to exhaust a Tokio worker stack when appended inline.
+        let release_result = tokio::spawn(async move {
+            pipeline_journal
+                .append_released(
+                    &release_issue_id,
+                    &release_identifier,
+                    release_run_id,
+                    "terminal tracker transition reconciled",
+                )
+                .await
+        })
+        .await;
+        let release_error = match release_result {
+            Ok(Ok(_)) => None,
+            Ok(Err(error)) => Some(error.to_string()),
+            Err(error) => Some(format!("pipeline release task failed: {error}")),
+        };
+        if let Some(error) = release_error {
             warn!(
                 issue_id = %issue_id,
-                error = %error,
+                error,
                 "failed to persist pipeline release after terminal tracker transition"
             );
             return;

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -11288,7 +11288,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_terminal_cleanup_does_not_resume_delivery_recovery() {
+    async fn failed_terminal_cleanup_blocks_delivery_recovery_and_finalize_commands() {
         let remote = Arc::new(RecoveryDeliveryRemote {
             pull_requests: std::sync::Mutex::new(Vec::new()),
             pushes: AtomicUsize::new(0),
@@ -11358,6 +11358,54 @@ mod tests {
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+        drop(state);
+
+        {
+            let mut state = orchestrator.state.write().await;
+            let repository = state
+                .delivery
+                .get_mut("1")
+                .unwrap()
+                .repositories
+                .get_mut("source-repo")
+                .unwrap();
+            repository.approval_required = true;
+            repository.phase = DeliveryPhase::AwaitingApproval;
+        }
+        assert_eq!(
+            orchestrator
+                .approve_finalize_delivery("1", &delivery.identifier)
+                .await,
+            Err(FinalizeApprovalError::NotAwaitingApproval)
+        );
+        {
+            let mut state = orchestrator.state.write().await;
+            let repository = state
+                .delivery
+                .get_mut("1")
+                .unwrap()
+                .repositories
+                .get_mut("source-repo")
+                .unwrap();
+            repository.phase = DeliveryPhase::Blocked;
+            repository.retry_from = Some(DeliveryPhase::Prepared);
+        }
+        assert_eq!(
+            orchestrator
+                .retry_finalize_delivery("1", &delivery.identifier)
+                .await,
+            Err(FinalizeRetryError::NotFailed)
+        );
+        assert_eq!(
+            orchestrator
+                .pipeline_journal
+                .latest_live_record_for_issue("1")
+                .await
+                .unwrap()
+                .unwrap()
+                .kind,
+            PipelineTransitionKind::PendingTerminalTransition
+        );
     }
 
     fn delivery_restart_orchestrator(

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6344,6 +6344,12 @@ impl Orchestrator {
                 .clear_terminal_interaction_waiting_state(issue_id)
                 .await
             {
+                self.record_pending_terminal_transition_failure(
+                    issue_id,
+                    &pending,
+                    error.to_string(),
+                )
+                .await;
                 warn!(
                     issue_id = %issue_id,
                     error = %error,
@@ -7060,8 +7066,10 @@ impl Orchestrator {
             .advance_delivery_record(delivery, &workspace, snapshot.as_ref())
             .await;
         let delivery = self.advance_review_projection(delivery).await;
-        let terminal_history = delivery.terminal_history.as_deref().cloned();
         self.project_delivery_artifacts(issue_id, &delivery).await;
+        let terminal_history = self
+            .projected_terminal_history(&delivery, HISTORY_OUTCOME_SUCCEEDED)
+            .await;
 
         let (final_status, should_complete, last_error) = {
             let mut state = self.state.write().await;
@@ -11258,6 +11266,18 @@ mod tests {
         repository.pr_url = None;
         delivery.terminal_history.as_deref_mut().unwrap().outcome =
             HISTORY_OUTCOME_SUCCEEDED.to_string();
+        let run_id = delivery.run_id.clone();
+        delivery.terminal_history.as_deref_mut().unwrap().artifacts =
+            Some(crate::history::artifacts::RunArtifacts {
+                run_id,
+                workspace_path: "/tmp/ensemble-test".to_string(),
+                repos: vec![crate::history::artifacts::RepoArtifact {
+                    repo: "source-repo".to_string(),
+                    finalize_status: "pending".to_string(),
+                    ..Default::default()
+                }],
+                transcripts: Vec::new(),
+            });
         let snapshot = {
             let config = orchestrator.config.read().await;
             let dag = build_dag(&config.steps).unwrap();
@@ -11307,6 +11327,12 @@ mod tests {
         assert_eq!(history.total, 1);
         assert_eq!(history.records[0].issue_id, delivery.issue_id);
         assert_eq!(history.records[0].outcome, HISTORY_OUTCOME_SUCCEEDED);
+        let artifact = &history.records[0].artifacts.as_ref().unwrap().repos[0];
+        assert_eq!(artifact.finalize_status, "succeeded");
+        assert_eq!(
+            artifact.pushed_ref.as_deref(),
+            Some("origin/ensemble/repo-1")
+        );
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
     }
@@ -11526,6 +11552,63 @@ mod tests {
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn terminal_interaction_cleanup_failure_uses_persisted_retry_backoff() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
+        repository.last_error = None;
+        let snapshot = {
+            let config = orchestrator.config.read().await;
+            let dag = build_dag(&config.steps).unwrap();
+            let run = PipelineRun::new(delivery.issue_id.clone(), 1, dag);
+            run.start();
+            run.to_snapshot()
+        };
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        orchestrator.tracker = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Done")])),
+        });
+        orchestrator
+            .interaction_store
+            .create(test_question_interaction(
+                &test_issue("1", "Done"),
+                1,
+                "terminal-interaction",
+            ))
+            .await
+            .unwrap();
+        orchestrator.interaction_store.fail_next_writes(1);
+
+        Box::pin(orchestrator.handle_tick()).await;
+        Box::pin(orchestrator.handle_tick()).await;
+
+        let state = orchestrator.state.read().await;
+        let pending = &state.pending_terminal_transitions["1"];
+        assert_eq!(pending.transition.attempt, 1);
+        assert!(pending
+            .transition
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("injected interaction write failure")));
+        assert!(pending.transition.last_attempted_at.is_some());
+        assert!(state.delivery.contains_key("1"));
+        assert!(state.is_claimed("1"));
+        assert!(!state.completed.contains_key("1"));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6770,10 +6770,24 @@ impl Orchestrator {
                 )
                 .await;
             let persisted = match prepared {
-                Ok((delivery, snapshot)) => self
-                    .persist_delivery_record(&delivery, snapshot.as_ref())
-                    .await
-                    .map(|()| (delivery, snapshot)),
+                Ok((delivery, snapshot)) => {
+                    match self
+                        .persist_delivery_record(&delivery, snapshot.as_ref())
+                        .await
+                    {
+                        Ok(()) => Ok((delivery, snapshot)),
+                        Err(error) => {
+                            if let Some(history) = delivery.terminal_history.as_deref().cloned() {
+                                self.state
+                                    .write()
+                                    .await
+                                    .finalize_terminal_history
+                                    .insert(issue_id.to_string(), history);
+                            }
+                            Err(error)
+                        }
+                    }
+                }
                 Err(error) => Err(error),
             };
             match persisted {
@@ -10719,7 +10733,7 @@ mod tests {
             WorkspaceManager::new(workspace_temp.path(), Some(vec![repo_config])).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
         let mut orchestrator = Orchestrator::new(
-            config,
+            Arc::clone(&config),
             tracker,
             runner,
             workspace_mgr,
@@ -10728,25 +10742,38 @@ mod tests {
         );
         orchestrator.delivery_remote = remote.clone();
         {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut run = PipelineRun::new("1".to_string(), 1, dag);
+            run.start();
+            run.mark_running("build", "session-1".to_string());
+            run.step_completed("build", succeeded_step_output(), false);
             let mut state = orchestrator.state.write().await;
-            state.claimed.insert("1".to_string());
-            state
-                .issue_run_ids
-                .insert("1".to_string(), "run-1".to_string());
-            state.set_finalize_state(
-                "1",
-                IssueFinalizeState {
-                    issue_identifier: "repo#1".to_string(),
-                    status: FinalizeStatus::Failed,
-                    repos: vec![RepoFinalizeState {
-                        repo: "source-repo".to_string(),
-                        mode: "push_and_pr".to_string(),
-                        approval_required: true,
-                        status: FinalizeStatus::Failed,
-                        last_error: Some("initial delivery persistence failed".to_string()),
-                    }],
-                },
-            );
+            state.add_running(&test_issue("1", "Todo"), None);
+            state.insert_pipeline_run("1", run, Arc::new(cfg.clone()));
+        }
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 1));
+        let config_snapshot = config.read().await.clone();
+        let finalize = orchestrator
+            .run_finalize_phase("1", "repo#1", &config_snapshot)
+            .await;
+        assert_eq!(finalize.status, FinalizeStatus::Failed);
+        assert!(orchestrator
+            .state
+            .read()
+            .await
+            .finalize_terminal_history
+            .contains_key("1"));
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = None;
+        {
+            let mut state = orchestrator.state.write().await;
+            state.remove_running("1");
+            state.remove_pipeline_run("1");
+            state.set_finalize_state("1", finalize);
         }
 
         orchestrator
@@ -10766,6 +10793,8 @@ mod tests {
             state.delivery["1"].repositories["source-repo"].phase,
             DeliveryPhase::AwaitingApproval
         );
+        assert!(state.delivery["1"].terminal_history.is_some());
+        assert!(!state.finalize_terminal_history.contains_key("1"));
         drop(state);
         assert_eq!(
             orchestrator.approve_finalize_delivery("1", "repo#1").await,

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -87,9 +87,9 @@ use reconciler::{
     startup_terminal_cleanup, ReconcileAction,
 };
 use retry::{
-    current_time_ms, defer_retry, get_due_retries, next_attempt, queue_manual_step_retry,
-    queue_manual_whole_issue_retry, schedule_failure_retry, FailureRetryDisposition,
-    FailureRetryRequest, ManualStepRetryError, ManualStepRetryRequest,
+    calculate_backoff, current_time_ms, defer_retry, get_due_retries, next_attempt,
+    queue_manual_step_retry, queue_manual_whole_issue_retry, schedule_failure_retry,
+    FailureRetryDisposition, FailureRetryRequest, ManualStepRetryError, ManualStepRetryRequest,
     ManualWholeIssueRetryRequest,
 };
 use scheduler::{
@@ -170,6 +170,22 @@ impl Drop for PendingWorkerReservation {
 }
 
 const INTERACTION_RESUME_REASON_PREFIX: &str = "interaction_resume:";
+
+fn terminal_transition_retry_due(
+    transition: &PendingTerminalTransition,
+    max_backoff_ms: u64,
+    now: chrono::DateTime<Utc>,
+) -> bool {
+    let Some(last_attempted_at) = transition.last_attempted_at else {
+        return true;
+    };
+    let elapsed_ms = now
+        .signed_duration_since(last_attempted_at)
+        .num_milliseconds();
+    let delay_ms =
+        i64::try_from(calculate_backoff(transition.attempt, max_backoff_ms)).unwrap_or(i64::MAX);
+    elapsed_ms >= delay_ms
+}
 
 fn interaction_id_from_resume_reason(reason: Option<&str>) -> Option<&str> {
     reason?.strip_prefix(INTERACTION_RESUME_REASON_PREFIX)
@@ -6087,6 +6103,10 @@ impl Orchestrator {
         };
 
         if pending.transition.tracker_write_confirmed {
+            let max_backoff_ms = self.config.read().await.agent.max_retry_backoff_ms;
+            if !terminal_transition_retry_due(&pending.transition, max_backoff_ms, Utc::now()) {
+                return;
+            }
             self.complete_pending_terminal_transition(issue_id, pending.run_id)
                 .await;
             return;
@@ -6117,38 +6137,12 @@ impl Orchestrator {
                     .await;
             }
             Err(error) => {
-                let refreshed_input = {
-                    let mut state = self.state.write().await;
-                    let Some(current) = state.pending_terminal_transitions.get_mut(issue_id) else {
-                        return;
-                    };
-                    if current.run_id != pending.run_id
-                        || current.transition.target_state != pending.transition.target_state
-                        || current.transition.outcome != pending.transition.outcome
-                    {
-                        return;
-                    }
-                    current.transition.attempt = current.transition.attempt.saturating_add(1);
-                    current.transition.last_error = Some(error.to_string());
-                    current.transition.last_attempted_at = Some(Utc::now());
-                    let current = current.clone();
-                    Self::pending_terminal_transition_input(
-                        &state,
-                        issue_id,
-                        &current,
-                        PipelineTransitionKind::PendingTerminalTransition,
-                    )
-                };
-
-                if let Some(input) = refreshed_input {
-                    if let Err(journal_error) = self.pipeline_journal.append(input).await {
-                        warn!(
-                            issue_id = %issue_id,
-                            error = %journal_error,
-                            "failed to refresh pending terminal transition retry metadata"
-                        );
-                    }
-                }
+                self.record_pending_terminal_transition_failure(
+                    issue_id,
+                    &pending,
+                    error.to_string(),
+                )
+                .await;
                 warn!(
                     issue_id = %issue_id,
                     target_state = %pending.transition.target_state,
@@ -6177,7 +6171,7 @@ impl Orchestrator {
             }
 
             let mut confirmed = current.clone();
-            confirmed.transition.tracker_write_confirmed = true;
+            confirmed.transition.confirm_tracker_write();
             let Some(input) = Self::pending_terminal_transition_input(
                 &state,
                 issue_id,
@@ -6209,7 +6203,7 @@ impl Orchestrator {
             {
                 return;
             }
-            current.transition.tracker_write_confirmed = true;
+            current.transition.confirm_tracker_write();
         }
 
         self.complete_pending_terminal_transition(issue_id, expected.run_id.clone())
@@ -6261,6 +6255,18 @@ impl Orchestrator {
             }
         }
 
+        if let Err(error) = self.workspace_mgr.remove_workspace(issue_id).await {
+            self.record_pending_terminal_transition_failure(issue_id, &pending, error.to_string())
+                .await;
+            warn!(
+                issue_id = %issue_id,
+                identifier = %pending.identifier,
+                error = %error,
+                "failed to clean terminal workspace before release"
+            );
+            return;
+        }
+
         if let Err(error) = self
             .pipeline_journal
             .append_released(
@@ -6303,6 +6309,46 @@ impl Orchestrator {
             state.release_claim(issue_id);
             state.remove_pipeline_run(issue_id);
             state.clear_finalize_state(issue_id);
+        }
+    }
+
+    async fn record_pending_terminal_transition_failure(
+        &self,
+        issue_id: &str,
+        expected: &PendingTerminalEntry,
+        error: String,
+    ) {
+        let refreshed_input = {
+            let mut state = self.state.write().await;
+            let Some(current) = state.pending_terminal_transitions.get_mut(issue_id) else {
+                return;
+            };
+            if current.run_id != expected.run_id
+                || current.transition.target_state != expected.transition.target_state
+                || current.transition.outcome != expected.transition.outcome
+            {
+                return;
+            }
+            current.transition.attempt = current.transition.attempt.saturating_add(1);
+            current.transition.last_error = Some(error);
+            current.transition.last_attempted_at = Some(Utc::now());
+            let current = current.clone();
+            Self::pending_terminal_transition_input(
+                &state,
+                issue_id,
+                &current,
+                PipelineTransitionKind::PendingTerminalTransition,
+            )
+        };
+
+        if let Some(input) = refreshed_input {
+            if let Err(journal_error) = self.pipeline_journal.append(input).await {
+                warn!(
+                    issue_id = %issue_id,
+                    error = %journal_error,
+                    "failed to refresh pending terminal transition retry metadata"
+                );
+            }
         }
     }
 
@@ -17517,6 +17563,7 @@ agent:
         let original_agent = original_config.steps[0].agent.clone();
         let mut current_config = original_config.clone();
         current_config.steps[0].agent = "replacement-agent".to_string();
+        let max_retry_backoff_ms = current_config.agent.max_retry_backoff_ms;
         let config = Arc::new(RwLock::new(current_config));
         let issue = test_issue("1", "Todo");
         let failures_remaining = Arc::new(RwLock::new(1));
@@ -17531,11 +17578,18 @@ agent:
             runs: Arc::clone(&agent_runs),
         });
         let workspace_mgr = WorkspaceManager::new(config_dir.path(), None).unwrap();
+        workspace_mgr
+            .prepare_workspace(&issue.id, &issue.identifier)
+            .await
+            .unwrap();
+        let workspace_path = workspace_mgr.workspace_path(&issue.id);
+        let metadata_path = workspace_mgr.metadata_path_for_test(&issue.id);
+        let original_metadata = std::fs::read_to_string(&metadata_path).unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
         let orchestrator = Orchestrator::new(
             Arc::clone(&config),
-            tracker,
-            runner,
+            Arc::clone(&tracker),
+            Arc::clone(&runner),
             workspace_mgr,
             config_dir.path(),
             shutdown_rx,
@@ -17592,10 +17646,85 @@ agent:
             assert!(!state.completed.contains_key("1"));
         }
         assert_eq!(agent_runs.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(workspace_path.exists());
 
+        std::fs::write(&metadata_path, "{not-json").unwrap();
         orchestrator.handle_tick().await;
 
-        let state = orchestrator.state.read().await;
+        {
+            let state = orchestrator.state.read().await;
+            assert!(state.is_claimed("1"));
+            assert!(state.get_pipeline_run("1").is_some());
+            let pending = state.pending_terminal_transitions.get("1").unwrap();
+            assert!(pending.transition.tracker_write_confirmed);
+            assert_eq!(pending.transition.attempt, 1);
+            assert!(pending.transition.last_attempted_at.is_some());
+            assert!(pending.transition.last_error.is_some());
+            assert!(!state.completed.contains_key("1"));
+        }
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        assert!(!records
+            .iter()
+            .any(|record| record.kind == PipelineTransitionKind::Released));
+        assert!(workspace_path.exists());
+
+        std::fs::write(&metadata_path, original_metadata).unwrap();
+        drop(orchestrator);
+
+        let workspace_mgr = WorkspaceManager::new(config_dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let recovered = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            config_dir.path(),
+            shutdown_rx,
+        );
+        recovered.restore_pipeline_runs_from_journal().await;
+        let restored_pending = {
+            let mut state = recovered.state.write().await;
+            let pending = state.pending_terminal_transitions.get_mut("1").unwrap();
+            let restored = pending.transition.clone();
+            pending.transition.last_attempted_at = Some(Utc::now() + chrono::Duration::minutes(1));
+            restored
+        };
+        assert!(restored_pending.tracker_write_confirmed);
+        assert_eq!(restored_pending.attempt, 1);
+        assert!(restored_pending.last_attempted_at.is_some());
+        assert!(restored_pending.last_error.is_some());
+
+        recovered.handle_tick().await;
+        assert!(workspace_path.exists());
+        let restored_records = recovered
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        assert!(!restored_records
+            .iter()
+            .any(|record| record.kind == PipelineTransitionKind::Released));
+
+        let elapsed_backoff_ms =
+            calculate_backoff(restored_pending.attempt, max_retry_backoff_ms) + 1;
+        let retry_due_at =
+            Utc::now() - chrono::Duration::milliseconds(i64::try_from(elapsed_backoff_ms).unwrap());
+        recovered
+            .state
+            .write()
+            .await
+            .pending_terminal_transitions
+            .get_mut("1")
+            .unwrap()
+            .transition
+            .last_attempted_at = Some(retry_due_at);
+        recovered.handle_tick().await;
+
+        let state = recovered.state.read().await;
         assert!(!state.is_claimed("1"));
         assert!(state.pending_terminal_transitions.get("1").is_none());
         assert!(state.get_pipeline_run("1").is_none());
@@ -17611,8 +17740,9 @@ agent:
             ]
         );
         assert_eq!(agent_runs.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(!workspace_path.exists());
 
-        let records = orchestrator
+        let records = recovered
             .pipeline_journal
             .read_records_for_issue("1")
             .await

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -6357,6 +6357,12 @@ impl Orchestrator {
                     .persist_history_record(pending.run_id.as_deref(), record)
                     .await
                 {
+                    self.record_pending_terminal_transition_failure(
+                        issue_id,
+                        &pending,
+                        error.to_string(),
+                    )
+                    .await;
                     warn!(
                         issue_id = %issue_id,
                         error = %error,
@@ -11429,7 +11435,10 @@ mod tests {
         assert!(state.delivery.contains_key("1"));
         assert!(state.is_claimed("1"));
         assert!(!state.completed.contains_key("1"));
-        assert!(state.pending_terminal_transitions.contains_key("1"));
+        let pending = &state.pending_terminal_transitions["1"];
+        assert_eq!(pending.transition.attempt, 1);
+        assert!(pending.transition.last_error.is_some());
+        assert!(pending.transition.last_attempted_at.is_some());
         drop(state);
         assert!(workspace.base_path.exists());
         let records = orchestrator
@@ -11439,7 +11448,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             records.last().map(|record| record.kind),
-            Some(PipelineTransitionKind::TerminalTransitionApplied)
+            Some(PipelineTransitionKind::PendingTerminalTransition)
         );
         assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -276,7 +276,7 @@ pub(crate) enum OrchestratorCommand {
     },
     ApproveFinalize {
         command: FinalizeApprovalCommand,
-        response: tokio::sync::oneshot::Sender<Result<(), FinalizeApprovalError>>,
+        response: tokio::sync::oneshot::Sender<Result<bool, FinalizeApprovalError>>,
     },
     RetryFinalize {
         command: FinalizeRetryCommand,
@@ -10120,7 +10120,7 @@ mod tests {
         );
 
         orchestrator.pipeline_journal.transaction_append_late_error = true;
-        for _ in 0..2 {
+        for newly_approved in [true, false] {
             let (response, result) = tokio::sync::oneshot::channel();
             orchestrator
                 .handle_command(OrchestratorCommand::ApproveFinalize {
@@ -10131,7 +10131,7 @@ mod tests {
                     response,
                 })
                 .await;
-            assert_eq!(result.await.unwrap(), Ok(()));
+            assert_eq!(result.await.unwrap(), Ok(newly_approved));
         }
         orchestrator.pipeline_journal.transaction_append_late_error = false;
 

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -626,6 +626,7 @@ mod tests {
                 DeliveryRepository {
                     mode: DeliveryMode::PushAndPr,
                     phase: DeliveryPhase::Prepared,
+                    approval_required: false,
                     remote: "origin".to_string(),
                     base_branch: "main".to_string(),
                     head_branch: "ensemble/repo-1".to_string(),

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -305,7 +305,11 @@ impl PipelineRunJournal {
             return Err(write_error);
         }
         file.flush().await?;
-        if record.kind == PipelineTransitionKind::DeliveryOwned {
+        if matches!(
+            record.kind,
+            PipelineTransitionKind::DeliveryOwned
+                | PipelineTransitionKind::TerminalTransitionApplied
+        ) {
             file.sync_data().await?;
         }
         Ok(record)

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -19,6 +19,16 @@ type IssueAppendLock = tokio::sync::Mutex<()>;
 type IssueAppendLockRegistry = Mutex<HashMap<PathBuf, Weak<IssueAppendLock>>>;
 static ISSUE_APPEND_LOCKS: OnceLock<IssueAppendLockRegistry> = OnceLock::new();
 
+fn requires_durable_sync(kind: PipelineTransitionKind, created: bool) -> bool {
+    created
+        || matches!(
+            kind,
+            PipelineTransitionKind::DeliveryOwned
+                | PipelineTransitionKind::PendingTerminalTransition
+                | PipelineTransitionKind::TerminalTransitionApplied
+        )
+}
+
 pub(crate) struct PipelineIssueJournalTransaction<'a> {
     journal: &'a PipelineRunJournal,
     issue_id: String,
@@ -263,6 +273,11 @@ impl PipelineRunJournal {
         tokio::fs::create_dir_all(&self.root).await?;
         let path = self.path_for_issue(&input.issue_id);
         self.repair_trailing_record(&path).await?;
+        let created = match tokio::fs::metadata(&path).await {
+            Ok(_) => false,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+            Err(error) => return Err(error),
+        };
         let seq = self
             .read_last_valid_record(&path)
             .await?
@@ -305,12 +320,11 @@ impl PipelineRunJournal {
             return Err(write_error);
         }
         file.flush().await?;
-        if matches!(
-            record.kind,
-            PipelineTransitionKind::DeliveryOwned
-                | PipelineTransitionKind::TerminalTransitionApplied
-        ) {
+        if requires_durable_sync(record.kind, created) {
             file.sync_data().await?;
+        }
+        if created {
+            tokio::fs::File::open(&self.root).await?.sync_all().await?;
         }
         Ok(record)
     }
@@ -594,6 +608,22 @@ mod tests {
     use crate::pipeline::engine::{PipelineRun, StepState};
     use tempfile::tempdir;
     use tokio::io::AsyncWriteExt;
+
+    #[test]
+    fn pending_terminal_intent_requires_durable_sync() {
+        assert!(requires_durable_sync(
+            PipelineTransitionKind::PendingTerminalTransition,
+            false,
+        ));
+    }
+
+    #[test]
+    fn newly_created_journal_requires_durable_sync() {
+        assert!(requires_durable_sync(
+            PipelineTransitionKind::RunStarted,
+            true,
+        ));
+    }
 
     fn step(name: &str, depends: Option<Vec<String>>) -> StepConfig {
         StepConfig {

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -640,6 +640,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            terminal_history: None,
             review_projection: None,
         };
 

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -132,6 +132,15 @@ pub struct PendingTerminalTransition {
     pub history_record: Option<HistoryRecord>,
 }
 
+impl PendingTerminalTransition {
+    pub(crate) fn confirm_tracker_write(&mut self) {
+        self.tracker_write_confirmed = true;
+        self.attempt = 0;
+        self.last_error = None;
+        self.last_attempted_at = None;
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PipelineTransitionRecord {
     pub schema_version: u32,

--- a/crates/ensemble-core/src/orchestrator/reconciler.rs
+++ b/crates/ensemble-core/src/orchestrator/reconciler.rs
@@ -94,12 +94,6 @@ pub async fn reconcile_tracker_states(
             tracked_ids.push(issue_id.clone());
         }
     }
-    for issue_id in state.delivery.keys() {
-        if !tracked_ids.contains(issue_id) {
-            tracked_ids.push(issue_id.clone());
-        }
-    }
-
     if tracked_ids.is_empty() {
         return ReconcileTrackerResult {
             updates: vec![],

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -1467,6 +1467,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            terminal_history: None,
             review_projection: None,
         };
         state

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -1453,6 +1453,7 @@ mod tests {
                 DeliveryRepository {
                     mode: DeliveryMode::PushAndPr,
                     phase: DeliveryPhase::Waiting,
+                    approval_required: false,
                     remote: "origin".to_string(),
                     base_branch: "main".to_string(),
                     head_branch: "ensemble/repo-1".to_string(),

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -151,6 +151,8 @@ pub struct OrchestratorState {
     pub pipeline_runs: HashMap<String, PipelineRun>,
     /// Finalization state for issues that have finished pipeline execution.
     pub finalize: HashMap<String, IssueFinalizeState>,
+    /// Completion history retained while an initial delivery owner is retried.
+    pub(crate) finalize_terminal_history: HashMap<String, crate::history::model::HistoryRecord>,
     /// Durable remote-publication owners that no longer consume worker capacity.
     pub(crate) delivery: HashMap<String, DeliveryRecord>,
     /// Terminal tracker writes that must reconcile before local run release.
@@ -198,6 +200,7 @@ impl OrchestratorState {
             agent_rate_limits: None,
             pipeline_runs: HashMap::new(),
             finalize: HashMap::new(),
+            finalize_terminal_history: HashMap::new(),
             delivery: HashMap::new(),
             pending_terminal_transitions: HashMap::new(),
             artifacts: HashMap::new(),
@@ -383,6 +386,7 @@ impl OrchestratorState {
         self.resume_requested.remove(issue_id);
         self.pipeline_configs.remove(issue_id);
         self.finalize.remove(issue_id);
+        self.finalize_terminal_history.remove(issue_id);
         self.delivery.remove(issue_id);
         self.pending_terminal_transitions.remove(issue_id);
         self.artifacts.remove(issue_id);
@@ -406,6 +410,7 @@ impl OrchestratorState {
 
     pub fn clear_finalize_state(&mut self, issue_id: &str) {
         self.finalize.remove(issue_id);
+        self.finalize_terminal_history.remove(issue_id);
     }
 
     /// Update session metadata on a running entry.

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -226,6 +226,20 @@ impl WorkspaceManager {
         Ok(file)
     }
 
+    #[cfg(unix)]
+    fn sync_metadata_directory(&self) -> Result<(), WorkspaceError> {
+        std::fs::File::open(self.metadata_dir())
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| WorkspaceError::CreationFailed {
+                reason: format!("failed to flush workspace metadata directory: {error}"),
+            })
+    }
+
+    #[cfg(not(unix))]
+    fn sync_metadata_directory(&self) -> Result<(), WorkspaceError> {
+        Ok(())
+    }
+
     fn create_metadata(
         &self,
         issue_id: &str,
@@ -250,7 +264,7 @@ impl WorkspaceManager {
             .map_err(|error| WorkspaceError::CreationFailed {
                 reason: format!("failed to create workspace metadata: {}", error.error),
             })?;
-        Ok(())
+        self.sync_metadata_directory()
     }
 
     fn refresh_metadata(&self, metadata: &WorkspaceMetadata) -> Result<(), WorkspaceError> {
@@ -260,7 +274,7 @@ impl WorkspaceManager {
             .map_err(|error| WorkspaceError::CreationFailed {
                 reason: format!("failed to refresh workspace metadata: {}", error.error),
             })?;
-        Ok(())
+        self.sync_metadata_directory()
     }
 
     fn verify_ownership(

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -139,6 +139,11 @@ impl WorkspaceManager {
             .join(format!("{}.json", issue_workspace_key(issue_id)))
     }
 
+    #[cfg(test)]
+    pub(crate) fn metadata_path_for_test(&self, issue_id: &str) -> PathBuf {
+        self.metadata_path(issue_id)
+    }
+
     fn lifecycle_lock(&self, workspace_key: &str) -> Arc<WorkspaceLifecycleLock> {
         let canonical_root = Self::canonicalize_allow_missing(&self.root);
         let path = canonical_root.join(workspace_key);

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -25,7 +25,7 @@ struct WorkspaceMetadata {
     #[serde(default)]
     repositories: BTreeMap<String, String>,
     #[serde(default)]
-    before_remove_completed: bool,
+    before_remove_started: bool,
 }
 
 /// Manage per-issue workspace directories.
@@ -243,7 +243,7 @@ impl WorkspaceManager {
             issue_identifier: identifier.to_string(),
             branch_date: date.to_string(),
             repositories: self.repository_identities(),
-            before_remove_completed: false,
+            before_remove_started: false,
         })?;
         self.write_metadata_temp(&content)?
             .persist_noclobber(self.metadata_path(issue_id))
@@ -375,7 +375,7 @@ impl WorkspaceManager {
                     issue_identifier: identifier.to_string(),
                     branch_date,
                     repositories: self.repository_identities(),
-                    before_remove_completed: false,
+                    before_remove_started: false,
                 },
                 Err(create_error) => match self.load_metadata(issue_id) {
                     Ok(mut existing) => {
@@ -522,11 +522,11 @@ impl WorkspaceManager {
             .hooks
             .before_remove
             .as_ref()
-            .filter(|_| !metadata.before_remove_completed)
+            .filter(|_| !metadata.before_remove_started)
         {
-            run_hook_best_effort("before_remove", script, &base_path, self.hooks.timeout_ms).await;
-            metadata.before_remove_completed = true;
+            metadata.before_remove_started = true;
             self.refresh_metadata(&metadata)?;
+            run_hook_best_effort("before_remove", script, &base_path, self.hooks.timeout_ms).await;
         }
 
         // Clean up worktrees first - use persisted branch date to avoid date drift
@@ -1435,7 +1435,7 @@ mod tests {
         assert!(
             mgr.load_metadata("NODE_CLEANUP")
                 .unwrap()
-                .before_remove_completed
+                .before_remove_started
         );
     }
 

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -28,6 +28,11 @@ struct WorkspaceMetadata {
     before_remove_started: bool,
 }
 
+enum MetadataCreation {
+    Created(WorkspaceMetadata),
+    AlreadyExists,
+}
+
 /// Manage per-issue workspace directories.
 pub struct WorkspaceManager {
     root: PathBuf,
@@ -37,6 +42,8 @@ pub struct WorkspaceManager {
     preparation_test_barriers: Option<(Arc<tokio::sync::Barrier>, Arc<tokio::sync::Barrier>)>,
     #[cfg(test)]
     removal_test_barriers: Option<(Arc<tokio::sync::Barrier>, Arc<tokio::sync::Barrier>)>,
+    #[cfg(test)]
+    fail_metadata_directory_sync: bool,
 }
 
 /// Result of preparing a workspace for an issue.
@@ -104,6 +111,8 @@ impl WorkspaceManager {
             preparation_test_barriers: None,
             #[cfg(test)]
             removal_test_barriers: None,
+            #[cfg(test)]
+            fail_metadata_directory_sync: false,
         })
     }
 
@@ -228,6 +237,12 @@ impl WorkspaceManager {
 
     #[cfg(unix)]
     fn sync_metadata_directory(&self) -> Result<(), WorkspaceError> {
+        #[cfg(test)]
+        if self.fail_metadata_directory_sync {
+            return Err(WorkspaceError::CreationFailed {
+                reason: "injected workspace metadata directory sync failure".to_string(),
+            });
+        }
         std::fs::File::open(self.metadata_dir())
             .and_then(|directory| directory.sync_all())
             .map_err(|error| WorkspaceError::CreationFailed {
@@ -237,6 +252,12 @@ impl WorkspaceManager {
 
     #[cfg(not(unix))]
     fn sync_metadata_directory(&self) -> Result<(), WorkspaceError> {
+        #[cfg(test)]
+        if self.fail_metadata_directory_sync {
+            return Err(WorkspaceError::CreationFailed {
+                reason: "injected workspace metadata directory sync failure".to_string(),
+            });
+        }
         Ok(())
     }
 
@@ -245,26 +266,36 @@ impl WorkspaceManager {
         issue_id: &str,
         identifier: &str,
         date: &str,
-    ) -> Result<(), WorkspaceError> {
+    ) -> Result<MetadataCreation, WorkspaceError> {
         let metadata_dir = self.metadata_dir();
         std::fs::create_dir_all(&metadata_dir).map_err(|error| WorkspaceError::CreationFailed {
             reason: format!("failed to create workspace metadata directory: {error}"),
         })?;
         self.validate_path_inside_root(&metadata_dir)?;
 
-        let content = Self::serialize_metadata(&WorkspaceMetadata {
+        let metadata = WorkspaceMetadata {
             issue_id: issue_id.to_string(),
             issue_identifier: identifier.to_string(),
             branch_date: date.to_string(),
             repositories: self.repository_identities(),
             before_remove_started: false,
-        })?;
-        self.write_metadata_temp(&content)?
+        };
+        let content = Self::serialize_metadata(&metadata)?;
+        match self
+            .write_metadata_temp(&content)?
             .persist_noclobber(self.metadata_path(issue_id))
-            .map_err(|error| WorkspaceError::CreationFailed {
+        {
+            Ok(_) => {
+                self.sync_metadata_directory()?;
+                Ok(MetadataCreation::Created(metadata))
+            }
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                Ok(MetadataCreation::AlreadyExists)
+            }
+            Err(error) => Err(WorkspaceError::CreationFailed {
                 reason: format!("failed to create workspace metadata: {}", error.error),
-            })?;
-        self.sync_metadata_directory()
+            }),
+        }
     }
 
     fn refresh_metadata(&self, metadata: &WorkspaceMetadata) -> Result<(), WorkspaceError> {
@@ -384,14 +415,8 @@ impl WorkspaceManager {
             })?;
             let branch_date = chrono::Local::now().format("%Y-%m-%d").to_string();
             let metadata = match self.create_metadata(issue_id, identifier, &branch_date) {
-                Ok(()) => WorkspaceMetadata {
-                    issue_id: issue_id.to_string(),
-                    issue_identifier: identifier.to_string(),
-                    branch_date,
-                    repositories: self.repository_identities(),
-                    before_remove_started: false,
-                },
-                Err(create_error) => match self.load_metadata(issue_id) {
+                Ok(MetadataCreation::Created(metadata)) => metadata,
+                Ok(MetadataCreation::AlreadyExists) => match self.load_metadata(issue_id) {
                     Ok(mut existing) => {
                         if let Err(error) = Self::verify_ownership(
                             &self.metadata_path(issue_id),
@@ -418,15 +443,14 @@ impl WorkspaceManager {
                         existing
                     }
                     Err(load_error) => {
-                        let metadata_exists = self.metadata_path(issue_id).exists();
                         let _ = std::fs::remove_dir(&base_path);
-                        return Err(if metadata_exists {
-                            load_error
-                        } else {
-                            create_error
-                        });
+                        return Err(load_error);
                     }
                 },
+                Err(create_error) => {
+                    let _ = std::fs::remove_dir(&base_path);
+                    return Err(create_error);
+                }
             };
             if !base_path.is_dir() {
                 if let Err(cleanup_error) = std::fs::remove_dir_all(&base_path) {
@@ -909,6 +933,21 @@ mod tests {
 
         assert!(matches!(error, WorkspaceError::OwnershipMismatch { .. }));
         assert_eq!(std::fs::read_to_string(metadata_path).unwrap(), original);
+        assert!(!mgr.workspace_path("NODE_42").exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_directory_sync_failure_does_not_adopt_visible_sidecar() {
+        let (_dir, mut mgr) = setup();
+        mgr.fail_metadata_directory_sync = true;
+
+        let error = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, WorkspaceError::CreationFailed { .. }));
+        assert!(mgr.metadata_path("NODE_42").exists());
         assert!(!mgr.workspace_path("NODE_42").exists());
     }
 

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -84,10 +84,10 @@ impl WorkspaceManager {
             .map(|repo_list| {
                 let mut repos_map = HashMap::new();
                 for (index, mut repo) in repo_list.into_iter().enumerate() {
+                    let name = repository_key(&repo, index);
                     repo.path = super::canonicalize_allow_missing(Path::new(&repo.path))
                         .to_string_lossy()
                         .into_owned();
-                    let name = repository_key(&repo, index);
                     repos_map.insert(name, repo);
                 }
                 repos_map
@@ -679,6 +679,25 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn repository_key_uses_the_configured_symlink_name() {
+        let root = TempDir::new().unwrap();
+        let aliases = TempDir::new().unwrap();
+        let (repo, mut config) = setup_repo("actual");
+        let alias = aliases.path().join("configured-alias");
+        std::os::unix::fs::symlink(repo.path(), &alias).unwrap();
+        config.path = alias.to_string_lossy().into_owned();
+
+        let mgr = WorkspaceManager::new(root.path(), Some(vec![config])).unwrap();
+
+        let configured = mgr.repos().get("configured-alias").unwrap();
+        assert_eq!(
+            Path::new(&configured.path),
+            repo.path().canonicalize().unwrap()
+        );
+    }
+
     #[tokio::test]
     async fn workspace_ownership_mismatch_blocks_reuse_without_modifying_workspace() {
         let (_dir, mgr) = setup();
@@ -966,7 +985,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn workspace_ownership_canonicalizes_equivalent_repository_paths() {
+    async fn workspace_ownership_fails_closed_when_an_equivalent_path_changes_the_key() {
         use std::os::unix::fs::symlink;
 
         let root = TempDir::new().unwrap();
@@ -986,17 +1005,17 @@ mod tests {
         };
         let alias_mgr = WorkspaceManager::new(root.path(), Some(vec![alias_repo])).unwrap();
 
-        let reused = alias_mgr
+        let error = alias_mgr
             .prepare_workspace("NODE_42", "my-repo#42")
             .await
-            .unwrap();
+            .unwrap_err();
 
-        assert!(!reused.created_now);
-        assert_eq!(
-            first.worktrees.keys().next(),
-            reused.worktrees.keys().next()
-        );
-        alias_mgr.remove_workspace("NODE_42").await.unwrap();
+        assert!(matches!(
+            error,
+            WorkspaceError::RepositoryConfigurationMismatch { .. }
+        ));
+        assert!(first.base_path.exists());
+        first_mgr.remove_workspace("NODE_42").await.unwrap();
         assert!(!first.base_path.exists());
     }
 

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -6,7 +6,7 @@ use crate::observability::events_contract::{
 use crate::workspace::coordinator::{WorktreeCoordinator, WorktreeInfo};
 use crate::workspace::hooks::run_hook_best_effort;
 use crate::workspace::key::issue_workspace_key;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
@@ -22,6 +22,8 @@ struct WorkspaceMetadata {
     issue_id: String,
     issue_identifier: String,
     branch_date: String,
+    #[serde(default)]
+    repositories: BTreeMap<String, String>,
 }
 
 /// Manage per-issue workspace directories.
@@ -120,8 +122,10 @@ impl WorkspaceManager {
         &self,
         issue_id: &str,
     ) -> Result<HashMap<String, PathBuf>, WorkspaceError> {
+        let metadata_path = self.metadata_path(issue_id);
         let metadata = self.load_metadata(issue_id)?;
-        Self::verify_ownership(&self.metadata_path(issue_id), &metadata, issue_id)?;
+        Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
+        self.verify_repository_configuration(&metadata_path, &metadata)?;
         let coordinator = WorktreeCoordinator::new(
             self.repos.clone(),
             metadata.branch_date,
@@ -194,6 +198,7 @@ impl WorkspaceManager {
     }
 
     fn serialize_metadata(
+        &self,
         issue_id: &str,
         identifier: &str,
         date: &str,
@@ -202,6 +207,7 @@ impl WorkspaceManager {
             issue_id: issue_id.to_string(),
             issue_identifier: identifier.to_string(),
             branch_date: date.to_string(),
+            repositories: self.repository_identities(),
         })
         .map_err(|error| WorkspaceError::CreationFailed {
             reason: format!("failed to serialize workspace metadata: {error}"),
@@ -238,7 +244,7 @@ impl WorkspaceManager {
         })?;
         self.validate_path_inside_root(&metadata_dir)?;
 
-        let content = Self::serialize_metadata(issue_id, identifier, date)?;
+        let content = self.serialize_metadata(issue_id, identifier, date)?;
         self.write_metadata_temp(&content)?
             .persist_noclobber(self.metadata_path(issue_id))
             .map_err(|error| WorkspaceError::CreationFailed {
@@ -253,7 +259,7 @@ impl WorkspaceManager {
         identifier: &str,
         date: &str,
     ) -> Result<(), WorkspaceError> {
-        let content = Self::serialize_metadata(issue_id, identifier, date)?;
+        let content = self.serialize_metadata(issue_id, identifier, date)?;
         self.write_metadata_temp(&content)?
             .persist(self.metadata_path(issue_id))
             .map_err(|error| WorkspaceError::CreationFailed {
@@ -274,6 +280,29 @@ impl WorkspaceManager {
             path: metadata_path.display().to_string(),
             expected_issue_id: issue_id.to_string(),
             actual_issue_id: metadata.issue_id.clone(),
+        })
+    }
+
+    fn repository_identities(&self) -> BTreeMap<String, String> {
+        self.repos
+            .iter()
+            .map(|(key, repo)| (key.clone(), repo.path.clone()))
+            .collect()
+    }
+
+    fn verify_repository_configuration(
+        &self,
+        metadata_path: &Path,
+        metadata: &WorkspaceMetadata,
+    ) -> Result<(), WorkspaceError> {
+        let actual_repositories = self.repository_identities();
+        if metadata.repositories == actual_repositories {
+            return Ok(());
+        }
+        Err(WorkspaceError::RepositoryConfigurationMismatch {
+            path: metadata_path.display().to_string(),
+            expected_repositories: metadata.repositories.clone(),
+            actual_repositories,
         })
     }
 
@@ -311,7 +340,9 @@ impl WorkspaceManager {
                 });
             }
             let mut metadata = self.load_metadata(issue_id)?;
-            Self::verify_ownership(&self.metadata_path(issue_id), &metadata, issue_id)?;
+            let metadata_path = self.metadata_path(issue_id);
+            Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
+            self.verify_repository_configuration(&metadata_path, &metadata)?;
             if metadata.issue_identifier != identifier {
                 self.refresh_metadata(issue_id, identifier, &metadata.branch_date)?;
                 metadata.issue_identifier = identifier.to_string();
@@ -330,6 +361,7 @@ impl WorkspaceManager {
                     issue_id: issue_id.to_string(),
                     issue_identifier: identifier.to_string(),
                     branch_date,
+                    repositories: self.repository_identities(),
                 },
                 Err(create_error) => match self.load_metadata(issue_id) {
                     Ok(mut existing) => {
@@ -337,6 +369,13 @@ impl WorkspaceManager {
                             &self.metadata_path(issue_id),
                             &existing,
                             issue_id,
+                        ) {
+                            let _ = std::fs::remove_dir(&base_path);
+                            return Err(error);
+                        }
+                        if let Err(error) = self.verify_repository_configuration(
+                            &self.metadata_path(issue_id),
+                            &existing,
                         ) {
                             let _ = std::fs::remove_dir(&base_path);
                             return Err(error);
@@ -439,6 +478,7 @@ impl WorkspaceManager {
             }
             let metadata = self.load_metadata(issue_id)?;
             Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
+            self.verify_repository_configuration(&metadata_path, &metadata)?;
             std::fs::remove_file(&metadata_path).map_err(|error| {
                 WorkspaceError::CreationFailed {
                     reason: format!("failed to remove workspace metadata: {error}"),
@@ -449,6 +489,7 @@ impl WorkspaceManager {
         let metadata_path = self.metadata_path(issue_id);
         let metadata = self.load_metadata(issue_id)?;
         Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
+        self.verify_repository_configuration(&metadata_path, &metadata)?;
         #[cfg(test)]
         if let Some((after_verification, resume_removal)) = &self.removal_test_barriers {
             after_verification.wait().await;
@@ -1283,6 +1324,28 @@ mod tests {
             ws_path.exists(),
             "workspace should not be deleted when cleanup fails"
         );
+    }
+
+    #[tokio::test]
+    async fn remove_workspace_fails_closed_when_repository_configuration_changes() {
+        let root = TempDir::new().unwrap();
+        let (_repo_dir, repo) = setup_repo("repo1");
+        let original_manager = WorkspaceManager::new(root.path(), Some(vec![repo])).unwrap();
+        let workspace = original_manager
+            .prepare_workspace("NODE_CONFIG_DRIFT", "repo#42")
+            .await
+            .unwrap();
+        let metadata_path = original_manager.metadata_path("NODE_CONFIG_DRIFT");
+
+        let changed_manager = WorkspaceManager::new(root.path(), None).unwrap();
+        let result = changed_manager.remove_workspace("NODE_CONFIG_DRIFT").await;
+
+        assert!(matches!(
+            result,
+            Err(WorkspaceError::RepositoryConfigurationMismatch { .. })
+        ));
+        assert!(workspace.base_path.exists());
+        assert!(metadata_path.exists());
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -24,6 +24,8 @@ struct WorkspaceMetadata {
     branch_date: String,
     #[serde(default)]
     repositories: BTreeMap<String, String>,
+    #[serde(default)]
+    before_remove_completed: bool,
 }
 
 /// Manage per-issue workspace directories.
@@ -200,19 +202,8 @@ impl WorkspaceManager {
         })
     }
 
-    fn serialize_metadata(
-        &self,
-        issue_id: &str,
-        identifier: &str,
-        date: &str,
-    ) -> Result<Vec<u8>, WorkspaceError> {
-        serde_json::to_vec(&WorkspaceMetadata {
-            issue_id: issue_id.to_string(),
-            issue_identifier: identifier.to_string(),
-            branch_date: date.to_string(),
-            repositories: self.repository_identities(),
-        })
-        .map_err(|error| WorkspaceError::CreationFailed {
+    fn serialize_metadata(metadata: &WorkspaceMetadata) -> Result<Vec<u8>, WorkspaceError> {
+        serde_json::to_vec(metadata).map_err(|error| WorkspaceError::CreationFailed {
             reason: format!("failed to serialize workspace metadata: {error}"),
         })
     }
@@ -247,7 +238,13 @@ impl WorkspaceManager {
         })?;
         self.validate_path_inside_root(&metadata_dir)?;
 
-        let content = self.serialize_metadata(issue_id, identifier, date)?;
+        let content = Self::serialize_metadata(&WorkspaceMetadata {
+            issue_id: issue_id.to_string(),
+            issue_identifier: identifier.to_string(),
+            branch_date: date.to_string(),
+            repositories: self.repository_identities(),
+            before_remove_completed: false,
+        })?;
         self.write_metadata_temp(&content)?
             .persist_noclobber(self.metadata_path(issue_id))
             .map_err(|error| WorkspaceError::CreationFailed {
@@ -256,15 +253,10 @@ impl WorkspaceManager {
         Ok(())
     }
 
-    fn refresh_metadata(
-        &self,
-        issue_id: &str,
-        identifier: &str,
-        date: &str,
-    ) -> Result<(), WorkspaceError> {
-        let content = self.serialize_metadata(issue_id, identifier, date)?;
+    fn refresh_metadata(&self, metadata: &WorkspaceMetadata) -> Result<(), WorkspaceError> {
+        let content = Self::serialize_metadata(metadata)?;
         self.write_metadata_temp(&content)?
-            .persist(self.metadata_path(issue_id))
+            .persist(self.metadata_path(&metadata.issue_id))
             .map_err(|error| WorkspaceError::CreationFailed {
                 reason: format!("failed to refresh workspace metadata: {}", error.error),
             })?;
@@ -365,8 +357,8 @@ impl WorkspaceManager {
             Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
             self.verify_repository_configuration(&metadata_path, &metadata)?;
             if metadata.issue_identifier != identifier {
-                self.refresh_metadata(issue_id, identifier, &metadata.branch_date)?;
                 metadata.issue_identifier = identifier.to_string();
+                self.refresh_metadata(&metadata)?;
             }
             (false, metadata)
         } else {
@@ -383,6 +375,7 @@ impl WorkspaceManager {
                     issue_identifier: identifier.to_string(),
                     branch_date,
                     repositories: self.repository_identities(),
+                    before_remove_completed: false,
                 },
                 Err(create_error) => match self.load_metadata(issue_id) {
                     Ok(mut existing) => {
@@ -402,13 +395,11 @@ impl WorkspaceManager {
                             return Err(error);
                         }
                         if existing.issue_identifier != identifier {
-                            if let Err(error) =
-                                self.refresh_metadata(issue_id, identifier, &existing.branch_date)
-                            {
+                            existing.issue_identifier = identifier.to_string();
+                            if let Err(error) = self.refresh_metadata(&existing) {
                                 let _ = std::fs::remove_dir(&base_path);
                                 return Err(error);
                             }
-                            existing.issue_identifier = identifier.to_string();
                         }
                         existing
                     }
@@ -518,7 +509,7 @@ impl WorkspaceManager {
             return Ok(());
         }
         let metadata_path = self.metadata_path(issue_id);
-        let metadata = self.load_metadata(issue_id)?;
+        let mut metadata = self.load_metadata(issue_id)?;
         Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
         self.verify_repository_configuration(&metadata_path, &metadata)?;
         #[cfg(test)]
@@ -527,8 +518,15 @@ impl WorkspaceManager {
             resume_removal.wait().await;
         }
 
-        if let Some(script) = &self.hooks.before_remove {
+        if let Some(script) = self
+            .hooks
+            .before_remove
+            .as_ref()
+            .filter(|_| !metadata.before_remove_completed)
+        {
             run_hook_best_effort("before_remove", script, &base_path, self.hooks.timeout_ms).await;
+            metadata.before_remove_completed = true;
+            self.refresh_metadata(&metadata)?;
         }
 
         // Clean up worktrees first - use persisted branch date to avoid date drift
@@ -1402,16 +1400,22 @@ mod tests {
         assert!(test_path.exists());
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_remove_workspace_blocks_on_cleanup_failure() {
         let dir = TempDir::new().unwrap();
+        let marker = dir.path().join("before-remove-runs");
         let repos = vec![RepoConfig {
             path: "/nonexistent/path".to_string(),
             branch: "main".to_string(),
             git_remote: "origin".to_string(),
             finalize: Default::default(),
         }];
-        let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
+        let hooks = HooksConfig {
+            before_remove: Some("echo ran >> ../before-remove-runs".to_string()),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new_with_hooks(dir.path(), Some(repos), hooks).unwrap();
 
         let ws_path = mgr.workspace_path("NODE_CLEANUP");
         std::fs::create_dir_all(&ws_path).unwrap();
@@ -1420,10 +1424,18 @@ mod tests {
 
         let remove_result = mgr.remove_workspace("NODE_CLEANUP").await;
         assert!(remove_result.is_err());
+        let retry_result = mgr.remove_workspace("NODE_CLEANUP").await;
+        assert!(retry_result.is_err());
 
         assert!(
             ws_path.exists(),
             "workspace should not be deleted when cleanup fails"
+        );
+        assert_eq!(std::fs::read_to_string(marker).unwrap(), "ran\n");
+        assert!(
+            mgr.load_metadata("NODE_CLEANUP")
+                .unwrap()
+                .before_remove_completed
         );
     }
 

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -83,7 +83,10 @@ impl WorkspaceManager {
             .filter(|r| !r.is_empty())
             .map(|repo_list| {
                 let mut repos_map = HashMap::new();
-                for (index, repo) in repo_list.into_iter().enumerate() {
+                for (index, mut repo) in repo_list.into_iter().enumerate() {
+                    repo.path = super::canonicalize_allow_missing(Path::new(&repo.path))
+                        .to_string_lossy()
+                        .into_owned();
                     let name = repository_key(&repo, index);
                     repos_map.insert(name, repo);
                 }
@@ -149,7 +152,7 @@ impl WorkspaceManager {
     }
 
     fn lifecycle_lock(&self, workspace_key: &str) -> Arc<WorkspaceLifecycleLock> {
-        let canonical_root = Self::canonicalize_allow_missing(&self.root);
+        let canonical_root = super::canonicalize_allow_missing(&self.root);
         let path = canonical_root.join(workspace_key);
         let mut locks = WORKSPACE_LIFECYCLE_LOCKS
             .get_or_init(|| Mutex::new(HashMap::new()))
@@ -295,15 +298,33 @@ impl WorkspaceManager {
         metadata_path: &Path,
         metadata: &WorkspaceMetadata,
     ) -> Result<(), WorkspaceError> {
-        let actual_repositories = self.repository_identities();
-        if metadata.repositories == actual_repositories {
+        let expected_repositories = Self::canonical_repository_identities(&metadata.repositories);
+        let actual_repositories =
+            Self::canonical_repository_identities(&self.repository_identities());
+        if expected_repositories == actual_repositories {
             return Ok(());
         }
         Err(WorkspaceError::RepositoryConfigurationMismatch {
             path: metadata_path.display().to_string(),
-            expected_repositories: metadata.repositories.clone(),
+            expected_repositories,
             actual_repositories,
         })
+    }
+
+    fn canonical_repository_identities(
+        repositories: &BTreeMap<String, String>,
+    ) -> BTreeMap<String, String> {
+        repositories
+            .iter()
+            .map(|(key, path)| {
+                (
+                    key.clone(),
+                    super::canonicalize_allow_missing(Path::new(path))
+                        .to_string_lossy()
+                        .into_owned(),
+                )
+            })
+            .collect()
     }
 
     /// Prepare (create or reuse) a workspace for the given immutable issue identity.
@@ -479,6 +500,16 @@ impl WorkspaceManager {
             let metadata = self.load_metadata(issue_id)?;
             Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
             self.verify_repository_configuration(&metadata_path, &metadata)?;
+            if !self.repos.is_empty() {
+                let coordinator =
+                    WorktreeCoordinator::new(self.repos.clone(), metadata.branch_date, base_path);
+                coordinator
+                    .cleanup_worktrees(issue_id)
+                    .await
+                    .map_err(|error| WorkspaceError::CreationFailed {
+                        reason: format!("worktree cleanup failed: {error}"),
+                    })?;
+            }
             std::fs::remove_file(&metadata_path).map_err(|error| {
                 WorkspaceError::CreationFailed {
                     reason: format!("failed to remove workspace metadata: {error}"),
@@ -536,8 +567,8 @@ impl WorkspaceManager {
     /// When `path` does not yet exist (pre-creation), its nearest existing ancestor
     /// is canonicalized and the missing components are re-appended.
     fn validate_path_inside_root(&self, path: &Path) -> Result<(), WorkspaceError> {
-        let canonical_root = Self::canonicalize_allow_missing(&self.root);
-        let canonical_path = Self::canonicalize_allow_missing(path);
+        let canonical_root = super::canonicalize_allow_missing(&self.root);
+        let canonical_path = super::canonicalize_allow_missing(path);
 
         if !canonical_path.starts_with(&canonical_root) {
             return Err(WorkspaceError::PathOutsideRoot {
@@ -545,26 +576,6 @@ impl WorkspaceManager {
             });
         }
         Ok(())
-    }
-
-    fn canonicalize_allow_missing(path: &Path) -> PathBuf {
-        let mut existing = path;
-        let mut missing = Vec::new();
-        while !existing.exists() {
-            let (Some(parent), Some(file_name)) = (existing.parent(), existing.file_name()) else {
-                return path.to_path_buf();
-            };
-            missing.push(file_name.to_os_string());
-            existing = parent;
-        }
-
-        let mut canonical = existing
-            .canonicalize()
-            .unwrap_or_else(|_| existing.to_path_buf());
-        for component in missing.into_iter().rev() {
-            canonical.push(component);
-        }
-        canonical
     }
 }
 
@@ -916,6 +927,77 @@ mod tests {
         mgr.remove_workspace("NODE_42").await.unwrap();
 
         assert!(!metadata_path.exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_ownership_absent_workspace_cleans_git_registration_and_branch() {
+        let root = TempDir::new().unwrap();
+        let (_repo_dir, repo) = setup_repo("repo1");
+        let repo_path = repo.path.clone();
+        let mgr = WorkspaceManager::new(root.path(), Some(vec![repo])).unwrap();
+        let workspace = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        let worktree = workspace.worktrees.values().next().unwrap();
+        let worktree_path = worktree.path.to_string_lossy().into_owned();
+        let branch = worktree.branch.clone();
+        std::fs::remove_dir_all(&workspace.base_path).unwrap();
+
+        assert!(
+            crate::workspace::worktree::worktree_exists(&repo_path, &worktree_path)
+                .await
+                .unwrap()
+        );
+        mgr.remove_workspace("NODE_42").await.unwrap();
+
+        assert!(
+            !crate::workspace::worktree::worktree_exists(&repo_path, &worktree_path)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !crate::workspace::worktree::branch_exists(&repo_path, &branch)
+                .await
+                .unwrap()
+        );
+        assert!(!mgr.metadata_path("NODE_42").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_ownership_canonicalizes_equivalent_repository_paths() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().unwrap();
+        let (repo_dir, repo) = setup_repo("repo1");
+        let alias_parent = TempDir::new().unwrap();
+        let alias = alias_parent.path().join("repository-alias");
+        symlink(repo_dir.path(), &alias).unwrap();
+
+        let first_mgr = WorkspaceManager::new(root.path(), Some(vec![repo.clone()])).unwrap();
+        let first = first_mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        let alias_repo = RepoConfig {
+            path: alias.to_string_lossy().into_owned(),
+            ..repo
+        };
+        let alias_mgr = WorkspaceManager::new(root.path(), Some(vec![alias_repo])).unwrap();
+
+        let reused = alias_mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+
+        assert!(!reused.created_now);
+        assert_eq!(
+            first.worktrees.keys().next(),
+            reused.worktrees.keys().next()
+        );
+        alias_mgr.remove_workspace("NODE_42").await.unwrap();
+        assert!(!first.base_path.exists());
     }
 
     #[cfg(unix)]

--- a/crates/ensemble-core/src/workspace/mod.rs
+++ b/crates/ensemble-core/src/workspace/mod.rs
@@ -4,3 +4,25 @@ pub mod hooks;
 pub mod key;
 pub mod manager;
 pub mod worktree;
+
+use std::path::{Path, PathBuf};
+
+pub(crate) fn canonicalize_allow_missing(path: &Path) -> PathBuf {
+    let mut existing = path;
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        let (Some(parent), Some(file_name)) = (existing.parent(), existing.file_name()) else {
+            return path.to_path_buf();
+        };
+        missing.push(file_name.to_os_string());
+        existing = parent;
+    }
+
+    let mut canonical = existing
+        .canonicalize()
+        .unwrap_or_else(|_| existing.to_path_buf());
+    for component in missing.into_iter().rev() {
+        canonical.push(component);
+    }
+    canonical
+}

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -344,9 +344,7 @@ pub async fn remove_worktree(
 
     debug!(worktree_path = %worktree_path, "Worktree removed successfully");
 
-    if let Err(e) = delete_branch_if_exists(repo_path, branch).await {
-        warn!(error = %e, branch = %branch, "Failed to delete branch");
-    }
+    delete_branch_if_exists(repo_path, branch).await?;
 
     Ok(())
 }
@@ -591,6 +589,34 @@ mod tests {
             error,
             &format!("git worktree remove --force {}", repo_path.display()),
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_remove_worktree_propagates_branch_deletion_failure() {
+        let repo = init_test_repo().await;
+        let repo_path = repo.path().to_string_lossy().into_owned();
+        let worktree_parent = TempDir::new().expect("worktree parent");
+        let worktree_path = worktree_parent.path().join("feature");
+        let worktree_path = worktree_path.to_string_lossy().into_owned();
+        create_worktree(&repo_path, &worktree_path, "feature", Some("main"))
+            .await
+            .expect("create feature worktree");
+        run_git(
+            &repo_path,
+            &["checkout", "--ignore-other-worktrees", "feature"],
+            "git checkout --ignore-other-worktrees feature",
+        )
+        .await
+        .expect("check out feature in the main worktree");
+
+        let error = remove_worktree(&repo_path, &worktree_path, "feature")
+            .await
+            .expect_err("deleting a branch checked out elsewhere should fail");
+
+        assert_git_command_failed(error, "git branch -D feature");
+        assert!(!Path::new(&worktree_path).exists());
+        assert!(branch_exists(&repo_path, "feature").await.unwrap());
     }
 
     #[cfg(unix)]

--- a/crates/ensemble-core/src/workspace/worktree.rs
+++ b/crates/ensemble-core/src/workspace/worktree.rs
@@ -219,16 +219,12 @@ pub async fn worktree_exists(repo_path: &str, worktree_path: &str) -> Result<boo
     )?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let worktree_path_normalized = Path::new(worktree_path)
-        .canonicalize()
-        .unwrap_or_else(|_| Path::new(worktree_path).to_path_buf());
+    let worktree_path_normalized = super::canonicalize_allow_missing(Path::new(worktree_path));
 
     for line in stdout.lines() {
         if line.starts_with("worktree ") {
             let listed_path = line.strip_prefix("worktree ").unwrap_or(line);
-            let listed_path_normalized = Path::new(listed_path)
-                .canonicalize()
-                .unwrap_or_else(|_| Path::new(listed_path).to_path_buf());
+            let listed_path_normalized = super::canonicalize_allow_missing(Path::new(listed_path));
 
             if listed_path_normalized == worktree_path_normalized {
                 debug!(worktree_path = %worktree_path, "Worktree found in list");
@@ -310,21 +306,28 @@ pub async fn remove_worktree(
     worktree_path: &str,
     branch: &str,
 ) -> Result<(), WorktreeError> {
+    let normalized_worktree_path = super::canonicalize_allow_missing(Path::new(worktree_path));
+    let normalized_worktree_path = normalized_worktree_path.to_string_lossy();
     info!(
         repo_path = %repo_path,
-        worktree_path = %worktree_path,
+        worktree_path = %normalized_worktree_path,
         branch = %branch,
         "Removing worktree"
     );
 
-    if !worktree_exists(repo_path, worktree_path).await? {
+    if !worktree_exists(repo_path, &normalized_worktree_path).await? {
         warn!(worktree_path = %worktree_path, "Worktree does not exist");
         return Err(WorktreeError::NotFound {
             path: worktree_path.to_string(),
         });
     }
 
-    let args = ["worktree", "remove", "--force", worktree_path];
+    let args = [
+        "worktree",
+        "remove",
+        "--force",
+        normalized_worktree_path.as_ref(),
+    ];
     let command = git_command_label(&args);
     let error_command = command.clone();
     ensure_git_success(
@@ -583,7 +586,11 @@ mod tests {
             .await
             .expect_err("removing the main worktree should fail");
 
-        assert_git_command_failed(error, &format!("git worktree remove --force {repo_path}"));
+        let repo_path = crate::workspace::canonicalize_allow_missing(Path::new(&repo_path));
+        assert_git_command_failed(
+            error,
+            &format!("git worktree remove --force {}", repo_path.display()),
+        );
     }
 
     #[cfg(unix)]

--- a/crates/ensemble-core/tests/openapi_spec.rs
+++ b/crates/ensemble-core/tests/openapi_spec.rs
@@ -76,6 +76,26 @@ fn openapi_documents_every_supported_ui_http_operation() {
 }
 
 #[test]
+fn openapi_documents_finalize_operational_errors() {
+    let spec: serde_json::Value =
+        serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+
+    for path in [
+        "/api/v1/{identifier}/finalize/approve",
+        "/api/v1/{identifier}/finalize/retry",
+    ] {
+        for status in ["500", "503"] {
+            assert_eq!(
+                spec["paths"][path]["post"]["responses"][status]["content"]["application/json"]
+                    ["schema"]["$ref"],
+                "#/components/schemas/ApiError",
+                "OpenAPI must document {status} ApiError for POST {path}",
+            );
+        }
+    }
+}
+
+#[test]
 fn openapi_keeps_editor_step_dependencies_optional() {
     let spec: serde_json::Value =
         serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1577,9 +1577,10 @@ Workspace persistence:
   identifier changes.
 - Successful runs do not auto-delete workspaces.
 - `<workspace.root>/.ensemble-workspace-metadata/<workspace_key>.json` stores `issue_id`,
-  `issue_identifier`, and the branch date used for repository worktrees. This manager-owned
-  sidecar, outside the agent workspace, is the ownership authority. Files inside an agent
-  workspace, including a forged `.ensemble-workspace.json`, have no lifecycle authority.
+  `issue_identifier`, the branch date used for repository worktrees, and the configured repository
+  identities (derived key and configured path). This manager-owned sidecar, outside the agent
+  workspace, is the ownership authority. Files inside an agent workspace, including a forged
+  `.ensemble-workspace.json`, have no lifecycle authority.
 - Built-in coordinated repository worktrees derive their branch identity from the same
   collision-resistant immutable-ID key. Display-identifier changes therefore reuse the same branch,
   while distinct issue IDs remain isolated even when lossy branch sanitization would otherwise
@@ -1599,22 +1600,25 @@ Algorithm summary:
 3. For a new directory, atomically create manager-owned owner metadata without replacing an
    existing sidecar, before hooks or repository worktree preparation. If metadata creation fails,
    remove the newly created empty directory.
-4. For an existing directory, load sidecar metadata and require `issue_id` to match before reuse,
-   hooks, repository worktree preparation, or any metadata write. `issue_identifier` is
-   informational display metadata and may be refreshed after immutable-ID verification using an
-   atomic replacement, so a failed refresh leaves the previous valid sidecar intact.
+4. For an existing directory, load sidecar metadata and require `issue_id` and the configured
+   repository identities to match before reuse, hooks, repository worktree preparation, or any
+   metadata write. `issue_identifier` is informational display metadata and may be refreshed after
+   verification using an atomic replacement, so a failed refresh leaves the previous valid
+   sidecar intact.
 5. Mark `created_now=true` only if the directory was created during this call; otherwise
    `created_now=false`.
 6. If `created_now=true`, run `after_create` hook if configured.
 
 Missing, malformed, ownerless legacy, or mismatched sidecar metadata is not repaired or adopted.
-Reuse and removal fail before any workspace side effect. Removing an absent canonical workspace
-with no sidecar remains idempotent; removing one with a valid matching leftover sidecar completes
-the interrupted cleanup. For an existing ownership-verified workspace, `before_remove` runs once
-in the base workspace before cleanup removes repository worktrees exhaustively, then the agent
-workspace, then the sidecar. A sidecar-removal failure is retryable because the valid sidecar
-remains authoritative. Implementations do not scan, migrate, rename, or remove legacy
-identifier-only directories, and do not migrate or adopt in-workspace metadata.
+Reuse and removal fail before any workspace side effect. This includes repository configuration
+drift: cleanup does not substitute newly configured repositories or abandon worktrees belonging to
+repositories recorded when the workspace was created. Removing an absent canonical workspace with
+no sidecar remains idempotent; removing one with a valid matching leftover sidecar completes the
+interrupted cleanup. For an existing verified workspace, `before_remove` runs once in the base
+workspace before cleanup removes repository worktrees exhaustively, then the agent workspace, then
+the sidecar. A sidecar-removal failure is retryable because the valid sidecar remains authoritative.
+Implementations do not scan, migrate, rename, or remove legacy identifier-only directories, and do
+not migrate or adopt in-workspace metadata.
 
 Notes:
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -446,6 +446,13 @@ Pipeline run recovery:
 - Automated failures that exhaust `max_cycles` transfer ownership to the same durable pending
   terminal transition used by normal terminal outcomes; they are never represented by an absent
   retry alone.
+- Approval-required repository delivery transfers ownership to a durable `DeliveryOwned` record
+  with an `awaiting_approval` repository phase, completion history, and pipeline snapshot before
+  the completed worker and live pipeline run are released. This phase consumes no agent capacity
+  and performs no remote mutation. Approval changes only the approved repositories to `prepared`,
+  after which normal idempotent delivery recovery resumes; restart restores the same pending
+  approval owner and history. Retrying a blocked approval-required delivery durably returns it to
+  `awaiting_approval`; a blocked delivery cannot be approved directly.
 - Reconciliation keeps the exact cancelled worker drain-owned until it has fully drained and the
   post-drain retry disposition is committed. A scheduled disposition transfers ownership to its
   retry entry; an exhausted disposition persists the pending terminal transition before clearing

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -366,8 +366,9 @@ Pipeline run recovery:
   deterministic order and retain the run ID, issue ID, configured repository key, mode, remote and
   base branch, exact head branch and local commit SHA, observed remote SHA, pull request identity,
   last error, retry origin, a stored deterministic marker, and the prepared terminal history.
-- Delivery repository phases are `prepared`, `push_in_flight`, `reconciling_push`,
-  `pr_create_in_flight`, `reconciling_pr`, `waiting`, `published`, and `blocked`. The issue-level
+- Delivery repository phases are `awaiting_approval`, `prepared`, `push_in_flight`,
+  `reconciling_push`, `pr_create_in_flight`, `reconciling_pr`, `waiting`, `published`, and
+  `blocked`. The issue-level
   delivery state is derived from those repository entries rather than serialized separately.
 - Before a push or pull request creation, Ensemble persists the corresponding in-flight phase, so
   delivery owns publication before the remote mutation. On a normal response or ambiguous failure

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1633,7 +1633,9 @@ repositories recorded when the workspace was created. Removing an absent canonic
 no sidecar remains idempotent; removing one with a valid matching leftover sidecar completes the
 interrupted cleanup. For an existing verified workspace, `before_remove` runs once in the base
 workspace before cleanup removes repository worktrees exhaustively, then the agent workspace, then
-the sidecar. A sidecar-removal failure is retryable because the valid sidecar remains authoritative.
+the sidecar. Completion of `before_remove` is recorded in the sidecar before worktree cleanup, so a
+cleanup retry resumes after the hook boundary. A sidecar-removal failure is retryable because the
+valid sidecar remains authoritative.
 Implementations do not scan, migrate, rename, or remove legacy identifier-only directories, and do
 not migrate or adopt in-workspace metadata.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2072,10 +2072,6 @@ Behavior:
 5. On any error, fail the worker attempt. The orchestrator decides whether the failure is
    retryable or terminal.
 
-Note:
-
-- Workspaces are intentionally preserved after successful runs.
-
 ## 11. Issue Tracker Integration Contract (GitHub-Compatible)
 
 ### 11.1 Required Operations

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -383,6 +383,10 @@ Pipeline run recovery:
   dispatches no pipeline work, and does not project a terminal tracker state. `blocked` is likewise
   retained for operator recovery. A fully `published` push-only delivery continues the existing
   durable terminal-transition protocol; it does not republish the branch.
+- If the tracker moves a retained delivery to any configured terminal state, delivery recovery
+  stops remote mutation and enters the same durable terminal-transition protocol using the
+  observed state. Release removes the owned workspace and durable delivery claim before another
+  candidate can dispatch.
 - An optional `push_and_pr` `review_state` is an issue-level retained projection, never a terminal
   outcome. Its journal phase is `pending`, `in_flight`, `applied`, or `blocked`; Ensemble persists
   `in_flight` before the tracker write and applies only after an exact target-state read. It writes

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1923,6 +1923,8 @@ Permission and user-input behavior on direct ACP paths is governed by `agent.per
 Policy requirements:
 
 - Each implementation should document its chosen permission and operator-confirmation posture.
+- Agent subprocesses must not inherit the host's `GITHUB_TOKEN`; tracker credentials remain owned
+  by the orchestrator process unless an explicit future agent-credential contract says otherwise.
 - Permission requests and user-input scenarios must not leave the orchestrator globally stalled.
   User-input waits should be issue-scoped, with other issues continuing to make progress.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -365,7 +365,7 @@ Pipeline run recovery:
   same versioned per-issue journal before any remote mutation. Repository entries are keyed in
   deterministic order and retain the run ID, issue ID, configured repository key, mode, remote and
   base branch, exact head branch and local commit SHA, observed remote SHA, pull request identity,
-  last error, retry origin, and a stored deterministic marker.
+  last error, retry origin, a stored deterministic marker, and the prepared terminal history.
 - Delivery repository phases are `prepared`, `push_in_flight`, `reconciling_push`,
   `pr_create_in_flight`, `reconciling_pr`, `waiting`, `published`, and `blocked`. The issue-level
   delivery state is derived from those repository entries rather than serialized separately.
@@ -385,8 +385,9 @@ Pipeline run recovery:
   durable terminal-transition protocol; it does not republish the branch.
 - If the tracker moves a retained delivery to any configured terminal state, delivery recovery
   stops remote mutation and enters the same durable terminal-transition protocol using the
-  observed state. Release removes the owned workspace and durable delivery claim before another
-  candidate can dispatch.
+  observed state. It persists the prepared history as succeeded for the success state, failed for
+  the configured failure state, or stopped for any other terminal state. Release removes the owned
+  workspace and durable delivery claim before another candidate can dispatch.
 - An optional `push_and_pr` `review_state` is an issue-level retained projection, never a terminal
   outcome. Its journal phase is `pending`, `in_flight`, `applied`, or `blocked`; Ensemble persists
   `in_flight` before the tracker write and applies only after an exact target-state read. It writes
@@ -1575,7 +1576,8 @@ Workspace persistence:
 
 - Workspaces are reused across runs for the same immutable issue ID, including when the display
   identifier changes.
-- Successful runs do not auto-delete workspaces.
+- Non-terminal runs retain their workspaces. After a terminal tracker transition is confirmed,
+  Ensemble removes the workspace before releasing the durable run owner.
 - `<workspace.root>/.ensemble-workspace-metadata/<workspace_key>.json` stores `issue_id`,
   `issue_identifier`, the branch date used for repository worktrees, and the configured repository
   identities (derived key and configured path). This manager-owned sidecar, outside the agent

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1633,9 +1633,10 @@ repositories recorded when the workspace was created. Removing an absent canonic
 no sidecar remains idempotent; removing one with a valid matching leftover sidecar completes the
 interrupted cleanup. For an existing verified workspace, `before_remove` runs once in the base
 workspace before cleanup removes repository worktrees exhaustively, then the agent workspace, then
-the sidecar. An at-most-once `before_remove` boundary is recorded in the sidecar before invoking the
-best-effort hook, so a cleanup retry resumes after the hook boundary without duplicating external
-side effects. A sidecar-removal failure is retryable because the valid sidecar remains authoritative.
+the sidecar. A crash-durable, at-most-once `before_remove` boundary is recorded in the sidecar before
+invoking the best-effort hook, so a cleanup retry resumes after the hook boundary without
+duplicating external side effects. A sidecar-removal failure is retryable because the valid sidecar
+remains authoritative.
 Implementations do not scan, migrate, rename, or remove legacy identifier-only directories, and do
 not migrate or adopt in-workspace metadata.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -456,14 +456,16 @@ Pipeline run recovery:
   configured state transition idempotently without rerunning pipeline steps or finalization, and
   persist updated attempt/error metadata after failures.
 - After the tracker write is confirmed, Ensemble records that applied state as a still-live journal
-  phase, clears any terminal interaction wait, and persists completion history idempotently. A
-  restart in this phase finishes those local effects without repeating tracker or agent work.
+  phase, clears any terminal interaction wait, persists completion history idempotently, and removes
+  the issue workspace. Workspace cleanup failure retains the pending transition for bounded-backoff
+  retry. A restart in this phase finishes those local effects without repeating tracker or agent
+  work.
 - Stale `Running` steps from a previous process are normalized to `Pending`; agent processes are not
   recovered across orchestrator restarts or in-process journal rehydration.
 - Ensemble appends `released` only after the terminal tracker transition is confirmed (or no
-  tracker write is supported) and completion history is durable. That boundary prevents older
-  snapshots for the issue from being restored after completion, stop, terminal reconciliation, or
-  whole-issue retry.
+  tracker write is supported), completion history is durable, and the issue workspace has been
+  removed. That boundary prevents older snapshots for the issue from being restored after
+  completion, stop, terminal reconciliation, or whole-issue retry.
 
 #### 4.1.7 StepOutput
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1633,9 +1633,9 @@ repositories recorded when the workspace was created. Removing an absent canonic
 no sidecar remains idempotent; removing one with a valid matching leftover sidecar completes the
 interrupted cleanup. For an existing verified workspace, `before_remove` runs once in the base
 workspace before cleanup removes repository worktrees exhaustively, then the agent workspace, then
-the sidecar. Completion of `before_remove` is recorded in the sidecar before worktree cleanup, so a
-cleanup retry resumes after the hook boundary. A sidecar-removal failure is retryable because the
-valid sidecar remains authoritative.
+the sidecar. An at-most-once `before_remove` boundary is recorded in the sidecar before invoking the
+best-effort hook, so a cleanup retry resumes after the hook boundary without duplicating external
+side effects. A sidecar-removal failure is retryable because the valid sidecar remains authoritative.
 Implementations do not scan, migrate, rename, or remove legacy identifier-only directories, and do
 not migrate or adopt in-workspace metadata.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1591,9 +1591,11 @@ Workspace persistence:
   Ensemble removes the workspace before releasing the durable run owner.
 - `<workspace.root>/.ensemble-workspace-metadata/<workspace_key>.json` stores `issue_id`,
   `issue_identifier`, the branch date used for repository worktrees, and the configured repository
-  identities (derived key and canonical repository path). Equivalent symlinked or lexical path
-  spellings resolve to the same identity. This manager-owned sidecar, outside the agent
-  workspace, is the ownership authority. Files inside an agent workspace, including a forged
+  identities (key derived from the configured path and canonical repository path). Equivalent
+  symlinked or lexical path spellings resolve to the same path identity when they preserve the
+  derived key. Changing the path's leaf-derived key is repository configuration drift and fails
+  closed so configured repository references are never silently renamed. This manager-owned
+  sidecar, outside the agent workspace, is the ownership authority. Files inside an agent workspace, including a forged
   `.ensemble-workspace.json`, have no lifecycle authority.
 - Built-in coordinated repository worktrees derive their branch identity from the same
   collision-resistant immutable-ID key. Display-identifier changes therefore reuse the same branch,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -470,11 +470,11 @@ Pipeline run recovery:
 - Every tracker error is treated as potentially ambiguous. Startup and poll ticks replay the same
   configured state transition idempotently without rerunning pipeline steps or finalization, and
   persist updated attempt/error metadata after failures.
-- After the tracker write is confirmed, Ensemble records that applied state as a still-live journal
-  phase, clears any terminal interaction wait, persists completion history idempotently, and removes
-  the issue workspace. Workspace cleanup failure retains the pending transition for bounded-backoff
-  retry. A restart in this phase finishes those local effects without repeating tracker or agent
-  work.
+- After the tracker write is confirmed, Ensemble crash-durably records that applied state as a
+  still-live journal phase before clearing any terminal interaction wait, persisting completion
+  history idempotently, and removing the issue workspace. Workspace cleanup failure retains the
+  pending transition for bounded-backoff retry. A restart in this phase finishes those local effects
+  without repeating tracker or agent work.
 - Stale `Running` steps from a previous process are normalized to `Pending`; agent processes are not
   recovered across orchestrator restarts or in-process journal rehydration.
 - Ensemble appends `released` only after the terminal tracker transition is confirmed (or no

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -452,7 +452,9 @@ Pipeline run recovery:
   and performs no remote mutation. Approval changes only the approved repositories to `prepared`,
   after which normal idempotent delivery recovery resumes; restart restores the same pending
   approval owner and history. Retrying a blocked approval-required delivery durably returns it to
-  `awaiting_approval`; a blocked delivery cannot be approved directly.
+  `awaiting_approval`; a blocked delivery cannot be approved directly. Replaying approval after
+  the durable phase has already advanced is idempotent and reports that the earlier approval was
+  confirmed rather than applied again.
 - Reconciliation keeps the exact cancelled worker drain-owned until it has fully drained and the
   post-drain retry disposition is committed. A scheduled disposition transfers ownership to its
   retry entry; an exhausted disposition persists the pending terminal transition before clearing
@@ -1555,7 +1557,9 @@ When the service starts:
 3. If the terminal-issues fetch fails, log a warning and continue startup.
 
 An absent canonical workspace with no sidecar is already clean. When the workspace is absent but a
-valid matching sidecar remains from interrupted cleanup, cleanup removes the sidecar and succeeds.
+valid matching sidecar remains from interrupted cleanup, cleanup uses the persisted repository
+identities and branch date to unregister any stale worktrees and delete their branches before it
+removes the sidecar. A Git cleanup failure retains the sidecar and durable owner for retry.
 A present workspace with missing, malformed, ownerless, or mismatched sidecar metadata is left
 untouched and reported as a cleanup failure; startup continues. Corrupt or mismatched leftover
 sidecars also fail closed.
@@ -1587,7 +1591,8 @@ Workspace persistence:
   Ensemble removes the workspace before releasing the durable run owner.
 - `<workspace.root>/.ensemble-workspace-metadata/<workspace_key>.json` stores `issue_id`,
   `issue_identifier`, the branch date used for repository worktrees, and the configured repository
-  identities (derived key and configured path). This manager-owned sidecar, outside the agent
+  identities (derived key and canonical repository path). Equivalent symlinked or lexical path
+  spellings resolve to the same identity. This manager-owned sidecar, outside the agent
   workspace, is the ownership authority. Files inside an agent workspace, including a forged
   `.ensemble-workspace.json`, have no lifecycle authority.
 - Built-in coordinated repository worktrees derive their branch identity from the same

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -668,6 +668,10 @@ Use `mode: off` to suppress auto-injection for a specific agent or step.
 
 `agent.permission_request_policy` only applies to direct ACP runtime paths. If all configured agents resolve to the `acpx` runtime, leave this at its default. In mixed configurations, it still applies only to agents using the direct runtime.
 
+Agent subprocesses do not inherit the orchestrator host's `GITHUB_TOKEN`. GitHub tracker and
+delivery credentials stay at the host boundary; configure an explicit future credential mechanism
+instead of depending on ambient token inheritance.
+
 `select_option` is client-specific. It selects an offered ACP `PermissionOption.option_id` exactly and cancels the permission request if that option is not offered. Known option IDs for ACP clients should be documented as verified examples, not protocol guarantees.
 
 ## Prompt templates

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -63,16 +63,32 @@ require GitHub, Notion, real ACP credentials, or non-localhost network access.
 ### Ignored live dogfood tracer bullet
 
 `live_bamboon_issue_publishes_pull_request` is a deliberately expensive, explicitly opted-in
-tracer bullet. It is ignored, is never part of CI, and creates a real synthetic issue in the
-private, operator-provisioned **Ensemble Dogfood** Project. It launches a real ACPX agent against
-an issue-owned Bamboon worktree, so it can consume network access and model time.
+tracer bullet. It is local-only, ignored by default, never part of CI, and creates a real synthetic
+issue in the private, operator-provisioned **Ensemble Dogfood** Project. It launches a real ACPX
+agent against an issue-owned Bamboon worktree, so expect a runtime of several minutes; it incurs
+network and model cost. The harness does not automate interactive first-run setup.
+It does not close the MVP release gate: passing this test alone is not sufficient to release
+Ensemble.
 
 Run it only when you have the dedicated fixture and a clean Bamboon clone. The project number and
 clone path are private local setup values: do not put either in shell history, documentation,
 issues, or logs.
 
 ```sh
+# Default routine mode
 ENSEMBLE_LIVE_DOGFOOD=1 \
+  ENSEMBLE_DOGFOOD_PROJECT_NUMBER=<local-project-number> \
+  ENSEMBLE_DOGFOOD_BAMBOON_PATH=<absolute-clean-bamboon-clone> \
+  SKIP_UI_BUILD=1 \
+  cargo test -p ensemble-cli --features web-ui --test product_e2e \
+  live_bamboon_issue_publishes_pull_request -- --ignored --nocapture
+```
+
+For a certification run, use the same invocation with the explicit preservation input:
+
+```sh
+ENSEMBLE_LIVE_DOGFOOD=1 \
+  ENSEMBLE_LIVE_DOGFOOD_PRESERVE=1 \
   ENSEMBLE_DOGFOOD_PROJECT_NUMBER=<local-project-number> \
   ENSEMBLE_DOGFOOD_BAMBOON_PATH=<absolute-clean-bamboon-clone> \
   SKIP_UI_BUILD=1 \
@@ -90,11 +106,23 @@ the child host in memory as `GITHUB_TOKEN`, and is not written into generated YA
 The tracer bullet creates one marker-owned Markdown artifact and commit. The agent may not publish:
 after capturing that local commit, Ensemble alone pushes the generated branch and creates exactly
 one open pull request at the captured SHA. It projects the Project issue to `In review` only after
-the delivery record persists its remote branch and pull-request identity. From that point it
-preserves the run directory, host stdout/stderr, issue, Project item, workspace, branch, and pull
-request for diagnosis. The test prints the redacted, run-scoped preservation location on success
-or failure. Do not perform routine cleanup or fixture repair from the harness; merge/close,
-and cleanup remain outside this slice.
+the delivery record persists its remote branch and pull-request identity. The test prints the
+redacted, run-scoped evidence location on success or failure.
+
+After the complete two-host restart proof, default routine mode performs one fixed, fail-closed
+sequence. It must revalidate and close the exact pull request. It then revalidates the exact Project
+item and moves it to `Done` while the second host remains running. It waits for public terminal state,
+zero claimed agent capacity, and removal of the captured worktree before stopping and reaping the
+host. Only then does it revalidate and close the exact issue, remove its exact Project item, and
+delete the exact generated remote ref if it is still at the stored SHA. Final checks require no
+open synthetic issue or pull request, no Project item, no generated ref, no registered worktree,
+and no active child process. The run directory, generated config, host logs, and evidence remain
+for inspection, so a succeeding routine run can be repeated without external residue.
+
+Preserve mode performs no GitHub or Git cleanup mutation. After the restart proof it only stops
+and reaps the second host, then records `preserved_certification`. The synthetic issue, Project
+item, generated branch, pull request, generated config, workspace/worktree, logs, and evidence stay
+available as the human-reviewable certification bundle.
 
 Once dispatch begins, the run retains one cumulative `<run-root>/evidence-v1.json` inspection
 document with format `ensemble.live-dogfood-evidence` and schema version 1. It records a
@@ -108,13 +136,36 @@ the marker-scoped GitHub pull request, Git ref, and persisted worktree/transcrip
 does not inspect private orchestrator state. Its preserved failure snapshot records a redacted last
 phase and assertions not reached. The document refers only to stable run identities and
 repository-relative artifacts: it excludes the private Project value, credentials, absolute paths,
-generated YAML, and raw command output.
+generated YAML, and raw command output. It also records the selected routine or preserve mode,
+each ordered cleanup or preservation transition, the final absent state, and resources retained
+intentionally.
 
 Each host lifetime has separate relative log names: `host-1.stdout.log`, `host-1.stderr.log`,
-`host-2.stdout.log`, and `host-2.stderr.log`. On a restart mismatch, timeout, or ambiguous
-observation, the harness stops without another remote mutation and preserves the evidence,
-both host log pairs, run, worktree, branch, and pull request for diagnosis. Do not clean or repair
-those retained artifacts from the harness.
+`host-2.stdout.log`, and `host-2.stderr.log`. On a restart mismatch, timeout, ambiguous observation,
+or partial cleanup failure, the harness stops the child, makes every later destructive transition
+unreachable, and preserves the evidence plus every resource not already changed. A failed setup
+before dispatch rolls back only the freshly created issue and Project item after revalidating their
+stored node IDs and ownership. Any ambiguity stops that rollback too.
+
+For failure recovery, use the `run_directory` printed by the test as the scope for the
+deliberate cleanup procedure:
+
+1. Read `evidence-v1.json`, the retained generated config, and both host log pairs to find the last
+   successful transition. Evidence supplies the issue number, pull request, ref/SHA, and worktree;
+   the local config supplies the private Project number. Do not copy the config into diagnostics or
+   infer a target from a title, marker search, or broad branch pattern.
+2. Before any mutation, revalidate each stored identity against fresh GitHub and Git observations: issue and Project
+   item node ownership, pull-request number/URL/head/base/head SHA, generated full ref and SHA, and
+   the worktree path beneath that run's workspace root. Stop if any read is missing, duplicated, or
+   different.
+3. Continue only the uncompleted suffix of the routine order: close the exact pull request; set the
+   exact item to `Done`; confirm no live Ensemble claim; remove only the captured registered
+   worktree; close the exact issue; remove the exact Project item; then delete the exact ref only if
+   it still resolves to the captured SHA.
+4. Re-query every surface and retain the run directory, logs, and evidence as the cleanup record.
+
+This procedure is deliberately manual: preservation is safer than unattended mutation after a
+partial or ambiguous run.
 
 The harness writes `evidence-v1.json` by flushing a same-directory temporary file and atomically
 replacing the prior document. If a replacement fails, the prior document and temporary diagnostic

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -155,7 +155,9 @@ deliberate cleanup procedure:
    request, ref/SHA, and worktree; the local config supplies the private Project number. Evidence may
    not exist before dispatch: for those setup failures, use the exact synthetic issue number printed
    with the rollback result and the same configured Project value. Do not copy the config into
-   diagnostics or infer a target from a title, marker search, or broad branch pattern.
+   diagnostics or infer a target from a title, marker search, or broad branch pattern. Once the
+   pre-publication snapshot exists, preserved-failure evidence conservatively lists the generated ref
+   and pull request until fresh observations prove they are absent.
 2. Before any mutation, revalidate each stored identity against fresh GitHub and Git observations: issue and Project
    item node ownership, pull-request number/URL/head/base/head SHA, generated full ref and SHA, and
    the worktree path beneath that run's workspace root. Stop if any read is missing, duplicated, or

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -102,6 +102,9 @@ and clone cleanliness before creating an issue; it never repairs fixture drift. 
 the `codex` named agent; set a non-empty `ENSEMBLE_DOGFOOD_AGENT` only for an explicit local
 override. The GitHub credential comes from `gh auth token` only after the opt-in gate, is passed to
 the child host in memory as `GITHUB_TOKEN`, and is not written into generated YAML or diagnostics.
+Agent subprocesses remove `GITHUB_TOKEN` from their environment. The generated dogfood agent uses
+read-approved launch permissions and rejects permission escalation, leaving GitHub publication to
+the orchestrator host.
 
 The tracer bullet creates one marker-owned Markdown artifact and commit. The agent may not publish:
 after capturing that local commit, Ensemble alone pushes the generated branch and creates exactly
@@ -138,7 +141,9 @@ phase and assertions not reached. The document refers only to stable run identit
 repository-relative artifacts: it excludes the private Project value, credentials, absolute paths,
 generated YAML, and raw command output. It also records the selected routine or preserve mode,
 each ordered cleanup or preservation transition, the final absent state, and resources retained
-intentionally.
+intentionally. Routine cleanup persists an `attempting` transition before each action, then appends
+a success or preserved-failure transition after observing the result. If the
+result cannot be persisted, recovery treats the attempted action as ambiguous and revalidates it.
 
 Each host lifetime has separate relative log names: `host-1.stdout.log`, `host-1.stderr.log`,
 `host-2.stdout.log`, and `host-2.stderr.log`. On a restart mismatch, timeout, ambiguous observation,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -150,10 +150,12 @@ stored node IDs and ownership. Any ambiguity stops that rollback too.
 For failure recovery, use the `run_directory` printed by the test as the scope for the
 deliberate cleanup procedure:
 
-1. Read `evidence-v1.json`, the retained generated config, and both host log pairs to find the last
-   successful transition. Evidence supplies the issue number, pull request, ref/SHA, and worktree;
-   the local config supplies the private Project number. Do not copy the config into diagnostics or
-   infer a target from a title, marker search, or broad branch pattern.
+1. For dispatch-and-later failures, read `evidence-v1.json`, the retained generated config, and both
+   host log pairs to find the last successful transition. Evidence supplies the issue number, pull
+   request, ref/SHA, and worktree; the local config supplies the private Project number. Evidence may
+   not exist before dispatch: for those setup failures, use the exact synthetic issue number printed
+   with the rollback result and the same configured Project value. Do not copy the config into
+   diagnostics or infer a target from a title, marker search, or broad branch pattern.
 2. Before any mutation, revalidate each stored identity against fresh GitHub and Git observations: issue and Project
    item node ownership, pull-request number/URL/head/base/head SHA, generated full ref and SHA, and
    the worktree path beneath that run's workspace root. Stop if any read is missing, duplicated, or


### PR DESCRIPTION
## Summary

- make the ignored live dogfood test clean up its exact run-owned GitHub issue, Project item, PR, remote branch, host process, and workspace by default
- add an explicit preserve mode with evidence that distinguishes absent resources from deliberately retained recovery state
- fail closed on identity drift or partial cleanup and document the operator workflow, cost, evidence, and recovery procedure

## Testing

- `cargo test --workspace --exclude ensemble-desktop -- --test-threads=1`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`

The private live routine/preserve runs were not executed because this environment did not set the explicit `ENSEMBLE_LIVE_DOGFOOD=1` opt-in. The ignored test and contributing guide retain that operator-only gate because each run creates real GitHub resources and invokes a real agent.

Closes #467
