### PR TITLE
Configure GitHub ownership recovery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,16 @@ _Avoid_: Completion, cleanup
 The durable owner of configured repository publication after pipeline work and approval are complete. It preserves exact local and remote identity until publication is confirmed, waiting on a pull request, or blocked for operator recovery.
 _Avoid_: Worker, tracker state
 
+**Claim**:
+Adapter-issued remote ownership evidence for one issue. It may supply an opaque workspace branch
+identity, but the orchestrator records it durably and remains the lifecycle authority.
+_Avoid_: Assignment, scheduler policy
+
+**Ownership conflict**:
+Bounded adapter evidence that an owner is foreign or ambiguous. It blocks admission or recovery
+without creating a competing run, workspace, or pull request.
+_Avoid_: Workflow branch, implicit adoption
+
 **Workspace**:
 The issue-owned filesystem area in which repository worktrees and run artifacts persist across steps and retries.
 _Avoid_: Checkout, repository

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -203,6 +203,9 @@ pub struct GithubTrackerConfig {
     pub status_field: String,
     #[serde(default)]
     pub priority: Option<GithubPriorityConfig>,
+    /// Optional adapter-owned policy for exclusive GitHub claims and delivery recovery.
+    #[serde(default)]
+    pub ownership: Option<GithubOwnershipConfig>,
 }
 
 /// The ordered single-select options that form GitHub Project priority ranks.
@@ -210,6 +213,42 @@ pub struct GithubTrackerConfig {
 pub struct GithubPriorityConfig {
     pub field: String,
     pub options: Vec<String>,
+}
+
+/// GitHub-specific ownership rules. Their values remain adapter data; the runtime
+/// receives only opaque leases and conflict outcomes.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct GithubOwnershipConfig {
+    #[serde(default)]
+    pub claim: Option<GithubClaimConfig>,
+    #[serde(default)]
+    pub delivery_adoption: Option<GithubDeliveryAdoptionConfig>,
+}
+
+/// An exclusive authenticated-assignee claim policy.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct GithubClaimConfig {
+    pub claimed_state: String,
+    pub resume_states: Vec<String>,
+}
+
+/// The exact identity required before an unpersisted pull request can be adopted.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct GithubDeliveryAdoptionConfig {
+    pub repository: String,
+    pub base_branch: String,
+    pub branch_template: String,
+    #[serde(default)]
+    pub require_authenticated_author: bool,
+}
+
+impl GithubDeliveryAdoptionConfig {
+    /// Render the sole supported immutable branch input. Callers pass the
+    /// workspace key rather than any tracker-specific identifier.
+    pub fn render_branch(&self, issue_workspace_key: &str) -> String {
+        self.branch_template
+            .replace("{issue_workspace_key}", issue_workspace_key)
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize, utoipa::ToSchema)]
@@ -969,21 +1008,25 @@ pub fn parse_config(yaml: &str) -> Result<EnsembleConfig, crate::error::ConfigEr
 fn validate_github_project_config(
     config: &EnsembleConfig,
 ) -> Result<(), crate::error::ConfigError> {
-    if config.tracker.kind != "github" || config.tracker.project_number.is_none() {
+    if config.tracker.kind != "github" {
         return Ok(());
     }
 
-    let github = config.tracker.github.as_ref().ok_or_else(|| {
-        crate::error::ConfigError::ConfigParseError {
+    let github = config.tracker.github.as_ref();
+    if config.tracker.project_number.is_some() {
+        let github = github.ok_or_else(|| crate::error::ConfigError::ConfigParseError {
             reason: "tracker.github.status_field is required when tracker.project_number is set"
                 .to_string(),
+        })?;
+        if github.status_field.trim().is_empty() {
+            return Err(crate::error::ConfigError::ConfigParseError {
+                reason: "tracker.github.status_field must not be empty".to_string(),
+            });
         }
-    })?;
-    if github.status_field.trim().is_empty() {
-        return Err(crate::error::ConfigError::ConfigParseError {
-            reason: "tracker.github.status_field must not be empty".to_string(),
-        });
     }
+    let Some(github) = github else {
+        return Ok(());
+    };
     if let Some(priority) = &github.priority {
         if priority.field.trim().is_empty() {
             return Err(crate::error::ConfigError::ConfigParseError {
@@ -1000,7 +1043,74 @@ fn validate_github_project_config(
             });
         }
     }
+    if let Some(ownership) = &github.ownership {
+        if let Some(claim) = &ownership.claim {
+            if claim.claimed_state.trim().is_empty() || claim.resume_states.is_empty() {
+                return Err(crate::error::ConfigError::ConfigParseError {
+                    reason: "tracker.github.ownership.claim requires a non-blank claimed_state and non-empty resume_states".to_string(),
+                });
+            }
+            if claim
+                .resume_states
+                .iter()
+                .any(|state| state.trim().is_empty())
+            {
+                return Err(crate::error::ConfigError::ConfigParseError {
+                    reason:
+                        "tracker.github.ownership.claim.resume_states must not contain blank names"
+                            .to_string(),
+                });
+            }
+            if !claim
+                .resume_states
+                .iter()
+                .any(|state| state.eq_ignore_ascii_case(&claim.claimed_state))
+            {
+                return Err(crate::error::ConfigError::ConfigParseError {
+                    reason: "tracker.github.ownership.claim.resume_states must include claimed_state so pre-journal claims remain recoverable".to_string(),
+                });
+            }
+        }
+        if let Some(adoption) = &ownership.delivery_adoption {
+            if adoption.repository.trim().is_empty()
+                || adoption.base_branch.trim().is_empty()
+                || adoption.branch_template.trim().is_empty()
+            {
+                return Err(crate::error::ConfigError::ConfigParseError {
+                    reason: "tracker.github.ownership.delivery_adoption fields must not be blank"
+                        .to_string(),
+                });
+            }
+            if adoption
+                .branch_template
+                .matches("{issue_workspace_key}")
+                .count()
+                != 1
+                || !valid_rendered_branch(&adoption.render_branch("issue-key-0123456789abcdef"))
+            {
+                return Err(crate::error::ConfigError::ConfigParseError {
+                    reason: "tracker.github.ownership.delivery_adoption.branch_template must contain exactly one {issue_workspace_key} and render a valid Git branch".to_string(),
+                });
+            }
+        }
+    }
     Ok(())
+}
+
+fn valid_rendered_branch(branch: &str) -> bool {
+    !branch.is_empty()
+        && branch != "@"
+        && !branch.starts_with(['-', '/'])
+        && !branch.ends_with(['/', '.'])
+        && !branch.chars().any(|character| {
+            character.is_ascii_control()
+                || matches!(character, ' ' | '~' | '^' | ':' | '?' | '*' | '[' | '\\')
+        })
+        && !branch.contains("..")
+        && !branch.contains("@{")
+        && branch.split('/').all(|component| {
+            !component.is_empty() && !component.starts_with('.') && !component.ends_with(".lock")
+        })
 }
 
 pub(crate) fn reject_unsupported_agent_max_turns(
@@ -1921,6 +2031,84 @@ on_failure: Failed
         let priority = config.tracker.github.unwrap().priority.unwrap();
         assert_eq!(priority.field, "Customer impact");
         assert_eq!(priority.options, ["Critical", "Elevated", "Normal"]);
+    }
+
+    #[test]
+    fn parses_opt_in_github_ownership_with_arbitrary_vocabulary() {
+        let yaml = minimal_yaml().replacen(
+            "kind: todo_file\n  path: TODO.md",
+            "kind: github\n  repository: acme/repo\n  project_number: 7\n  github:\n    status_field: Delivery state\n    ownership:\n      claim:\n        claimed_state: Agent-owned\n        resume_states: [Agent-owned, Resuming]\n      delivery_adoption:\n        repository: acme/repo\n        base_branch: release/2026\n        branch_template: agent/{issue_workspace_key}\n        require_authenticated_author: true",
+            1,
+        );
+
+        let config = parse_config(&yaml).unwrap();
+        let ownership = config.tracker.github.unwrap().ownership.unwrap();
+        assert_eq!(ownership.claim.unwrap().claimed_state, "Agent-owned");
+        assert_eq!(
+            ownership.delivery_adoption.unwrap().branch_template,
+            "agent/{issue_workspace_key}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_github_ownership_policy_before_activation() {
+        let yaml = minimal_yaml().replacen(
+            "kind: todo_file\n  path: TODO.md",
+            "kind: github\n  repository: acme/repo\n  project_number: 7\n  github:\n    status_field: Delivery state\n    ownership:\n      claim:\n        claimed_state: ' '\n        resume_states: []\n      delivery_adoption:\n        repository: acme/repo\n        base_branch: main\n        branch_template: agent/no-key",
+            1,
+        );
+
+        let error = parse_config(&yaml).unwrap_err();
+        assert!(error.to_string().contains("tracker.github.ownership.claim"));
+    }
+
+    #[test]
+    fn claimed_state_must_be_recoverable_before_the_first_journal_append() {
+        let yaml = minimal_yaml().replacen(
+            "kind: todo_file\n  path: TODO.md",
+            "kind: github\n  repository: acme/repo\n  github:\n    status_field: Status\n    ownership:\n      claim:\n        claimed_state: Agent-owned\n        resume_states: [Recovering]",
+            1,
+        );
+
+        let error = parse_config(&yaml).unwrap_err();
+        assert!(error.to_string().contains("must include claimed_state"));
+    }
+
+    #[test]
+    fn rejects_blank_or_invalid_github_delivery_adoption_fields() {
+        for policy in [
+            "repository: ' '\n        base_branch: main\n        branch_template: agent/{issue_workspace_key}",
+            "repository: acme/repo\n        base_branch: ' '\n        branch_template: agent/{issue_workspace_key}",
+            "repository: acme/repo\n        base_branch: main\n        branch_template: agent/no-key",
+            "repository: acme/repo\n        base_branch: main\n        branch_template: agent/{issue_workspace_key}..lock",
+        ] {
+            let yaml = minimal_yaml().replacen(
+                "kind: todo_file\n  path: TODO.md",
+                &format!(
+                    "kind: github\n  repository: acme/repo\n  github:\n    status_field: Delivery state\n    ownership:\n      delivery_adoption:\n        {policy}"
+                ),
+                1,
+            );
+
+            let error = parse_config(&yaml).unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("tracker.github.ownership.delivery_adoption"));
+        }
+    }
+
+    #[test]
+    fn git_branch_validation_rejects_invalid_components_and_controls() {
+        for invalid in [
+            "@",
+            "agent//issue",
+            "agent/.hidden",
+            "agent/topic.lock/child",
+            "agent/issue\u{7f}",
+        ] {
+            assert!(!valid_rendered_branch(invalid), "accepted {invalid:?}");
+        }
+        assert!(valid_rendered_branch("agent/release-2026.08/issue_1"));
     }
 
     #[test]

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -75,6 +75,14 @@ pub enum WorkspaceError {
         expected_repositories: BTreeMap<String, String>,
         actual_repositories: BTreeMap<String, String>,
     },
+    #[error(
+        "workspace branch identity mismatch at {path}: expected {expected_branch:?}, found {actual_branch:?}"
+    )]
+    BranchIdentityMismatch {
+        path: String,
+        expected_branch: Option<String>,
+        actual_branch: Option<String>,
+    },
     #[error("hook failed: {hook} — {reason}")]
     HookFailed { hook: String, reason: String },
     #[error("hook timed out: {hook} after {timeout_ms}ms")]

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -16,7 +16,9 @@ use super::{
 };
 use crate::history::model::HistoryRecord;
 use crate::pipeline::engine::{PipelineRun, PipelineRunSnapshot};
+use crate::tracker::OwnershipConflict;
 use crate::workspace::finalize::FinalizeMode;
+use crate::workspace::key::issue_workspace_key;
 
 const DELIVERY_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
 const PULL_REQUEST_DISCOVERY_LIMIT: usize = 1_000;
@@ -56,6 +58,8 @@ pub(crate) struct DeliveryRepository {
     pub marker: String,
     pub pr_number: Option<u64>,
     pub pr_url: Option<String>,
+    #[serde(default)]
+    pub ownership_conflict: Option<OwnershipConflict>,
     pub last_error: Option<String>,
     pub retry_from: Option<DeliveryPhase>,
 }
@@ -202,12 +206,24 @@ pub(crate) fn canonical_marker(run_id: &str, issue_id: &str, repository_key: &st
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RemotePullRequest {
     pub repository_key: String,
+    pub repository: Option<String>,
+    pub head_repository: Option<String>,
+    pub author: Option<String>,
+    pub authored_by_authenticated_viewer: bool,
     pub head_branch: String,
     pub base_branch: String,
     pub head_sha: String,
     pub body: String,
     pub number: u64,
     pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PullRequestAdoptionPolicy {
+    pub repository: String,
+    pub base_branch: String,
+    pub head_branch: String,
+    pub require_authenticated_author: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -218,6 +234,14 @@ pub(crate) struct LocalRepositoryIdentity {
 
 #[async_trait]
 pub(crate) trait DeliveryRemote: Send + Sync {
+    fn pull_request_adoption_policy(
+        &self,
+        _config: &crate::config::ensemble::EnsembleConfig,
+        _issue_id: &str,
+    ) -> Option<PullRequestAdoptionPolicy> {
+        None
+    }
+
     async fn local_identity(
         &self,
         repository_path: &Path,
@@ -242,6 +266,7 @@ pub(crate) trait DeliveryRemote: Send + Sync {
         &self,
         repository_path: &Path,
         repository_key: &str,
+        adoption_policy: Option<&PullRequestAdoptionPolicy>,
     ) -> Result<Vec<RemotePullRequest>, String>;
 
     async fn create_pull_request(
@@ -264,10 +289,47 @@ struct GhPullRequest {
     head_ref_name: String,
     base_ref_name: String,
     head_ref_oid: String,
+    author: Option<GhActor>,
+    head_repository: Option<GhRepository>,
+}
+
+#[derive(Deserialize)]
+struct GhActor {
+    login: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhRepository {
+    name_with_owner: String,
 }
 
 #[async_trait]
 impl DeliveryRemote for CliDeliveryRemote {
+    fn pull_request_adoption_policy(
+        &self,
+        config: &crate::config::ensemble::EnsembleConfig,
+        issue_id: &str,
+    ) -> Option<PullRequestAdoptionPolicy> {
+        if config.tracker.kind != "github" {
+            return None;
+        }
+        let configured = config
+            .tracker
+            .github
+            .as_ref()?
+            .ownership
+            .as_ref()?
+            .delivery_adoption
+            .as_ref()?;
+        Some(PullRequestAdoptionPolicy {
+            repository: configured.repository.clone(),
+            base_branch: configured.base_branch.clone(),
+            head_branch: configured.render_branch(&issue_workspace_key(issue_id)),
+            require_authenticated_author: configured.require_authenticated_author,
+        })
+    }
+
     async fn local_identity(
         &self,
         repository_path: &Path,
@@ -335,7 +397,31 @@ impl DeliveryRemote for CliDeliveryRemote {
         &self,
         repository_path: &Path,
         repository_key: &str,
+        adoption_policy: Option<&PullRequestAdoptionPolicy>,
     ) -> Result<Vec<RemotePullRequest>, String> {
+        let (repository, authenticated_viewer) = if let Some(policy) = adoption_policy {
+            let repository_json = command_stdout(
+                repository_path,
+                "gh",
+                &["repo", "view", "--json", "nameWithOwner"],
+            )
+            .await?;
+            let repository: GhRepository = serde_json::from_str(&repository_json)
+                .map_err(|error| format!("invalid gh repo view output: {error}"))?;
+            let viewer = if policy.require_authenticated_author {
+                let viewer_json = command_stdout(repository_path, "gh", &["api", "user"]).await?;
+                Some(
+                    serde_json::from_str::<GhActor>(&viewer_json)
+                        .map_err(|error| format!("invalid authenticated GitHub user: {error}"))?
+                        .login,
+                )
+            } else {
+                None
+            };
+            (Some(repository.name_with_owner), viewer)
+        } else {
+            (None, None)
+        };
         let stdout = command_stdout(
             repository_path,
             "gh",
@@ -347,7 +433,7 @@ impl DeliveryRemote for CliDeliveryRemote {
                 "--limit",
                 "1000",
                 "--json",
-                "number,url,body,headRefName,baseRefName,headRefOid",
+                "number,url,body,headRefName,baseRefName,headRefOid,author,headRepository",
             ],
         )
         .await?;
@@ -362,6 +448,19 @@ impl DeliveryRemote for CliDeliveryRemote {
             .into_iter()
             .map(|pull_request| RemotePullRequest {
                 repository_key: repository_key.to_string(),
+                repository: repository.clone(),
+                head_repository: pull_request
+                    .head_repository
+                    .map(|repository| repository.name_with_owner),
+                authored_by_authenticated_viewer: authenticated_viewer.as_deref().is_some_and(
+                    |viewer| {
+                        pull_request
+                            .author
+                            .as_ref()
+                            .is_some_and(|author| author.login.eq_ignore_ascii_case(viewer))
+                    },
+                ),
+                author: pull_request.author.map(|author| author.login),
                 head_branch: pull_request.head_ref_name,
                 base_branch: pull_request.base_ref_name,
                 head_sha: pull_request.head_ref_oid,
@@ -454,14 +553,24 @@ pub(crate) fn reconcile_push(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PullRequestReconciliation {
     Create,
-    Adopted { number: u64, url: String },
-    Blocked { error: String },
+    Adopted {
+        number: u64,
+        url: String,
+    },
+    Blocked {
+        error: String,
+    },
+    Conflict {
+        conflict: OwnershipConflict,
+        error: String,
+    },
 }
 
 pub(crate) fn reconcile_pull_requests(
     repository_key: &str,
     repository: &DeliveryRepository,
     pull_requests: &[RemotePullRequest],
+    adoption_policy: Option<&PullRequestAdoptionPolicy>,
 ) -> PullRequestReconciliation {
     if repository.observed_remote_sha.as_deref() != Some(repository.local_sha.as_str()) {
         return PullRequestReconciliation::Blocked {
@@ -469,7 +578,7 @@ pub(crate) fn reconcile_pull_requests(
         };
     }
 
-    let same_identity = |pull_request: &&RemotePullRequest| {
+    let same_delivery_identity = |pull_request: &&RemotePullRequest| {
         pull_request.repository_key == repository_key
             && pull_request.head_branch == repository.head_branch
             && pull_request.base_branch == repository.base_branch
@@ -477,46 +586,112 @@ pub(crate) fn reconcile_pull_requests(
     let marker_matches =
         |pull_request: &&RemotePullRequest| pull_request.body.contains(repository.marker.as_str());
 
-    if pull_requests
-        .iter()
-        .filter(same_identity)
-        .any(|pull_request| !marker_matches(&pull_request))
-    {
-        return PullRequestReconciliation::Blocked {
-            error: "pull request identity matched but its delivery marker did not".to_string(),
-        };
-    }
-    if pull_requests
+    let marked = pull_requests
         .iter()
         .filter(marker_matches)
-        .any(|pull_request| !same_identity(&pull_request))
+        .collect::<Vec<_>>();
+    if marked
+        .iter()
+        .any(|pull_request| !same_delivery_identity(pull_request))
     {
-        return PullRequestReconciliation::Blocked {
+        return PullRequestReconciliation::Conflict {
+            conflict: OwnershipConflict::Foreign,
             error: "delivery marker matched a different repository or branch identity".to_string(),
         };
     }
-
-    let matches: Vec<&RemotePullRequest> = pull_requests
-        .iter()
-        .filter(same_identity)
-        .filter(marker_matches)
-        .collect();
-    match matches.as_slice() {
-        [] => PullRequestReconciliation::Create,
+    match marked.as_slice() {
+        [] => {}
         [pull_request] if pull_request.head_sha == repository.local_sha => {
-            PullRequestReconciliation::Adopted {
+            return PullRequestReconciliation::Adopted {
                 number: pull_request.number,
                 url: pull_request.url.clone(),
-            }
+            };
         }
-        [pull_request] => PullRequestReconciliation::Blocked {
+        [pull_request] => {
+            return PullRequestReconciliation::Conflict {
+                conflict: OwnershipConflict::Foreign,
+                error: format!(
+                    "pull request head is {}, expected {}",
+                    pull_request.head_sha, repository.local_sha
+                ),
+            };
+        }
+        _ => {
+            return PullRequestReconciliation::Conflict {
+                conflict: OwnershipConflict::Ambiguous,
+                error: "multiple pull requests match the delivery marker".to_string(),
+            };
+        }
+    }
+
+    let same_unpersisted_identity = pull_requests
+        .iter()
+        .filter(same_delivery_identity)
+        .collect::<Vec<_>>();
+    let Some(policy) = adoption_policy else {
+        return if same_unpersisted_identity.is_empty() {
+            PullRequestReconciliation::Create
+        } else {
+            PullRequestReconciliation::Conflict {
+                conflict: if same_unpersisted_identity.len() == 1 {
+                    OwnershipConflict::Foreign
+                } else {
+                    OwnershipConflict::Ambiguous
+                },
+                error: "pull request identity matched but its delivery marker did not".to_string(),
+            }
+        };
+    };
+
+    if repository.head_branch != policy.head_branch || repository.base_branch != policy.base_branch
+    {
+        return PullRequestReconciliation::Blocked {
+            error: "delivery identity does not match the configured adoption policy".to_string(),
+        };
+    }
+
+    let branch_candidates = pull_requests
+        .iter()
+        .filter(|pull_request| pull_request.head_branch == policy.head_branch)
+        .collect::<Vec<_>>();
+    if branch_candidates.is_empty() {
+        return PullRequestReconciliation::Create;
+    }
+    let exact = branch_candidates
+        .iter()
+        .copied()
+        .filter(|pull_request| {
+            pull_request.repository_key == repository_key
+                && pull_request
+                    .repository
+                    .as_deref()
+                    .is_some_and(|name| name.eq_ignore_ascii_case(&policy.repository))
+                && pull_request
+                    .head_repository
+                    .as_deref()
+                    .is_some_and(|name| name.eq_ignore_ascii_case(&policy.repository))
+                && pull_request.base_branch == policy.base_branch
+                && pull_request.head_sha == repository.local_sha
+                && (!policy.require_authenticated_author
+                    || pull_request.authored_by_authenticated_viewer)
+        })
+        .collect::<Vec<_>>();
+    match (branch_candidates.as_slice(), exact.as_slice()) {
+        ([_], [pull_request]) => PullRequestReconciliation::Adopted {
+            number: pull_request.number,
+            url: pull_request.url.clone(),
+        },
+        ([candidate], []) => PullRequestReconciliation::Conflict {
+            conflict: OwnershipConflict::Foreign,
             error: format!(
-                "pull request head is {}, expected {}",
-                pull_request.head_sha, repository.local_sha
+                "unpersisted pull request #{} by '{}' conflicts with the configured repository, author, head, base, or SHA",
+                candidate.number,
+                candidate.author.as_deref().unwrap_or("unknown")
             ),
         },
-        _ => PullRequestReconciliation::Blocked {
-            error: "multiple pull requests match the delivery identity".to_string(),
+        _ => PullRequestReconciliation::Conflict {
+            conflict: OwnershipConflict::Ambiguous,
+            error: "multiple pull requests contend for the configured adoption identity".to_string(),
         },
     }
 }
@@ -634,6 +809,7 @@ impl Orchestrator {
                 if retry_from != DeliveryPhase::Waiting {
                     repository.retry_from = None;
                 }
+                repository.ownership_conflict = None;
                 repository.last_error = None;
                 changed = true;
             }
@@ -709,6 +885,7 @@ impl Orchestrator {
                     repository.retry_from = None;
                 }
             }
+            repository.ownership_conflict = None;
             repository.last_error = None;
             changed = true;
         }
@@ -1468,6 +1645,7 @@ impl Orchestrator {
                         &repository_key,
                         DeliveryPhase::Prepared,
                         "delivery worktree is missing".to_string(),
+                        None,
                         snapshot,
                     )
                     .await;
@@ -1631,6 +1809,7 @@ impl Orchestrator {
                 if repository.retry_from == Some(DeliveryPhase::Waiting) {
                     repository.phase = DeliveryPhase::Waiting;
                     repository.retry_from = None;
+                    repository.ownership_conflict = None;
                     repository.last_error = None;
                 }
             } else {
@@ -1658,6 +1837,7 @@ impl Orchestrator {
             let mut reconciling = delivery.clone();
             let entry = reconciling.repositories.get_mut(repository_key).unwrap();
             entry.phase = DeliveryPhase::ReconcilingPr;
+            entry.ownership_conflict = None;
             entry.last_error = None;
             delivery = match self
                 .persist_delivery_candidate(&delivery, reconciling, snapshot)
@@ -1671,9 +1851,14 @@ impl Orchestrator {
         if repository.phase != DeliveryPhase::ReconcilingPr {
             return (delivery, false);
         }
+        let adoption_policy = {
+            let config = self.config.read().await;
+            self.delivery_remote
+                .pull_request_adoption_policy(&config, &delivery.issue_id)
+        };
         let pull_requests = match self
             .delivery_remote
-            .list_pull_requests(repository_path, repository_key)
+            .list_pull_requests(repository_path, repository_key, adoption_policy.as_ref())
             .await
         {
             Ok(pull_requests) => pull_requests,
@@ -1684,6 +1869,7 @@ impl Orchestrator {
                         repository_key,
                         DeliveryPhase::ReconcilingPr,
                         error,
+                        None,
                         snapshot,
                     )
                     .await,
@@ -1691,13 +1877,19 @@ impl Orchestrator {
                 )
             }
         };
-        match reconcile_pull_requests(repository_key, &repository, &pull_requests) {
+        match reconcile_pull_requests(
+            repository_key,
+            &repository,
+            &pull_requests,
+            adoption_policy.as_ref(),
+        ) {
             PullRequestReconciliation::Adopted { number, url } => {
                 let mut waiting = delivery.clone();
                 let entry = waiting.repositories.get_mut(repository_key).unwrap();
                 entry.phase = DeliveryPhase::Waiting;
                 entry.pr_number = Some(number);
                 entry.pr_url = Some(url);
+                entry.ownership_conflict = None;
                 entry.last_error = None;
                 entry.retry_from = None;
                 (
@@ -1712,6 +1904,7 @@ impl Orchestrator {
                 let mut in_flight = delivery.clone();
                 let entry = in_flight.repositories.get_mut(repository_key).unwrap();
                 entry.phase = DeliveryPhase::PrCreateInFlight;
+                entry.ownership_conflict = None;
                 entry.last_error = None;
                 delivery = match self
                     .persist_delivery_candidate(&delivery, in_flight, snapshot)
@@ -1734,6 +1927,7 @@ impl Orchestrator {
                 match result {
                     Ok(_) => {
                         entry.phase = DeliveryPhase::ReconcilingPr;
+                        entry.ownership_conflict = None;
                         entry.last_error = None;
                     }
                     Err(error) => entry.last_error = Some(error),
@@ -1752,6 +1946,19 @@ impl Orchestrator {
                     repository_key,
                     DeliveryPhase::ReconcilingPr,
                     error,
+                    None,
+                    snapshot,
+                )
+                .await,
+                false,
+            ),
+            PullRequestReconciliation::Conflict { conflict, error } => (
+                self.block_delivery_repository(
+                    &delivery,
+                    repository_key,
+                    DeliveryPhase::ReconcilingPr,
+                    error,
+                    Some(conflict),
                     snapshot,
                 )
                 .await,
@@ -1759,6 +1966,7 @@ impl Orchestrator {
             ),
         }
     }
+
     async fn advance_delivery_push(
         &self,
         mut delivery: DeliveryRecord,
@@ -1771,6 +1979,7 @@ impl Orchestrator {
             let mut reconciling = delivery.clone();
             let entry = reconciling.repositories.get_mut(repository_key).unwrap();
             entry.phase = DeliveryPhase::ReconcilingPush;
+            entry.ownership_conflict = None;
             entry.last_error = None;
             entry.retry_from = None;
             delivery = match self
@@ -1798,6 +2007,7 @@ impl Orchestrator {
                         repository_key,
                         DeliveryPhase::ReconcilingPush,
                         error,
+                        None,
                         snapshot,
                     )
                     .await
@@ -1808,6 +2018,7 @@ impl Orchestrator {
                 let mut in_flight = delivery.clone();
                 let entry = in_flight.repositories.get_mut(repository_key).unwrap();
                 entry.phase = DeliveryPhase::PushInFlight;
+                entry.ownership_conflict = None;
                 entry.last_error = None;
                 delivery = match self
                     .persist_delivery_candidate(&delivery, in_flight, snapshot)
@@ -1830,6 +2041,7 @@ impl Orchestrator {
                 match result {
                     Ok(_) => {
                         entry.phase = DeliveryPhase::ReconcilingPush;
+                        entry.ownership_conflict = None;
                         entry.last_error = None;
                     }
                     Err(error) => entry.last_error = Some(error),
@@ -1842,6 +2054,7 @@ impl Orchestrator {
                 let mut advanced = delivery.clone();
                 let entry = advanced.repositories.get_mut(repository_key).unwrap();
                 entry.observed_remote_sha = observed;
+                entry.ownership_conflict = None;
                 entry.last_error = None;
                 entry.retry_from = None;
                 entry.phase = match entry.mode {
@@ -1858,6 +2071,7 @@ impl Orchestrator {
                     repository_key,
                     DeliveryPhase::ReconcilingPush,
                     error,
+                    None,
                     snapshot,
                 )
                 .await
@@ -1870,12 +2084,14 @@ impl Orchestrator {
         repository_key: &str,
         retry_from: DeliveryPhase,
         error: String,
+        ownership_conflict: Option<OwnershipConflict>,
         snapshot: Option<&PipelineRunSnapshot>,
     ) -> DeliveryRecord {
         let mut blocked = current.clone();
         if let Some(repository) = blocked.repositories.get_mut(repository_key) {
             repository.phase = DeliveryPhase::Blocked;
             repository.last_error = Some(error);
+            repository.ownership_conflict = ownership_conflict;
             repository.retry_from = Some(retry_from);
         }
         self.persist_delivery_candidate(current, blocked, snapshot)
@@ -2031,6 +2247,7 @@ impl Orchestrator {
                     marker: canonical_marker(&run_id, issue_id, repository_key),
                     pr_number: None,
                     pr_url: None,
+                    ownership_conflict: None,
                     last_error: None,
                     retry_from: None,
                 },
@@ -2095,6 +2312,7 @@ mod tests {
             marker: "<!-- ensemble:delivery:v1 -->".to_string(),
             pr_number: None,
             pr_url: None,
+            ownership_conflict: None,
             last_error: None,
             retry_from: None,
         }
@@ -2103,6 +2321,10 @@ mod tests {
     fn pull_request(marker: &str, head_sha: &str) -> RemotePullRequest {
         RemotePullRequest {
             repository_key: "primary".to_string(),
+            repository: Some("example/project".to_string()),
+            head_repository: Some("example/project".to_string()),
+            author: Some("octocat".to_string()),
+            authored_by_authenticated_viewer: true,
             head_branch: "ensemble/issue-420".to_string(),
             base_branch: "main".to_string(),
             head_sha: head_sha.to_string(),
@@ -2237,7 +2459,7 @@ mod tests {
         let exact = pull_request(&repo.marker, &repo.local_sha);
 
         assert_eq!(
-            reconcile_pull_requests("primary", &repo, std::slice::from_ref(&exact)),
+            reconcile_pull_requests("primary", &repo, std::slice::from_ref(&exact), None),
             PullRequestReconciliation::Adopted {
                 number: exact.number,
                 url: exact.url.clone(),
@@ -2246,12 +2468,18 @@ mod tests {
 
         let wrong_head = pull_request(&repo.marker, "aaaaaaaaaaaaaaaa");
         assert!(matches!(
-            reconcile_pull_requests("primary", &repo, &[wrong_head]),
-            PullRequestReconciliation::Blocked { .. }
+            reconcile_pull_requests("primary", &repo, &[wrong_head], None),
+            PullRequestReconciliation::Conflict {
+                conflict: OwnershipConflict::Foreign,
+                ..
+            }
         ));
         assert!(matches!(
-            reconcile_pull_requests("primary", &repo, &[exact.clone(), exact]),
-            PullRequestReconciliation::Blocked { .. }
+            reconcile_pull_requests("primary", &repo, &[exact.clone(), exact], None),
+            PullRequestReconciliation::Conflict {
+                conflict: OwnershipConflict::Ambiguous,
+                ..
+            }
         ));
     }
 
@@ -2261,9 +2489,94 @@ mod tests {
         repo.observed_remote_sha = Some(repo.local_sha.clone());
 
         assert_eq!(
-            reconcile_pull_requests("primary", &repo, &[]),
+            reconcile_pull_requests("primary", &repo, &[], None),
             PullRequestReconciliation::Create
         );
+    }
+
+    fn adoption_policy() -> PullRequestAdoptionPolicy {
+        PullRequestAdoptionPolicy {
+            repository: "example/project".to_string(),
+            base_branch: "main".to_string(),
+            head_branch: "ensemble/issue-420".to_string(),
+            require_authenticated_author: true,
+        }
+    }
+
+    #[test]
+    fn marker_identity_precedes_an_exact_unpersisted_fallback() {
+        let mut repo = repository(DeliveryPhase::ReconcilingPr);
+        repo.observed_remote_sha = Some(repo.local_sha.clone());
+        let marked = pull_request(&repo.marker, &repo.local_sha);
+        let mut unmarked = pull_request("", &repo.local_sha);
+        unmarked.number = 421;
+        unmarked.url = "https://github.com/example/project/pull/421".to_string();
+
+        assert_eq!(
+            reconcile_pull_requests(
+                "primary",
+                &repo,
+                &[unmarked, marked.clone()],
+                Some(&adoption_policy()),
+            ),
+            PullRequestReconciliation::Adopted {
+                number: marked.number,
+                url: marked.url,
+            }
+        );
+    }
+
+    #[test]
+    fn one_exact_configured_unpersisted_pull_request_is_adopted() {
+        let mut repo = repository(DeliveryPhase::ReconcilingPr);
+        repo.observed_remote_sha = Some(repo.local_sha.clone());
+        let exact = pull_request("", &repo.local_sha);
+
+        assert_eq!(
+            reconcile_pull_requests(
+                "primary",
+                &repo,
+                std::slice::from_ref(&exact),
+                Some(&adoption_policy()),
+            ),
+            PullRequestReconciliation::Adopted {
+                number: exact.number,
+                url: exact.url.clone(),
+            }
+        );
+    }
+
+    #[test]
+    fn configured_fallback_blocks_foreign_or_ambiguous_pull_requests() {
+        let mut repo = repository(DeliveryPhase::ReconcilingPr);
+        repo.observed_remote_sha = Some(repo.local_sha.clone());
+        let exact = pull_request("", &repo.local_sha);
+        let mut foreign_author = exact.clone();
+        foreign_author.authored_by_authenticated_viewer = false;
+        let mut fork = exact.clone();
+        fork.head_repository = Some("contributor/fork".to_string());
+
+        for candidates in [vec![foreign_author], vec![fork]] {
+            assert!(matches!(
+                reconcile_pull_requests("primary", &repo, &candidates, Some(&adoption_policy()),),
+                PullRequestReconciliation::Conflict {
+                    conflict: OwnershipConflict::Foreign,
+                    ..
+                }
+            ));
+        }
+        assert!(matches!(
+            reconcile_pull_requests(
+                "primary",
+                &repo,
+                &[exact.clone(), exact],
+                Some(&adoption_policy()),
+            ),
+            PullRequestReconciliation::Conflict {
+                conflict: OwnershipConflict::Ambiguous,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -76,7 +76,7 @@ use crate::pipeline::engine::{
 use crate::pipeline::verdict::StepResult;
 use crate::timeline::persistence::TimelinePersistence;
 use crate::tracker::model::{Issue, RetryEntry, RunningEntry};
-use crate::tracker::IssueTracker;
+use crate::tracker::{IssueTracker, OwnershipClaim, OwnershipLease};
 use crate::transcript::events::TranscriptEventBus;
 use crate::transcript::model::TranscriptRecordKind;
 use crate::transcript::persistence::{TranscriptPersistRequest, TranscriptPersistence};
@@ -225,6 +225,13 @@ struct PendingAcceptanceTransition {
     candidate: PipelineRunSnapshot,
     owner: AcceptanceOwnerIdentity,
     baseline: PipelineRunSnapshot,
+}
+
+#[derive(Clone)]
+struct PendingRunStartedTransition {
+    expected: PipelineTransitionInput,
+    issue: Issue,
+    attempt: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -445,7 +452,11 @@ pub struct Orchestrator {
     history_store: Option<HistoryStore>,
     pipeline_journal: PipelineRunJournal,
     pipeline_journal_restored: AtomicBool,
+    pending_run_started_transitions:
+        Box<std::sync::Mutex<HashMap<String, PendingRunStartedTransition>>>,
     pending_acceptance_transitions: std::sync::Mutex<HashMap<String, PendingAcceptanceTransition>>,
+    /// Remote claims held only until their first synchronous `RunStarted` journal append.
+    pending_ownership_leases: std::sync::Mutex<HashMap<String, OwnershipLease>>,
     event_bus: EventBus,
     timeline_persistence: Option<TimelinePersistence>,
     transcript_persistence: Option<TranscriptPersistence>,
@@ -623,7 +634,9 @@ impl Orchestrator {
             history_store,
             pipeline_journal: PipelineRunJournal::new(config_dir.to_path_buf()),
             pipeline_journal_restored: AtomicBool::new(false),
+            pending_run_started_transitions: Box::new(std::sync::Mutex::new(HashMap::new())),
             pending_acceptance_transitions: std::sync::Mutex::new(HashMap::new()),
+            pending_ownership_leases: std::sync::Mutex::new(HashMap::new()),
             event_bus: parts.event_bus,
             timeline_persistence,
             transcript_persistence: Some(TranscriptPersistence::new_with_event_bus(
@@ -905,7 +918,11 @@ impl Orchestrator {
     }
 
     /// Handle a poll tick: reconcile, validate, fetch, dispatch.
-    async fn handle_tick(&self) {
+    fn handle_tick(&self) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(self.handle_tick_inner())
+    }
+
+    async fn handle_tick_inner(&self) {
         if self.quiescing.is_requested() {
             return;
         }
@@ -936,6 +953,7 @@ impl Orchestrator {
             state.last_tick_at = Some(Utc::now());
         }
 
+        Box::pin(self.reconcile_pending_run_started_transitions()).await;
         self.reconcile_pending_acceptance_transitions().await;
         self.restore_pipeline_runs_from_journal().await;
         self.reconcile_pending_terminal_transitions().await;
@@ -1070,8 +1088,12 @@ impl Orchestrator {
         // Give already-claimed pipelines the first opportunity to consume
         // newly available worker capacity before admitting new issues.
         if let Some(permit) = self.quiescing.begin_dispatch() {
-            self.dispatch_ready_active_pipelines(&permit).await;
+            Box::pin(self.dispatch_ready_active_pipelines(&permit)).await;
         }
+
+        // Durable journal owners always win. Only after they have had an
+        // opportunity to resume may an adapter supply a remotely-owned orphan.
+        Box::pin(self.dispatch_recovered_claims_before_fresh_work()).await;
 
         // 3. Fetch candidate issues
         let mut candidates = match self.tracker.fetch_candidate_issues().await {
@@ -1106,60 +1128,8 @@ impl Orchestrator {
                 }
             }
 
-            let eligible = {
-                let state = self.state.read().await;
-                is_dispatch_eligible(issue, &state, &active_lower, &terminal_lower)
-            };
-
-            let restored_pipeline_ready = {
-                let state = self.state.read().await;
-                Self::restored_pipeline_ready_for_dispatch(&state, &issue.id)
-            };
-
-            if restored_pipeline_ready {
-                self.dispatch_issue(issue, None).await;
-                continue;
-            }
-
-            {
-                let config = self.config.read().await;
-                if !self.state_worker_capacity_available(issue, &config).await {
-                    continue;
-                }
-            }
-
-            if eligible.is_some() {
-                continue;
-            }
-
-            match self.restore_pipeline_run_for_candidate(issue).await {
-                Ok(
-                    CandidateRestoreOutcome::NotRestored
-                    | CandidateRestoreOutcome::ReadyForDispatch,
-                ) => {
-                    self.dispatch_issue(issue, None).await;
-                }
-                Ok(CandidateRestoreOutcome::Parked) => {}
-                Err(
-                    error @ EnsembleError::Agent(AgentError::DurableSequenceUnavailable { .. }),
-                ) => {
-                    warn!(
-                        issue_id = %issue.id,
-                        identifier = %issue.identifier,
-                        error = %error,
-                        "failed to restore live pipeline journal before dispatch, leaving issue undispatched"
-                    );
-                }
-                Err(error) => {
-                    warn!(
-                        issue_id = %issue.id,
-                        identifier = %issue.identifier,
-                        error = %error,
-                        "failed to restore live pipeline journal before dispatch, falling back to fresh dispatch"
-                    );
-                    self.dispatch_issue(issue, None).await;
-                }
-            }
+            Box::pin(self.consider_candidate_for_dispatch(issue, &active_lower, &terminal_lower))
+                .await;
         }
 
         info!(
@@ -1167,6 +1137,157 @@ impl Orchestrator {
             duration_ms = elapsed_ms(tick_started_at),
             "orchestrator tick finished"
         );
+    }
+
+    async fn consider_candidate_for_dispatch(
+        &self,
+        issue: &Issue,
+        active_lower: &[String],
+        terminal_lower: &[String],
+    ) {
+        let eligible = {
+            let state = self.state.read().await;
+            is_dispatch_eligible(issue, &state, active_lower, terminal_lower)
+        };
+
+        let restored_pipeline_ready = {
+            let state = self.state.read().await;
+            Self::restored_pipeline_ready_for_dispatch(&state, &issue.id)
+        };
+
+        if restored_pipeline_ready {
+            Box::pin(self.dispatch_issue(issue, None)).await;
+            return;
+        }
+
+        {
+            let config = self.config.read().await;
+            if !self.state_worker_capacity_available(issue, &config).await {
+                return;
+            }
+        }
+
+        if eligible.is_some() {
+            return;
+        }
+
+        match self.restore_pipeline_run_for_candidate(issue).await {
+            Ok(CandidateRestoreOutcome::ReadyForDispatch) => {
+                Box::pin(self.dispatch_issue(issue, None)).await;
+            }
+            Ok(CandidateRestoreOutcome::NotRestored) => {
+                if let Some(owned_issue) = Box::pin(self.claim_candidate_for_dispatch(issue)).await
+                {
+                    Box::pin(self.dispatch_issue(&owned_issue, None)).await;
+                }
+            }
+            Ok(CandidateRestoreOutcome::Parked) => {}
+            Err(error @ EnsembleError::Agent(AgentError::DurableSequenceUnavailable { .. })) => {
+                warn!(
+                    issue_id = %issue.id,
+                    identifier = %issue.identifier,
+                    error = %error,
+                    "failed to restore live pipeline journal before dispatch, leaving issue undispatched"
+                );
+            }
+            Err(error) => {
+                if self.tracker.has_remote_ownership_policy() {
+                    warn!(
+                        issue_id = %issue.id,
+                        identifier = %issue.identifier,
+                        error = %error,
+                        "failed to restore live pipeline journal before remote-owned dispatch; leaving issue undispatched"
+                    );
+                } else {
+                    warn!(
+                        issue_id = %issue.id,
+                        identifier = %issue.identifier,
+                        error = %error,
+                        "failed to restore live pipeline journal before dispatch, falling back to fresh dispatch"
+                    );
+                    Box::pin(self.dispatch_issue(issue, None)).await;
+                }
+            }
+        }
+    }
+
+    async fn dispatch_recovered_claims_before_fresh_work(&self) {
+        let recovered = match self.tracker.recover_owned_claims().await {
+            Ok(recovered) => recovered,
+            Err(error) => {
+                warn!(error = %error, "failed to recover remote-owned claims before fresh dispatch");
+                return;
+            }
+        };
+
+        for (issue, lease) in recovered {
+            let already_owned = {
+                let state = self.state.read().await;
+                state.get_pipeline_run(&issue.id).is_some()
+                    || state.is_running(&issue.id)
+                    || state.is_claimed(&issue.id)
+                    || state.delivery.contains_key(&issue.id)
+            };
+            if already_owned {
+                continue;
+            }
+
+            let config = self.config.read().await;
+            if !self.state_worker_capacity_available(&issue, &config).await {
+                return;
+            }
+            drop(config);
+
+            let mut owned_issue = issue;
+            owned_issue.branch_name = lease.branch_name.clone();
+            self.pending_ownership_leases
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(owned_issue.id.clone(), lease);
+            Box::pin(self.dispatch_issue(&owned_issue, None)).await;
+        }
+    }
+
+    /// Requests adapter-owned remote ownership only after the existing journal
+    /// has proved there is no local run to restore. Tracker-specific evidence
+    /// stays at the adapter boundary; dispatch receives at most an opaque
+    /// workspace branch identity.
+    async fn claim_candidate_for_dispatch(&self, issue: &Issue) -> Option<Issue> {
+        match self.tracker.claim_issue(issue).await {
+            Ok(OwnershipClaim::Unavailable) => {
+                let mut issue = issue.clone();
+                issue.branch_name = self.tracker.workspace_branch_name(&issue);
+                Some(issue)
+            }
+            Ok(OwnershipClaim::Acquired(lease) | OwnershipClaim::Recovered(lease)) => {
+                let mut owned = issue.clone();
+                owned.branch_name = lease.branch_name.clone();
+                self.pending_ownership_leases
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .insert(issue.id.clone(), lease);
+                Some(owned)
+            }
+            Ok(OwnershipClaim::NotEligible) => None,
+            Ok(OwnershipClaim::Conflict(conflict)) => {
+                warn!(
+                    issue_id = %issue.id,
+                    identifier = %issue.identifier,
+                    ?conflict,
+                    "remote ownership conflict left candidate undispatched"
+                );
+                None
+            }
+            Err(error) => {
+                warn!(
+                    issue_id = %issue.id,
+                    identifier = %issue.identifier,
+                    error = %error,
+                    "remote ownership claim failed; leaving candidate undispatched"
+                );
+                None
+            }
+        }
     }
 
     async fn restore_pipeline_run_for_candidate(
@@ -1592,7 +1713,19 @@ impl Orchestrator {
             }
         };
 
+        let ownership_lease = self
+            .pending_ownership_leases
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&issue.id)
+            .cloned();
         let mut pipeline_run = PipelineRun::new(issue.id.clone(), cycle, dag);
+        if let Some(lease) = ownership_lease.clone() {
+            pipeline_run.set_ownership_lease(lease);
+        }
+        if let Some(branch_name) = issue.branch_name.clone() {
+            pipeline_run.set_workspace_branch_name(branch_name);
+        }
         let acceptance_plan = match ResolvedAcceptancePlan::from_config(&config_snapshot) {
             Ok(plan) => plan,
             Err(error) => {
@@ -1631,7 +1764,58 @@ impl Orchestrator {
             )
         };
         if let Some(input) = run_started_transition {
-            self.append_pipeline_transition(input).await;
+            if ownership_lease.is_some() {
+                let transaction = self
+                    .pipeline_journal
+                    .begin_issue_transition(&issue.id)
+                    .await;
+                if let Err(error) = transaction.append(input.clone()).await {
+                    match transaction.latest_record_matches(&input).await {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            warn!(
+                                issue_id = %issue.id,
+                                identifier = %issue.identifier,
+                                error = %error,
+                                "remote ownership transition was not journaled"
+                            );
+                            let mut state = self.state.write().await;
+                            state.release_claim(&issue.id);
+                            state.remove_pipeline_run(&issue.id);
+                            return;
+                        }
+                        Err(reconciliation_error) => {
+                            warn!(
+                                issue_id = %issue.id,
+                                identifier = %issue.identifier,
+                                append_error = %error,
+                                reconciliation_error = %reconciliation_error,
+                                "remote ownership transition remains ambiguous; retaining the owner"
+                            );
+                            self.pending_run_started_transitions
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                                .insert(
+                                    issue.id.clone(),
+                                    PendingRunStartedTransition {
+                                        expected: input,
+                                        issue: issue.clone(),
+                                        attempt,
+                                    },
+                                );
+                            self.refresh_requested.notify_one();
+                            return;
+                        }
+                    }
+                }
+                drop(transaction);
+                self.pending_ownership_leases
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .remove(&issue.id);
+            } else {
+                self.append_pipeline_transition(input).await;
+            }
         }
 
         // Process initial dispatch requests
@@ -1718,6 +1902,61 @@ impl Orchestrator {
         );
     }
 
+    async fn reconcile_pending_run_started_transitions(&self) {
+        let pending = self
+            .pending_run_started_transitions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for pending in pending {
+            let issue_id = pending.issue.id.clone();
+            let transaction = self
+                .pipeline_journal
+                .begin_issue_transition(&issue_id)
+                .await;
+            let visibility = transaction.latest_record_matches(&pending.expected).await;
+            drop(transaction);
+            match visibility {
+                Ok(is_exact) => {
+                    let owner_is_current = {
+                        let state = self.state.read().await;
+                        state
+                            .get_running(&issue_id)
+                            .is_some_and(|running| running.run_id == pending.expected.run_id)
+                            && state.get_pipeline_run(&issue_id).is_some_and(|run| {
+                                pending.expected.snapshot.as_ref() == Some(&run.to_snapshot())
+                            })
+                    };
+                    self.pending_run_started_transitions
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .remove(&issue_id);
+                    if !owner_is_current {
+                        continue;
+                    }
+                    if is_exact {
+                        self.pending_ownership_leases
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .remove(&issue_id);
+                    } else {
+                        let mut state = self.state.write().await;
+                        state.release_claim(&issue_id);
+                        state.remove_pipeline_run(&issue_id);
+                    }
+                    Box::pin(self.dispatch_issue(&pending.issue, pending.attempt)).await;
+                }
+                Err(error) => warn!(
+                    issue_id,
+                    error = %error,
+                    "remote ownership transition remains ambiguous; retaining the owner"
+                ),
+            }
+        }
+    }
+
     async fn dispatch_ready_active_pipelines(&self, permit: &DispatchPermit) {
         let mut active_issue_ids = {
             let state = self.state.read().await;
@@ -1730,6 +1969,14 @@ impl Orchestrator {
         active_issue_ids.sort();
 
         for (_, issue_id) in active_issue_ids {
+            if self
+                .pending_run_started_transitions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .contains_key(&issue_id)
+            {
+                continue;
+            }
             let max_workers = self.config.read().await.concurrency.max_concurrent_agents;
             if !has_available_worker_slots(
                 live_worker_count(&self.cancellation_registry),
@@ -1983,9 +2230,17 @@ impl Orchestrator {
         issue: &Issue,
         config_snapshot: &Arc<EnsembleConfig>,
     ) -> Result<std::path::PathBuf, EnsembleError> {
+        let branch_name = {
+            let state = self.state.read().await;
+            state
+                .get_pipeline_run(&issue.id)
+                .and_then(PipelineRun::workspace_branch_name)
+                .map(str::to_owned)
+                .or_else(|| issue.branch_name.clone())
+        };
         let workspace = self
             .workspace_mgr
-            .prepare_workspace(&issue.id, &issue.identifier)
+            .prepare_workspace_with_branch(&issue.id, &issue.identifier, branch_name.as_deref())
             .await?;
 
         if workspace.created_now {
@@ -4361,9 +4616,23 @@ impl Orchestrator {
             .get_pipeline_run(issue_id)
             .map(|run| run.acceptance_attempts.clone())
             .unwrap_or_default();
+        let ownership_lease = state
+            .get_pipeline_run(issue_id)
+            .and_then(PipelineRun::ownership_lease)
+            .cloned();
+        let workspace_branch_name = state
+            .get_pipeline_run(issue_id)
+            .and_then(PipelineRun::workspace_branch_name)
+            .map(str::to_owned);
         let mut next_run = PipelineRun::new(issue_id.to_string(), retry_entry.attempt, dag);
         next_run.acceptance_attempts = acceptance_attempts;
         next_run.resolved_acceptance_plan = Some(ResolvedAcceptancePlan::from_config(config).ok()?);
+        if let Some(ownership_lease) = ownership_lease {
+            next_run.set_ownership_lease(ownership_lease);
+        }
+        if let Some(workspace_branch_name) = workspace_branch_name {
+            next_run.set_workspace_branch_name(workspace_branch_name);
+        }
         state.insert_pipeline_run(issue_id, next_run, Arc::new(config.clone()));
         Self::transition_input_for_run(
             state,
@@ -8153,10 +8422,44 @@ impl Orchestrator {
             }
         };
 
-        // Find the issue in candidates
-        let issue = candidates.iter().find(|i| i.id == *issue_id);
+        // Claimed tracker states may intentionally sit outside the ordinary candidate
+        // states. Revalidate remote ownership before treating a missing candidate as a
+        // release signal.
+        let mut issue = candidates.into_iter().find(|issue| issue.id == *issue_id);
+        if issue.is_none() && self.tracker.has_remote_ownership_policy() {
+            match self.tracker.recover_owned_claims().await {
+                Ok(recovered) => {
+                    if let Some((recovered_issue, lease)) = recovered
+                        .into_iter()
+                        .find(|(recovered_issue, _)| recovered_issue.id == *issue_id)
+                    {
+                        {
+                            let mut state = self.state.write().await;
+                            if let Some(run) = state.get_pipeline_run_mut(issue_id) {
+                                run.set_ownership_lease(lease.clone());
+                            }
+                        }
+                        self.pending_ownership_leases
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .insert(issue_id.clone(), lease);
+                        issue = Some(recovered_issue);
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        issue_id = %issue_id,
+                        error = %error,
+                        "retry ownership revalidation failed, rescheduling"
+                    );
+                    self.defer_single_retry(retry_entry, "retry ownership revalidation failed")
+                        .await;
+                    return;
+                }
+            }
+        }
 
-        match issue {
+        match issue.as_ref() {
             None => {
                 // Issue not found in candidates — release claim
                 info!(
@@ -8837,7 +9140,7 @@ mod tests {
     use crate::orchestrator::retry::current_time_ms;
     use crate::pipeline::verdict::{StepOutput, StepResult};
     use crate::tracker::model::RetryEntry;
-    use crate::tracker::TrackerError;
+    use crate::tracker::{OwnershipConflict, TrackerError};
     use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
@@ -8942,6 +9245,11 @@ mod tests {
     }
 
     struct FailingCandidateTracker;
+
+    struct OwnedRetryTracker {
+        issue: Issue,
+        lease: OwnershipLease,
+    }
 
     struct CommandMockTracker {
         issues: Arc<RwLock<Vec<Issue>>>,
@@ -9099,6 +9407,39 @@ mod tests {
             _ids: &[String],
         ) -> Result<Vec<Issue>, TrackerError> {
             Ok(Vec::new())
+        }
+    }
+
+    #[async_trait]
+    impl IssueTracker for OwnedRetryTracker {
+        async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+            Ok(Vec::new())
+        }
+
+        async fn fetch_issues_by_states(
+            &self,
+            _states: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            Ok(Vec::new())
+        }
+
+        async fn fetch_issue_states_by_ids(
+            &self,
+            ids: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            Ok(ids
+                .contains(&self.issue.id)
+                .then(|| self.issue.clone())
+                .into_iter()
+                .collect())
+        }
+
+        async fn recover_owned_claims(&self) -> Result<Vec<(Issue, OwnershipLease)>, TrackerError> {
+            Ok(vec![(self.issue.clone(), self.lease.clone())])
+        }
+
+        fn has_remote_ownership_policy(&self) -> bool {
+            true
         }
     }
 
@@ -9856,6 +10197,7 @@ mod tests {
             &self,
             _repository_path: &Path,
             _repository_key: &str,
+            _adoption_policy: Option<&crate::orchestrator::delivery::PullRequestAdoptionPolicy>,
         ) -> Result<Vec<crate::orchestrator::delivery::RemotePullRequest>, String> {
             Ok(self.pull_requests.lock().unwrap().clone())
         }
@@ -9872,6 +10214,10 @@ mod tests {
             self.pull_requests.lock().unwrap().push(
                 crate::orchestrator::delivery::RemotePullRequest {
                     repository_key: "source-repo".to_string(),
+                    repository: None,
+                    head_repository: None,
+                    author: None,
+                    authored_by_authenticated_viewer: false,
                     head_branch: head_branch.to_string(),
                     base_branch: base_branch.to_string(),
                     head_sha: "0123456789abcdef".to_string(),
@@ -10335,6 +10681,14 @@ mod tests {
 
     #[async_trait]
     impl crate::orchestrator::delivery::DeliveryRemote for RecoveryDeliveryRemote {
+        fn pull_request_adoption_policy(
+            &self,
+            config: &EnsembleConfig,
+            issue_id: &str,
+        ) -> Option<crate::orchestrator::delivery::PullRequestAdoptionPolicy> {
+            CliDeliveryRemote.pull_request_adoption_policy(config, issue_id)
+        }
+
         async fn local_identity(
             &self,
             _repository_path: &Path,
@@ -10370,6 +10724,7 @@ mod tests {
             &self,
             _repository_path: &Path,
             _repository_key: &str,
+            _adoption_policy: Option<&crate::orchestrator::delivery::PullRequestAdoptionPolicy>,
         ) -> Result<Vec<crate::orchestrator::delivery::RemotePullRequest>, String> {
             self.lists.fetch_add(1, Ordering::SeqCst);
             Ok(self.pull_requests.lock().unwrap().clone())
@@ -10432,9 +10787,10 @@ mod tests {
             &self,
             repository_path: &Path,
             repository_key: &str,
+            adoption_policy: Option<&crate::orchestrator::delivery::PullRequestAdoptionPolicy>,
         ) -> Result<Vec<crate::orchestrator::delivery::RemotePullRequest>, String> {
             self.inner
-                .list_pull_requests(repository_path, repository_key)
+                .list_pull_requests(repository_path, repository_key, adoption_policy)
                 .await
         }
 
@@ -10501,6 +10857,7 @@ mod tests {
                     marker,
                     pr_number: None,
                     pr_url: None,
+                    ownership_conflict: None,
                     last_error: Some("create response was ambiguous".to_string()),
                     retry_from: None,
                 },
@@ -10543,6 +10900,10 @@ mod tests {
         remote.pull_requests.lock().unwrap().push(
             crate::orchestrator::delivery::RemotePullRequest {
                 repository_key: "source-repo".to_string(),
+                repository: None,
+                head_repository: None,
+                author: None,
+                authored_by_authenticated_viewer: false,
                 head_branch: observed_delivery.repositories["source-repo"]
                     .head_branch
                     .clone(),
@@ -11138,6 +11499,10 @@ mod tests {
         remote.pull_requests.lock().unwrap().push(
             crate::orchestrator::delivery::RemotePullRequest {
                 repository_key: "source-repo".to_string(),
+                repository: None,
+                head_repository: None,
+                author: None,
+                authored_by_authenticated_viewer: false,
                 head_branch: "ensemble/repo-1".to_string(),
                 base_branch: "main".to_string(),
                 head_sha: "0123456789abcdef".to_string(),
@@ -11159,6 +11524,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn exact_unpersisted_pr_adoption_is_journaled_once() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let workspace_key = crate::workspace::key::issue_workspace_key("1");
+        let branch_template = "configured/{issue_workspace_key}".to_string();
+        let head_branch = branch_template.replace("{issue_workspace_key}", &workspace_key);
+        {
+            let mut config = orchestrator.config.write().await;
+            config.tracker.kind = "github".to_string();
+            config.tracker.github = Some(crate::config::ensemble::GithubTrackerConfig {
+                status_field: "Delivery state".to_string(),
+                priority: None,
+                ownership: Some(crate::config::ensemble::GithubOwnershipConfig {
+                    claim: None,
+                    delivery_adoption: Some(
+                        crate::config::ensemble::GithubDeliveryAdoptionConfig {
+                            repository: "example/project".to_string(),
+                            base_branch: "main".to_string(),
+                            branch_template,
+                            require_authenticated_author: true,
+                        },
+                    ),
+                }),
+            });
+        }
+        delivery
+            .repositories
+            .get_mut("source-repo")
+            .unwrap()
+            .head_branch = head_branch.clone();
+        orchestrator
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+        remote.pull_requests.lock().unwrap().push(
+            crate::orchestrator::delivery::RemotePullRequest {
+                repository_key: "source-repo".to_string(),
+                repository: Some("example/project".to_string()),
+                head_repository: Some("example/project".to_string()),
+                author: Some("octocat".to_string()),
+                authored_by_authenticated_viewer: true,
+                head_branch,
+                base_branch: "main".to_string(),
+                head_sha: "0123456789abcdef".to_string(),
+                body: String::new(),
+                number: 511,
+                url: "https://github.com/example/project/pull/511".to_string(),
+            },
+        );
+
+        orchestrator.process_delivery_recovery(None).await;
+        orchestrator.process_delivery_recovery(None).await;
+
+        let state = orchestrator.state.read().await;
+        let repository = &state.delivery["1"].repositories["source-repo"];
+        assert_eq!(repository.phase, DeliveryPhase::Waiting);
+        assert_eq!(repository.pr_number, Some(511));
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 1);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn ambiguous_publication_conflict_enters_blocked_without_mutation() {
         let remote = Arc::new(RecoveryDeliveryRemote {
             pull_requests: std::sync::Mutex::new(Vec::new()),
@@ -11170,6 +11603,10 @@ mod tests {
             recovery_test_orchestrator(Arc::clone(&remote)).await;
         let exact = crate::orchestrator::delivery::RemotePullRequest {
             repository_key: "source-repo".to_string(),
+            repository: None,
+            head_repository: None,
+            author: None,
+            authored_by_authenticated_viewer: false,
             head_branch: "ensemble/repo-1".to_string(),
             base_branch: "main".to_string(),
             head_sha: "0123456789abcdef".to_string(),
@@ -11184,6 +11621,10 @@ mod tests {
         let state = orchestrator.state.read().await;
         let repository = &state.delivery["1"].repositories["source-repo"];
         assert_eq!(repository.phase, DeliveryPhase::Blocked);
+        assert_eq!(
+            repository.ownership_conflict,
+            Some(OwnershipConflict::Ambiguous)
+        );
         assert_eq!(repository.retry_from, Some(DeliveryPhase::ReconcilingPr));
         assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
         assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
@@ -11208,6 +11649,10 @@ mod tests {
         remote.pull_requests.lock().unwrap().push(
             crate::orchestrator::delivery::RemotePullRequest {
                 repository_key: "source-repo".to_string(),
+                repository: None,
+                head_repository: None,
+                author: None,
+                authored_by_authenticated_viewer: false,
                 head_branch: repository.head_branch.clone(),
                 base_branch: repository.base_branch.clone(),
                 head_sha: repository.local_sha.clone(),
@@ -11971,6 +12416,7 @@ mod tests {
                     marker,
                     pr_number: None,
                     pr_url: None,
+                    ownership_conflict: None,
                     last_error: Some("process stopped after create".to_string()),
                     retry_from: None,
                 },
@@ -11994,6 +12440,10 @@ mod tests {
             pull_requests: std::sync::Mutex::new(vec![
                 crate::orchestrator::delivery::RemotePullRequest {
                     repository_key: "source-repo".to_string(),
+                    repository: None,
+                    head_repository: None,
+                    author: None,
+                    authored_by_authenticated_viewer: false,
                     head_branch: "ensemble/repo-1".to_string(),
                     base_branch: "main".to_string(),
                     head_sha: "0123456789abcdef".to_string(),
@@ -12067,6 +12517,10 @@ mod tests {
             pull_requests: std::sync::Mutex::new(vec![
                 crate::orchestrator::delivery::RemotePullRequest {
                     repository_key: "source-repo".to_string(),
+                    repository: None,
+                    head_repository: None,
+                    author: None,
+                    authored_by_authenticated_viewer: false,
                     head_branch: "ensemble/repo-1".to_string(),
                     base_branch: "main".to_string(),
                     head_sha: "0123456789abcdef".to_string(),
@@ -13213,6 +13667,16 @@ agent:
         let (orchestrator, state) =
             make_acceptance_test_orchestrator(&temp, &config, &issue, runner);
         install_succeeded_run(&state, &issue, &config).await;
+        let ownership_lease = OwnershipLease {
+            id: issue.id.clone(),
+            branch_name: Some("agent/acceptance-retry".into()),
+        };
+        state
+            .write()
+            .await
+            .get_pipeline_run_mut(&issue.id)
+            .unwrap()
+            .set_ownership_lease(ownership_lease.clone());
         assert!(matches!(
             orchestrator.run_acceptance_phase(&issue, &config).await,
             AcceptancePhaseOutcome::Failed { .. }
@@ -13243,6 +13707,7 @@ agent:
         assert_eq!(snapshot.cycle, 2);
         assert_eq!(snapshot.acceptance_attempts.len(), 1);
         assert_eq!(snapshot.acceptance_attempts[0].cycle, 1);
+        assert_eq!(snapshot.ownership_lease, Some(ownership_lease));
         assert_eq!(
             snapshot.acceptance_attempts[0].results[0].status,
             AcceptanceStatus::Failed
@@ -20162,6 +20627,182 @@ agent:
     }
 
     #[tokio::test]
+    async fn claimed_dispatch_journals_opaque_lease_before_agent_work() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let observed_commands = Arc::new(RwLock::new(Vec::new()));
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: Some(Arc::clone(&observed_commands)),
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let issue = test_issue("1", "Todo");
+        let lease = OwnershipLease {
+            id: "remote-lease-1".to_string(),
+            branch_name: Some("ensemble/issue-1".to_string()),
+        };
+        orchestrator
+            .pending_ownership_leases
+            .lock()
+            .unwrap()
+            .insert(issue.id.clone(), lease.clone());
+
+        orchestrator.dispatch_issue(&issue, None).await;
+
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        let run_started = records
+            .iter()
+            .find(|record| record.kind == PipelineTransitionKind::RunStarted)
+            .unwrap();
+        assert_eq!(
+            run_started
+                .snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.ownership_lease.clone()),
+            Some(lease)
+        );
+        let metadata: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(orchestrator.workspace_mgr.metadata_path_for_test(&issue.id))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(metadata["branch_name"], "ensemble/issue-1");
+        assert!(!observed_commands.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn claimed_dispatch_append_failure_starts_no_agent_or_workspace() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let observed_commands = Arc::new(RwLock::new(Vec::new()));
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: Some(Arc::clone(&observed_commands)),
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 1));
+        let issue = test_issue("1", "Todo");
+        orchestrator
+            .pending_ownership_leases
+            .lock()
+            .unwrap()
+            .insert(
+                issue.id.clone(),
+                OwnershipLease {
+                    id: "remote-lease-1".to_string(),
+                    branch_name: None,
+                },
+            );
+
+        orchestrator.dispatch_issue(&issue, None).await;
+
+        assert!(observed_commands.read().await.is_empty());
+        assert!(!orchestrator
+            .workspace_mgr
+            .workspace_path(&issue.id)
+            .exists());
+        let state = orchestrator.state.read().await;
+        assert!(!state.is_running(&issue.id));
+        assert!(state.get_pipeline_run(&issue.id).is_none());
+        assert!(!state.is_claimed(&issue.id));
+    }
+
+    #[tokio::test]
+    async fn claimed_dispatch_ambiguous_append_retains_owner_until_exact_reconciliation() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let observed_commands = Arc::new(RwLock::new(Vec::new()));
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: Some(Arc::clone(&observed_commands)),
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        orchestrator.pipeline_journal.transaction_append_late_error = true;
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = true;
+        let issue = test_issue("1", "Todo");
+        orchestrator
+            .pending_ownership_leases
+            .lock()
+            .unwrap()
+            .insert(
+                issue.id.clone(),
+                OwnershipLease {
+                    id: "remote-lease-1".into(),
+                    branch_name: Some("agent/issue-1".into()),
+                },
+            );
+
+        orchestrator.dispatch_issue(&issue, None).await;
+
+        assert!(observed_commands.read().await.is_empty());
+        assert!(orchestrator.state.read().await.is_running(&issue.id));
+        assert!(!orchestrator
+            .workspace_mgr
+            .workspace_path(&issue.id)
+            .exists());
+
+        orchestrator.pipeline_journal.transaction_append_late_error = false;
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = false;
+        orchestrator.handle_tick().await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(observed_commands.read().await.len(), 1);
+        assert!(orchestrator.state.read().await.is_running(&issue.id));
+    }
+
+    #[tokio::test]
     async fn restored_pipeline_dispatch_persistence_failure_schedules_recoverable_retry() {
         let config = Arc::new(RwLock::new(make_config()));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
@@ -24480,6 +25121,63 @@ agent:
         assert_eq!(deferred.retry_from_step, retry.retry_from_step);
         assert_eq!(deferred.with_fixup, retry.with_fixup);
         assert!(state.is_claimed("1"));
+    }
+
+    #[tokio::test]
+    async fn retry_fire_recovers_owned_issue_outside_candidate_states() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let issue = test_issue("1", "Agent-owned");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(OwnedRetryTracker {
+            issue: issue.clone(),
+            lease: OwnershipLease {
+                id: issue.id.clone(),
+                branch_name: Some("agent/retry-1".into()),
+            },
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let retry = RetryEntry {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            attempt: 3,
+            due_at_ms: 0,
+            error: Some("agent crashed".into()),
+            retry_from_step: None,
+            with_fixup: false,
+        };
+        orchestrator.state.write().await.add_retry(retry.clone());
+
+        orchestrator.handle_single_retry(&retry).await;
+
+        let state = orchestrator.state.read().await;
+        assert_eq!(
+            state
+                .get_running(&issue.id)
+                .and_then(|entry| entry.retry_attempt),
+            Some(retry.attempt)
+        );
+        assert_eq!(
+            state
+                .get_pipeline_run(&issue.id)
+                .and_then(PipelineRun::workspace_branch_name),
+            Some("agent/retry-1")
+        );
+        assert!(!state.retry_attempts.contains_key(&issue.id));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -669,6 +669,7 @@ mod tests {
                     marker: "<!-- ensemble:delivery:v1 -->".to_string(),
                     pr_number: None,
                     pr_url: None,
+                    ownership_conflict: None,
                     last_error: None,
                     retry_from: None,
                 },

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -1463,6 +1463,7 @@ mod tests {
                     marker: canonical_marker("run-1", "issue-1", "primary"),
                     pr_number: Some(420),
                     pr_url: Some("https://github.com/example/project/pull/420".to_string()),
+                    ownership_conflict: None,
                     last_error: None,
                     retry_from: None,
                 },

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -6,6 +6,7 @@ use crate::acceptance::AcceptanceAttempt;
 use crate::config::ensemble::{OnFailure, StepKind};
 use crate::pipeline::dag::{DagStep, StepDag};
 use crate::pipeline::verdict::{StepOutput, StepResult};
+use crate::tracker::OwnershipLease;
 
 /// The execution state of a single pipeline step.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -128,6 +129,10 @@ pub struct PipelineRun {
     dag: StepDag,
     /// Synthetic fixup steps generated for step-level retries.
     synthetic_fixup_steps: HashSet<String>,
+    /// Opaque adapter ownership captured before any agent work starts.
+    ownership_lease: Option<OwnershipLease>,
+    /// Opaque configured workspace branch, including policies that do not claim remotely.
+    workspace_branch_name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -142,6 +147,10 @@ pub struct PipelineRunSnapshot {
     pub resolved_acceptance_plan: Option<crate::acceptance::ResolvedAcceptancePlan>,
     pub dag_steps: Vec<DagStep>,
     pub synthetic_fixup_steps: HashSet<String>,
+    #[serde(default)]
+    pub ownership_lease: Option<OwnershipLease>,
+    #[serde(default)]
+    pub workspace_branch_name: Option<String>,
 }
 
 impl PipelineRun {
@@ -162,6 +171,8 @@ impl PipelineRun {
             resolved_acceptance_plan: None,
             dag,
             synthetic_fixup_steps: HashSet::new(),
+            ownership_lease: None,
+            workspace_branch_name: None,
         }
     }
 
@@ -175,6 +186,8 @@ impl PipelineRun {
             resolved_acceptance_plan: self.resolved_acceptance_plan.clone(),
             dag_steps: self.dag.steps.clone(),
             synthetic_fixup_steps: self.synthetic_fixup_steps.clone(),
+            ownership_lease: self.ownership_lease.clone(),
+            workspace_branch_name: self.workspace_branch_name.clone(),
         }
     }
 
@@ -193,7 +206,30 @@ impl PipelineRun {
                 steps: snapshot.dag_steps,
             },
             synthetic_fixup_steps: snapshot.synthetic_fixup_steps,
+            ownership_lease: snapshot.ownership_lease,
+            workspace_branch_name: snapshot.workspace_branch_name,
         })
+    }
+
+    /// Records opaque adapter ownership alongside the durable pipeline snapshot.
+    pub(crate) fn set_ownership_lease(&mut self, lease: OwnershipLease) {
+        self.ownership_lease = Some(lease);
+    }
+
+    pub(crate) fn workspace_branch_name(&self) -> Option<&str> {
+        self.workspace_branch_name.as_deref().or_else(|| {
+            self.ownership_lease
+                .as_ref()
+                .and_then(|lease| lease.branch_name.as_deref())
+        })
+    }
+
+    pub(crate) fn set_workspace_branch_name(&mut self, branch_name: String) {
+        self.workspace_branch_name = Some(branch_name);
+    }
+
+    pub(crate) fn ownership_lease(&self) -> Option<&OwnershipLease> {
+        self.ownership_lease.as_ref()
     }
 
     pub fn normalize_stale_running_steps(&mut self) {
@@ -822,6 +858,29 @@ mod tests {
             restored.step("review").unwrap().depends,
             vec!["fixup-review".to_string()]
         );
+    }
+
+    #[test]
+    fn pipeline_run_snapshot_preserves_opaque_ownership_lease() {
+        let dag = crate::pipeline::dag::build_dag(&[test_step("build", "builder", Some(vec![]))])
+            .unwrap();
+        let mut run = PipelineRun::new("issue-1".to_string(), 1, dag);
+        run.set_ownership_lease(OwnershipLease {
+            id: "adapter-lease-1".to_string(),
+            branch_name: Some("ensemble/issue-1".to_string()),
+        });
+        run.set_workspace_branch_name("configured/issue-1".to_string());
+
+        let snapshot = run.to_snapshot();
+        assert_eq!(
+            snapshot.ownership_lease,
+            Some(OwnershipLease {
+                id: "adapter-lease-1".to_string(),
+                branch_name: Some("ensemble/issue-1".to_string()),
+            })
+        );
+        let restored = PipelineRun::from_snapshot(snapshot).unwrap();
+        assert_eq!(restored.workspace_branch_name(), Some("configured/issue-1"));
     }
 
     #[test]

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -5,8 +5,9 @@ use std::collections::{HashMap, HashSet};
 use tracing::{debug, info, warn};
 
 use super::model::{InteractionThreadRoot, Issue, TrackerComment};
-use super::{IssueTracker, TrackerError};
-use crate::config::ensemble::GithubTrackerConfig;
+use super::{IssueTracker, OwnershipClaim, OwnershipConflict, OwnershipLease, TrackerError};
+use crate::config::ensemble::{GithubClaimConfig, GithubTrackerConfig};
+use crate::workspace::key::issue_workspace_key;
 
 mod graphql;
 
@@ -23,6 +24,24 @@ pub struct GithubTracker {
     client: reqwest::Client,
     project_fields: Option<GithubTrackerConfig>,
     project_metadata: tokio::sync::RwLock<Option<ProjectMetadata>>,
+    authenticated_viewer: tokio::sync::RwLock<Option<AuthenticatedViewer>>,
+}
+
+#[derive(Clone)]
+struct AuthenticatedViewer {
+    id: String,
+    login: String,
+}
+
+#[derive(Clone, Copy)]
+enum AssigneeEvidence {
+    Unassigned,
+    Owned,
+}
+
+enum OwnershipConflictOrTrackerError {
+    Conflict(OwnershipConflict),
+    Tracker(TrackerError),
 }
 
 #[derive(Clone)]
@@ -78,7 +97,27 @@ impl GithubTracker {
             labels_filter: settings.labels_filter,
             client,
             project_metadata: tokio::sync::RwLock::new(None),
+            authenticated_viewer: tokio::sync::RwLock::new(None),
         })
+    }
+
+    fn claim_config(&self) -> Option<GithubClaimConfig> {
+        self.project_fields
+            .as_ref()?
+            .ownership
+            .as_ref()?
+            .claim
+            .clone()
+    }
+
+    fn configured_branch_name(&self, issue: &Issue) -> Option<String> {
+        self.project_fields
+            .as_ref()?
+            .ownership
+            .as_ref()?
+            .delivery_adoption
+            .as_ref()
+            .map(|policy| policy.render_branch(&issue_workspace_key(&issue.id)))
     }
 
     /// Execute a GraphQL query against the configured endpoint.
@@ -145,6 +184,200 @@ impl GithubTracker {
             return Ok(metadata);
         }
         self.refresh_project_metadata().await
+    }
+
+    async fn refresh_authenticated_viewer(&self) -> Result<AuthenticatedViewer, TrackerError> {
+        let data = self.graphql::<graphql::Viewer>(json!({})).await?;
+        let viewer = data.viewer.ok_or_else(|| {
+            graphql::unexpected_payload::<graphql::Viewer>("authenticated viewer is missing")
+        })?;
+        let id = viewer.id.ok_or_else(|| {
+            graphql::unexpected_payload::<graphql::Viewer>("authenticated viewer is missing ID")
+        })?;
+        let login = viewer.login.ok_or_else(|| {
+            graphql::unexpected_payload::<graphql::Viewer>("authenticated viewer is missing login")
+        })?;
+        let viewer = AuthenticatedViewer { id, login };
+        debug!(viewer = %viewer.login, "authenticated GitHub viewer refreshed");
+        *self.authenticated_viewer.write().await = Some(viewer.clone());
+        Ok(viewer)
+    }
+
+    async fn authenticated_viewer(&self) -> Result<AuthenticatedViewer, TrackerError> {
+        if let Some(viewer) = self.authenticated_viewer.read().await.clone() {
+            return Ok(viewer);
+        }
+        self.refresh_authenticated_viewer().await
+    }
+
+    async fn issue_assignees(
+        &self,
+        issue_id: &str,
+    ) -> Result<(Option<u64>, Vec<graphql::User>), TrackerError> {
+        let data = self
+            .graphql::<graphql::IssueAssignees>(json!({ "issueId": issue_id }))
+            .await?;
+        let assignees = data.node.and_then(|issue| issue.assignees).ok_or_else(|| {
+            graphql::unexpected_payload::<graphql::IssueAssignees>(
+                "issue assignees payload is missing",
+            )
+        })?;
+        Ok((
+            assignees.total_count,
+            assignees.nodes.into_iter().flatten().collect(),
+        ))
+    }
+
+    async fn fresh_issue(&self, issue_id: &str) -> Result<Option<Issue>, TrackerError> {
+        Ok(self
+            .fetch_states_by_node_ids(&[issue_id.to_string()])
+            .await?
+            .into_iter()
+            .next())
+    }
+
+    fn is_active_state(&self, state: &str) -> bool {
+        self.active_states
+            .iter()
+            .any(|configured| configured.eq_ignore_ascii_case(state))
+    }
+
+    fn is_resumable_state(claim: &GithubClaimConfig, state: &str) -> bool {
+        claim
+            .resume_states
+            .iter()
+            .any(|configured| configured.eq_ignore_ascii_case(state))
+    }
+
+    fn classify_assignees(
+        total_count: Option<u64>,
+        assignees: &[graphql::User],
+        viewer: &AuthenticatedViewer,
+    ) -> Result<AssigneeEvidence, OwnershipConflict> {
+        if total_count.is_some_and(|count| count != assignees.len() as u64) || assignees.len() > 1 {
+            return Err(OwnershipConflict::Ambiguous);
+        }
+        let Some(assignee) = assignees.first() else {
+            return Ok(AssigneeEvidence::Unassigned);
+        };
+        let Some(id) = assignee.id.as_deref() else {
+            return Err(OwnershipConflict::Ambiguous);
+        };
+        if id == viewer.id {
+            Ok(AssigneeEvidence::Owned)
+        } else {
+            Err(OwnershipConflict::Foreign)
+        }
+    }
+
+    async fn revalidated_assignee_evidence(
+        &self,
+        issue_id: &str,
+        viewer: &AuthenticatedViewer,
+    ) -> Result<AssigneeEvidence, OwnershipConflictOrTrackerError> {
+        let (total_count, assignees) = self
+            .issue_assignees(issue_id)
+            .await
+            .map_err(OwnershipConflictOrTrackerError::Tracker)?;
+        Self::classify_assignees(total_count, &assignees, viewer)
+            .map_err(OwnershipConflictOrTrackerError::Conflict)
+    }
+
+    fn lease_for(&self, issue: &Issue) -> OwnershipLease {
+        OwnershipLease {
+            id: issue.id.clone(),
+            branch_name: self.configured_branch_name(issue),
+        }
+    }
+
+    async fn claim_fresh_issue(&self, issue: &Issue) -> Result<OwnershipClaim, TrackerError> {
+        let Some(claim) = self.claim_config() else {
+            return Ok(OwnershipClaim::Unavailable);
+        };
+        let viewer = self.refresh_authenticated_viewer().await?;
+        let Some(fresh) = self.fresh_issue(&issue.id).await? else {
+            return Ok(OwnershipClaim::NotEligible);
+        };
+        if !self.is_active_state(&fresh.state) {
+            return Ok(OwnershipClaim::NotEligible);
+        }
+
+        let assignment_error = match self.revalidated_assignee_evidence(&fresh.id, &viewer).await {
+            Ok(AssigneeEvidence::Unassigned) => self
+                .graphql::<graphql::AddAssignees>(json!({
+                    "issueId": fresh.id,
+                    "assigneeId": viewer.id,
+                }))
+                .await
+                .err(),
+            Ok(AssigneeEvidence::Owned) if Self::is_resumable_state(&claim, &fresh.state) => {
+                return Ok(OwnershipClaim::Recovered(self.lease_for(&fresh)));
+            }
+            Ok(AssigneeEvidence::Owned) => None,
+            Err(OwnershipConflictOrTrackerError::Conflict(conflict)) => {
+                return Ok(OwnershipClaim::Conflict(conflict));
+            }
+            Err(OwnershipConflictOrTrackerError::Tracker(error)) => return Err(error),
+        };
+
+        let Some(revalidated) = self.fresh_issue(&issue.id).await? else {
+            return Ok(OwnershipClaim::NotEligible);
+        };
+        if !self.is_active_state(&revalidated.state) {
+            return Ok(OwnershipClaim::NotEligible);
+        }
+        match self
+            .revalidated_assignee_evidence(&revalidated.id, &viewer)
+            .await
+        {
+            Ok(AssigneeEvidence::Owned) => {}
+            Ok(AssigneeEvidence::Unassigned) => {
+                if let Some(error) = assignment_error {
+                    return Err(error);
+                }
+                return Ok(OwnershipClaim::Conflict(OwnershipConflict::Ambiguous));
+            }
+            Err(OwnershipConflictOrTrackerError::Conflict(conflict)) => {
+                return Ok(OwnershipClaim::Conflict(conflict));
+            }
+            Err(OwnershipConflictOrTrackerError::Tracker(error)) => return Err(error),
+        }
+
+        if !revalidated.state.eq_ignore_ascii_case(&claim.claimed_state) {
+            let mutation_error = self
+                .set_issue_state(&revalidated.id, &claim.claimed_state)
+                .await
+                .err();
+            let Some(after_state_mutation) = self.fresh_issue(&issue.id).await? else {
+                return Ok(OwnershipClaim::NotEligible);
+            };
+            if !after_state_mutation
+                .state
+                .eq_ignore_ascii_case(&claim.claimed_state)
+            {
+                if let Some(error) = mutation_error {
+                    return Err(error);
+                }
+                return Ok(OwnershipClaim::NotEligible);
+            }
+            match self
+                .revalidated_assignee_evidence(&after_state_mutation.id, &viewer)
+                .await
+            {
+                Ok(AssigneeEvidence::Owned) => {}
+                Ok(AssigneeEvidence::Unassigned) => {
+                    return Ok(OwnershipClaim::Conflict(OwnershipConflict::Ambiguous));
+                }
+                Err(OwnershipConflictOrTrackerError::Conflict(conflict)) => {
+                    return Ok(OwnershipClaim::Conflict(conflict));
+                }
+                Err(OwnershipConflictOrTrackerError::Tracker(error)) => return Err(error),
+            }
+            return Ok(OwnershipClaim::Acquired(
+                self.lease_for(&after_state_mutation),
+            ));
+        }
+        Ok(OwnershipClaim::Acquired(self.lease_for(&revalidated)))
     }
 
     /// Resolve the configured readable Project field identities to stable IDs.
@@ -380,6 +613,18 @@ impl GithubTracker {
                 .find(|s| s.eq_ignore_ascii_case(label))
             {
                 return s.clone();
+            }
+            if let Some(claim) = self.claim_config() {
+                if claim.claimed_state.eq_ignore_ascii_case(label) {
+                    return claim.claimed_state;
+                }
+                if let Some(resume_state) = claim
+                    .resume_states
+                    .iter()
+                    .find(|state| state.eq_ignore_ascii_case(label))
+                {
+                    return resume_state.clone();
+                }
             }
         }
         fallback
@@ -834,6 +1079,16 @@ impl IssueTracker for GithubTracker {
         if self.project_number.is_some() {
             self.refresh_project_metadata().await?;
         }
+        if self.claim_config().is_some()
+            || self
+                .project_fields
+                .as_ref()
+                .and_then(|fields| fields.ownership.as_ref())
+                .and_then(|ownership| ownership.delivery_adoption.as_ref())
+                .is_some_and(|adoption| adoption.require_authenticated_author)
+        {
+            self.refresh_authenticated_viewer().await?;
+        }
         Ok(())
     }
 
@@ -861,6 +1116,43 @@ impl IssueTracker for GithubTracker {
     /// Fetch current states for specific issue IDs (used for reconciliation).
     async fn fetch_issue_states_by_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError> {
         self.fetch_states_by_node_ids(ids).await
+    }
+
+    async fn claim_issue(&self, issue: &Issue) -> Result<OwnershipClaim, TrackerError> {
+        self.claim_fresh_issue(issue).await
+    }
+
+    async fn recover_owned_claims(&self) -> Result<Vec<(Issue, OwnershipLease)>, TrackerError> {
+        let Some(claim) = self.claim_config() else {
+            return Ok(Vec::new());
+        };
+        let viewer = self.authenticated_viewer().await?;
+        let candidates = self.fetch_issues_by_states(&claim.resume_states).await?;
+        let mut recovered = Vec::new();
+        for issue in candidates {
+            match self.revalidated_assignee_evidence(&issue.id, &viewer).await {
+                Ok(AssigneeEvidence::Owned) => {
+                    let Some(fresh) = self.fresh_issue(&issue.id).await? else {
+                        continue;
+                    };
+                    if Self::is_resumable_state(&claim, &fresh.state) {
+                        recovered.push((fresh.clone(), self.lease_for(&fresh)));
+                    }
+                }
+                Ok(AssigneeEvidence::Unassigned)
+                | Err(OwnershipConflictOrTrackerError::Conflict(_)) => {}
+                Err(OwnershipConflictOrTrackerError::Tracker(error)) => return Err(error),
+            }
+        }
+        Ok(recovered)
+    }
+
+    fn has_remote_ownership_policy(&self) -> bool {
+        self.claim_config().is_some()
+    }
+
+    fn workspace_branch_name(&self, issue: &Issue) -> Option<String> {
+        self.configured_branch_name(issue)
     }
 
     fn supports_writes(&self) -> bool {
@@ -1000,8 +1292,61 @@ impl IssueTracker for GithubTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use wiremock::matchers::{body_string_contains, method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    struct AssigneeSequence {
+        calls: AtomicUsize,
+    }
+
+    impl Respond for AssigneeSequence {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            let assignees = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                json!({ "totalCount": 0, "nodes": [] })
+            } else {
+                json!({
+                    "totalCount": 1,
+                    "nodes": [{ "id": "U_viewer", "login": "viewer" }]
+                })
+            };
+            ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                "node": { "id": "I_issue", "assignees": assignees }
+            })))
+        }
+    }
+
+    struct IssueStateSequence {
+        calls: AtomicUsize,
+    }
+
+    impl Respond for IssueStateSequence {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            let labels = if self.calls.fetch_add(1, Ordering::SeqCst) < 3 {
+                json!({ "nodes": [] })
+            } else {
+                json!({ "nodes": [{ "name": "In Progress" }] })
+            };
+            ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                "nodes": [{
+                    "id": "I_issue", "number": 1, "title": "Issue", "state": "OPEN",
+                    "url": "https://example.test/issues/1", "labels": labels
+                }]
+            })))
+        }
+    }
+
+    struct RepositoryLabelResponder;
+
+    impl Respond for RepositoryLabelResponder {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let request: Value = serde_json::from_slice(&request.body).unwrap();
+            let name = request["variables"]["name"].as_str().unwrap();
+            ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                "repository": { "label": { "id": format!("L_{name}"), "name": name } }
+            })))
+        }
+    }
 
     /// Helper to create a GithubTracker pointed at a wiremock server.
     fn create_test_tracker(server_url: &str, project_number: Option<i64>) -> GithubTracker {
@@ -1014,6 +1359,7 @@ mod tests {
                 project_fields: project_number.map(|_| GithubTrackerConfig {
                     status_field: "Status".to_string(),
                     priority: None,
+                    ownership: None,
                 }),
                 active_states: vec!["Todo".to_string(), "In Progress".to_string()],
                 terminal_states: vec!["Done".to_string(), "Closed".to_string()],
@@ -1021,6 +1367,96 @@ mod tests {
             },
         )
         .unwrap()
+    }
+
+    fn create_claim_test_tracker(server_url: &str) -> GithubTracker {
+        GithubTracker::new(
+            format!("{}/graphql", server_url),
+            "ghp_test_token".to_string(),
+            "acme/my-repo".to_string(),
+            GithubTrackerSettings {
+                project_number: None,
+                project_fields: Some(GithubTrackerConfig {
+                    status_field: "Status".to_string(),
+                    priority: None,
+                    ownership: Some(crate::config::ensemble::GithubOwnershipConfig {
+                        claim: Some(crate::config::ensemble::GithubClaimConfig {
+                            claimed_state: "Todo".to_string(),
+                            resume_states: vec!["Recovering".to_string()],
+                        }),
+                        delivery_adoption: None,
+                    }),
+                }),
+                active_states: vec!["Todo".to_string()],
+                terminal_states: vec!["Done".to_string()],
+                labels_filter: vec![],
+            },
+        )
+        .unwrap()
+    }
+
+    fn create_claim_transition_test_tracker(server_url: &str) -> GithubTracker {
+        GithubTracker::new(
+            format!("{}/graphql", server_url),
+            "ghp_test_token".to_string(),
+            "acme/my-repo".to_string(),
+            GithubTrackerSettings {
+                project_number: None,
+                project_fields: Some(GithubTrackerConfig {
+                    status_field: "Status".to_string(),
+                    priority: None,
+                    ownership: Some(crate::config::ensemble::GithubOwnershipConfig {
+                        claim: Some(crate::config::ensemble::GithubClaimConfig {
+                            claimed_state: "In Progress".to_string(),
+                            resume_states: vec!["Recovering".to_string()],
+                        }),
+                        delivery_adoption: None,
+                    }),
+                }),
+                active_states: vec!["Open".to_string(), "In Progress".to_string()],
+                terminal_states: vec!["Done".to_string()],
+                labels_filter: vec![],
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn adoption_only_policy_supplies_the_opaque_workspace_branch() {
+        let tracker = GithubTracker::new(
+            "https://example.invalid/graphql".to_string(),
+            "token".to_string(),
+            "acme/my-repo".to_string(),
+            GithubTrackerSettings {
+                project_number: None,
+                project_fields: Some(GithubTrackerConfig {
+                    status_field: "Status".to_string(),
+                    priority: None,
+                    ownership: Some(crate::config::ensemble::GithubOwnershipConfig {
+                        claim: None,
+                        delivery_adoption: Some(
+                            crate::config::ensemble::GithubDeliveryAdoptionConfig {
+                                repository: "acme/my-repo".to_string(),
+                                base_branch: "main".to_string(),
+                                branch_template: "agent/{issue_workspace_key}".to_string(),
+                                require_authenticated_author: false,
+                            },
+                        ),
+                    }),
+                }),
+                active_states: vec!["Todo".to_string()],
+                terminal_states: vec!["Done".to_string()],
+                labels_filter: Vec::new(),
+            },
+        )
+        .unwrap();
+        let issue = crate::tracker::model::test_helpers::test_issue("I_issue", "Todo");
+
+        assert_eq!(
+            tracker.workspace_branch_name(&issue),
+            Some(format!("agent/{}", issue_workspace_key("I_issue")))
+        );
+        assert!(tracker.claim_config().is_none());
     }
 
     /// Build a GraphQL response body wrapping the given data.
@@ -1516,6 +1952,396 @@ mod tests {
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].identifier, "my-repo#10");
         assert_eq!(issues[0].labels, vec!["todo"]);
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_a_foreign_authenticated_assignee_without_mutating() {
+        let server = MockServer::start().await;
+        let issue = crate::tracker::model::test_helpers::test_issue("I_issue", "Todo");
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("viewer { id login }"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "viewer": { "id": "U_viewer", "login": "viewer" }
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("nodes(ids: $ids)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "nodes": [{
+                        "id": "I_issue", "number": 1, "title": "Issue", "state": "OPEN",
+                        "url": "https://example.test/issues/1",
+                        "labels": { "nodes": [{ "name": "Todo" }] }
+                    }]
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("query($issueId: ID!)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "node": {
+                        "id": "I_issue",
+                        "assignees": {
+                            "totalCount": 1,
+                            "nodes": [{ "id": "U_foreign", "login": "foreign" }]
+                        }
+                    }
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let outcome = create_claim_test_tracker(&server.uri())
+            .claim_issue(&issue)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            OwnershipClaim::Conflict(OwnershipConflict::Foreign)
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_revalidates_a_sole_authenticated_assignee_before_acquiring() {
+        let server = MockServer::start().await;
+        let issue = crate::tracker::model::test_helpers::test_issue("I_issue", "Todo");
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("viewer { id login }"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "viewer": { "id": "U_viewer", "login": "viewer" }
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("nodes(ids: $ids)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "nodes": [{
+                        "id": "I_issue", "number": 1, "title": "Issue", "state": "OPEN",
+                        "url": "https://example.test/issues/1",
+                        "labels": { "nodes": [{ "name": "Todo" }] }
+                    }]
+                }))),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("query($issueId: ID!)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "node": {
+                        "id": "I_issue",
+                        "assignees": {
+                            "totalCount": 1,
+                            "nodes": [{ "id": "U_viewer", "login": "viewer" }]
+                        }
+                    }
+                }))),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let outcome = create_claim_test_tracker(&server.uri())
+            .claim_issue(&issue)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            OwnershipClaim::Acquired(OwnershipLease {
+                id: "I_issue".to_string(),
+                branch_name: None,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_reconciles_an_ambiguous_assignee_mutation_before_acquiring() {
+        let server = MockServer::start().await;
+        let issue = crate::tracker::model::test_helpers::test_issue("I_issue", "Todo");
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("viewer { id login }"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "viewer": { "id": "U_viewer", "login": "viewer" }
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("nodes(ids: $ids)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "nodes": [{
+                        "id": "I_issue", "number": 1, "title": "Issue", "state": "OPEN",
+                        "url": "https://example.test/issues/1",
+                        "labels": { "nodes": [{ "name": "Todo" }] }
+                    }]
+                }))),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("query($issueId: ID!)"))
+            .respond_with(AssigneeSequence {
+                calls: AtomicUsize::new(0),
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("addAssigneesToAssignable"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let outcome = create_claim_test_tracker(&server.uri())
+            .claim_issue(&issue)
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, OwnershipClaim::Acquired(_)));
+    }
+
+    #[tokio::test]
+    async fn claim_reconciles_an_ambiguous_state_mutation_before_acquiring() {
+        let server = MockServer::start().await;
+        let issue = crate::tracker::model::test_helpers::test_issue("I_issue", "Open");
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("viewer { id login }"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "viewer": { "id": "U_viewer", "login": "viewer" }
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("nodes(ids: $ids)"))
+            .respond_with(IssueStateSequence {
+                calls: AtomicUsize::new(0),
+            })
+            .expect(4)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("query($issueId: ID!)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "node": {
+                        "id": "I_issue",
+                        "assignees": {
+                            "totalCount": 1,
+                            "nodes": [{ "id": "U_viewer", "login": "viewer" }]
+                        }
+                    }
+                }))),
+            )
+            .expect(3)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("repository(owner: $owner"))
+            .respond_with(RepositoryLabelResponder)
+            .expect(3)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("addLabelsToLabelable"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let outcome = create_claim_transition_test_tracker(&server.uri())
+            .claim_issue(&issue)
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, OwnershipClaim::Acquired(_)));
+    }
+
+    #[tokio::test]
+    async fn recovery_returns_only_a_sole_authenticated_resumable_claim() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("viewer { id login }"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "viewer": { "id": "U_viewer", "login": "viewer" }
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("issues(first: 50"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "repository": { "issues": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [{
+                            "id": "I_issue", "number": 1, "title": "Issue", "state": "OPEN",
+                            "url": "https://example.test/issues/1",
+                            "labels": { "nodes": [{ "name": "Recovering" }] }
+                        }]
+                    }}
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("query($issueId: ID!)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "node": {
+                        "id": "I_issue",
+                        "assignees": {
+                            "totalCount": 1,
+                            "nodes": [{ "id": "U_viewer", "login": "viewer" }]
+                        }
+                    }
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("nodes(ids: $ids)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "nodes": [{
+                        "id": "I_issue", "number": 1, "title": "Issue", "state": "OPEN",
+                        "url": "https://example.test/issues/1",
+                        "labels": { "nodes": [{ "name": "Recovering" }] }
+                    }]
+                }))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let recovered = create_claim_test_tracker(&server.uri())
+            .recover_owned_claims()
+            .await
+            .unwrap();
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].0.id, "I_issue");
+        assert_eq!(recovered[0].1.id, "I_issue");
+    }
+
+    #[tokio::test]
+    async fn recovery_rejects_an_owned_issue_that_left_its_resumable_state() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("viewer { id login }"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "viewer": { "id": "U_viewer", "login": "viewer" }
+                }))),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("issues(first: 50"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "repository": { "issues": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [{
+                            "id": "I_issue", "number": 1, "title": "Issue", "state": "OPEN",
+                            "url": "https://example.test/issues/1",
+                            "labels": { "nodes": [{ "name": "Recovering" }] }
+                        }]
+                    }}
+                }))),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("query($issueId: ID!)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "node": {
+                        "id": "I_issue",
+                        "assignees": {
+                            "totalCount": 1,
+                            "nodes": [{ "id": "U_viewer", "login": "viewer" }]
+                        }
+                    }
+                }))),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("nodes(ids: $ids)"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "nodes": [{
+                        "id": "I_issue", "number": 1, "title": "Issue", "state": "OPEN",
+                        "url": "https://example.test/issues/1",
+                        "labels": { "nodes": [{ "name": "Done" }] }
+                    }]
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let recovered = create_claim_test_tracker(&server.uri())
+            .recover_owned_claims()
+            .await
+            .unwrap();
+
+        assert!(recovered.is_empty());
     }
 
     #[tokio::test]
@@ -2316,6 +3142,7 @@ mod tests {
                         field: "Customer impact".to_string(),
                         options: vec!["Critical".to_string(), "Normal".to_string()],
                     }),
+                    ownership: None,
                 }),
                 active_states: vec!["Queued".to_string()],
                 terminal_states: vec!["Done".to_string()],
@@ -2402,6 +3229,7 @@ mod tests {
                 project_fields: Some(GithubTrackerConfig {
                     status_field: "Status".to_string(),
                     priority: None,
+                    ownership: None,
                 }),
                 active_states: vec!["Todo".to_string()],
                 terminal_states: vec!["Done".to_string()],

--- a/crates/ensemble-core/src/tracker/github/graphql.rs
+++ b/crates/ensemble-core/src/tracker/github/graphql.rs
@@ -121,7 +121,41 @@ pub(super) struct IssueNode {
     pub(super) url: Option<String>,
     pub(super) state: Option<String>,
     pub(super) labels: Option<Nodes<Label>>,
+    pub(super) assignees: Option<AssigneeConnection>,
     pub(super) project_items: Option<Nodes<ProjectItem>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct User {
+    pub(super) id: Option<String>,
+    pub(super) login: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct AssigneeConnection {
+    #[serde(default)]
+    pub(super) total_count: Option<u64>,
+    pub(super) nodes: Vec<Option<User>>,
+}
+
+pub(super) struct Viewer;
+
+impl Operation for Viewer {
+    const NAME: &'static str = "Viewer";
+    const QUERY: &'static str = VIEWER_QUERY;
+    type Response = ViewerData;
+}
+
+pub(super) const VIEWER_QUERY: &str = r#"
+query {
+  viewer { id login }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ViewerData {
+    pub(super) viewer: Option<User>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -240,6 +274,7 @@ query($projectId: ID!, $cursor: String) {
               ... on Issue {
                 id number title body createdAt updatedAt url
                 labels(first: 20) { nodes { name } }
+                assignees(first: 100) { totalCount nodes { id login } }
               }
             }
           }
@@ -283,6 +318,7 @@ query($owner: String!, $repo: String!, $cursor: String, $labels: [String!]) {
       nodes {
         id number title body createdAt updatedAt url state
         labels(first: 20) { nodes { name } }
+        assignees(first: 100) { totalCount nodes { id login } }
       }
     }
   }
@@ -313,6 +349,7 @@ query($ids: [ID!]!) {
     ... on Issue {
       id number title state url
       labels(first: 20) { nodes { name } }
+      assignees(first: 100) { totalCount nodes { id login } }
     }
   }
 }
@@ -321,6 +358,55 @@ query($ids: [ID!]!) {
 #[derive(Debug, Deserialize)]
 pub(super) struct IssueStatesData {
     pub(super) nodes: Vec<Option<IssueNode>>,
+}
+
+pub(super) struct IssueAssignees;
+
+impl Operation for IssueAssignees {
+    const NAME: &'static str = "IssueAssignees";
+    const QUERY: &'static str = ISSUE_ASSIGNEES_QUERY;
+    type Response = IssueAssigneesData;
+}
+
+pub(super) const ISSUE_ASSIGNEES_QUERY: &str = r#"
+query($issueId: ID!) {
+  node(id: $issueId) {
+    ... on Issue { id assignees(first: 100) { totalCount nodes { id login } } }
+  }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct IssueAssigneesData {
+    pub(super) node: Option<IssueNode>,
+}
+
+pub(super) struct AddAssignees;
+
+impl Operation for AddAssignees {
+    const NAME: &'static str = "AddAssignees";
+    const QUERY: &'static str = ADD_ASSIGNEES_MUTATION;
+    type Response = AddAssigneesData;
+}
+
+pub(super) const ADD_ASSIGNEES_MUTATION: &str = r#"
+mutation($issueId: ID!, $assigneeId: ID!) {
+  addAssigneesToAssignable(input: {assignableId: $issueId, assigneeIds: [$assigneeId]}) {
+    assignable { ... on Issue { id } }
+  }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct AddAssigneesData {
+    #[serde(rename = "addAssigneesToAssignable")]
+    _result: Option<AssignableMutationPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct AssignableMutationPayload {
+    _assignable: Option<IdNode>,
 }
 
 pub(super) struct IssueComments;
@@ -586,6 +672,8 @@ mod tests {
             decode_response::<ProjectItems>(br#"{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"edges":[]}}}}"#, "").map(|_| ()),
             decode_response::<RepositoryIssues>(br#"{"data":{"repository":{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}"#, "").map(|_| ()),
             decode_response::<IssueStates>(br#"{"data":{"nodes":[]}}"#, "").map(|_| ()),
+            decode_response::<Viewer>(br#"{"data":{"viewer":{"id":"U_1","login":"octocat"}}}"#, "").map(|_| ()),
+            decode_response::<IssueAssignees>(br#"{"data":{"node":{"id":"I_1","assignees":{"totalCount":0,"nodes":[]}}}}"#, "").map(|_| ()),
             decode_response::<IssueComments>(br#"{"data":{"node":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}"#, "").map(|_| ()),
             decode_response::<RepositoryLabel>(br#"{"data":{"repository":{"label":{"id":"L_1","name":"Todo"}}}}"#, "").map(|_| ()),
             decode_response::<FindProjectItem>(br#"{"data":{"node":{"projectItems":{"nodes":[]}}}}"#, "").map(|_| ()),
@@ -601,6 +689,7 @@ mod tests {
             decode_response::<UpdateProjectItemField>(br#"{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_1"}}}}"#, "").map(|_| ()),
             decode_response::<AddLabels>(br#"{"data":{"addLabelsToLabelable":{"labelable":{"id":"I_1"}}}}"#, "").map(|_| ()),
             decode_response::<RemoveLabels>(br#"{"data":{"removeLabelsFromLabelable":{"labelable":{"id":"I_1"}}}}"#, "").map(|_| ()),
+            decode_response::<AddAssignees>(br#"{"data":{"addAssigneesToAssignable":{"assignable":{"id":"I_1"}}}}"#, "").map(|_| ()),
         ] {
             result.unwrap();
         }
@@ -613,6 +702,7 @@ mod tests {
             decode_response::<UpdateProjectItemField>(br#"{"data":{}}"#, "").map(|_| ()),
             decode_response::<AddLabels>(br#"{"data":{}}"#, "").map(|_| ()),
             decode_response::<RemoveLabels>(br#"{"data":{}}"#, "").map(|_| ()),
+            decode_response::<AddAssignees>(br#"{"data":{}}"#, "").map(|_| ()),
         ] {
             result.unwrap();
         }

--- a/crates/ensemble-core/src/tracker/mod.rs
+++ b/crates/ensemble-core/src/tracker/mod.rs
@@ -7,6 +7,7 @@ pub mod todo_file;
 use crate::config::ensemble::TrackerConfig;
 use async_trait::async_trait;
 use model::{InteractionThreadRoot, Issue, TrackerComment};
+use serde::{Deserialize, Serialize};
 
 /// Error type for tracker operations.
 #[derive(Debug, thiserror::Error)]
@@ -41,6 +42,35 @@ pub enum TrackerError {
     WritesNotSupported,
 }
 
+/// Opaque conflict evidence returned by an adapter when ownership cannot be
+/// safely determined. The orchestrator records the bounded outcome but never
+/// interprets tracker-specific identities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnershipConflict {
+    Foreign,
+    Ambiguous,
+}
+
+/// An adapter-issued ownership lease. `branch_name` is optional so adapters
+/// without a configured delivery convention do not change workspace behavior.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnershipLease {
+    pub id: String,
+    pub branch_name: Option<String>,
+}
+
+/// The generic result of either taking or recovering a tracker claim.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnershipClaim {
+    Unavailable,
+    NotEligible,
+    Acquired(OwnershipLease),
+    Recovered(OwnershipLease),
+    Conflict(OwnershipConflict),
+}
+
 /// Trait for issue tracker adapters.
 ///
 /// Trackers are integration adapters: they fetch ticket metadata from external sources and
@@ -62,6 +92,29 @@ pub trait IssueTracker: Send + Sync {
 
     /// Fetch current states for specific issue IDs (used for reconciliation).
     async fn fetch_issue_states_by_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError>;
+
+    /// Request exclusive remote ownership immediately before first dispatch.
+    /// Adapters must revalidate their own authority before returning a lease.
+    async fn claim_issue(&self, _issue: &Issue) -> Result<OwnershipClaim, TrackerError> {
+        Ok(OwnershipClaim::Unavailable)
+    }
+
+    /// Discover adapter-owned claims that have no local journal owner yet.
+    /// The default preserves existing non-GitHub behavior.
+    async fn recover_owned_claims(&self) -> Result<Vec<(Issue, OwnershipLease)>, TrackerError> {
+        Ok(Vec::new())
+    }
+
+    /// Whether claim/recovery failures must block fresh dispatch. The default
+    /// preserves trackers that do not opt into remote ownership.
+    fn has_remote_ownership_policy(&self) -> bool {
+        false
+    }
+
+    /// Return an adapter-configured opaque workspace branch, if any.
+    fn workspace_branch_name(&self, _issue: &Issue) -> Option<String> {
+        None
+    }
 
     /// Whether this tracker supports state-transition writes (`set_issue_state`).
     ///
@@ -207,6 +260,45 @@ mod tests {
     use crate::test_support::env::ENV_LOCK;
     use std::path::PathBuf;
     use tempfile::TempDir;
+
+    struct ReadOnlyTracker;
+
+    #[async_trait]
+    impl IssueTracker for ReadOnlyTracker {
+        async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+            Ok(Vec::new())
+        }
+
+        async fn fetch_issues_by_states(
+            &self,
+            _states: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            Ok(Vec::new())
+        }
+
+        async fn fetch_issue_states_by_ids(
+            &self,
+            _ids: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[tokio::test]
+    async fn default_claim_capability_leaves_existing_trackers_available_for_dispatch() {
+        let tracker = ReadOnlyTracker;
+        let issue = crate::tracker::model::test_helpers::test_issue("issue-1", "Todo");
+
+        assert_eq!(
+            tracker.claim_issue(&issue).await.unwrap(),
+            OwnershipClaim::Unavailable
+        );
+        assert!(tracker.recover_owned_claims().await.unwrap().is_empty());
+        assert_eq!(
+            serde_json::to_string(&OwnershipConflict::Ambiguous).unwrap(),
+            "\"ambiguous\""
+        );
+    }
 
     struct EnvVarGuard {
         key: &'static str,

--- a/crates/ensemble-core/src/workspace/coordinator.rs
+++ b/crates/ensemble-core/src/workspace/coordinator.rs
@@ -25,6 +25,7 @@ pub struct WorktreeCoordinator {
     repos: HashMap<String, RepoConfig>,
     base_date: String,
     worktree_root: PathBuf,
+    branch_name: Option<String>,
 }
 
 impl WorktreeCoordinator {
@@ -37,6 +38,21 @@ impl WorktreeCoordinator {
             repos,
             base_date,
             worktree_root,
+            branch_name: None,
+        }
+    }
+
+    pub fn new_with_branch(
+        repos: HashMap<String, RepoConfig>,
+        base_date: String,
+        worktree_root: PathBuf,
+        branch_name: Option<String>,
+    ) -> Self {
+        Self {
+            repos,
+            base_date,
+            worktree_root,
+            branch_name,
         }
     }
 
@@ -64,7 +80,7 @@ impl WorktreeCoordinator {
                 });
             }
 
-            let worktree_path = self.worktree_root.join(repo_name).join(&branch);
+            let worktree_path = self.worktree_path(repo_name, &branch);
             let worktree_path_str = worktree_path.to_string_lossy().to_string();
             let repo_path_str = &repo_config.path;
 
@@ -189,12 +205,7 @@ impl WorktreeCoordinator {
         let branch = self.format_branch_name(issue_id);
         self.repos
             .keys()
-            .map(|repo_name| {
-                (
-                    repo_name.clone(),
-                    self.worktree_root.join(repo_name).join(&branch),
-                )
-            })
+            .map(|repo_name| (repo_name.clone(), self.worktree_path(repo_name, &branch)))
             .collect()
     }
 
@@ -207,7 +218,7 @@ impl WorktreeCoordinator {
         let mut errors: Vec<(String, String)> = Vec::new();
 
         for (repo_name, repo_config) in &self.repos {
-            let worktree_path = self.worktree_root.join(repo_name).join(&branch);
+            let worktree_path = self.worktree_path(repo_name, &branch);
             let worktree_path_str = worktree_path.to_string_lossy().to_string();
 
             if let Err(e) = remove_worktree(&repo_config.path, &worktree_path_str, &branch).await {
@@ -250,7 +261,7 @@ impl WorktreeCoordinator {
         let mut paths = HashMap::new();
 
         for repo_name in self.repos.keys() {
-            let worktree_path = self.worktree_root.join(repo_name).join(&branch);
+            let worktree_path = self.worktree_path(repo_name, &branch);
             paths.insert(repo_name.clone(), worktree_path);
         }
 
@@ -258,8 +269,20 @@ impl WorktreeCoordinator {
     }
 
     fn format_branch_name(&self, issue_id: &str) -> String {
+        if let Some(branch_name) = &self.branch_name {
+            return branch_name.clone();
+        }
         let sanitized = sanitize_branch_name(&issue_workspace_key(issue_id));
         format!("ensemble-{}-{}", self.base_date, sanitized)
+    }
+
+    fn worktree_path(&self, repository: &str, branch: &str) -> PathBuf {
+        let directory = if self.branch_name.is_some() {
+            issue_workspace_key(branch)
+        } else {
+            branch.to_string()
+        };
+        self.worktree_root.join(repository).join(directory)
     }
 
     async fn rollback(

--- a/crates/ensemble-core/src/workspace/manager.rs
+++ b/crates/ensemble-core/src/workspace/manager.rs
@@ -23,6 +23,8 @@ struct WorkspaceMetadata {
     issue_identifier: String,
     branch_date: String,
     #[serde(default)]
+    branch_name: Option<String>,
+    #[serde(default)]
     repositories: BTreeMap<String, String>,
     #[serde(default)]
     before_remove_started: bool,
@@ -140,10 +142,11 @@ impl WorkspaceManager {
         let metadata = self.load_metadata(issue_id)?;
         Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
         self.verify_repository_configuration(&metadata_path, &metadata)?;
-        let coordinator = WorktreeCoordinator::new(
+        let coordinator = WorktreeCoordinator::new_with_branch(
             self.repos.clone(),
             metadata.branch_date,
             self.workspace_path(issue_id),
+            metadata.branch_name,
         );
         Ok(coordinator.worktree_paths(issue_id))
     }
@@ -266,6 +269,7 @@ impl WorkspaceManager {
         issue_id: &str,
         identifier: &str,
         date: &str,
+        branch_name: Option<&str>,
     ) -> Result<MetadataCreation, WorkspaceError> {
         let metadata_dir = self.metadata_dir();
         std::fs::create_dir_all(&metadata_dir).map_err(|error| WorkspaceError::CreationFailed {
@@ -277,6 +281,7 @@ impl WorkspaceManager {
             issue_id: issue_id.to_string(),
             issue_identifier: identifier.to_string(),
             branch_date: date.to_string(),
+            branch_name: branch_name.map(str::to_owned),
             repositories: self.repository_identities(),
             before_remove_started: false,
         };
@@ -348,6 +353,21 @@ impl WorkspaceManager {
         })
     }
 
+    fn verify_branch_identity(
+        metadata_path: &Path,
+        metadata: &WorkspaceMetadata,
+        requested_branch: Option<&str>,
+    ) -> Result<(), WorkspaceError> {
+        if requested_branch.is_none() || metadata.branch_name.as_deref() == requested_branch {
+            return Ok(());
+        }
+        Err(WorkspaceError::BranchIdentityMismatch {
+            path: metadata_path.display().to_string(),
+            expected_branch: metadata.branch_name.clone(),
+            actual_branch: requested_branch.map(str::to_owned),
+        })
+    }
+
     fn canonical_repository_identities(
         repositories: &BTreeMap<String, String>,
     ) -> BTreeMap<String, String> {
@@ -369,6 +389,17 @@ impl WorkspaceManager {
         &self,
         issue_id: &str,
         identifier: &str,
+    ) -> Result<WorkspaceResult, WorkspaceError> {
+        self.prepare_workspace_with_branch(issue_id, identifier, None)
+            .await
+    }
+
+    /// Prepare a workspace while preserving an adapter-provided opaque branch identity.
+    pub async fn prepare_workspace_with_branch(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+        branch_name: Option<&str>,
     ) -> Result<WorkspaceResult, WorkspaceError> {
         let prepare_started_at = std::time::Instant::now();
         info!(
@@ -401,6 +432,7 @@ impl WorkspaceManager {
             let metadata_path = self.metadata_path(issue_id);
             Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
             self.verify_repository_configuration(&metadata_path, &metadata)?;
+            Self::verify_branch_identity(&metadata_path, &metadata, branch_name)?;
             if metadata.issue_identifier != identifier {
                 metadata.issue_identifier = identifier.to_string();
                 self.refresh_metadata(&metadata)?;
@@ -414,44 +446,53 @@ impl WorkspaceManager {
                 reason: format!("mkdir failed: {e}"),
             })?;
             let branch_date = chrono::Local::now().format("%Y-%m-%d").to_string();
-            let metadata = match self.create_metadata(issue_id, identifier, &branch_date) {
-                Ok(MetadataCreation::Created(metadata)) => metadata,
-                Ok(MetadataCreation::AlreadyExists) => match self.load_metadata(issue_id) {
-                    Ok(mut existing) => {
-                        if let Err(error) = Self::verify_ownership(
-                            &self.metadata_path(issue_id),
-                            &existing,
-                            issue_id,
-                        ) {
-                            let _ = std::fs::remove_dir(&base_path);
-                            return Err(error);
-                        }
-                        if let Err(error) = self.verify_repository_configuration(
-                            &self.metadata_path(issue_id),
-                            &existing,
-                        ) {
-                            let _ = std::fs::remove_dir(&base_path);
-                            return Err(error);
-                        }
-                        if existing.issue_identifier != identifier {
-                            existing.issue_identifier = identifier.to_string();
-                            if let Err(error) = self.refresh_metadata(&existing) {
+            let metadata =
+                match self.create_metadata(issue_id, identifier, &branch_date, branch_name) {
+                    Ok(MetadataCreation::Created(metadata)) => metadata,
+                    Ok(MetadataCreation::AlreadyExists) => match self.load_metadata(issue_id) {
+                        Ok(mut existing) => {
+                            if let Err(error) = Self::verify_ownership(
+                                &self.metadata_path(issue_id),
+                                &existing,
+                                issue_id,
+                            ) {
                                 let _ = std::fs::remove_dir(&base_path);
                                 return Err(error);
                             }
+                            if let Err(error) = self.verify_repository_configuration(
+                                &self.metadata_path(issue_id),
+                                &existing,
+                            ) {
+                                let _ = std::fs::remove_dir(&base_path);
+                                return Err(error);
+                            }
+                            if let Err(error) = Self::verify_branch_identity(
+                                &self.metadata_path(issue_id),
+                                &existing,
+                                branch_name,
+                            ) {
+                                let _ = std::fs::remove_dir(&base_path);
+                                return Err(error);
+                            }
+                            if existing.issue_identifier != identifier {
+                                existing.issue_identifier = identifier.to_string();
+                                if let Err(error) = self.refresh_metadata(&existing) {
+                                    let _ = std::fs::remove_dir(&base_path);
+                                    return Err(error);
+                                }
+                            }
+                            existing
                         }
-                        existing
-                    }
-                    Err(load_error) => {
+                        Err(load_error) => {
+                            let _ = std::fs::remove_dir(&base_path);
+                            return Err(load_error);
+                        }
+                    },
+                    Err(create_error) => {
                         let _ = std::fs::remove_dir(&base_path);
-                        return Err(load_error);
+                        return Err(create_error);
                     }
-                },
-                Err(create_error) => {
-                    let _ = std::fs::remove_dir(&base_path);
-                    return Err(create_error);
-                }
-            };
+                };
             if !base_path.is_dir() {
                 if let Err(cleanup_error) = std::fs::remove_dir_all(&base_path) {
                     warn!(
@@ -469,10 +510,11 @@ impl WorkspaceManager {
 
         // Prepare worktrees if repos configured
         let worktrees = if !self.repos.is_empty() {
-            let coordinator = WorktreeCoordinator::new(
+            let coordinator = WorktreeCoordinator::new_with_branch(
                 self.repos.clone(),
                 metadata.branch_date,
                 base_path.clone(),
+                metadata.branch_name.clone(),
             );
             info!(workspace = %base_path.display(), "preparing worktrees inside workspace");
             match coordinator.prepare_worktrees(issue_id).await {
@@ -530,8 +572,12 @@ impl WorkspaceManager {
             Self::verify_ownership(&metadata_path, &metadata, issue_id)?;
             self.verify_repository_configuration(&metadata_path, &metadata)?;
             if !self.repos.is_empty() {
-                let coordinator =
-                    WorktreeCoordinator::new(self.repos.clone(), metadata.branch_date, base_path);
+                let coordinator = WorktreeCoordinator::new_with_branch(
+                    self.repos.clone(),
+                    metadata.branch_date,
+                    base_path,
+                    metadata.branch_name,
+                );
                 coordinator
                     .cleanup_worktrees(issue_id)
                     .await
@@ -569,10 +615,11 @@ impl WorkspaceManager {
 
         // Clean up worktrees first - use persisted branch date to avoid date drift
         if !self.repos.is_empty() {
-            let coordinator = WorktreeCoordinator::new(
+            let coordinator = WorktreeCoordinator::new_with_branch(
                 self.repos.clone(),
                 metadata.branch_date,
                 base_path.clone(),
+                metadata.branch_name,
             );
             warn!(workspace = %base_path.display(), "cleaning up worktrees");
             coordinator.cleanup_worktrees(issue_id).await.map_err(|e| {
@@ -712,6 +759,35 @@ mod tests {
                 .into_iter()
                 .map(|(name, worktree)| (name, worktree.path))
                 .collect()
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_uses_and_persists_an_opaque_claim_branch() {
+        let root = TempDir::new().unwrap();
+        let (_repo, config) = setup_repo("owned");
+        let mgr = WorkspaceManager::new(root.path(), Some(vec![config])).unwrap();
+
+        let prepared = mgr
+            .prepare_workspace_with_branch(
+                "NODE_42",
+                "my-repo#42",
+                Some("configured/NODE_42-lease"),
+            )
+            .await
+            .unwrap();
+        let worktree = prepared.worktrees.values().next().unwrap();
+
+        assert_eq!(worktree.branch, "configured/NODE_42-lease");
+        assert!(worktree.path.is_dir());
+
+        let reused = mgr
+            .prepare_workspace("NODE_42", "my-repo#42")
+            .await
+            .unwrap();
+        assert_eq!(
+            reused.worktrees.values().next().unwrap().branch,
+            "configured/NODE_42-lease"
         );
     }
 
@@ -1422,7 +1498,7 @@ mod tests {
         let test_path = dir.path().join("test-workspace");
         std::fs::create_dir_all(&test_path).unwrap();
 
-        mgr.create_metadata("NODE_TEST", "test-workspace", "2024-06-15")
+        mgr.create_metadata("NODE_TEST", "test-workspace", "2024-06-15", None)
             .unwrap();
 
         let loaded = mgr.load_metadata("NODE_TEST").unwrap();
@@ -1445,7 +1521,7 @@ mod tests {
             finalize: Default::default(),
         }];
         let mgr = WorkspaceManager::new(dir.path(), Some(repos)).unwrap();
-        mgr.create_metadata(issue_id, "test-issue", "2020-01-01")
+        mgr.create_metadata(issue_id, "test-issue", "2020-01-01", None)
             .unwrap();
 
         let result = mgr.remove_workspace(issue_id).await;
@@ -1472,7 +1548,7 @@ mod tests {
 
         let ws_path = mgr.workspace_path("NODE_CLEANUP");
         std::fs::create_dir_all(&ws_path).unwrap();
-        mgr.create_metadata("NODE_CLEANUP", "cleanup-test", "2020-01-01")
+        mgr.create_metadata("NODE_CLEANUP", "cleanup-test", "2020-01-01", None)
             .unwrap();
 
         let remove_result = mgr.remove_workspace("NODE_CLEANUP").await;

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -769,6 +769,15 @@ Fields:
   - `priority` (object, optional): `field` is the readable single-select field name and `options`
     is the ordered list of readable option names normalized to ascending generic priority ranks.
     Omit it to disable priority normalization; missing or unlisted selections normalize to no rank.
+  - `ownership` (object, optional): adapter-scoped exclusive claim and delivery-adoption rules.
+    Its configured state names, repository, base branch, and branch template are never generic
+    scheduler predicates. Claims require fresh adapter revalidation; journal restoration remains
+    authoritative on restart: live journal and delivery owners are restored first, adapter-owned
+    resumable orphans second, and fresh candidates last. The opaque lease branch becomes the
+    workspace/worktree branch without exposing GitHub policy to the workspace layer. An unpersisted
+    pull request is adoptable only as one exact configured repository/head/base/SHA (and optionally
+    authenticated-author) match. Persisted delivery marker identity wins over this fallback;
+    foreign or ambiguous evidence blocks without replacement.
 
 GitHub auth host resolution (for `gh auth token` fallback):
 1. `tracker.gh_hostname` (if set)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,6 +183,16 @@ tracker:
     priority:
       field: Customer impact
       options: [Critical, Elevated, Normal]
+    # Optional: adapter-owned exclusive claims and exact orphan-PR adoption.
+    ownership:
+      claim:
+        claimed_state: Agent-owned
+        resume_states: [Agent-owned, Recovering]
+      delivery_adoption:
+        repository: acme/my-project
+        base_branch: main
+        branch_template: ensemble/{issue_workspace_key}
+        require_authenticated_author: true
   active_states:
     - Todo
     - In Progress
@@ -731,3 +741,19 @@ This is retry attempt {{ attempt }}. Review previous work in the workspace and f
 
 Implement the changes described above. Run tests before finishing.
 ```
+
+### GitHub ownership policy
+
+`tracker.github.ownership` is optional. When omitted, GitHub, Notion, and TODO trackers keep their
+existing dispatch behavior. `claim` configures an adapter-owned exclusive authenticated-assignee
+claim: `claimed_state` and every non-empty `resume_states` entry are arbitrary configured normalized
+state names. `resume_states` must include `claimed_state`, so a claim remains discoverable if the
+runtime stops before its first journal append. The adapter must re-read remote evidence before reporting a lease; the orchestrator
+receives only opaque ownership outcomes and remains the lifecycle authority.
+
+`delivery_adoption` permits recovery of an unpersisted pull-request identity only when one pull
+request matches the configured repository, base branch, rendered `branch_template`, and the stored
+commit identity. The template must contain exactly one `{issue_workspace_key}` token and render a
+valid Git branch. `require_authenticated_author` additionally requires the GitHub viewer to be the
+PR author. A persisted delivery marker always takes precedence; foreign or multiple candidates are
+conflicts and never cause a replacement pull request.


### PR DESCRIPTION
Fixes #511

Adds configuration-driven GitHub ownership and recovery without introducing GitHub lifecycle vocabulary into the generic runtime. Claims are sole-assignee authenticated and revalidated, ownership leases are journaled before workspace or agent work, configured branch identity survives restart/retry, and orphan pull requests are adopted only after exact repository/author/head/base/SHA matching with persisted marker precedence.

Validation:

- `cargo test --workspace --exclude ensemble-desktop -- --test-threads=1`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- Product E2E: 44 passed, 1 explicitly ignored
- `cargo fmt --all -- --check`
- `git diff --check`

Parallel core test execution can still expose the pre-existing concurrent Git-spawn ENOENT class; the complete serial workspace suite passes.
