### PR TITLE
Add configurable workflow selection

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: Board, runtime
 The configured directed graph that defines which steps run and how their results control delivery.
 _Avoid_: Workflow when referring to the executable graph
 
+**Scheduler lane**:
+A named, configuration-defined live-worker capacity bucket shared by runs selected into that lane.
+_Avoid_: Tracker state, workflow role
+
 **Step**:
 A named unit of agent or synthesis work within a pipeline.
 _Avoid_: Stage, phase

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -14,6 +14,9 @@ use tempfile::TempDir;
 
 const ISSUE_ID: &str = "E2E-1";
 const ISSUE_TITLE: &str = "Exercise product workflow";
+// Exercise acceptance-failure lifecycle boundaries below Tokio's 2 MiB worker default so future
+// growth cannot silently reintroduce platform-dependent stack overflows.
+const ACCEPTANCE_FAILURE_WORKER_STACK_BYTES: usize = 15 * 128 * 1024;
 
 struct ChildGuard {
     child: Child,
@@ -156,6 +159,10 @@ async fn acceptance_failure_dominates_successful_agent_and_exhausts_the_issue() 
         .arg(port.to_string())
         .env("PATH", fixture.path_with_mock_bin())
         .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env(
+            "RUST_MIN_STACK",
+            ACCEPTANCE_FAILURE_WORKER_STACK_BYTES.to_string(),
+        )
         .stdout(Stdio::null())
         .stderr(Stdio::inherit());
     let child = command.spawn().expect("spawn ensemble web");
@@ -209,6 +216,10 @@ async fn missing_file_and_handoff_are_durable_acceptance_failures() {
         .arg(port.to_string())
         .env("PATH", fixture.path_with_mock_bin())
         .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env(
+            "RUST_MIN_STACK",
+            ACCEPTANCE_FAILURE_WORKER_STACK_BYTES.to_string(),
+        )
         .env("ENSEMBLE_E2E_SKIP_REQUIRED_FILE", "1")
         .env("ENSEMBLE_E2E_MISSING_HANDOFF", "1")
         .stdout(Stdio::null())

--- a/crates/ensemble-core/src/agent/cancellation.rs
+++ b/crates/ensemble-core/src/agent/cancellation.rs
@@ -13,7 +13,7 @@ use crate::config::ensemble::normalize_state_worker_cap_key;
 struct ActiveWorker {
     cancellation: CancellationToken,
     completion: watch::Receiver<bool>,
-    state_bucket: String,
+    capacity_bucket: String,
     reconciliation_owned: bool,
     launched: bool,
 }
@@ -31,25 +31,60 @@ pub(crate) enum WorkerReservationError {
     DuplicateIdentity,
     GlobalCapacityExhausted,
     IssueCapacityExhausted,
-    StateCapacityExhausted,
+    CapacityBucketExhausted,
 }
 
-pub(crate) struct StateWorkerCapacity<'a> {
-    issue_state: &'a str,
-    max_workers_by_state: &'a BTreeMap<String, u32>,
+pub(crate) struct WorkerCapacity<'a> {
+    source: CapacitySource<'a>,
 }
 
-impl<'a> StateWorkerCapacity<'a> {
+enum CapacitySource<'a> {
+    State {
+        issue_state: &'a str,
+        max_workers_by_state: &'a BTreeMap<String, u32>,
+    },
+    Lane {
+        lane: &'a str,
+        capacity: u32,
+    },
+}
+
+impl<'a> WorkerCapacity<'a> {
     pub(crate) fn new(
         issue_state: &'a str,
         max_workers_by_state: &'a BTreeMap<String, u32>,
     ) -> Self {
         Self {
-            issue_state,
-            max_workers_by_state,
+            source: CapacitySource::State {
+                issue_state,
+                max_workers_by_state,
+            },
+        }
+    }
+
+    pub(crate) fn lane(lane: &'a str, capacity: u32) -> Self {
+        Self {
+            source: CapacitySource::Lane { lane, capacity },
+        }
+    }
+
+    fn bucket_and_limit(&self) -> (String, Option<u32>) {
+        match self.source {
+            CapacitySource::State {
+                issue_state,
+                max_workers_by_state,
+            } => {
+                let bucket = normalize_state_worker_cap_key(issue_state);
+                let limit = max_workers_by_state.get(&bucket).copied();
+                (format!("state:{bucket}"), limit)
+            }
+            CapacitySource::Lane { lane, capacity } => (format!("lane:{lane}"), Some(capacity)),
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) type StateWorkerCapacity<'a> = WorkerCapacity<'a>;
 
 pub fn new_cancellation_registry() -> CancellationRegistry {
     CancellationRegistry::default()
@@ -67,7 +102,7 @@ pub fn register_worker(
         ActiveWorker {
             cancellation,
             completion,
-            state_bucket: String::new(),
+            capacity_bucket: String::new(),
             reconciliation_owned: false,
             launched: true,
         },
@@ -81,7 +116,7 @@ pub(crate) fn try_reserve_worker(
     completion: watch::Receiver<bool>,
     max_global_workers: u32,
     max_issue_workers: u32,
-    state_capacity: StateWorkerCapacity<'_>,
+    capacity: WorkerCapacity<'_>,
 ) -> Result<(), WorkerReservationError> {
     let mut workers = registry_guard(registry);
     if workers.contains_key(&identity) {
@@ -98,20 +133,16 @@ pub(crate) fn try_reserve_worker(
     {
         return Err(WorkerReservationError::IssueCapacityExhausted);
     }
-    let state_bucket = normalize_state_worker_cap_key(state_capacity.issue_state);
-    if !state_worker_capacity_available(
-        &workers,
-        &state_bucket,
-        state_capacity.max_workers_by_state,
-    ) {
-        return Err(WorkerReservationError::StateCapacityExhausted);
+    let (capacity_bucket, limit) = capacity.bucket_and_limit();
+    if !capacity_available(&workers, &capacity_bucket, limit) {
+        return Err(WorkerReservationError::CapacityBucketExhausted);
     }
     workers.insert(
         identity,
         ActiveWorker {
             cancellation,
             completion,
-            state_bucket,
+            capacity_bucket,
             reconciliation_owned: false,
             launched: false,
         },
@@ -128,20 +159,34 @@ pub(crate) fn has_available_state_worker_capacity(
         return true;
     }
     let state_bucket = normalize_state_worker_cap_key(issue_state);
-    state_worker_capacity_available(&registry_guard(registry), &state_bucket, max_state_workers)
+    let bucket = format!("state:{state_bucket}");
+    capacity_available(
+        &registry_guard(registry),
+        &bucket,
+        max_state_workers.get(&state_bucket).copied(),
+    )
 }
 
-fn state_worker_capacity_available(
-    workers: &HashMap<WorkerIdentity, ActiveWorker>,
-    state_bucket: &str,
-    max_state_workers: &BTreeMap<String, u32>,
+pub(crate) fn has_available_lane_worker_capacity(
+    registry: &CancellationRegistry,
+    lane: &str,
+    capacity: u32,
 ) -> bool {
-    max_state_workers.get(state_bucket).is_none_or(|limit| {
+    let bucket = format!("lane:{lane}");
+    capacity_available(&registry_guard(registry), &bucket, Some(capacity))
+}
+
+fn capacity_available(
+    workers: &HashMap<WorkerIdentity, ActiveWorker>,
+    capacity_bucket: &str,
+    limit: Option<u32>,
+) -> bool {
+    limit.is_none_or(|limit| {
         workers
             .values()
-            .filter(|worker| worker.state_bucket == state_bucket)
+            .filter(|worker| worker.capacity_bucket == capacity_bucket)
             .count()
-            < *limit as usize
+            < limit as usize
     })
 }
 
@@ -717,7 +762,7 @@ mod tests {
                 3,
                 2
             ),
-            Err(WorkerReservationError::StateCapacityExhausted)
+            Err(WorkerReservationError::CapacityBucketExhausted)
         );
         assert_eq!(
             reserve(
@@ -786,7 +831,7 @@ mod tests {
         assert!(outcomes
             .iter()
             .filter(|outcome| outcome.is_err())
-            .all(|outcome| { *outcome == Err(WorkerReservationError::StateCapacityExhausted) }));
+            .all(|outcome| { *outcome == Err(WorkerReservationError::CapacityBucketExhausted) }));
         assert_eq!(live_worker_count(&racing_registry), 1);
     }
 
@@ -853,7 +898,7 @@ mod tests {
                 2,
                 StateWorkerCapacity::new("todo", &caps),
             ),
-            Err(WorkerReservationError::StateCapacityExhausted)
+            Err(WorkerReservationError::CapacityBucketExhausted)
         );
 
         first_complete_tx.send(true).unwrap();
@@ -874,5 +919,61 @@ mod tests {
             ),
             Ok(())
         );
+    }
+
+    #[test]
+    fn selected_lane_capacity_is_namespaced_and_reserved_atomically() {
+        let registry = new_cancellation_registry();
+        let state_caps = BTreeMap::from([("delivery".to_string(), 1)]);
+        let (_, first_completion) = watch::channel(false);
+        try_reserve_worker(
+            &registry,
+            identity("state", 1),
+            CancellationToken::new(),
+            first_completion,
+            4,
+            1,
+            WorkerCapacity::new("delivery", &state_caps),
+        )
+        .unwrap();
+
+        let lane_identity = WorkerIdentity {
+            issue_id: "issue-2".to_string(),
+            ..identity("lane", 2)
+        };
+        let (_, lane_completion) = watch::channel(false);
+        try_reserve_worker(
+            &registry,
+            lane_identity.clone(),
+            CancellationToken::new(),
+            lane_completion,
+            4,
+            1,
+            WorkerCapacity::lane("delivery", 1),
+        )
+        .unwrap();
+        assert!(!has_available_lane_worker_capacity(
+            &registry, "delivery", 1
+        ));
+
+        let (_, blocked_completion) = watch::channel(false);
+        assert_eq!(
+            try_reserve_worker(
+                &registry,
+                WorkerIdentity {
+                    issue_id: "issue-3".to_string(),
+                    ..identity("blocked", 3)
+                },
+                CancellationToken::new(),
+                blocked_completion,
+                4,
+                1,
+                WorkerCapacity::lane("delivery", 1),
+            ),
+            Err(WorkerReservationError::CapacityBucketExhausted)
+        );
+
+        assert!(rollback_worker_reservation(&registry, &lane_identity));
+        assert!(has_available_lane_worker_capacity(&registry, "delivery", 1));
     }
 }

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -14,7 +14,7 @@ use crate::orchestrator::{
     OrchestratorRuntimeParts, QuiescingLatch,
 };
 use crate::tracker::model::RetryEntry;
-use crate::tracker::{create_tracker, IssueTracker};
+use crate::tracker::{create_tracker_for_runtime, IssueTracker};
 use crate::transcript::events::TranscriptEventBus;
 use crate::workspace::manager::WorkspaceManager;
 use std::path::Path;
@@ -310,8 +310,8 @@ pub(crate) async fn prepare_orchestrator_runtime(
         return Ok(None);
     };
 
-    let config = Arc::new(RwLock::new(config.clone()));
-    let tracker: Arc<dyn IssueTracker> = Arc::from(create_tracker(&config.read().await.tracker)?);
+    let tracker: Arc<dyn IssueTracker> = Arc::from(create_tracker_for_runtime(&config)?);
+    let config = Arc::new(RwLock::new(config));
     tracker.validate_configuration().await?;
     // `AcpAgentRunner` is the shared runtime dispatcher: `acpx_agent` steps run through the
     // acpx CLI/session runtime, while explicit direct configs keep the ACP stdio path.

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -129,9 +129,11 @@ pub(crate) fn parse_raw_yaml_with_dotenv(
                         report.issues.push(pipeline_error_to_validation_issue(e));
                         config_valid = false;
                     }
-                    if let Err(e) = build_dag(&config.steps) {
-                        report.issues.push(pipeline_error_to_validation_issue(e));
-                        config_valid = false;
+                    if config.workflow_selection.is_empty() {
+                        if let Err(e) = build_dag(&config.steps) {
+                            report.issues.push(pipeline_error_to_validation_issue(e));
+                            config_valid = false;
+                        }
                     }
                     ConfigDocumentState {
                         path,
@@ -190,19 +192,33 @@ pub fn validate_document(document: &serde_yaml::Value) -> DraftValidationReport 
 
     if let Some(mapping) = document.as_mapping() {
         // Validate presence of required top-level sections
-        let required_sections = [
-            ("tracker", "tracker"),
-            ("agents", "agents"),
-            ("steps", "workflow"),
-            ("on_success", "transitions"),
-            ("on_failure", "transitions"),
-        ];
+        let selected_mode = mapping
+            .get("workflow_selection")
+            .and_then(serde_yaml::Value::as_sequence)
+            .is_some_and(|rules| !rules.is_empty());
+        let required_sections: &[(&str, &str)] = if selected_mode {
+            &[
+                ("tracker", "tracker"),
+                ("agents", "agents"),
+                ("pipelines", "workflow"),
+                ("scheduler", "workflow"),
+                ("workflow_selection", "workflow"),
+            ]
+        } else {
+            &[
+                ("tracker", "tracker"),
+                ("agents", "agents"),
+                ("steps", "workflow"),
+                ("on_success", "transitions"),
+                ("on_failure", "transitions"),
+            ]
+        };
         for (key, section) in required_sections {
             if !mapping.contains_key(serde_yaml::Value::String(key.to_string())) {
                 issues.push(ValidationIssue {
                     kind: ValidationIssueKind::Config,
                     message: format!("missing required section: {}", key),
-                    section: section.to_string(),
+                    section: (*section).to_string(),
                     field: None,
                     path: Some(key.to_string()),
                 });
@@ -311,6 +327,27 @@ fn pipeline_error_to_validation_issue(e: PipelineError) -> ValidationIssue {
     use crate::error::PipelineError;
 
     match e {
+        PipelineError::InvalidWorkflowSelection { rule, reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("invalid workflow selection rule '{rule}': {reason}"),
+            section: "workflow".to_string(),
+            field: Some(rule.clone()),
+            path: Some(format!("workflow_selection.{rule}")),
+        },
+        PipelineError::InvalidSchedulerLane { lane, reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("invalid scheduler lane '{lane}': {reason}"),
+            section: "workflow".to_string(),
+            field: Some(lane.clone()),
+            path: Some(format!("scheduler.lanes.{lane}")),
+        },
+        PipelineError::InvalidNamedPipeline { pipeline, reason } => ValidationIssue {
+            kind: ValidationIssueKind::Config,
+            message: format!("invalid named pipeline '{pipeline}': {reason}"),
+            section: "workflow".to_string(),
+            field: Some(pipeline.clone()),
+            path: Some(format!("pipelines.{pipeline}")),
+        },
         PipelineError::InvalidFinalizeConfig { repo, reason } => ValidationIssue {
             kind: ValidationIssueKind::Config,
             message: format!("invalid repository finalization config for '{repo}': {reason}"),
@@ -811,6 +848,47 @@ on_failure: Failed
         assert!(state.document.is_some());
         assert!(state.active_config.is_some());
         assert!(state.validation.issues.is_empty());
+    }
+
+    #[test]
+    fn parse_raw_yaml_activates_selected_pipeline_config() {
+        let raw = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  builder:
+    acpx_agent: claude
+    prompt: "Build it."
+pipelines:
+  delivery:
+    steps:
+      - name: build
+        agent: builder
+    on_success: Done
+    on_failure: Failed
+scheduler:
+  lanes:
+    delivery:
+      capacity: 1
+workflow_selection:
+  - name: delivery
+    precedence: 1
+    pipeline: delivery
+    lane: delivery
+    states: [Ready]
+    order_by: [tracker_position]
+"#;
+
+        let state = parse_raw_yaml(PathBuf::from("/tmp/config.yaml"), raw.to_string());
+
+        assert_eq!(state.kind, ConfigStateKind::Parsed);
+        assert!(
+            state.validation.issues.is_empty(),
+            "{:?}",
+            state.validation.issues
+        );
+        assert!(state.active_config.is_some());
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -18,9 +18,21 @@ pub struct EnsembleConfig {
     #[serde(default)]
     pub repos: Vec<RepoConfig>,
     pub agents: HashMap<String, AgentConfig>,
+    #[serde(default)]
     pub steps: Vec<StepConfig>,
+    #[serde(default)]
     pub on_success: String,
+    #[serde(default)]
     pub on_failure: String,
+    /// Neutral named pipelines used only when `workflow_selection` is non-empty.
+    #[serde(default)]
+    pub pipelines: BTreeMap<String, PipelineConfig>,
+    /// Capacity lanes referenced by workflow-selection rules.
+    #[serde(default)]
+    pub scheduler: SchedulerConfig,
+    /// Fixed-vocabulary rules that select a named pipeline and scheduler lane.
+    #[serde(default)]
+    pub workflow_selection: Vec<WorkflowSelectionRuleConfig>,
     #[serde(default)]
     pub concurrency: ConcurrencyConfig,
     #[serde(default = "default_max_cycles")]
@@ -37,6 +49,61 @@ pub struct EnsembleConfig {
     pub human_interaction: HumanInteractionConfig,
     #[serde(default)]
     pub acceptance: AcceptanceConfig,
+}
+
+/// One complete named pipeline selected by a workflow rule.
+#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PipelineConfig {
+    pub steps: Vec<StepConfig>,
+    pub on_success: String,
+    pub on_failure: String,
+}
+
+/// Scheduler configuration for selected workflows.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SchedulerConfig {
+    #[serde(default)]
+    pub lanes: BTreeMap<String, SchedulerLaneConfig>,
+}
+
+/// A positive-capacity worker bucket shared by selected runs in one lane.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SchedulerLaneConfig {
+    pub capacity: u32,
+}
+
+/// A precedence-ordered rule over normalized tracker fields.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowSelectionRuleConfig {
+    pub name: String,
+    pub precedence: u32,
+    pub pipeline: String,
+    pub lane: String,
+    #[serde(default)]
+    pub states: Option<Vec<String>>,
+    #[serde(default)]
+    pub labels_all: Option<Vec<String>>,
+    #[serde(default)]
+    pub labels_any: Option<Vec<String>>,
+    #[serde(default)]
+    pub labels_none: Option<Vec<String>>,
+    #[serde(default)]
+    pub require_unblocked: bool,
+    pub order_by: Vec<WorkflowOrderKey>,
+}
+
+/// Stable ascending sort keys available to workflow-selection rules.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowOrderKey {
+    Priority,
+    TrackerPosition,
+    CreatedAt,
+    Identifier,
 }
 
 /// Commands that must pass after the pipeline and its approval gates succeed.
@@ -880,6 +947,52 @@ pub(crate) fn read_dotenv(path: &Path) -> HashMap<String, String> {
 }
 
 impl EnsembleConfig {
+    pub fn uses_workflow_selection(&self) -> bool {
+        !self.workflow_selection.is_empty()
+    }
+
+    /// Resolve a durable selected-workflow identity into the whole immutable
+    /// configuration snapshot used by the existing pipeline runtime.
+    pub fn resolve_selected_workflow(
+        &self,
+        rule_name: &str,
+        pipeline_name: &str,
+        lane_name: &str,
+    ) -> Result<Self, PipelineError> {
+        let rule = self
+            .workflow_selection
+            .iter()
+            .find(|rule| rule.name == rule_name)
+            .ok_or_else(|| PipelineError::InvalidSnapshot {
+                reason: format!("selected workflow rule '{rule_name}' no longer exists"),
+            })?;
+        if rule.pipeline != pipeline_name || rule.lane != lane_name {
+            return Err(PipelineError::InvalidSnapshot {
+                reason: format!(
+                    "selected workflow rule '{rule_name}' no longer resolves to pipeline '{pipeline_name}' and lane '{lane_name}'"
+                ),
+            });
+        }
+        let pipeline =
+            self.pipelines
+                .get(pipeline_name)
+                .ok_or_else(|| PipelineError::InvalidSnapshot {
+                    reason: format!("selected pipeline '{pipeline_name}' no longer exists"),
+                })?;
+        self.scheduler
+            .lanes
+            .get(lane_name)
+            .ok_or_else(|| PipelineError::InvalidSnapshot {
+                reason: format!("selected scheduler lane '{lane_name}' no longer exists"),
+            })?;
+
+        let mut effective = self.clone();
+        effective.steps = pipeline.steps.clone();
+        effective.on_success.clone_from(&pipeline.on_success);
+        effective.on_failure.clone_from(&pipeline.on_failure);
+        Ok(effective)
+    }
+
     /// Resolve environment variables and path expansions in config values.
     ///
     /// Call this after `parse_config()` to process `$VAR` and `~` in:
@@ -1213,6 +1326,171 @@ fn reject_legacy_agent_permission_policy(
 
 /// Validate the config for consistency: prompt config, agent references, step name uniqueness, etc.
 pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
+    let selected_mode = !config.workflow_selection.is_empty();
+    if selected_mode {
+        if !config.steps.is_empty()
+            || !config.on_success.trim().is_empty()
+            || !config.on_failure.trim().is_empty()
+        {
+            return Err(PipelineError::InvalidWorkflowSelection {
+                rule: "<mode>".to_string(),
+                reason:
+                    "selected mode cannot be mixed with top-level steps, on_success, or on_failure"
+                        .to_string(),
+            });
+        }
+        if config.pipelines.is_empty() {
+            return Err(PipelineError::InvalidNamedPipeline {
+                pipeline: "<missing>".to_string(),
+                reason: "selected mode requires at least one named pipeline".to_string(),
+            });
+        }
+        if config.scheduler.lanes.is_empty() {
+            return Err(PipelineError::InvalidSchedulerLane {
+                lane: "<missing>".to_string(),
+                reason: "selected mode requires at least one scheduler lane".to_string(),
+            });
+        }
+    } else if !config.pipelines.is_empty() || !config.scheduler.lanes.is_empty() {
+        return Err(PipelineError::InvalidWorkflowSelection {
+            rule: "<mode>".to_string(),
+            reason: "named pipelines and scheduler lanes require non-empty workflow_selection"
+                .to_string(),
+        });
+    }
+
+    for (name, lane) in &config.scheduler.lanes {
+        if name.trim().is_empty() {
+            return Err(PipelineError::InvalidSchedulerLane {
+                lane: "<unnamed>".to_string(),
+                reason: "name must not be blank".to_string(),
+            });
+        }
+        if lane.capacity == 0 {
+            return Err(PipelineError::InvalidSchedulerLane {
+                lane: name.clone(),
+                reason: "capacity must be greater than 0".to_string(),
+            });
+        }
+    }
+
+    let mut rule_names = std::collections::HashSet::new();
+    let mut precedences = std::collections::HashSet::new();
+    for rule in &config.workflow_selection {
+        let normalized_name = rule.name.trim().to_lowercase();
+        let display_name = if normalized_name.is_empty() {
+            "<unnamed>"
+        } else {
+            rule.name.as_str()
+        };
+        if normalized_name.is_empty() || !rule_names.insert(normalized_name) {
+            return Err(PipelineError::InvalidWorkflowSelection {
+                rule: display_name.to_string(),
+                reason: "name must be non-blank and unique after normalization".to_string(),
+            });
+        }
+        if rule.precedence == 0 || !precedences.insert(rule.precedence) {
+            return Err(PipelineError::InvalidWorkflowSelection {
+                rule: display_name.to_string(),
+                reason: "precedence must be positive and globally unique".to_string(),
+            });
+        }
+        if !config.pipelines.contains_key(&rule.pipeline) {
+            return Err(PipelineError::InvalidWorkflowSelection {
+                rule: display_name.to_string(),
+                reason: format!("unknown pipeline '{}'", rule.pipeline),
+            });
+        }
+        if !config.scheduler.lanes.contains_key(&rule.lane) {
+            return Err(PipelineError::InvalidWorkflowSelection {
+                rule: display_name.to_string(),
+                reason: format!("unknown scheduler lane '{}'", rule.lane),
+            });
+        }
+        for (predicate, values) in [
+            ("states", rule.states.as_ref()),
+            ("labels_all", rule.labels_all.as_ref()),
+            ("labels_any", rule.labels_any.as_ref()),
+            ("labels_none", rule.labels_none.as_ref()),
+        ] {
+            if let Some(values) = values {
+                if values.is_empty() {
+                    return Err(PipelineError::InvalidWorkflowSelection {
+                        rule: display_name.to_string(),
+                        reason: format!("{predicate} must not be empty when supplied"),
+                    });
+                }
+                let mut normalized = std::collections::HashSet::new();
+                if values.iter().any(|value| {
+                    let value = value.trim().to_lowercase();
+                    value.is_empty() || !normalized.insert(value)
+                }) {
+                    return Err(PipelineError::InvalidWorkflowSelection {
+                        rule: display_name.to_string(),
+                        reason: format!(
+                            "{predicate} values must be non-blank and unique after normalization"
+                        ),
+                    });
+                }
+            }
+        }
+        if rule.order_by.is_empty() {
+            return Err(PipelineError::InvalidWorkflowSelection {
+                rule: display_name.to_string(),
+                reason: "order_by must not be empty".to_string(),
+            });
+        }
+        let mut order_keys = std::collections::HashSet::new();
+        if rule.order_by.iter().any(|key| !order_keys.insert(*key)) {
+            return Err(PipelineError::InvalidWorkflowSelection {
+                rule: display_name.to_string(),
+                reason: "order_by keys must be unique".to_string(),
+            });
+        }
+        if rule
+            .order_by
+            .iter()
+            .position(|key| *key == WorkflowOrderKey::Identifier)
+            .is_some_and(|index| index + 1 != rule.order_by.len())
+        {
+            return Err(PipelineError::InvalidWorkflowSelection {
+                rule: display_name.to_string(),
+                reason: "identifier may appear only as the final order_by key".to_string(),
+            });
+        }
+    }
+
+    let effective_pipelines: Vec<(&str, &[StepConfig], &str, &str)> = if selected_mode {
+        config
+            .pipelines
+            .iter()
+            .map(|(name, pipeline)| {
+                (
+                    name.as_str(),
+                    pipeline.steps.as_slice(),
+                    pipeline.on_success.as_str(),
+                    pipeline.on_failure.as_str(),
+                )
+            })
+            .collect()
+    } else {
+        vec![(
+            "<legacy>",
+            config.steps.as_slice(),
+            config.on_success.as_str(),
+            config.on_failure.as_str(),
+        )]
+    };
+
+    for (name, _, on_success, on_failure) in &effective_pipelines {
+        if name.trim().is_empty() || on_success.trim().is_empty() || on_failure.trim().is_empty() {
+            return Err(PipelineError::InvalidNamedPipeline {
+                pipeline: (*name).to_string(),
+                reason: "name, on_success, and on_failure must be non-blank".to_string(),
+            });
+        }
+    }
+
     let mut review_state: Option<&str> = None;
     for (index, repo) in config.repos.iter().enumerate() {
         let Some(target) = repo.finalize.review_state.as_deref() else {
@@ -1231,7 +1509,10 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
                 reason: "review_state is valid only with push_and_pr finalization".to_string(),
             });
         }
-        if target.eq_ignore_ascii_case(&config.on_success) {
+        if effective_pipelines
+            .iter()
+            .any(|(_, _, on_success, _)| target.eq_ignore_ascii_case(on_success))
+        {
             return Err(PipelineError::InvalidFinalizeConfig {
                 repo: repo_key,
                 reason: "review_state must not equal on_success".to_string(),
@@ -1371,7 +1652,10 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
 
     for rule in &config.acceptance.required_handoff_sections {
         validate_name(&mut acceptance_names, "handoff", &rule.name)?;
-        if !config.steps.iter().any(|step| step.name == rule.step) {
+        if effective_pipelines
+            .iter()
+            .any(|(_, steps, _, _)| !steps.iter().any(|step| step.name == rule.step))
+        {
             return Err(PipelineError::InvalidAcceptanceRequirement {
                 kind: "handoff".to_string(),
                 name: rule.name.clone(),
@@ -1535,49 +1819,54 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         });
     }
 
-    // Step names must be unique
-    let mut seen_names = std::collections::HashSet::new();
-    for step in &config.steps {
-        if !seen_names.insert(&step.name) {
-            return Err(PipelineError::DuplicateStepName {
-                name: step.name.clone(),
-            });
-        }
-    }
-    // Each step must reference a valid agent
-    for step in &config.steps {
-        if !config.agents.contains_key(&step.agent) {
-            return Err(PipelineError::UnknownAgent {
-                name: step.agent.clone(),
-            });
-        }
-        if step.timeout_ms == Some(0) {
-            return Err(PipelineError::InvalidStepConfig {
-                step: step.name.clone(),
-                reason: "timeout_ms must be greater than 0".to_string(),
-            });
-        }
-        if step.on_failure == OnFailure::Fixup {
-            let Some(fixup_agent) = step.fixup_agent.as_deref() else {
+    for (pipeline_name, steps, _, _) in effective_pipelines {
+        let mut seen_names = std::collections::HashSet::new();
+        for step in steps {
+            if !seen_names.insert(&step.name) {
+                return Err(PipelineError::DuplicateStepName {
+                    name: step.name.clone(),
+                });
+            }
+            if !config.agents.contains_key(&step.agent) {
+                return Err(PipelineError::UnknownAgent {
+                    name: step.agent.clone(),
+                });
+            }
+            if step.timeout_ms == Some(0) {
                 return Err(PipelineError::InvalidStepConfig {
                     step: step.name.clone(),
-                    reason: "on_failure: fixup requires fixup_agent".to_string(),
+                    reason: "timeout_ms must be greater than 0".to_string(),
                 });
-            };
-            if !config.agents.contains_key(fixup_agent) {
-                return Err(PipelineError::UnknownAgent {
-                    name: fixup_agent.to_string(),
+            }
+            if step.on_failure == OnFailure::Fixup {
+                let Some(fixup_agent) = step.fixup_agent.as_deref() else {
+                    return Err(PipelineError::InvalidStepConfig {
+                        step: step.name.clone(),
+                        reason: "on_failure: fixup requires fixup_agent".to_string(),
+                    });
+                };
+                if !config.agents.contains_key(fixup_agent) {
+                    return Err(PipelineError::UnknownAgent {
+                        name: fixup_agent.to_string(),
+                    });
+                }
+            }
+            if step.kind == StepKind::Synthesis && step.depends.as_ref().is_none_or(Vec::is_empty) {
+                return Err(PipelineError::InvalidSynthesisStep {
+                    step: step.name.clone(),
+                    reason: "synthesis steps require explicit non-empty depends".to_string(),
                 });
             }
         }
-    }
-    // Synthesis steps must have explicit non-empty dependencies
-    for step in &config.steps {
-        if step.kind == StepKind::Synthesis && step.depends.as_ref().is_none_or(Vec::is_empty) {
-            return Err(PipelineError::InvalidSynthesisStep {
-                step: step.name.clone(),
-                reason: "synthesis steps require explicit non-empty depends".to_string(),
-            });
+        if selected_mode {
+            crate::pipeline::dag::build_dag(steps).map_err(|error| {
+                PipelineError::InvalidNamedPipeline {
+                    pipeline: pipeline_name.to_string(),
+                    reason: error.to_string(),
+                }
+            })?;
+        } else {
+            crate::pipeline::dag::build_dag(steps)?;
         }
     }
     Ok(())
@@ -1664,6 +1953,128 @@ on_failure: Failed
         assert!(config.acceptance.required_files.is_empty());
         assert!(config.acceptance.required_handoff_sections.is_empty());
         assert!(config.acceptance.required_pull_requests.is_empty());
+    }
+
+    #[test]
+    fn selected_mode_parses_named_pipeline_lane_and_rule() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: "Build the thing."
+pipelines:
+  delivery:
+    steps:
+      - name: build
+        agent: build
+    on_success: Done
+    on_failure: Failed
+scheduler:
+  lanes:
+    delivery:
+      capacity: 2
+workflow_selection:
+  - name: ready
+    precedence: 10
+    pipeline: delivery
+    lane: delivery
+    states: [Ready]
+    labels_all: [ready-for-agent]
+    labels_any: [backend, frontend]
+    labels_none: [hold]
+    require_unblocked: true
+    order_by: [priority, tracker_position, created_at]
+"#,
+        )
+        .unwrap();
+
+        assert!(config.steps.is_empty());
+        assert_eq!(config.pipelines["delivery"].steps[0].name, "build");
+        assert_eq!(config.scheduler.lanes["delivery"].capacity, 2);
+        assert_eq!(config.workflow_selection[0].name, "ready");
+        assert_eq!(
+            config.workflow_selection[0].order_by,
+            vec![
+                WorkflowOrderKey::Priority,
+                WorkflowOrderKey::TrackerPosition,
+                WorkflowOrderKey::CreatedAt,
+            ]
+        );
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn selected_mode_rejects_ambiguous_or_nondeterministic_rules() {
+        let selected = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: build
+pipelines:
+  main:
+    steps: [{ name: build, agent: build }]
+    on_success: Done
+    on_failure: Failed
+scheduler:
+  lanes:
+    main: { capacity: 1 }
+workflow_selection:
+  - name: first
+    precedence: 1
+    pipeline: main
+    lane: main
+    states: [Ready]
+    order_by: [priority]
+"#;
+
+        let mut config = parse_config(selected).unwrap();
+        config.steps = vec![config.pipelines["main"].steps[0].clone()];
+        config.on_success = "Done".to_string();
+        config.on_failure = "Failed".to_string();
+        assert!(matches!(
+            validate_config(&config),
+            Err(PipelineError::InvalidWorkflowSelection { .. })
+        ));
+
+        let mut config = parse_config(selected).unwrap();
+        config
+            .workflow_selection
+            .push(config.workflow_selection[0].clone());
+        assert!(matches!(
+            validate_config(&config),
+            Err(PipelineError::InvalidWorkflowSelection { .. })
+        ));
+
+        let mut config = parse_config(selected).unwrap();
+        config.workflow_selection[0].states = Some(Vec::new());
+        assert!(matches!(
+            validate_config(&config),
+            Err(PipelineError::InvalidWorkflowSelection { .. })
+        ));
+
+        let mut config = parse_config(selected).unwrap();
+        config.workflow_selection[0].order_by =
+            vec![WorkflowOrderKey::Identifier, WorkflowOrderKey::CreatedAt];
+        assert!(matches!(
+            validate_config(&config),
+            Err(PipelineError::InvalidWorkflowSelection { .. })
+        ));
+
+        let mut config = parse_config(selected).unwrap();
+        config.scheduler.lanes.get_mut("main").unwrap().capacity = 0;
+        assert!(matches!(
+            validate_config(&config),
+            Err(PipelineError::InvalidSchedulerLane { .. })
+        ));
     }
 
     #[test]

--- a/crates/ensemble-core/src/error.rs
+++ b/crates/ensemble-core/src/error.rs
@@ -149,6 +149,12 @@ pub enum AgentError {
 
 #[derive(Debug, Error)]
 pub enum PipelineError {
+    #[error("invalid workflow selection rule {rule}: {reason}")]
+    InvalidWorkflowSelection { rule: String, reason: String },
+    #[error("invalid scheduler lane {lane}: {reason}")]
+    InvalidSchedulerLane { lane: String, reason: String },
+    #[error("invalid named pipeline {pipeline}: {reason}")]
+    InvalidNamedPipeline { pipeline: String, reason: String },
     #[error("invalid repository finalization config for {repo}: {reason}")]
     InvalidFinalizeConfig { repo: String, reason: String },
     #[error("invalid acceptance command {name}: {reason}")]

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -969,6 +969,9 @@ mod tests {
 
     fn test_config_with_steps() -> std::sync::Arc<EnsembleConfig> {
         std::sync::Arc::new(EnsembleConfig {
+            pipelines: Default::default(),
+            scheduler: Default::default(),
+            workflow_selection: Default::default(),
             tracker: TrackerConfig {
                 kind: "todo_file".to_string(),
                 active_states: vec!["In Progress".to_string()],

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -999,18 +999,14 @@ impl Orchestrator {
         .into_iter()
         .map(|issue| (issue.id.clone(), issue))
         .collect::<BTreeMap<_, _>>();
-        let (terminal_states, success_state, failure_state) = {
+        let terminal_states = {
             let config = self.config.read().await;
-            (
-                config
-                    .tracker
-                    .terminal_states
-                    .iter()
-                    .map(|state| state.to_lowercase())
-                    .collect::<Vec<_>>(),
-                config.on_success.clone(),
-                config.on_failure.clone(),
-            )
+            config
+                .tracker
+                .terminal_states
+                .iter()
+                .map(|state| state.to_lowercase())
+                .collect::<Vec<_>>()
         };
 
         let mut recoverable_issue_ids = BTreeSet::new();
@@ -1023,14 +1019,41 @@ impl Orchestrator {
                 continue;
             };
             if terminal_states.contains(&issue.state.to_lowercase()) {
-                let outcome = if issue.state.eq_ignore_ascii_case(&success_state) {
+                let snapshot = match self.load_delivery_snapshot(&delivery).await {
+                    Ok(snapshot) => snapshot,
+                    Err(error) => {
+                        warn!(
+                            issue_id = %delivery.issue_id,
+                            error = %error,
+                            "terminal delivery reconciliation could not load its durable snapshot"
+                        );
+                        continue;
+                    }
+                };
+                let pipeline_config = match self
+                    .current_config_for_snapshot(snapshot.as_ref())
+                    .await
+                {
+                    Ok(config) => config,
+                    Err(error) => {
+                        warn!(
+                            issue_id = %delivery.issue_id,
+                            error = %error,
+                            "terminal delivery reconciliation could not resolve its selected workflow"
+                        );
+                        continue;
+                    }
+                };
+                let success_state = &pipeline_config.on_success;
+                let failure_state = &pipeline_config.on_failure;
+                let outcome = if issue.state.eq_ignore_ascii_case(success_state) {
                     TerminalOutcome::Succeeded
                 } else {
                     TerminalOutcome::Failed
                 };
-                let history_outcome = if issue.state.eq_ignore_ascii_case(&success_state) {
+                let history_outcome = if issue.state.eq_ignore_ascii_case(success_state) {
                     HISTORY_OUTCOME_SUCCEEDED
-                } else if issue.state.eq_ignore_ascii_case(&failure_state) {
+                } else if issue.state.eq_ignore_ascii_case(failure_state) {
                     HISTORY_OUTCOME_FAILED
                 } else {
                     HISTORY_OUTCOME_STOPPED
@@ -1165,7 +1188,8 @@ impl Orchestrator {
                 .await;
             let delivery = self.advance_review_projection(delivery).await;
             if delivery.aggregate() == DeliveryAggregate::Published {
-                self.complete_published_delivery(&delivery).await;
+                self.complete_published_delivery(&delivery, snapshot.as_ref())
+                    .await;
                 continue;
             }
             if delivery.aggregate() == DeliveryAggregate::Waiting {
@@ -1208,7 +1232,8 @@ impl Orchestrator {
             self.project_delivery_artifacts(&delivery.issue_id, &delivery)
                 .await;
             if delivery.aggregate() == DeliveryAggregate::Published {
-                self.complete_published_delivery(&delivery).await;
+                self.complete_published_delivery(&delivery, snapshot.as_ref())
+                    .await;
                 continue;
             }
             let finalize = Self::finalize_state_from_delivery(&delivery);
@@ -1495,7 +1520,11 @@ impl Orchestrator {
         record.artifacts = artifacts;
     }
 
-    async fn complete_published_delivery(&self, delivery: &DeliveryRecord) {
+    async fn complete_published_delivery(
+        &self,
+        delivery: &DeliveryRecord,
+        snapshot: Option<&PipelineRunSnapshot>,
+    ) {
         let Some(history_record) = self
             .projected_terminal_history(delivery, HISTORY_OUTCOME_SUCCEEDED)
             .await
@@ -1506,7 +1535,17 @@ impl Orchestrator {
             );
             return;
         };
-        let config = self.config.read().await.clone();
+        let config = match self.current_config_for_snapshot(snapshot).await {
+            Ok(config) => config,
+            Err(error) => {
+                warn!(
+                    issue_id = %delivery.issue_id,
+                    error = %error,
+                    "published delivery could not resolve its selected workflow"
+                );
+                return;
+            }
+        };
         let finalize = Self::finalize_state_from_delivery(delivery);
         self.state
             .write()
@@ -1523,7 +1562,7 @@ impl Orchestrator {
             &delivery.identifier,
             issue,
             TerminalOutcome::Succeeded,
-            config.on_success,
+            config.on_success.clone(),
             Some(history_record),
         )
         .await;

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -3,6 +3,7 @@ pub mod pipeline_journal;
 pub mod reconciler;
 pub mod retry;
 pub mod scheduler;
+pub mod selection;
 pub mod state;
 
 use std::collections::{HashMap, HashSet};
@@ -26,13 +27,15 @@ use crate::acceptance::{
     evaluate_file_requirement, evaluate_handoff_requirement, AcceptanceCommandRunner,
     AcceptanceEvidence, AcceptanceStatus, ResolvedAcceptancePlan, ShellAcceptanceCommandRunner,
 };
+#[cfg(test)]
+use crate::agent::cancellation::StateWorkerCapacity;
 use crate::agent::cancellation::{
-    await_worker_drain, await_worker_quiescence, has_available_state_worker_capacity,
-    is_reconciliation_owned, live_worker_count, mark_all_for_drain, mark_issue_for_drain,
-    mark_worker_launched, new_cancellation_registry, pending_reconciliation_issue_ids,
-    remove_completed_worker, remove_drained_workers, rollback_worker_reservation,
-    try_reserve_worker, CancellationRegistry, StateWorkerCapacity, WorkerDrainHandle,
-    WorkerReservationError,
+    await_worker_drain, await_worker_quiescence, has_available_lane_worker_capacity,
+    has_available_state_worker_capacity, is_reconciliation_owned, live_worker_count,
+    mark_all_for_drain, mark_issue_for_drain, mark_worker_launched, new_cancellation_registry,
+    pending_reconciliation_issue_ids, remove_completed_worker, remove_drained_workers,
+    rollback_worker_reservation, try_reserve_worker, CancellationRegistry, WorkerCapacity,
+    WorkerDrainHandle, WorkerReservationError,
 };
 use crate::agent::events::{
     AgentEvent, InteractionRequestDraft, OrchestratorWorkerEvent, StepApprovalRequestDraft,
@@ -70,8 +73,8 @@ use crate::orchestrator::pipeline_journal::{
 };
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{
-    DispatchRequest, PipelineAction, PipelineRun, PipelineRunSnapshot, StepOutputTemplateContext,
-    StepState,
+    DispatchRequest, PipelineAction, PipelineRun, PipelineRunSnapshot, SelectedWorkflowSnapshot,
+    StepOutputTemplateContext, StepState,
 };
 use crate::pipeline::verdict::StepResult;
 use crate::timeline::persistence::TimelinePersistence;
@@ -95,9 +98,10 @@ use retry::{
     ManualWholeIssueRetryRequest,
 };
 use scheduler::{
-    has_available_worker_slots, is_dispatch_eligible, is_resume_dispatch_eligible,
-    sort_for_dispatch,
+    has_available_worker_slots, is_dispatch_eligible, is_dispatch_structurally_eligible,
+    is_resume_dispatch_eligible, sort_for_dispatch,
 };
+use selection::{sort_selected_candidates, SelectedWorkflow, WorkflowSelector};
 use state::{
     FinalizeStatus, IssueFinalizeState, OrchestratorState, PendingTerminalEntry, RepoFinalizeState,
     WaitingOnHumanEntry,
@@ -718,9 +722,19 @@ impl Orchestrator {
                     let _ = response.send(Err(ManualStepRetryError::RuntimeUnavailable));
                     return;
                 }
-                let (max_backoff_ms, max_cycles) = {
-                    let config = self.config.read().await;
-                    (config.agent.max_retry_backoff_ms, config.max_cycles)
+                let retry_limits = {
+                    let state = self.state.read().await;
+                    if state.get_pipeline_run(&command.issue_id).is_none() {
+                        let _ = response.send(Err(ManualStepRetryError::NoPipelineRun));
+                        return;
+                    }
+                    state
+                        .get_pipeline_config(&command.issue_id)
+                        .map(|config| (config.agent.max_retry_backoff_ms, config.max_cycles))
+                };
+                let Some((max_backoff_ms, max_cycles)) = retry_limits else {
+                    let _ = response.send(Err(ManualStepRetryError::RuntimeUnavailable));
+                    return;
                 };
                 let result = queue_manual_step_retry(
                     &self.state,
@@ -884,7 +898,7 @@ impl Orchestrator {
 
                 // Worker events
                 Some(event) = recv_worker_event(&self.worker_rx) => {
-                    self.handle_worker_event(event).await;
+                    Box::pin(self.handle_worker_event(event)).await;
                 }
 
                 // Retry timer (if any)
@@ -1109,11 +1123,45 @@ impl Orchestrator {
             }
         };
 
-        // 4. Sort by dispatch priority
-        sort_for_dispatch(&mut candidates);
+        let selected_candidates = {
+            let config = self.config.read().await;
+            if config.uses_workflow_selection() {
+                match WorkflowSelector::compile(&config.workflow_selection, &config.scheduler.lanes)
+                {
+                    Ok(selector) => {
+                        let mut selected = candidates
+                            .iter()
+                            .filter_map(|issue| {
+                                selector
+                                    .select(issue, &config.tracker.terminal_states)
+                                    .map(|workflow| (issue.clone(), workflow))
+                            })
+                            .collect::<Vec<_>>();
+                        sort_selected_candidates(&mut selected);
+                        Some(selected)
+                    }
+                    Err(error) => {
+                        warn!(error = %error, "failed to compile workflow selector");
+                        return;
+                    }
+                }
+            } else {
+                sort_for_dispatch(&mut candidates);
+                None
+            }
+        };
 
-        // 5. Dispatch eligible issues while slots remain
-        for issue in &candidates {
+        // 5. Dispatch eligible issues while slots remain.
+        let dispatch_candidates = selected_candidates
+            .as_ref()
+            .map(|selected| {
+                selected
+                    .iter()
+                    .map(|(issue, workflow)| (issue, Some(workflow.clone())))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_else(|| candidates.iter().map(|issue| (issue, None)).collect());
+        for (issue, selected) in dispatch_candidates {
             if self.quiescing.is_requested() {
                 break;
             }
@@ -1128,8 +1176,13 @@ impl Orchestrator {
                 }
             }
 
-            Box::pin(self.consider_candidate_for_dispatch(issue, &active_lower, &terminal_lower))
-                .await;
+            Box::pin(self.consider_candidate_for_dispatch(
+                issue,
+                &active_lower,
+                &terminal_lower,
+                selected,
+            ))
+            .await;
         }
 
         info!(
@@ -1144,10 +1197,15 @@ impl Orchestrator {
         issue: &Issue,
         active_lower: &[String],
         terminal_lower: &[String],
+        selected: Option<SelectedWorkflow>,
     ) {
         let eligible = {
             let state = self.state.read().await;
-            is_dispatch_eligible(issue, &state, active_lower, terminal_lower)
+            if selected.is_some() {
+                is_dispatch_structurally_eligible(issue, &state, terminal_lower)
+            } else {
+                is_dispatch_eligible(issue, &state, active_lower, terminal_lower)
+            }
         };
 
         let restored_pipeline_ready = {
@@ -1162,7 +1220,16 @@ impl Orchestrator {
 
         {
             let config = self.config.read().await;
-            if !self.state_worker_capacity_available(issue, &config).await {
+            let capacity_available = if let Some(selected) = selected.as_ref() {
+                has_available_lane_worker_capacity(
+                    &self.cancellation_registry,
+                    &selected.lane,
+                    selected.lane_capacity,
+                )
+            } else {
+                self.state_worker_capacity_available(issue, &config).await
+            };
+            if !capacity_available {
                 return;
             }
         }
@@ -1176,9 +1243,27 @@ impl Orchestrator {
                 Box::pin(self.dispatch_issue(issue, None)).await;
             }
             Ok(CandidateRestoreOutcome::NotRestored) => {
-                if let Some(owned_issue) = Box::pin(self.claim_candidate_for_dispatch(issue)).await
-                {
-                    Box::pin(self.dispatch_issue(&owned_issue, None)).await;
+                let refreshed = if let Some(expected) = selected.as_ref() {
+                    Box::pin(self.refresh_selected_candidate_for_claim(
+                        issue,
+                        expected,
+                        terminal_lower,
+                    ))
+                    .await
+                } else {
+                    Some((issue.clone(), None))
+                };
+                if let Some((fresh_issue, fresh_selected)) = refreshed {
+                    if let Some(owned_issue) =
+                        Box::pin(self.claim_candidate_for_dispatch(&fresh_issue)).await
+                    {
+                        if let Some(selected) = fresh_selected {
+                            Box::pin(self.dispatch_selected_issue(&owned_issue, None, selected))
+                                .await;
+                        } else {
+                            Box::pin(self.dispatch_issue(&owned_issue, None)).await;
+                        }
+                    }
                 }
             }
             Ok(CandidateRestoreOutcome::Parked) => {}
@@ -1211,6 +1296,61 @@ impl Orchestrator {
         }
     }
 
+    async fn refresh_selected_candidate_for_claim(
+        &self,
+        issue: &Issue,
+        expected: &SelectedWorkflow,
+        terminal_states: &[String],
+    ) -> Option<(Issue, Option<SelectedWorkflow>)> {
+        let mut refreshed = match self
+            .tracker
+            .fetch_issue_states_by_ids(std::slice::from_ref(&issue.id))
+            .await
+        {
+            Ok(refreshed) => refreshed,
+            Err(error) => {
+                warn!(issue_id = %issue.id, error = %error, "selected candidate refresh failed");
+                return None;
+            }
+        };
+        if refreshed.len() != 1 {
+            return None;
+        }
+        let fresh = refreshed.pop()?;
+        {
+            let state = self.state.read().await;
+            if is_dispatch_structurally_eligible(&fresh, &state, terminal_states).is_some() {
+                return None;
+            }
+        }
+        let config = self.config.read().await;
+        let selector = match WorkflowSelector::compile(
+            &config.workflow_selection,
+            &config.scheduler.lanes,
+        ) {
+            Ok(selector) => selector,
+            Err(error) => {
+                warn!(issue_id = %issue.id, error = %error, "selected candidate refresh could not compile workflow rules");
+                return None;
+            }
+        };
+        let selected = selector.select(&fresh, terminal_states)?;
+        if selected.rule != expected.rule
+            || selected.pipeline != expected.pipeline
+            || selected.lane != expected.lane
+        {
+            return None;
+        }
+        if !has_available_lane_worker_capacity(
+            &self.cancellation_registry,
+            &selected.lane,
+            selected.lane_capacity,
+        ) {
+            return None;
+        }
+        Some((fresh, Some(selected)))
+    }
+
     async fn dispatch_recovered_claims_before_fresh_work(&self) {
         let recovered = match self.tracker.recover_owned_claims().await {
             Ok(recovered) => recovered,
@@ -1232,11 +1372,41 @@ impl Orchestrator {
                 continue;
             }
 
-            let config = self.config.read().await;
-            if !self.state_worker_capacity_available(&issue, &config).await {
-                return;
-            }
-            drop(config);
+            let selected = {
+                let config = self.config.read().await;
+                if config.uses_workflow_selection() {
+                    let terminal_states = config.tracker.terminal_states.clone();
+                    let Ok(selector) = WorkflowSelector::compile(
+                        &config.workflow_selection,
+                        &config.scheduler.lanes,
+                    ) else {
+                        return;
+                    };
+                    drop(config);
+                    let state = self.state.read().await;
+                    if is_dispatch_structurally_eligible(&issue, &state, &terminal_states).is_some()
+                    {
+                        continue;
+                    }
+                    drop(state);
+                    let Some(selected) = selector.select(&issue, &terminal_states) else {
+                        continue;
+                    };
+                    if !has_available_lane_worker_capacity(
+                        &self.cancellation_registry,
+                        &selected.lane,
+                        selected.lane_capacity,
+                    ) {
+                        return;
+                    }
+                    Some(selected)
+                } else {
+                    if !self.state_worker_capacity_available(&issue, &config).await {
+                        return;
+                    }
+                    None
+                }
+            };
 
             let mut owned_issue = issue;
             owned_issue.branch_name = lease.branch_name.clone();
@@ -1244,7 +1414,11 @@ impl Orchestrator {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .insert(owned_issue.id.clone(), lease);
-            Box::pin(self.dispatch_issue(&owned_issue, None)).await;
+            if let Some(selected) = selected {
+                Box::pin(self.dispatch_selected_issue(&owned_issue, None, selected)).await;
+            } else {
+                Box::pin(self.dispatch_issue(&owned_issue, None)).await;
+            }
         }
     }
 
@@ -1380,13 +1554,26 @@ impl Orchestrator {
             .await;
     }
 
+    async fn dispatch_selected_issue(
+        &self,
+        issue: &Issue,
+        attempt: Option<u32>,
+        selected: SelectedWorkflow,
+    ) {
+        let Some(permit) = self.quiescing.begin_dispatch() else {
+            return;
+        };
+        self.dispatch_issue_with_owned_retry(issue, attempt, None, Some(&selected), &permit)
+            .await;
+    }
+
     async fn dispatch_issue_with_permit(
         &self,
         issue: &Issue,
         attempt: Option<u32>,
         permit: &DispatchPermit,
     ) {
-        self.dispatch_issue_with_owned_retry(issue, attempt, None, permit)
+        self.dispatch_issue_with_owned_retry(issue, attempt, None, None, permit)
             .await;
     }
 
@@ -1400,6 +1587,7 @@ impl Orchestrator {
             issue,
             Some(retry_entry.attempt),
             Some(retry_entry),
+            None,
             permit,
         )
         .await;
@@ -1410,6 +1598,7 @@ impl Orchestrator {
         issue: &Issue,
         attempt: Option<u32>,
         expected_retry: Option<&RetryEntry>,
+        selected: Option<&SelectedWorkflow>,
         permit: &DispatchPermit,
     ) {
         let cycle = attempt.unwrap_or(1);
@@ -1704,8 +1893,23 @@ impl Orchestrator {
 
         let (dag, config_snapshot) = {
             let config = self.config.read().await;
-            match build_dag(&config.steps) {
-                Ok(d) => (d, Arc::new(config.clone())),
+            let effective = if let Some(selected) = selected {
+                match config.resolve_selected_workflow(
+                    &selected.rule,
+                    &selected.pipeline,
+                    &selected.lane,
+                ) {
+                    Ok(effective) => effective,
+                    Err(error) => {
+                        warn!(issue_id = %issue.id, error = %error, "failed to resolve selected workflow");
+                        return;
+                    }
+                }
+            } else {
+                config.clone()
+            };
+            match build_dag(&effective.steps) {
+                Ok(d) => (d, Arc::new(effective)),
                 Err(e) => {
                     warn!(issue_id = %issue.id, error = %e, "failed to build step DAG, skipping dispatch");
                     return;
@@ -1720,6 +1924,13 @@ impl Orchestrator {
             .get(&issue.id)
             .cloned();
         let mut pipeline_run = PipelineRun::new(issue.id.clone(), cycle, dag);
+        if let Some(selected) = selected {
+            pipeline_run.set_selected_workflow(SelectedWorkflowSnapshot {
+                rule: selected.rule.clone(),
+                pipeline: selected.pipeline.clone(),
+                lane: selected.lane.clone(),
+            });
+        }
         if let Some(lease) = ownership_lease.clone() {
             pipeline_run.set_ownership_lease(lease);
         }
@@ -1993,13 +2204,32 @@ impl Orchestrator {
         issue: &Issue,
         config: &EnsembleConfig,
     ) -> bool {
-        let issue_state = {
+        let (issue_state, selected_lane) = {
             let state = self.state.read().await;
-            state
-                .get_running(&issue.id)
-                .map(|entry| entry.issue.state.clone())
-                .unwrap_or_else(|| issue.state.clone())
+            (
+                state
+                    .get_running(&issue.id)
+                    .map(|entry| entry.issue.state.clone())
+                    .unwrap_or_else(|| issue.state.clone()),
+                state
+                    .get_pipeline_run(&issue.id)
+                    .and_then(PipelineRun::selected_workflow)
+                    .map(|selected| selected.lane.clone()),
+            )
         };
+        if let Some(lane) = selected_lane {
+            return config
+                .scheduler
+                .lanes
+                .get(&lane)
+                .is_some_and(|lane_config| {
+                    has_available_lane_worker_capacity(
+                        &self.cancellation_registry,
+                        &lane,
+                        lane_config.capacity,
+                    )
+                });
+        }
         has_available_state_worker_capacity(
             &self.cancellation_registry,
             &issue_state,
@@ -2261,7 +2491,17 @@ impl Orchestrator {
         Ok(workspace.base_path)
     }
 
-    async fn run_acceptance_phase(
+    // Type-erase this lifecycle boundary so the acceptance state machine is not embedded in the
+    // already-large worker-exit future.
+    fn run_acceptance_phase<'a>(
+        &'a self,
+        issue: &'a Issue,
+        config: &'a EnsembleConfig,
+    ) -> Pin<Box<dyn Future<Output = AcceptancePhaseOutcome> + Send + 'a>> {
+        Box::pin(self.run_acceptance_phase_inner(issue, config))
+    }
+
+    async fn run_acceptance_phase_inner(
         &self,
         issue: &Issue,
         config: &EnsembleConfig,
@@ -2617,7 +2857,18 @@ impl Orchestrator {
         released
     }
 
-    async fn schedule_acceptance_failure(
+    // Keep terminal failure bookkeeping behind a separate poll boundary from acceptance checks.
+    fn schedule_acceptance_failure<'a>(
+        &'a self,
+        issue: &'a Issue,
+        config: &'a EnsembleConfig,
+        reason: &'a str,
+        owner: &'a AcceptanceOwnerIdentity,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(self.schedule_acceptance_failure_inner(issue, config, reason, owner))
+    }
+
+    async fn schedule_acceptance_failure_inner(
         &self,
         issue: &Issue,
         config: &EnsembleConfig,
@@ -2720,6 +2971,32 @@ impl Orchestrator {
         let issue = &issue_snapshot;
         let cancel_token = tokio_util::sync::CancellationToken::new();
         let (completion_tx, completion_rx) = watch::channel(false);
+        let selected_lane = {
+            let state = self.state.read().await;
+            state
+                .get_pipeline_run(&issue.id)
+                .and_then(PipelineRun::selected_workflow)
+                .map(|selected| selected.lane.clone())
+        };
+        let worker_capacity = if let Some(lane) = selected_lane.as_deref() {
+            let Some(capacity) = config_snapshot
+                .scheduler
+                .lanes
+                .get(lane)
+                .map(|lane| lane.capacity)
+            else {
+                return Err(AgentError::PromptError {
+                    reason: format!("selected scheduler lane '{lane}' no longer exists"),
+                }
+                .into());
+            };
+            WorkerCapacity::lane(lane, capacity)
+        } else {
+            WorkerCapacity::new(
+                &issue.state,
+                &config_snapshot.agent.max_concurrent_agents_by_state,
+            )
+        };
         match try_reserve_worker(
             &self.cancellation_registry,
             worker_identity.clone(),
@@ -2727,16 +3004,13 @@ impl Orchestrator {
             completion_rx,
             config_snapshot.concurrency.max_concurrent_agents,
             config_snapshot.concurrency.max_step_parallelism,
-            StateWorkerCapacity::new(
-                &issue.state,
-                &config_snapshot.agent.max_concurrent_agents_by_state,
-            ),
+            worker_capacity,
         ) {
             Ok(()) => {}
             Err(
                 WorkerReservationError::GlobalCapacityExhausted
                 | WorkerReservationError::IssueCapacityExhausted
-                | WorkerReservationError::StateCapacityExhausted,
+                | WorkerReservationError::CapacityBucketExhausted,
             ) => {
                 debug!(
                     issue_id = %issue.id,
@@ -3515,10 +3789,6 @@ impl Orchestrator {
                 } else {
                     "worker cancelled during reconciliation"
                 };
-                let retry_config = {
-                    let config = self.config.read().await;
-                    config.clone()
-                };
                 let mut state = self.state.write().await;
                 if !drained.owner.is_current(&state, issue_id) {
                     warn!(
@@ -3527,6 +3797,13 @@ impl Orchestrator {
                     );
                     return;
                 }
+                let Some(retry_config) = state.get_pipeline_config(issue_id).cloned() else {
+                    warn!(
+                        issue_id = %issue_id,
+                        "retaining stalled run because its config snapshot is missing"
+                    );
+                    return;
+                };
                 let terminal = state.remove_running(issue_id).map(|entry| {
                     self.schedule_whole_issue_failure_retry(
                         &mut state,
@@ -3742,7 +4019,24 @@ impl Orchestrator {
             .await;
     }
 
-    async fn handle_worker_exit_with_permit(
+    // Type-erase worker-exit handling so its large pipeline transition state machine is not
+    // embedded in the long-lived orchestrator event future.
+    fn handle_worker_exit_with_permit<'a>(
+        &'a self,
+        issue_id: &'a str,
+        step_name: &'a str,
+        result: WorkerResult,
+        worker_exit_permit: &'a DispatchPermit,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(self.handle_worker_exit_with_permit_inner(
+            issue_id,
+            step_name,
+            result,
+            worker_exit_permit,
+        ))
+    }
+
+    async fn handle_worker_exit_with_permit_inner(
         &self,
         issue_id: &str,
         step_name: &str,
@@ -3760,7 +4054,6 @@ impl Orchestrator {
                 output,
                 approval_request,
             } => {
-                let config = self.config.read().await;
                 info!(
                     issue_id = %issue_id,
                     step = step_name,
@@ -3923,8 +4216,10 @@ impl Orchestrator {
                             let acceptance_issue = issue_snapshot.clone().or_else(|| {
                                 state.running.get(issue_id).map(|entry| entry.issue.clone())
                             });
-                            let config_snapshot = config.clone();
-                            drop(config);
+                            let Some(config_snapshot) = config_snapshot else {
+                                warn!(issue_id = %issue_id, "no config snapshot found for pipeline success");
+                                return;
+                            };
                             drop(state);
                             if let Some(input) = step_transition {
                                 self.append_pipeline_transition(input).await;
@@ -3939,12 +4234,12 @@ impl Orchestrator {
                             {
                                 AcceptancePhaseOutcome::Passed => {}
                                 AcceptancePhaseOutcome::Failed { reason, owner } => {
-                                    Box::pin(self.schedule_acceptance_failure(
+                                    self.schedule_acceptance_failure(
                                         &acceptance_issue,
                                         &config_snapshot,
                                         &reason,
                                         &owner,
-                                    ))
+                                    )
                                     .await;
                                     return;
                                 }
@@ -4035,6 +4330,10 @@ impl Orchestrator {
                             }
                         }
                         PipelineAction::Failed { step, reason } => {
+                            let Some(config_snapshot) = config_snapshot else {
+                                warn!(issue_id = %issue_id, "no config snapshot found for pipeline failure");
+                                return;
+                            };
                             warn!(
                                 issue_id = %issue_id,
                                 step = %step,
@@ -4054,7 +4353,7 @@ impl Orchestrator {
                                 .get_pipeline_run(issue_id)
                                 .and_then(|run| run.step(&step))
                                 .cloned();
-                            let step_config = config.steps.iter().find(|s| s.name == step);
+                            let step_config = config_snapshot.steps.iter().find(|s| s.name == step);
                             let on_failure = runtime_step
                                 .as_ref()
                                 .map(|s| s.on_failure)
@@ -4074,8 +4373,10 @@ impl Orchestrator {
                                                 issue_id,
                                                 identifier: &entry.identifier,
                                                 attempt,
-                                                max_backoff_ms: config.agent.max_retry_backoff_ms,
-                                                max_cycles: config.max_cycles,
+                                                max_backoff_ms: config_snapshot
+                                                    .agent
+                                                    .max_retry_backoff_ms,
+                                                max_cycles: config_snapshot.max_cycles,
                                                 error: &reason,
                                                 retry_from_step: Some(step.clone()),
                                                 with_fixup: false,
@@ -4156,8 +4457,10 @@ impl Orchestrator {
                                                 issue_id,
                                                 identifier: &entry.identifier,
                                                 attempt,
-                                                max_backoff_ms: config.agent.max_retry_backoff_ms,
-                                                max_cycles: config.max_cycles,
+                                                max_backoff_ms: config_snapshot
+                                                    .agent
+                                                    .max_retry_backoff_ms,
+                                                max_cycles: config_snapshot.max_cycles,
                                                 error: &reason,
                                                 retry_from_step: Some(step.clone()),
                                                 with_fixup: true,
@@ -4262,8 +4565,10 @@ impl Orchestrator {
                                                 issue_id,
                                                 identifier: &entry.identifier,
                                                 attempt,
-                                                max_backoff_ms: config.agent.max_retry_backoff_ms,
-                                                max_cycles: config.max_cycles,
+                                                max_backoff_ms: config_snapshot
+                                                    .agent
+                                                    .max_retry_backoff_ms,
+                                                max_cycles: config_snapshot.max_cycles,
                                                 error: &reason,
                                                 retry_from_step: None,
                                                 with_fixup: false,
@@ -4295,7 +4600,7 @@ impl Orchestrator {
                                         if let Some(retry_entry) = retry_scheduled.scheduled() {
                                             if let Some(input) = Self::prepare_whole_issue_retry(
                                                 &mut state,
-                                                &config,
+                                                &config_snapshot,
                                                 issue_id,
                                                 &entry.identifier,
                                                 &reason,
@@ -4313,9 +4618,8 @@ impl Orchestrator {
                                 }
                             }
 
-                            let target_state = config.on_failure.clone();
+                            let target_state = config_snapshot.on_failure.clone();
                             drop(state);
-                            drop(config);
                             for input in post_failure_transitions {
                                 self.append_pipeline_transition(input).await;
                             }
@@ -4342,6 +4646,10 @@ impl Orchestrator {
                             step,
                             approval_state,
                         } => {
+                            let Some(config_snapshot) = config_snapshot else {
+                                warn!(issue_id = %issue_id, "no config snapshot found for pipeline approval");
+                                return;
+                            };
                             drop(state);
                             if let Some(input) = step_transition {
                                 self.append_pipeline_transition(input).await;
@@ -4370,7 +4678,7 @@ impl Orchestrator {
                                 let terminal = state.remove_running(issue_id).map(|entry| {
                                     self.schedule_whole_issue_failure_retry(
                                         &mut state,
-                                        &config,
+                                        &config_snapshot,
                                         entry,
                                         &error.to_string(),
                                         ScheduledRetryPipeline::Release,
@@ -4413,15 +4721,21 @@ impl Orchestrator {
                         "blocked-on-human handling failed"
                     );
 
-                    let config = self.config.read().await;
                     let mut state = self.state.write().await;
+                    let Some(config_snapshot) = state.get_pipeline_config(issue_id).cloned() else {
+                        warn!(
+                            issue_id = %issue_id,
+                            "retaining failed blocked interaction because its config snapshot is missing"
+                        );
+                        return;
+                    };
                     if let Some(run) = state.get_pipeline_run_mut(issue_id) {
                         run.step_failed(step_name, error.to_string());
                     }
                     let terminal = state.remove_running(issue_id).map(|entry| {
                         self.schedule_whole_issue_failure_retry(
                             &mut state,
-                            &config,
+                            &config_snapshot,
                             entry,
                             &error.to_string(),
                             ScheduledRetryPipeline::Release,
@@ -4444,8 +4758,14 @@ impl Orchestrator {
                     return;
                 }
 
-                let config = self.config.read().await;
                 let mut state = self.state.write().await;
+                let Some(config_snapshot) = state.get_pipeline_config(issue_id).cloned() else {
+                    warn!(
+                        issue_id = %issue_id,
+                        "retaining failed worker because its config snapshot is missing"
+                    );
+                    return;
+                };
                 warn!(
                     issue_id = %issue_id,
                     step = step_name,
@@ -4474,8 +4794,8 @@ impl Orchestrator {
                                 issue_id,
                                 identifier: &entry.identifier,
                                 attempt: next_attempt(entry.retry_attempt),
-                                max_backoff_ms: config.agent.max_retry_backoff_ms,
-                                max_cycles: config.max_cycles,
+                                max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
+                                max_cycles: config_snapshot.max_cycles,
                                 error: &error,
                                 retry_from_step: None,
                                 with_fixup: false,
@@ -4504,7 +4824,7 @@ impl Orchestrator {
                         }
                         retry_transition = Self::prepare_whole_issue_retry(
                             &mut state,
-                            &config,
+                            &config_snapshot,
                             issue_id,
                             &entry.identifier,
                             &error,
@@ -4513,9 +4833,8 @@ impl Orchestrator {
                     }
                 }
 
-                let target_state = config.on_failure.clone();
+                let target_state = config_snapshot.on_failure.clone();
                 drop(state);
-                drop(config);
                 if let Some(input) = retry_transition {
                     self.append_pipeline_transition(input).await;
                 }
@@ -4624,6 +4943,10 @@ impl Orchestrator {
             .get_pipeline_run(issue_id)
             .and_then(PipelineRun::workspace_branch_name)
             .map(str::to_owned);
+        let selected_workflow = state
+            .get_pipeline_run(issue_id)
+            .and_then(PipelineRun::selected_workflow)
+            .cloned();
         let mut next_run = PipelineRun::new(issue_id.to_string(), retry_entry.attempt, dag);
         next_run.acceptance_attempts = acceptance_attempts;
         next_run.resolved_acceptance_plan = Some(ResolvedAcceptancePlan::from_config(config).ok()?);
@@ -4632,6 +4955,9 @@ impl Orchestrator {
         }
         if let Some(workspace_branch_name) = workspace_branch_name {
             next_run.set_workspace_branch_name(workspace_branch_name);
+        }
+        if let Some(selected_workflow) = selected_workflow {
+            next_run.set_selected_workflow(selected_workflow);
         }
         state.insert_pipeline_run(issue_id, next_run, Arc::new(config.clone()));
         Self::transition_input_for_run(
@@ -4645,7 +4971,18 @@ impl Orchestrator {
         )
     }
 
-    async fn commit_whole_issue_failure_retry(&self, outcome: Option<WholeIssueFailureRetry>) {
+    // Keep terminal transition delivery out of the already-large failure scheduling future.
+    fn commit_whole_issue_failure_retry(
+        &self,
+        outcome: Option<WholeIssueFailureRetry>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(self.commit_whole_issue_failure_retry_inner(outcome))
+    }
+
+    async fn commit_whole_issue_failure_retry_inner(
+        &self,
+        outcome: Option<WholeIssueFailureRetry>,
+    ) {
         match outcome {
             Some(WholeIssueFailureRetry::Scheduled(Some(input))) => {
                 self.append_pipeline_transition(*input).await;
@@ -4665,8 +5002,14 @@ impl Orchestrator {
     }
 
     async fn handle_pipeline_step_failure(&self, issue_id: &str, step: &str, reason: String) {
-        let config = self.config.read().await;
         let mut state = self.state.write().await;
+        let Some(config_snapshot) = state.get_pipeline_config(issue_id).cloned() else {
+            warn!(
+                issue_id = %issue_id,
+                "retaining timed-out worker because its config snapshot is missing"
+            );
+            return;
+        };
 
         if let Some(run) = state.get_pipeline_run_mut(issue_id) {
             run.step_failed(step, reason.clone());
@@ -4699,7 +5042,7 @@ impl Orchestrator {
             .get_pipeline_run(issue_id)
             .and_then(|run| run.step(step))
             .cloned();
-        let step_config = config.steps.iter().find(|s| s.name == step);
+        let step_config = config_snapshot.steps.iter().find(|s| s.name == step);
         let on_failure = runtime_step
             .as_ref()
             .map(|s| s.on_failure)
@@ -4720,8 +5063,8 @@ impl Orchestrator {
                             issue_id,
                             identifier: &entry.identifier,
                             attempt,
-                            max_backoff_ms: config.agent.max_retry_backoff_ms,
-                            max_cycles: config.max_cycles,
+                            max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
+                            max_cycles: config_snapshot.max_cycles,
                             error: &reason,
                             retry_from_step: Some(step_name.clone()),
                             with_fixup: false,
@@ -4791,8 +5134,8 @@ impl Orchestrator {
                             issue_id,
                             identifier: &entry.identifier,
                             attempt,
-                            max_backoff_ms: config.agent.max_retry_backoff_ms,
-                            max_cycles: config.max_cycles,
+                            max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
+                            max_cycles: config_snapshot.max_cycles,
                             error: &reason,
                             retry_from_step: Some(step_name.clone()),
                             with_fixup: true,
@@ -4886,8 +5229,8 @@ impl Orchestrator {
                             issue_id,
                             identifier: &entry.identifier,
                             attempt,
-                            max_backoff_ms: config.agent.max_retry_backoff_ms,
-                            max_cycles: config.max_cycles,
+                            max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
+                            max_cycles: config_snapshot.max_cycles,
                             error: &reason,
                             retry_from_step: None,
                             with_fixup: false,
@@ -4910,7 +5253,7 @@ impl Orchestrator {
                     if let Some(retry_entry) = retry_scheduled.scheduled() {
                         if let Some(input) = Self::prepare_whole_issue_retry(
                             &mut state,
-                            &config,
+                            &config_snapshot,
                             issue_id,
                             &entry.identifier,
                             &reason,
@@ -4928,9 +5271,8 @@ impl Orchestrator {
             }
         }
 
-        let target_state = config.on_failure.clone();
+        let target_state = config_snapshot.on_failure.clone();
         drop(state);
-        drop(config);
         for input in post_failure_transitions {
             self.append_pipeline_transition(input).await;
         }
@@ -6074,6 +6416,17 @@ impl Orchestrator {
                 ),
             })?;
 
+        let config_snapshot = if let Some(selected) = snapshot.selected_workflow.as_ref() {
+            let effective = config_snapshot.resolve_selected_workflow(
+                &selected.rule,
+                &selected.pipeline,
+                &selected.lane,
+            )?;
+            Arc::new(effective)
+        } else {
+            config_snapshot
+        };
+
         let is_pending_terminal = record.terminal_transition.is_some();
         if !is_pending_terminal {
             validate_restored_snapshot_against_config(&snapshot, &config_snapshot)?;
@@ -6189,6 +6542,20 @@ impl Orchestrator {
         }
 
         Ok(())
+    }
+
+    async fn current_config_for_snapshot(
+        &self,
+        snapshot: Option<&PipelineRunSnapshot>,
+    ) -> Result<Arc<EnsembleConfig>, EnsembleError> {
+        let config = self.config.read().await;
+        let Some(selected) = snapshot.and_then(|snapshot| snapshot.selected_workflow.as_ref())
+        else {
+            return Ok(Arc::new(config.clone()));
+        };
+        let effective =
+            config.resolve_selected_workflow(&selected.rule, &selected.pipeline, &selected.lane)?;
+        Ok(Arc::new(effective))
     }
 
     async fn append_pipeline_transition(&self, input: PipelineTransitionInput) {
@@ -7401,9 +7768,16 @@ impl Orchestrator {
 
         if should_complete {
             let outcome = TerminalOutcome::Succeeded;
-            let config_snapshot = {
-                let config = self.config.read().await;
-                config.clone()
+            let config_snapshot = match self.current_config_for_snapshot(snapshot.as_ref()).await {
+                Ok(config) => config,
+                Err(error) => {
+                    warn!(
+                        issue_id = %issue_id,
+                        error = %error,
+                        "finalize retry could not resolve its selected workflow"
+                    );
+                    return;
+                }
             };
             let target_state = config_snapshot.on_success.clone();
             if let Some(finalize_state) = self
@@ -7416,7 +7790,7 @@ impl Orchestrator {
                 self.stage_finalization_terminal_transition(
                     issue_id,
                     issue_identifier,
-                    &config_snapshot,
+                    config_snapshot.as_ref(),
                     &finalize_state,
                 )
                 .await;
@@ -7674,9 +8048,24 @@ impl Orchestrator {
     }
 
     pub async fn resume_blocked_issue(&self, issue: &Issue) -> Result<(), EnsembleError> {
+        let selected = {
+            let state = self.state.read().await;
+            state
+                .get_pipeline_run(&issue.id)
+                .and_then(PipelineRun::selected_workflow)
+                .cloned()
+        };
         let current_config = {
             let config = self.config.read().await;
-            Arc::new(config.clone())
+            if let Some(selected) = selected.as_ref() {
+                Arc::new(config.resolve_selected_workflow(
+                    &selected.rule,
+                    &selected.pipeline,
+                    &selected.lane,
+                )?)
+            } else {
+                Arc::new(config.clone())
+            }
         };
 
         self.hydrate_waiting_on_human_from_store().await;
@@ -8515,12 +8904,21 @@ impl Orchestrator {
                 }
             }
             Some(issue) => {
-                let max_backoff_ms = self.config.read().await.agent.max_retry_backoff_ms;
                 let (ready_for_dispatch, transition) = {
                     let mut state = self.state.write().await;
                     if state.retry_attempts.get(issue_id) != Some(retry_entry) {
                         return;
                     }
+                    let Some(max_backoff_ms) = state
+                        .get_pipeline_config(issue_id)
+                        .map(|config| config.agent.max_retry_backoff_ms)
+                    else {
+                        warn!(
+                            issue_id = %issue_id,
+                            "retaining retry because its config snapshot is missing"
+                        );
+                        return;
+                    };
                     let max_workers = state.max_concurrent_agents;
                     if has_available_worker_slots(
                         live_worker_count(&self.cancellation_registry),
@@ -8589,9 +8987,18 @@ impl Orchestrator {
     }
 
     async fn defer_single_retry(&self, retry_entry: &RetryEntry, reason: &str) {
-        let max_backoff_ms = self.config.read().await.agent.max_retry_backoff_ms;
         let transition = {
             let mut state = self.state.write().await;
+            let Some(max_backoff_ms) = state
+                .get_pipeline_config(&retry_entry.issue_id)
+                .map(|config| config.agent.max_retry_backoff_ms)
+            else {
+                warn!(
+                    issue_id = %retry_entry.issue_id,
+                    "retaining retry because its config snapshot is missing"
+                );
+                return;
+            };
             Self::defer_owned_retry(&mut state, retry_entry, max_backoff_ms, reason)
         };
         if let Some(input) = transition {
@@ -8802,7 +9209,12 @@ fn build_reconcile_active_states_lower(config: &EnsembleConfig) -> Vec<String> {
         }
     }
 
-    for step in &config.steps {
+    for step in config.steps.iter().chain(
+        config
+            .pipelines
+            .values()
+            .flat_map(|pipeline| &pipeline.steps),
+    ) {
         if let Some(state) = step.tracker_state.as_deref() {
             let state = state.to_lowercase();
             if !terminal.contains(&state) {
@@ -9130,7 +9542,10 @@ mod tests {
         AgentEvent, InteractionRequestDraft, OrchestratorWorkerEvent, StepApprovalRequestDraft,
         WorkerEvent, WorkerIdentity, WorkerResult,
     };
-    use crate::config::ensemble::{parse_config, ConcurrencyConfig, StepConfig};
+    use crate::config::ensemble::{
+        parse_config, ConcurrencyConfig, PipelineConfig, SchedulerConfig, SchedulerLaneConfig,
+        StepConfig, WorkflowOrderKey, WorkflowSelectionRuleConfig,
+    };
     use crate::error::AgentError;
     use crate::interaction::{
         InteractionKind, InteractionRequest, InteractionResponse, InteractionResumeStrategy,
@@ -9144,6 +9559,7 @@ mod tests {
     use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use std::collections::BTreeMap;
     use tokio::sync::watch;
     use tower::ServiceExt;
 
@@ -9255,6 +9671,12 @@ mod tests {
         issues: Arc<RwLock<Vec<Issue>>>,
         comments: Arc<RwLock<Vec<crate::tracker::model::TrackerComment>>>,
         list_barrier: Option<Arc<tokio::sync::Barrier>>,
+    }
+
+    struct SelectedClaimTracker {
+        candidates: Vec<Issue>,
+        fresh: Arc<RwLock<Vec<Issue>>>,
+        claim_calls: Arc<AtomicUsize>,
     }
 
     async fn worker_identity_test_orchestrator() -> (Orchestrator, tempfile::TempDir, WorkerIdentity)
@@ -9407,6 +9829,46 @@ mod tests {
             _ids: &[String],
         ) -> Result<Vec<Issue>, TrackerError> {
             Ok(Vec::new())
+        }
+    }
+
+    #[async_trait]
+    impl IssueTracker for SelectedClaimTracker {
+        async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+            Ok(self.candidates.clone())
+        }
+
+        async fn fetch_issues_by_states(
+            &self,
+            _states: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            Ok(Vec::new())
+        }
+
+        async fn fetch_issue_states_by_ids(
+            &self,
+            ids: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            Ok(self
+                .fresh
+                .read()
+                .await
+                .iter()
+                .filter(|issue| ids.contains(&issue.id))
+                .cloned()
+                .collect())
+        }
+
+        async fn claim_issue(&self, issue: &Issue) -> Result<OwnershipClaim, TrackerError> {
+            self.claim_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(OwnershipClaim::Acquired(OwnershipLease {
+                id: format!("lease-{}", issue.id),
+                branch_name: Some(format!("selected/{}", issue.id)),
+            }))
+        }
+
+        fn has_remote_ownership_policy(&self) -> bool {
+            true
         }
     }
 
@@ -10058,6 +10520,7 @@ mod tests {
             with_fixup: false,
         };
         let original_due_at_ms = retry.due_at_ms;
+        install_retry_pipeline_config(&orchestrator, &retry.issue_id).await;
         orchestrator.state.write().await.add_retry(retry.clone());
         let quiescing = orchestrator.quiescing_latch_owner();
 
@@ -11833,6 +12296,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn selected_published_delivery_recovery_uses_frozen_pipeline_transition() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(Arc::clone(&remote)).await;
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.mode = DeliveryMode::Push;
+        repository.phase = DeliveryPhase::Published;
+        repository.pr_number = None;
+        repository.pr_url = None;
+
+        let config = selected_test_config();
+        let pipeline = config.pipelines["delivery"].clone();
+        *orchestrator.config.write().await = config;
+        let mut run = PipelineRun::new(
+            delivery.issue_id.clone(),
+            1,
+            build_dag(&pipeline.steps).unwrap(),
+        );
+        run.set_selected_workflow(SelectedWorkflowSnapshot {
+            rule: "ready".to_string(),
+            pipeline: "delivery".to_string(),
+            lane: "delivery".to_string(),
+        });
+        let snapshot = run.to_snapshot();
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+
+        orchestrator.process_delivery_recovery(None).await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.delivery.contains_key("1"));
+        assert!(!state.is_claimed("1"));
+        assert!(state.completed.contains_key("1"));
+    }
+
+    #[tokio::test]
     async fn waiting_delivery_releases_when_tracker_becomes_terminal() {
         let remote = Arc::new(RecoveryDeliveryRemote {
             pull_requests: std::sync::Mutex::new(Vec::new()),
@@ -12609,6 +13115,16 @@ agent:
   stall_timeout_ms: 300000
 "#;
         parse_config(yaml).unwrap()
+    }
+
+    async fn install_retry_pipeline_config(orchestrator: &Orchestrator, issue_id: &str) {
+        let config = orchestrator.config.read().await.clone();
+        let run = PipelineRun::new(issue_id.to_string(), 1, build_dag(&config.steps).unwrap());
+        orchestrator
+            .state
+            .write()
+            .await
+            .insert_pipeline_run(issue_id, run, Arc::new(config));
     }
 
     fn test_question_interaction(
@@ -13671,12 +14187,17 @@ agent:
             id: issue.id.clone(),
             branch_name: Some("agent/acceptance-retry".into()),
         };
-        state
-            .write()
-            .await
-            .get_pipeline_run_mut(&issue.id)
-            .unwrap()
-            .set_ownership_lease(ownership_lease.clone());
+        let selected_workflow = SelectedWorkflowSnapshot {
+            rule: "ready".to_string(),
+            pipeline: "delivery".to_string(),
+            lane: "delivery".to_string(),
+        };
+        {
+            let mut state = state.write().await;
+            let run = state.get_pipeline_run_mut(&issue.id).unwrap();
+            run.set_ownership_lease(ownership_lease.clone());
+            run.set_selected_workflow(selected_workflow.clone());
+        }
         assert!(matches!(
             orchestrator.run_acceptance_phase(&issue, &config).await,
             AcceptancePhaseOutcome::Failed { .. }
@@ -13708,6 +14229,7 @@ agent:
         assert_eq!(snapshot.acceptance_attempts.len(), 1);
         assert_eq!(snapshot.acceptance_attempts[0].cycle, 1);
         assert_eq!(snapshot.ownership_lease, Some(ownership_lease));
+        assert_eq!(snapshot.selected_workflow, Some(selected_workflow));
         assert_eq!(
             snapshot.acceptance_attempts[0].results[0].status,
             AcceptanceStatus::Failed
@@ -15051,7 +15573,7 @@ agent:
         let orchestrator = Orchestrator::new_with_state(
             OrchestratorRuntimeParts {
                 state: Arc::clone(&state),
-                config,
+                config: Arc::clone(&config),
                 tracker,
                 agent_runner: runner,
                 acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
@@ -15131,6 +15653,8 @@ agent:
             assert!(state.is_waiting_on_human(&issue.id));
             assert!(state.get_pipeline_run(&issue.id).is_some());
         }
+
+        config.write().await.max_cycles = 1;
 
         let (response, result) = tokio::sync::oneshot::channel();
         orchestrator
@@ -16731,6 +17255,8 @@ agent:
             state.insert_pipeline_run(&issue.id, pipeline_run, Arc::new(cfg.clone()));
         }
 
+        config.write().await.steps[0].on_failure = OnFailure::Halt;
+
         orchestrator
             .handle_worker_exit(
                 &issue.id,
@@ -17378,6 +17904,65 @@ agent:
             state.get_pipeline_run("1").map(|run| run.cycle),
             Some(3),
             "whole-issue retry should install the fresh pipeline cycle"
+        );
+    }
+
+    #[tokio::test]
+    async fn worker_failure_uses_frozen_pipeline_config_after_reload() {
+        let mut frozen_config = make_config();
+        frozen_config.max_cycles = 1;
+        let config = Arc::new(RwLock::new(frozen_config.clone()));
+        let issues = Arc::new(RwLock::new(vec![]));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+
+        {
+            let dag = build_dag(&frozen_config.steps).unwrap();
+            let mut run = PipelineRun::new("1".to_string(), 1, dag);
+            run.start();
+            run.mark_running("build", "session-1".to_string());
+            run.set_selected_workflow(SelectedWorkflowSnapshot {
+                rule: "ready".to_string(),
+                pipeline: "delivery".to_string(),
+                lane: "delivery".to_string(),
+            });
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), Some(1));
+            state.insert_pipeline_run("1", run, Arc::new(frozen_config.clone()));
+        }
+
+        config.write().await.max_cycles = 10;
+        orchestrator
+            .handle_worker_exit(
+                "1",
+                "build",
+                WorkerResult::Failed {
+                    error: "agent crashed".to_string(),
+                    kind: WorkerFailureKind::Runtime,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(
+            !state.retry_attempts.contains_key("1"),
+            "the selected run's frozen max_cycles must govern failure exhaustion"
         );
     }
 
@@ -20686,6 +21271,132 @@ agent:
         .unwrap();
         assert_eq!(metadata["branch_name"], "ensemble/issue-1");
         assert!(!observed_commands.read().await.is_empty());
+    }
+
+    fn selected_test_config() -> EnsembleConfig {
+        let mut config = make_config();
+        config.tracker.terminal_states = vec!["Done".to_string()];
+        config.pipelines.insert(
+            "delivery".to_string(),
+            PipelineConfig {
+                steps: config.steps.clone(),
+                on_success: config.on_success.clone(),
+                on_failure: config.on_failure.clone(),
+            },
+        );
+        config.scheduler = SchedulerConfig {
+            lanes: BTreeMap::from([("delivery".to_string(), SchedulerLaneConfig { capacity: 1 })]),
+        };
+        config.workflow_selection = vec![WorkflowSelectionRuleConfig {
+            name: "ready".to_string(),
+            precedence: 1,
+            pipeline: "delivery".to_string(),
+            lane: "delivery".to_string(),
+            states: Some(vec!["ready".to_string()]),
+            labels_all: Some(vec!["ready-for-agent".to_string()]),
+            labels_any: None,
+            labels_none: None,
+            require_unblocked: true,
+            order_by: vec![WorkflowOrderKey::TrackerPosition],
+        }];
+        config.steps.clear();
+        config.on_success.clear();
+        config.on_failure.clear();
+        config
+    }
+
+    async fn selected_claim_test_orchestrator(
+        fresh: Vec<Issue>,
+    ) -> (
+        Orchestrator,
+        tempfile::TempDir,
+        Arc<AtomicUsize>,
+        Issue,
+        SelectedWorkflow,
+    ) {
+        let config = selected_test_config();
+        let mut issue = test_issue("1", "Ready");
+        issue.labels = vec!["ready-for-agent".to_string()];
+        issue.tracker_position = Some(4);
+        let claim_calls = Arc::new(AtomicUsize::new(0));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(SelectedClaimTracker {
+            candidates: vec![issue.clone()],
+            fresh: Arc::new(RwLock::new(fresh)),
+            claim_calls: Arc::clone(&claim_calls),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let selected =
+            WorkflowSelector::compile(&config.workflow_selection, &config.scheduler.lanes)
+                .unwrap()
+                .select(&issue, &config.tracker.terminal_states)
+                .unwrap();
+        let orchestrator = Orchestrator::new(
+            Arc::new(RwLock::new(config)),
+            tracker,
+            runner,
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        (orchestrator, dir, claim_calls, issue, selected)
+    }
+
+    #[tokio::test]
+    async fn selected_dispatch_refreshes_before_one_claim_and_journals_workflow_with_lease() {
+        let mut fresh = test_issue("1", "Ready");
+        fresh.labels = vec!["ready-for-agent".to_string()];
+        fresh.tracker_position = Some(4);
+        let (orchestrator, _dir, claim_calls, issue, selected) =
+            selected_claim_test_orchestrator(vec![fresh]).await;
+
+        orchestrator
+            .consider_candidate_for_dispatch(&issue, &[], &["done".to_string()], Some(selected))
+            .await;
+
+        assert_eq!(claim_calls.load(Ordering::SeqCst), 1);
+        let record = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue(&issue.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let snapshot = record.snapshot.unwrap();
+        assert_eq!(
+            snapshot.selected_workflow,
+            Some(SelectedWorkflowSnapshot {
+                rule: "ready".to_string(),
+                pipeline: "delivery".to_string(),
+                lane: "delivery".to_string(),
+            })
+        );
+        assert_eq!(snapshot.ownership_lease.unwrap().id, "lease-1");
+    }
+
+    #[tokio::test]
+    async fn selected_dispatch_lost_match_during_refresh_never_claims() {
+        let fresh = test_issue("1", "Ready");
+        let (orchestrator, _dir, claim_calls, issue, selected) =
+            selected_claim_test_orchestrator(vec![fresh]).await;
+
+        orchestrator
+            .consider_candidate_for_dispatch(&issue, &[], &["done".to_string()], Some(selected))
+            .await;
+
+        assert_eq!(claim_calls.load(Ordering::SeqCst), 0);
+        assert!(orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue(&issue.id)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]
@@ -24858,10 +25569,15 @@ agent:
         {
             let mut config = orchestrator.config.write().await;
             config.agent.stall_timeout_ms = 1;
-            config.max_cycles = 1;
+            config.max_cycles = 10;
         }
         {
             let mut state = orchestrator.state.write().await;
+            let mut frozen_config = state.get_pipeline_config("1").unwrap().as_ref().clone();
+            frozen_config.max_cycles = 1;
+            state
+                .pipeline_configs
+                .insert("1".to_string(), Arc::new(frozen_config));
             state.running.get_mut("1").unwrap().last_agent_timestamp =
                 Some(Utc::now() - chrono::Duration::seconds(1));
         }
@@ -25110,6 +25826,7 @@ agent:
             retry_from_step: Some("review".to_string()),
             with_fixup: true,
         };
+        install_retry_pipeline_config(&orchestrator, &retry.issue_id).await;
         orchestrator.state.write().await.add_retry(retry.clone());
 
         orchestrator.handle_single_retry(&retry).await;
@@ -25160,6 +25877,7 @@ agent:
             retry_from_step: None,
             with_fixup: false,
         };
+        install_retry_pipeline_config(&orchestrator, &retry.issue_id).await;
         orchestrator.state.write().await.add_retry(retry.clone());
 
         orchestrator.handle_single_retry(&retry).await;
@@ -25281,6 +25999,7 @@ agent:
             retry_from_step: Some("review".to_string()),
             with_fixup: true,
         };
+        install_retry_pipeline_config(&orchestrator, &retry.issue_id).await;
         orchestrator.state.write().await.add_retry(retry.clone());
 
         let retry_fire = tokio::spawn({
@@ -25310,7 +26029,7 @@ agent:
     async fn retry_fire_capacity_deferral_does_not_consume_a_pipeline_cycle() {
         let mut raw_config = make_config();
         raw_config.concurrency.max_concurrent_agents = 1;
-        let config = Arc::new(RwLock::new(raw_config));
+        let config = Arc::new(RwLock::new(raw_config.clone()));
         let issues = Arc::new(RwLock::new(vec![test_issue("1", "Todo")]));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker { issues });
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
@@ -25341,6 +26060,14 @@ agent:
         };
         {
             let mut state = orchestrator.state.write().await;
+            let mut frozen_config = raw_config.clone();
+            frozen_config.agent.max_retry_backoff_ms = 0;
+            let run = PipelineRun::new(
+                "1".to_string(),
+                retry.attempt,
+                build_dag(&frozen_config.steps).unwrap(),
+            );
+            state.insert_pipeline_run("1", run, Arc::new(frozen_config));
             state.add_running(&test_issue("2", "Todo"), None);
             state.add_retry(retry.clone());
         }
@@ -25364,6 +26091,10 @@ agent:
         assert_eq!(
             state.retry_attempts.get("1").map(|entry| entry.attempt),
             Some(retry.attempt)
+        );
+        assert!(
+            state.retry_attempts["1"].due_at_ms <= current_time_ms() + 1_000,
+            "retry deferral must use the frozen run backoff"
         );
         assert!(state.is_claimed("1"));
     }
@@ -25401,6 +26132,7 @@ agent:
             retry_from_step: None,
             with_fixup: false,
         };
+        install_retry_pipeline_config(&orchestrator, &retry.issue_id).await;
         orchestrator.state.write().await.add_retry(retry.clone());
 
         orchestrator.handle_single_retry(&retry).await;

--- a/crates/ensemble-core/src/orchestrator/scheduler.rs
+++ b/crates/ensemble-core/src/orchestrator/scheduler.rs
@@ -69,6 +69,42 @@ pub fn is_dispatch_eligible(
     None
 }
 
+/// Apply only tracker-independent run ownership and completion gates.
+///
+/// Selected workflow policy (states, labels and blockers) is evaluated by the
+/// configured selector. The legacy path continues to use `is_dispatch_eligible`.
+pub fn is_dispatch_structurally_eligible(
+    issue: &Issue,
+    state: &OrchestratorState,
+    terminal_states: &[String],
+) -> Option<String> {
+    if issue.id.is_empty() {
+        return Some("missing issue id".to_string());
+    }
+    if issue.identifier.is_empty() {
+        return Some("missing issue identifier".to_string());
+    }
+    if issue.title.is_empty() {
+        return Some("missing issue title".to_string());
+    }
+    if issue.state.is_empty() {
+        return Some("missing issue state".to_string());
+    }
+    if contains_state(terminal_states, &issue.state) {
+        return Some(format!("state '{}' is terminal", issue.state));
+    }
+    if state.is_running(&issue.id) {
+        return Some("already running".to_string());
+    }
+    if state.is_claimed(&issue.id) {
+        return Some("already claimed".to_string());
+    }
+    if state.completed.contains_key(&issue.id) {
+        return Some("already completed".to_string());
+    }
+    None
+}
+
 /// Check if an explicitly requested resume dispatch may proceed.
 ///
 /// This bypasses the normal claimed-issue filter so resolved waiting issues can
@@ -179,6 +215,22 @@ mod tests {
 
         let result = is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal());
         assert!(result.is_none(), "expected eligible, got: {:?}", result);
+    }
+
+    #[test]
+    fn selected_structural_gate_does_not_embed_legacy_todo_blocker_policy() {
+        let state = OrchestratorState::new(30000, &ConcurrencyConfig::default());
+        let mut issue = test_issue("1", "Todo");
+        issue.blocked_by = vec![BlockerRef {
+            id: Some("2".to_string()),
+            identifier: Some("repo#2".to_string()),
+            state: Some("Todo".to_string()),
+        }];
+
+        assert!(is_dispatch_structurally_eligible(&issue, &state, &default_terminal()).is_none());
+        assert!(
+            is_dispatch_eligible(&issue, &state, &default_active(), &default_terminal()).is_some()
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/orchestrator/selection.rs
+++ b/crates/ensemble-core/src/orchestrator/selection.rs
@@ -1,0 +1,346 @@
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashSet};
+
+use crate::config::ensemble::{SchedulerLaneConfig, WorkflowOrderKey, WorkflowSelectionRuleConfig};
+use crate::error::PipelineError;
+use crate::tracker::model::Issue;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedWorkflow {
+    pub rule: String,
+    pub pipeline: String,
+    pub lane: String,
+    pub lane_capacity: u32,
+    precedence: u32,
+    order_by: Vec<WorkflowOrderKey>,
+}
+
+#[derive(Debug, Clone)]
+struct CompiledRule {
+    selected: SelectedWorkflow,
+    states: Option<HashSet<String>>,
+    labels_all: Option<HashSet<String>>,
+    labels_any: Option<HashSet<String>>,
+    labels_none: Option<HashSet<String>>,
+    require_unblocked: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowSelector {
+    rules: Vec<CompiledRule>,
+}
+
+impl WorkflowSelector {
+    pub fn compile(
+        rules: &[WorkflowSelectionRuleConfig],
+        lanes: &BTreeMap<String, SchedulerLaneConfig>,
+    ) -> Result<Self, PipelineError> {
+        let mut compiled = Vec::with_capacity(rules.len());
+        for rule in rules {
+            let lane_capacity =
+                lanes
+                    .get(&rule.lane)
+                    .map(|lane| lane.capacity)
+                    .ok_or_else(|| PipelineError::InvalidSchedulerLane {
+                        lane: rule.lane.clone(),
+                        reason: "referenced by a workflow-selection rule but not configured"
+                            .to_string(),
+                    })?;
+            let mut order_by = rule.order_by.clone();
+            if !order_by.contains(&WorkflowOrderKey::Identifier) {
+                order_by.push(WorkflowOrderKey::Identifier);
+            }
+            compiled.push(CompiledRule {
+                selected: SelectedWorkflow {
+                    rule: rule.name.clone(),
+                    pipeline: rule.pipeline.clone(),
+                    lane: rule.lane.clone(),
+                    lane_capacity,
+                    precedence: rule.precedence,
+                    order_by,
+                },
+                states: normalize_set(rule.states.as_ref()),
+                labels_all: normalize_set(rule.labels_all.as_ref()),
+                labels_any: normalize_set(rule.labels_any.as_ref()),
+                labels_none: normalize_set(rule.labels_none.as_ref()),
+                require_unblocked: rule.require_unblocked,
+            });
+        }
+        compiled.sort_by_key(|rule| rule.selected.precedence);
+        Ok(Self { rules: compiled })
+    }
+
+    pub fn select(&self, issue: &Issue, terminal_states: &[String]) -> Option<SelectedWorkflow> {
+        let state = normalize(&issue.state);
+        let labels = issue
+            .labels
+            .iter()
+            .map(|label| normalize(label))
+            .collect::<HashSet<_>>();
+        self.rules
+            .iter()
+            .find(|rule| {
+                rule.states
+                    .as_ref()
+                    .is_none_or(|states| states.contains(&state))
+                    && rule
+                        .labels_all
+                        .as_ref()
+                        .is_none_or(|required| required.is_subset(&labels))
+                    && rule
+                        .labels_any
+                        .as_ref()
+                        .is_none_or(|required| !required.is_disjoint(&labels))
+                    && rule
+                        .labels_none
+                        .as_ref()
+                        .is_none_or(|excluded| excluded.is_disjoint(&labels))
+                    && (!rule.require_unblocked
+                        || issue.blocked_by.iter().all(|blocker| {
+                            blocker.state.as_deref().is_some_and(|state| {
+                                terminal_states
+                                    .iter()
+                                    .any(|terminal| terminal.eq_ignore_ascii_case(state))
+                            })
+                        }))
+            })
+            .map(|rule| rule.selected.clone())
+    }
+}
+
+fn normalize_set(values: Option<&Vec<String>>) -> Option<HashSet<String>> {
+    values.map(|values| values.iter().map(|value| normalize(value)).collect())
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
+pub fn sort_selected_candidates(candidates: &mut [(Issue, SelectedWorkflow)]) {
+    candidates.sort_by(|(left_issue, left), (right_issue, right)| {
+        left.precedence
+            .cmp(&right.precedence)
+            .then_with(|| {
+                if left.rule == right.rule {
+                    compare_by_rule(left_issue, right_issue, &left.order_by)
+                } else {
+                    left.rule.cmp(&right.rule)
+                }
+            })
+            .then_with(|| left_issue.identifier.cmp(&right_issue.identifier))
+    });
+}
+
+fn compare_by_rule(left: &Issue, right: &Issue, order_by: &[WorkflowOrderKey]) -> Ordering {
+    for key in order_by {
+        let ordering = match key {
+            WorkflowOrderKey::Priority => cmp_optional(left.priority, right.priority),
+            WorkflowOrderKey::TrackerPosition => {
+                cmp_optional(left.tracker_position, right.tracker_position)
+            }
+            WorkflowOrderKey::CreatedAt => cmp_optional(left.created_at, right.created_at),
+            WorkflowOrderKey::Identifier => left.identifier.cmp(&right.identifier),
+        };
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+    Ordering::Equal
+}
+
+fn cmp_optional<T: Ord>(left: Option<T>, right: Option<T>) -> Ordering {
+    match (left, right) {
+        (Some(left), Some(right)) => left.cmp(&right),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ensemble::{WorkflowOrderKey, WorkflowSelectionRuleConfig};
+    use crate::tracker::model::{test_helpers::test_issue, BlockerRef};
+
+    fn rule(name: &str, precedence: u32) -> WorkflowSelectionRuleConfig {
+        WorkflowSelectionRuleConfig {
+            name: name.to_string(),
+            precedence,
+            pipeline: format!("{name}-pipeline"),
+            lane: format!("{name}-lane"),
+            states: Some(vec![" READY ".to_string()]),
+            labels_all: None,
+            labels_any: None,
+            labels_none: None,
+            require_unblocked: false,
+            order_by: vec![WorkflowOrderKey::TrackerPosition],
+        }
+    }
+
+    #[test]
+    fn selector_matches_normalized_predicates_and_lowest_precedence() {
+        let mut lower = rule("lower", 20);
+        lower.labels_all = Some(vec![" Agent ".to_string()]);
+        let mut higher = rule("higher", 10);
+        higher.labels_any = Some(vec!["UI".to_string(), "API".to_string()]);
+        higher.labels_none = Some(vec!["hold".to_string()]);
+        let selector = WorkflowSelector::compile(&[lower, higher], &lanes()).unwrap();
+        let mut issue = test_issue("1", "ready");
+        issue.labels = vec!["agent".to_string(), "api".to_string()];
+
+        let selected = selector.select(&issue, &["done".to_string()]).unwrap();
+
+        assert_eq!(selected.rule, "higher");
+        assert_eq!(selected.pipeline, "higher-pipeline");
+        assert_eq!(selected.lane, "higher-lane");
+    }
+
+    #[test]
+    fn unblocked_predicate_treats_unknown_and_nonterminal_blockers_as_blocking() {
+        let mut required = rule("required", 1);
+        required.require_unblocked = true;
+        let selector = WorkflowSelector::compile(&[required], &lanes()).unwrap();
+        let mut issue = test_issue("1", "Ready");
+        issue.blocked_by = vec![BlockerRef {
+            id: Some("B".to_string()),
+            identifier: Some("repo#2".to_string()),
+            state: None,
+        }];
+        assert!(selector.select(&issue, &["done".to_string()]).is_none());
+
+        issue.blocked_by[0].state = Some("Done".to_string());
+        assert!(selector.select(&issue, &["done".to_string()]).is_some());
+    }
+
+    #[test]
+    fn selected_candidates_sort_by_rule_then_declared_nulls_last_keys_and_identifier() {
+        let selector = WorkflowSelector::compile(&[rule("ready", 1)], &lanes()).unwrap();
+        let mut later = test_issue("later", "Ready");
+        later.tracker_position = Some(9);
+        later.identifier = "repo#9".to_string();
+        let mut first = test_issue("first", "Ready");
+        first.tracker_position = Some(1);
+        first.identifier = "repo#2".to_string();
+        let mut missing = test_issue("missing", "Ready");
+        missing.tracker_position = None;
+        missing.identifier = "repo#1".to_string();
+        let terminal = vec!["done".to_string()];
+        let mut candidates = vec![later, missing, first]
+            .into_iter()
+            .map(|issue| {
+                let selected = selector.select(&issue, &terminal).unwrap();
+                (issue, selected)
+            })
+            .collect::<Vec<_>>();
+
+        sort_selected_candidates(&mut candidates);
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|(issue, _)| issue.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "later", "missing"]
+        );
+    }
+
+    #[test]
+    fn selector_supports_catch_all_and_labels_only_gate_eligibility() {
+        let mut labelled = rule("labelled", 1);
+        labelled.states = None;
+        labelled.labels_all = Some(vec!["agent".to_string()]);
+        labelled.labels_any = Some(vec!["ui".to_string(), "api".to_string()]);
+        labelled.labels_none = Some(vec!["hold".to_string()]);
+        labelled.order_by = vec![WorkflowOrderKey::Priority];
+        let mut tail = rule("tail", 2);
+        tail.states = None;
+        let selector = WorkflowSelector::compile(&[labelled, tail], &lanes()).unwrap();
+
+        let mut preferred = test_issue("2", "Ausstehend");
+        preferred.priority = Some(1);
+        preferred.labels = vec!["agent".to_string(), "api".to_string()];
+        let mut later = test_issue("1", "Ausstehend");
+        later.priority = Some(2);
+        later.labels = vec!["agent".to_string(), "ui".to_string(), "extra".to_string()];
+        let mut held = test_issue("3", "Ausstehend");
+        held.labels = vec!["agent".to_string(), "api".to_string(), "hold".to_string()];
+
+        let terminal = vec!["done".to_string()];
+        let mut selected = vec![later, held, preferred]
+            .into_iter()
+            .map(|issue| {
+                let workflow = selector.select(&issue, &terminal).unwrap();
+                (issue, workflow)
+            })
+            .collect::<Vec<_>>();
+        sort_selected_candidates(&mut selected);
+
+        assert_eq!(selected[0].0.id, "2");
+        assert_eq!(selected[1].0.id, "1");
+        assert_eq!(selected[2].1.rule, "tail");
+    }
+
+    #[test]
+    fn comparator_applies_every_key_with_nulls_last_and_rule_precedence_first() {
+        let mut primary = rule("ready", 2);
+        primary.order_by = vec![
+            WorkflowOrderKey::Priority,
+            WorkflowOrderKey::TrackerPosition,
+            WorkflowOrderKey::CreatedAt,
+            WorkflowOrderKey::Identifier,
+        ];
+        let mut earlier_rule = rule("urgent", 1);
+        earlier_rule.states = Some(vec!["urgent".to_string()]);
+        let selector = WorkflowSelector::compile(&[primary, earlier_rule], &lanes()).unwrap();
+        let now = chrono::Utc::now();
+
+        let mut urgent = test_issue("urgent", "urgent");
+        urgent.priority = None;
+        let mut first = test_issue("first", "ready");
+        first.priority = Some(1);
+        first.tracker_position = Some(2);
+        first.created_at = Some(now);
+        let mut older = test_issue("older", "ready");
+        older.priority = Some(1);
+        older.tracker_position = Some(2);
+        older.created_at = Some(now - chrono::Duration::seconds(1));
+        let mut missing = test_issue("missing", "ready");
+        missing.priority = None;
+        missing.tracker_position = None;
+        missing.created_at = None;
+
+        let terminal = vec!["done".to_string()];
+        let mut selected = vec![first, missing, older, urgent]
+            .into_iter()
+            .map(|issue| {
+                let workflow = selector.select(&issue, &terminal).unwrap();
+                (issue, workflow)
+            })
+            .collect::<Vec<_>>();
+        sort_selected_candidates(&mut selected);
+
+        assert_eq!(
+            selected
+                .iter()
+                .map(|(issue, _)| issue.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["urgent", "older", "first", "missing"]
+        );
+    }
+
+    fn lanes() -> std::collections::BTreeMap<String, SchedulerLaneConfig> {
+        [
+            ("lower-lane".to_string(), 1),
+            ("higher-lane".to_string(), 1),
+            ("required-lane".to_string(), 1),
+            ("ready-lane".to_string(), 1),
+            ("labelled-lane".to_string(), 1),
+            ("tail-lane".to_string(), 1),
+            ("urgent-lane".to_string(), 1),
+        ]
+        .into_iter()
+        .map(|(name, capacity)| (name, SchedulerLaneConfig { capacity }))
+        .collect()
+    }
+}

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -133,6 +133,15 @@ pub struct PipelineRun {
     ownership_lease: Option<OwnershipLease>,
     /// Opaque configured workspace branch, including policies that do not claim remotely.
     workspace_branch_name: Option<String>,
+    /// Configured workflow identity frozen before ownership is journaled.
+    selected_workflow: Option<SelectedWorkflowSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SelectedWorkflowSnapshot {
+    pub rule: String,
+    pub pipeline: String,
+    pub lane: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -151,6 +160,8 @@ pub struct PipelineRunSnapshot {
     pub ownership_lease: Option<OwnershipLease>,
     #[serde(default)]
     pub workspace_branch_name: Option<String>,
+    #[serde(default)]
+    pub selected_workflow: Option<SelectedWorkflowSnapshot>,
 }
 
 impl PipelineRun {
@@ -173,6 +184,7 @@ impl PipelineRun {
             synthetic_fixup_steps: HashSet::new(),
             ownership_lease: None,
             workspace_branch_name: None,
+            selected_workflow: None,
         }
     }
 
@@ -188,6 +200,7 @@ impl PipelineRun {
             synthetic_fixup_steps: self.synthetic_fixup_steps.clone(),
             ownership_lease: self.ownership_lease.clone(),
             workspace_branch_name: self.workspace_branch_name.clone(),
+            selected_workflow: self.selected_workflow.clone(),
         }
     }
 
@@ -208,6 +221,7 @@ impl PipelineRun {
             synthetic_fixup_steps: snapshot.synthetic_fixup_steps,
             ownership_lease: snapshot.ownership_lease,
             workspace_branch_name: snapshot.workspace_branch_name,
+            selected_workflow: snapshot.selected_workflow,
         })
     }
 
@@ -230,6 +244,14 @@ impl PipelineRun {
 
     pub(crate) fn ownership_lease(&self) -> Option<&OwnershipLease> {
         self.ownership_lease.as_ref()
+    }
+
+    pub(crate) fn set_selected_workflow(&mut self, selected: SelectedWorkflowSnapshot) {
+        self.selected_workflow = Some(selected);
+    }
+
+    pub(crate) fn selected_workflow(&self) -> Option<&SelectedWorkflowSnapshot> {
+        self.selected_workflow.as_ref()
     }
 
     pub fn normalize_stale_running_steps(&mut self) {
@@ -668,6 +690,15 @@ impl PipelineRun {
 }
 
 fn validate_snapshot(snapshot: &PipelineRunSnapshot) -> Result<(), crate::error::PipelineError> {
+    if snapshot.selected_workflow.as_ref().is_some_and(|selected| {
+        selected.rule.trim().is_empty()
+            || selected.pipeline.trim().is_empty()
+            || selected.lane.trim().is_empty()
+    }) {
+        return Err(crate::error::PipelineError::InvalidSnapshot {
+            reason: "selected workflow rule, pipeline, and lane must be non-blank".to_string(),
+        });
+    }
     if snapshot.dag_steps.is_empty() {
         return Err(crate::error::PipelineError::InvalidSnapshot {
             reason: "runtime dag has no steps".to_string(),
@@ -870,6 +901,11 @@ mod tests {
             branch_name: Some("ensemble/issue-1".to_string()),
         });
         run.set_workspace_branch_name("configured/issue-1".to_string());
+        run.set_selected_workflow(SelectedWorkflowSnapshot {
+            rule: "ready".to_string(),
+            pipeline: "delivery".to_string(),
+            lane: "delivery".to_string(),
+        });
 
         let snapshot = run.to_snapshot();
         assert_eq!(
@@ -881,6 +917,14 @@ mod tests {
         );
         let restored = PipelineRun::from_snapshot(snapshot).unwrap();
         assert_eq!(restored.workspace_branch_name(), Some("configured/issue-1"));
+        assert_eq!(
+            restored.selected_workflow(),
+            Some(&SelectedWorkflowSnapshot {
+                rule: "ready".to_string(),
+                pipeline: "delivery".to_string(),
+                lane: "delivery".to_string(),
+            })
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use tracing::{debug, info, warn};
 
-use super::model::{InteractionThreadRoot, Issue, TrackerComment};
+use super::model::{BlockerRef, InteractionThreadRoot, Issue, TrackerComment};
 use super::{IssueTracker, OwnershipClaim, OwnershipConflict, OwnershipLease, TrackerError};
 use crate::config::ensemble::{GithubClaimConfig, GithubTrackerConfig};
 use crate::workspace::key::issue_workspace_key;
@@ -25,6 +25,7 @@ pub struct GithubTracker {
     project_fields: Option<GithubTrackerConfig>,
     project_metadata: tokio::sync::RwLock<Option<ProjectMetadata>>,
     authenticated_viewer: tokio::sync::RwLock<Option<AuthenticatedViewer>>,
+    hydrate_native_relationships: bool,
 }
 
 #[derive(Clone)]
@@ -64,9 +65,12 @@ pub(crate) struct GithubTrackerSettings {
     pub active_states: Vec<String>,
     pub terminal_states: Vec<String>,
     pub labels_filter: Vec<String>,
+    pub hydrate_native_relationships: bool,
 }
 
 impl GithubTracker {
+    const MAX_RELATIONSHIP_NODES: usize = 10_000;
+    const MAX_RELATIONSHIP_PAGES: usize = 200;
     /// Create a new GithubTracker.
     ///
     /// Parses `owner/repo` from the repository string.
@@ -98,6 +102,7 @@ impl GithubTracker {
             client,
             project_metadata: tokio::sync::RwLock::new(None),
             authenticated_viewer: tokio::sync::RwLock::new(None),
+            hydrate_native_relationships: settings.hydrate_native_relationships,
         })
     }
 
@@ -487,6 +492,17 @@ impl GithubTracker {
         filter_states: &[String],
         apply_labels_filter: bool,
     ) -> Result<Vec<Issue>, TrackerError> {
+        let issues = self
+            .fetch_project_items_without_relationships(filter_states, apply_labels_filter)
+            .await?;
+        Ok(self.hydrate_issue_relationships(issues).await)
+    }
+
+    async fn fetch_project_items_without_relationships(
+        &self,
+        filter_states: &[String],
+        apply_labels_filter: bool,
+    ) -> Result<Vec<Issue>, TrackerError> {
         let metadata = self.ensure_project_metadata().await?;
 
         let mut all_issues = Vec::new();
@@ -672,7 +688,7 @@ impl GithubTracker {
             }
         }
 
-        Ok(all_issues)
+        Ok(self.hydrate_issue_relationships(all_issues).await)
     }
 
     /// Normalize a single repository issue node into an Issue.
@@ -732,6 +748,154 @@ impl GithubTracker {
         })
     }
 
+    async fn hydrate_issue_relationships(&self, issues: Vec<Issue>) -> Vec<Issue> {
+        if !self.hydrate_native_relationships {
+            return issues;
+        }
+        let mut hydrated = Vec::with_capacity(issues.len());
+        for mut issue in issues {
+            match self.relationships_for_issue(&issue.id).await {
+                Ok(blockers) => {
+                    issue.blocked_by = blockers;
+                    hydrated.push(issue);
+                }
+                Err(error) => {
+                    warn!(
+                        issue_id = %issue.id,
+                        identifier = %issue.identifier,
+                        error = %error,
+                        "GitHub relationship hydration failed; omitting authoritative issue"
+                    );
+                }
+            }
+        }
+        hydrated
+    }
+
+    async fn relationships_for_issue(
+        &self,
+        issue_id: &str,
+    ) -> Result<Vec<BlockerRef>, TrackerError> {
+        let mut blockers = Vec::new();
+        let mut emitted = HashSet::new();
+        let mut relationship_nodes = HashSet::from([issue_id.to_string()]);
+        for related in self.fetch_direct_blockers(issue_id).await? {
+            let related = relationship_ref(related)?;
+            relationship_nodes.insert(related.id.clone().unwrap_or_default());
+            if relationship_nodes.len() > Self::MAX_RELATIONSHIP_NODES {
+                return Err(graphql::unexpected_payload::<graphql::IssueBlockedBy>(
+                    "relationship traversal exceeded bounded node limit",
+                ));
+            }
+            if related.state.as_deref() == Some("OPEN")
+                && emitted.insert(related.id.clone().unwrap_or_default())
+            {
+                blockers.push(related);
+            }
+        }
+
+        let mut seen = HashSet::from([issue_id.to_string()]);
+        let mut frontier = VecDeque::from([issue_id.to_string()]);
+        while let Some(parent_id) = frontier.pop_front() {
+            for child in self.fetch_sub_issues(&parent_id).await? {
+                let child_id = child.id.clone().ok_or_else(|| {
+                    graphql::unexpected_payload::<graphql::IssueSubIssues>(
+                        "sub-issue missing node ID",
+                    )
+                })?;
+                if !seen.insert(child_id.clone()) {
+                    continue;
+                }
+                relationship_nodes.insert(child_id.clone());
+                if relationship_nodes.len() > Self::MAX_RELATIONSHIP_NODES {
+                    return Err(graphql::unexpected_payload::<graphql::IssueSubIssues>(
+                        "relationship traversal exceeded bounded node limit",
+                    ));
+                }
+                frontier.push_back(child_id.clone());
+                let related = relationship_ref(child)?;
+                if related.state.as_deref() == Some("OPEN") && emitted.insert(child_id) {
+                    blockers.push(related);
+                }
+            }
+        }
+
+        Ok(blockers)
+    }
+
+    async fn fetch_direct_blockers(
+        &self,
+        issue_id: &str,
+    ) -> Result<Vec<graphql::RelatedIssueNode>, TrackerError> {
+        let mut nodes = Vec::new();
+        let mut cursor = None;
+        let mut pages = 0;
+        loop {
+            pages += 1;
+            if pages > Self::MAX_RELATIONSHIP_PAGES {
+                return Err(graphql::unexpected_payload::<graphql::IssueBlockedBy>(
+                    "relationship pagination exceeded bounded page limit",
+                ));
+            }
+            let data = self
+                .graphql::<graphql::IssueBlockedBy>(json!({
+                    "issueId": issue_id,
+                    "cursor": cursor,
+                }))
+                .await?;
+            let connection = data
+                .node
+                .ok_or_else(|| {
+                    graphql::unexpected_payload::<graphql::IssueBlockedBy>("issue not found")
+                })?
+                .blocked_by;
+            nodes.extend(connection.nodes.into_iter().flatten());
+            if nodes.len() > Self::MAX_RELATIONSHIP_NODES {
+                return Err(graphql::unexpected_payload::<graphql::IssueBlockedBy>(
+                    "direct blockers exceeded bounded node limit",
+                ));
+            }
+            match connection.page_info.next_cursor()? {
+                Some(next) => cursor = Some(next),
+                None => return Ok(nodes),
+            }
+        }
+    }
+
+    async fn fetch_sub_issues(
+        &self,
+        issue_id: &str,
+    ) -> Result<Vec<graphql::RelatedIssueNode>, TrackerError> {
+        let mut nodes = Vec::new();
+        let mut cursor = None;
+        let mut pages = 0;
+        loop {
+            pages += 1;
+            if pages > Self::MAX_RELATIONSHIP_PAGES {
+                return Err(graphql::unexpected_payload::<graphql::IssueSubIssues>(
+                    "relationship pagination exceeded bounded page limit",
+                ));
+            }
+            let data = self
+                .graphql::<graphql::IssueSubIssues>(json!({
+                    "issueId": issue_id,
+                    "cursor": cursor,
+                }))
+                .await?;
+            let connection = data
+                .node
+                .ok_or_else(|| {
+                    graphql::unexpected_payload::<graphql::IssueSubIssues>("issue not found")
+                })?
+                .sub_issues;
+            nodes.extend(connection.nodes.into_iter().flatten());
+            match connection.page_info.next_cursor()? {
+                Some(next) => cursor = Some(next),
+                None => return Ok(nodes),
+            }
+        }
+    }
+
     /// Batch fetch issue states by node IDs.
     async fn fetch_states_by_node_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError> {
         if ids.is_empty() {
@@ -740,12 +904,13 @@ impl GithubTracker {
 
         if self.project_number.is_some() {
             let requested_ids: HashSet<&str> = ids.iter().map(String::as_str).collect();
-            return Ok(self
-                .fetch_project_items(&[], false)
+            let issues = self
+                .fetch_project_items_without_relationships(&[], false)
                 .await?
                 .into_iter()
                 .filter(|issue| requested_ids.contains(issue.id.as_str()))
-                .collect());
+                .collect();
+            return Ok(self.hydrate_issue_relationships(issues).await);
         }
 
         let variables = json!({
@@ -761,7 +926,7 @@ impl GithubTracker {
             }
         }
 
-        Ok(issues)
+        Ok(self.hydrate_issue_relationships(issues).await)
     }
 
     async fn repository_label_id(&self, name: &str) -> Result<Option<String>, TrackerError> {
@@ -1073,6 +1238,32 @@ fn priority_rank(node: &graphql::ProjectItem, metadata: &ProjectMetadata) -> Opt
     priority.option_ranks.get(option_id).copied()
 }
 
+fn relationship_ref(node: graphql::RelatedIssueNode) -> Result<BlockerRef, TrackerError> {
+    let id = node.id.ok_or_else(|| {
+        graphql::unexpected_payload::<graphql::IssueSubIssues>("related issue missing node ID")
+    })?;
+    let number = node.number.ok_or_else(|| {
+        graphql::unexpected_payload::<graphql::IssueSubIssues>("related issue missing number")
+    })?;
+    let state = node.state.ok_or_else(|| {
+        graphql::unexpected_payload::<graphql::IssueSubIssues>("related issue missing state")
+    })?;
+    let repository = node
+        .repository
+        .and_then(|repository| repository.name_with_owner)
+        .filter(|repository| !repository.trim().is_empty())
+        .ok_or_else(|| {
+            graphql::unexpected_payload::<graphql::IssueSubIssues>(
+                "related issue missing repository identity",
+            )
+        })?;
+    Ok(BlockerRef {
+        id: Some(id),
+        identifier: Some(format!("{repository}#{number}")),
+        state: Some(state.to_uppercase()),
+    })
+}
+
 #[async_trait]
 impl IssueTracker for GithubTracker {
     async fn validate_configuration(&self) -> Result<(), TrackerError> {
@@ -1348,6 +1539,75 @@ mod tests {
         }
     }
 
+    struct RelationshipBlockedByResponder {
+        fail_issue: Option<&'static str>,
+    }
+
+    impl Respond for RelationshipBlockedByResponder {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let request: Value = serde_json::from_slice(&request.body).unwrap();
+            let issue_id = request["variables"]["issueId"].as_str().unwrap();
+            if self.fail_issue == Some(issue_id) {
+                return ResponseTemplate::new(200)
+                    .set_body_json(graphql_response(json!({ "node": null })));
+            }
+            if issue_id == "I_paged" {
+                let cursor = request["variables"]["cursor"].as_str();
+                let (nodes, has_next, end_cursor) = if cursor.is_none() {
+                    (
+                        json!([{"id":"I_page_1","number":11,"state":"OPEN","repository":{"nameWithOwner":"acme/one"}}]),
+                        true,
+                        json!("page-2"),
+                    )
+                } else {
+                    (
+                        json!([{"id":"I_page_2","number":12,"state":"OPEN","repository":{"nameWithOwner":"acme/two"}}]),
+                        false,
+                        Value::Null,
+                    )
+                };
+                return ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "node": {"blockedBy": {"pageInfo":{"hasNextPage":has_next,"endCursor":end_cursor},"nodes":nodes}}
+                })));
+            }
+            let nodes = if issue_id == "I_root" {
+                json!([
+                    {"id":"I_block","number":7,"state":"OPEN","repository":{"nameWithOwner":"other/repo"}},
+                    {"id":"I_closed","number":8,"state":"CLOSED","repository":{"nameWithOwner":"other/repo"}}
+                ])
+            } else {
+                json!([])
+            };
+            ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                "node": {"blockedBy": {"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":nodes}}
+            })))
+        }
+    }
+
+    struct RelationshipSubIssuesResponder;
+
+    impl Respond for RelationshipSubIssuesResponder {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let request: Value = serde_json::from_slice(&request.body).unwrap();
+            let issue_id = request["variables"]["issueId"].as_str().unwrap();
+            let nodes = match issue_id {
+                "I_root" => json!([
+                    {"id":"I_mid","number":8,"state":"CLOSED","repository":{"nameWithOwner":"acme/my-repo"}}
+                ]),
+                "I_mid" => json!([
+                    {"id":"I_leaf","number":9,"state":"OPEN","repository":{"nameWithOwner":"acme/child"}}
+                ]),
+                "I_leaf" => json!([
+                    {"id":"I_root","number":1,"state":"OPEN","repository":{"nameWithOwner":"acme/my-repo"}}
+                ]),
+                _ => json!([]),
+            };
+            ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                "node": {"subIssues": {"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":nodes}}
+            })))
+        }
+    }
+
     /// Helper to create a GithubTracker pointed at a wiremock server.
     fn create_test_tracker(server_url: &str, project_number: Option<i64>) -> GithubTracker {
         GithubTracker::new(
@@ -1364,6 +1624,7 @@ mod tests {
                 active_states: vec!["Todo".to_string(), "In Progress".to_string()],
                 terminal_states: vec!["Done".to_string(), "Closed".to_string()],
                 labels_filter: vec![],
+                hydrate_native_relationships: false,
             },
         )
         .unwrap()
@@ -1390,6 +1651,7 @@ mod tests {
                 active_states: vec!["Todo".to_string()],
                 terminal_states: vec!["Done".to_string()],
                 labels_filter: vec![],
+                hydrate_native_relationships: false,
             },
         )
         .unwrap()
@@ -1416,9 +1678,119 @@ mod tests {
                 active_states: vec!["Open".to_string(), "In Progress".to_string()],
                 terminal_states: vec!["Done".to_string()],
                 labels_filter: vec![],
+                hydrate_native_relationships: false,
             },
         )
         .unwrap()
+    }
+
+    async fn mount_relationship_operations(server: &MockServer, fail_issue: Option<&'static str>) {
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("blockedBy(first:"))
+            .respond_with(RelationshipBlockedByResponder { fail_issue })
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("subIssues(first:"))
+            .respond_with(RelationshipSubIssuesResponder)
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn native_relationships_hydrate_candidates_and_fresh_snapshots() {
+        let server = MockServer::start().await;
+        let root = json!({
+            "id":"I_root","number":1,"title":"Root","body":"","createdAt":"2026-01-01T00:00:00Z",
+            "updatedAt":"2026-01-01T00:00:00Z","url":"https://example.test/issues/1","state":"OPEN",
+            "labels":{"nodes":[{"name":"Todo"}]},"assignees":{"totalCount":0,"nodes":[]}
+        });
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("issues(first:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                "repository":{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[root.clone()]}}
+            }))))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("nodes(ids:"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                    "nodes":[root]
+                }))),
+            )
+            .mount(&server)
+            .await;
+        mount_relationship_operations(&server, None).await;
+        let mut tracker = create_test_tracker(&server.uri(), None);
+        tracker.hydrate_native_relationships = true;
+
+        let candidates = tracker.fetch_candidate_issues().await.unwrap();
+        let fresh = tracker
+            .fetch_issue_states_by_ids(&["I_root".to_string()])
+            .await
+            .unwrap();
+
+        for issue in [&candidates[0], &fresh[0]] {
+            assert_eq!(
+                issue
+                    .blocked_by
+                    .iter()
+                    .filter_map(|blocker| blocker.identifier.as_deref())
+                    .collect::<Vec<_>>(),
+                vec!["other/repo#7", "acme/child#9"]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn inaccessible_relationships_omit_only_the_authoritative_issue() {
+        let server = MockServer::start().await;
+        let issue = |id: &str, number: u64| {
+            json!({
+                "id":id,"number":number,"title":id,"body":"","createdAt":"2026-01-01T00:00:00Z",
+                "updatedAt":"2026-01-01T00:00:00Z","url":format!("https://example.test/issues/{number}"),"state":"OPEN",
+                "labels":{"nodes":[{"name":"Todo"}]},"assignees":{"totalCount":0,"nodes":[]}
+            })
+        };
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("issues(first:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                "repository":{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[issue("I_bad",1),issue("I_good",2)]}}
+            }))))
+            .mount(&server)
+            .await;
+        mount_relationship_operations(&server, Some("I_bad")).await;
+        let mut tracker = create_test_tracker(&server.uri(), None);
+        tracker.hydrate_native_relationships = true;
+
+        let candidates = tracker.fetch_candidate_issues().await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].id, "I_good");
+    }
+
+    #[tokio::test]
+    async fn native_relationship_pagination_completes_before_admission() {
+        let server = MockServer::start().await;
+        mount_relationship_operations(&server, None).await;
+        let mut tracker = create_test_tracker(&server.uri(), None);
+        tracker.hydrate_native_relationships = true;
+
+        let blockers = tracker.relationships_for_issue("I_paged").await.unwrap();
+
+        assert_eq!(
+            blockers
+                .iter()
+                .filter_map(|blocker| blocker.identifier.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["acme/one#11", "acme/two#12"]
+        );
     }
 
     #[test]
@@ -1447,6 +1819,7 @@ mod tests {
                 active_states: vec!["Todo".to_string()],
                 terminal_states: vec!["Done".to_string()],
                 labels_filter: Vec::new(),
+                hydrate_native_relationships: false,
             },
         )
         .unwrap();
@@ -2855,6 +3228,7 @@ mod tests {
                 active_states: vec![],
                 terminal_states: vec![],
                 labels_filter: vec![],
+                hydrate_native_relationships: false,
             },
         )
         .unwrap();
@@ -3147,6 +3521,7 @@ mod tests {
                 active_states: vec!["Queued".to_string()],
                 terminal_states: vec!["Done".to_string()],
                 labels_filter: vec![],
+                hydrate_native_relationships: false,
             },
         )
         .unwrap();
@@ -3234,6 +3609,7 @@ mod tests {
                 active_states: vec!["Todo".to_string()],
                 terminal_states: vec!["Done".to_string()],
                 labels_filter: vec!["bug".to_string()],
+                hydrate_native_relationships: false,
             },
         )
         .unwrap();

--- a/crates/ensemble-core/src/tracker/github/graphql.rs
+++ b/crates/ensemble-core/src/tracker/github/graphql.rs
@@ -360,6 +360,84 @@ pub(super) struct IssueStatesData {
     pub(super) nodes: Vec<Option<IssueNode>>,
 }
 
+pub(super) struct IssueBlockedBy;
+
+impl Operation for IssueBlockedBy {
+    const NAME: &'static str = "IssueBlockedBy";
+    const QUERY: &'static str = ISSUE_BLOCKED_BY_QUERY;
+    type Response = IssueBlockedByData;
+}
+
+pub(super) const ISSUE_BLOCKED_BY_QUERY: &str = r#"
+query($issueId: ID!, $cursor: String) {
+  node(id: $issueId) {
+    ... on Issue {
+      blockedBy(first: 50, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { id number state repository { nameWithOwner } }
+      }
+    }
+  }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct IssueBlockedByData {
+    pub(super) node: Option<IssueBlockedByNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct IssueBlockedByNode {
+    pub(super) blocked_by: Connection<RelatedIssueNode>,
+}
+
+pub(super) struct IssueSubIssues;
+
+impl Operation for IssueSubIssues {
+    const NAME: &'static str = "IssueSubIssues";
+    const QUERY: &'static str = ISSUE_SUB_ISSUES_QUERY;
+    type Response = IssueSubIssuesData;
+}
+
+pub(super) const ISSUE_SUB_ISSUES_QUERY: &str = r#"
+query($issueId: ID!, $cursor: String) {
+  node(id: $issueId) {
+    ... on Issue {
+      subIssues(first: 50, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { id number state repository { nameWithOwner } }
+      }
+    }
+  }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct IssueSubIssuesData {
+    pub(super) node: Option<IssueSubIssuesNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct IssueSubIssuesNode {
+    pub(super) sub_issues: Connection<RelatedIssueNode>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct RelatedIssueNode {
+    pub(super) id: Option<String>,
+    pub(super) number: Option<u64>,
+    pub(super) state: Option<String>,
+    pub(super) repository: Option<RelatedRepository>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RelatedRepository {
+    pub(super) name_with_owner: Option<String>,
+}
+
 pub(super) struct IssueAssignees;
 
 impl Operation for IssueAssignees {
@@ -672,6 +750,8 @@ mod tests {
             decode_response::<ProjectItems>(br#"{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"edges":[]}}}}"#, "").map(|_| ()),
             decode_response::<RepositoryIssues>(br#"{"data":{"repository":{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}"#, "").map(|_| ()),
             decode_response::<IssueStates>(br#"{"data":{"nodes":[]}}"#, "").map(|_| ()),
+            decode_response::<IssueBlockedBy>(br#"{"data":{"node":{"blockedBy":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}"#, "").map(|_| ()),
+            decode_response::<IssueSubIssues>(br#"{"data":{"node":{"subIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}"#, "").map(|_| ()),
             decode_response::<Viewer>(br#"{"data":{"viewer":{"id":"U_1","login":"octocat"}}}"#, "").map(|_| ()),
             decode_response::<IssueAssignees>(br#"{"data":{"node":{"id":"I_1","assignees":{"totalCount":0,"nodes":[]}}}}"#, "").map(|_| ()),
             decode_response::<IssueComments>(br#"{"data":{"node":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}"#, "").map(|_| ()),

--- a/crates/ensemble-core/src/tracker/mod.rs
+++ b/crates/ensemble-core/src/tracker/mod.rs
@@ -4,7 +4,7 @@ pub mod model;
 pub mod notion;
 pub mod todo_file;
 
-use crate::config::ensemble::TrackerConfig;
+use crate::config::ensemble::{EnsembleConfig, TrackerConfig};
 use async_trait::async_trait;
 use model::{InteractionThreadRoot, Issue, TrackerComment};
 use serde::{Deserialize, Serialize};
@@ -185,6 +185,19 @@ pub fn resolve_github_token_for_endpoint(
 /// Returns an error if the tracker kind is unsupported, or
 /// if required configuration is absent (e.g., missing API key for GitHub).
 pub fn create_tracker(config: &TrackerConfig) -> Result<Box<dyn IssueTracker>, TrackerError> {
+    create_tracker_with_relationships(config, false)
+}
+
+pub(crate) fn create_tracker_for_runtime(
+    config: &EnsembleConfig,
+) -> Result<Box<dyn IssueTracker>, TrackerError> {
+    create_tracker_with_relationships(&config.tracker, config.uses_workflow_selection())
+}
+
+fn create_tracker_with_relationships(
+    config: &TrackerConfig,
+    hydrate_native_relationships: bool,
+) -> Result<Box<dyn IssueTracker>, TrackerError> {
     match config.kind.as_str() {
         "todo_file" => {
             let path = config
@@ -231,6 +244,7 @@ pub fn create_tracker(config: &TrackerConfig) -> Result<Box<dyn IssueTracker>, T
                     active_states: config.active_states.clone(),
                     terminal_states: config.terminal_states.clone(),
                     labels_filter: config.labels_filter.clone(),
+                    hydrate_native_relationships,
                 },
             )?;
             Ok(Box::new(tracker))

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -621,7 +621,8 @@ Loader behavior:
 ### 5.2 File Format
 
 `config.yaml` is a YAML file containing all pipeline configuration: tracker settings, agent
-definitions, step DAG, concurrency limits, and prompt references.
+definitions, one legacy step DAG or a set of named pipeline DAGs, concurrency limits, selection
+rules, and prompt references.
 
 Design note:
 
@@ -645,6 +646,9 @@ Top-level keys:
 - `steps`
 - `on_success`
 - `on_failure`
+- `pipelines`
+- `scheduler`
+- `workflow_selection`
 - `concurrency`
 - `max_cycles`
 - `polling`
@@ -652,6 +656,21 @@ Top-level keys:
 - `hooks`
 
 Unknown keys should be ignored for forward compatibility.
+
+Pipeline mode rules:
+
+- Legacy mode requires top-level `steps`, `on_success`, and `on_failure`.
+- Selected mode requires non-empty `pipelines`, `scheduler.lanes`, and `workflow_selection` and
+  forbids the legacy pipeline fields.
+- Every named pipeline is independently DAG-validated and supplies its own `steps`, `on_success`,
+  and `on_failure`.
+- Every scheduler lane has a positive live-worker `capacity`.
+- Selection rules have unique normalized names and unique positive precedence values, reference an
+  existing pipeline and lane, and may constrain normalized `states`, `labels_all`, `labels_any`,
+  `labels_none`, and `require_unblocked`.
+- Rule ordering keys are a non-empty, duplicate-free list drawn from `priority`,
+  `tracker_position`, `created_at`, and `identifier`. Values sort ascending with nulls last;
+  `identifier` is required as the final effective tie-breaker and is appended when omitted.
 
 Note:
 
@@ -1297,7 +1316,8 @@ Every live worker is also registered by an exact in-memory identity:
 until the worker's local event channel has closed and every event has been forwarded. More than one
 identity-distinct handle may temporarily exist for an issue, and issue-wide cancellation signals all
 of them. Registration is also the worker's capacity reservation: one mutex-protected operation
-checks the global and per-issue limits and inserts the exact identity before tracker step-entry,
+checks the global, per-issue, and selected capacity-bucket limits and inserts the exact identity
+before tracker step-entry,
 `StepRunning` publication, or process launch. A pre-launch failure rolls back only that exact
 reservation; a launched worker retains it until the bridge proves quiescence. Worker event channels
 remain bounded; while reconciliation or shutdown awaits bridge
@@ -1408,16 +1428,18 @@ Tick sequence:
 4. Run dispatch preflight validation.
 5. Fetch candidate issues from tracker using active states.
 6. Re-scan claimed pipelines for ready pending steps while live-worker slots remain.
-7. Sort issues by dispatch priority.
-8. Dispatch eligible issues while slots remain.
+7. In legacy mode, sort issues by the legacy dispatch priority. In selected mode, match rules and
+   sort by rule precedence plus each rule's configured ordering keys.
+8. Dispatch eligible issues while slots remain. Selected-mode fresh work is refreshed by stable ID
+   and re-matched immediately before the existing claim seam.
 9. Notify observability/status consumers of state changes.
 
 If per-tick validation fails, dispatch is skipped for that tick, but reconciliation still happens
 first.
 
 Reconciliation uses a broader active-state set than candidate dispatch. In addition to
-`tracker.active_states`, any non-terminal `steps[].tracker_state` and approval `state` written by
-the workflow are considered active for already-running or waiting issues. This prevents the
+`tracker.active_states`, any non-terminal tracker or approval state written by the legacy pipeline
+or any named pipeline is considered active for already-running or waiting issues. This prevents the
 orchestrator from abandoning a run just because it moved the tracker item into a workflow-owned
 intermediate state such as `Review` or `Plan Review`.
 
@@ -1439,6 +1461,29 @@ Sorting order (stable intent):
 1. `priority` ascending (1..4 are preferred; null/unknown sorts last)
 2. `created_at` oldest first
 3. `identifier` lexicographic tie-breaker
+
+Selected-mode admission instead applies these rules:
+
+- Structural eligibility requires the issue identity and title fields, a non-terminal state, and
+  no existing running, claimed, or completed owner. Active-state and blocker meanings come from the
+  matching rule rather than hard-coded state vocabulary.
+- Rules are matched by ascending precedence. `states` requires one normalized match;
+  `labels_all`, `labels_any`, and `labels_none` apply their literal set predicates;
+  `require_unblocked` rejects an issue while any normalized blocker is absent from the snapshot or
+  is in a non-terminal state.
+- Candidates sort first by matching-rule precedence, then by that rule's configured ascending keys
+  with nulls last, and finally by identifier.
+- Immediately before claiming, the orchestrator fetches exactly that issue by stable ID, recomputes
+  its relationship normalization and selection, and proceeds only when the same rule, pipeline, and
+  lane still match and lane capacity remains advisably available.
+- That refresh invokes the existing claim operation at most once. Recovered remote ownership is
+  adopted without a second claim.
+- The rule, pipeline, and lane identity are written into the first pipeline snapshot alongside any
+  opaque ownership lease and branch identity. Retries and recovery use the frozen pipeline and lane;
+  they do not reselect. A removed or changed identity fails closed.
+
+These rules preserve the single lifecycle authority in ADR-0012 and the configuration/runtime
+boundary for development methods in ADR-0014.
 
 ### 8.3 Concurrency Control
 
@@ -2206,9 +2251,14 @@ Additional normalization details:
 - `tracker_position` -> In project-board mode, the fresh numeric ordinal from the complete ordered
   Project-items traversal. Otherwise `null` unless another adapter supplies its own snapshot data.
 - `labels` -> lowercase strings from GitHub Issue labels
-- `blocked_by` -> GitHub Issues have no native blocking relations. Implementations may populate this
-  by scanning issue body/comments for `blocked by #N` patterns, using a label convention, or leave
-  it as an empty list.
+- `blocked_by` -> In selected-mode runtimes, native GitHub issue relationships. Include every open issue in the direct
+  `blockedBy` connection and every open descendant in the recursive `subIssues` graph. Traverse
+  through closed intermediate sub-issues, paginate each connection completely, and deduplicate or
+  break cycles by GitHub node ID. Use `owner/repository#<number>` for every related issue so
+  cross-repository relations remain unambiguous. A relationship authorization or payload
+  failure omits only the authoritative candidate whose dependency snapshot is incomplete; a base
+  Project-items query failure remains tracker-wide. Legacy no-selection runtimes retain the prior
+  GitHub snapshot and hard-coded `Todo` blocker behavior without issuing these relationship reads.
 - `branch_name` -> GitHub Issues do not provide branch metadata natively. Implementations may derive
   from issue number (for example `issue-42`), check for linked branches via the GitHub API, or
   leave it `null`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -533,6 +533,86 @@ opencode adapter command.
 - Direct runtime command strings are parsed with shell-style quoting into program arguments, then launched without shell interpolation.
 - Provide either `prompt` (inline) or `prompt_template` (file), not both.
 
+### Pipeline configuration modes
+
+Ensemble accepts exactly one of two pipeline modes:
+
+- **Legacy mode** uses the top-level `steps`, `on_success`, and `on_failure` fields documented
+  below. Existing single-pipeline configurations continue to use this mode.
+- **Selected mode** defines named `pipelines`, capacity-limited `scheduler.lanes`, and an ordered
+  `workflow_selection` rule list. Do not combine these fields with the legacy pipeline fields.
+
+Selected mode keeps issue vocabulary in configuration rather than assigning semantic roles to
+states or labels inside Ensemble:
+
+```yaml
+pipelines:
+  delivery:
+    steps:
+      - name: build
+        agent: builder
+    on_success: Done
+    on_failure: Failed
+  planning:
+    steps:
+      - name: plan
+        agent: planner
+    on_success: Plan Review
+    on_failure: Failed
+
+scheduler:
+  lanes:
+    delivery:
+      capacity: 3
+    planning:
+      capacity: 1
+
+workflow_selection:
+  - name: ready-delivery
+    precedence: 10
+    pipeline: delivery
+    lane: delivery
+    states: [Ready]
+    labels_all: [ready-for-agent]
+    labels_none: [hold]
+    require_unblocked: true
+    order_by: [priority, tracker_position, created_at]
+  - name: requested-planning
+    precedence: 20
+    pipeline: planning
+    lane: planning
+    states: [Planning]
+    labels_any: [needs-plan, revise-plan]
+    order_by: [created_at]
+  - name: alternate-vocabulary
+    precedence: 30
+    pipeline: delivery
+    lane: delivery
+    states: [Ausstehend]
+    labels_all: [bereit]
+    order_by: [tracker_position]
+  - name: tail
+    precedence: 100
+    pipeline: delivery
+    lane: delivery
+    order_by: [created_at]
+```
+
+Each rule may constrain `states`, `labels_all`, `labels_any`, `labels_none`, and
+`require_unblocked`. Omitted predicates are unconstrained, so a final catch-all rule is allowed.
+State and label comparisons trim whitespace and ignore case. A supplied predicate list must be
+non-empty and contain no blank or normalized-duplicate values.
+
+Rules are evaluated by ascending positive `precedence`; the first matching rule selects one named
+pipeline and one scheduler lane. Rule names and precedence values must be unique, and every
+pipeline and lane reference must exist. Lane capacity must be a positive integer. Every named
+pipeline is validated as a complete DAG with non-blank terminal transitions.
+
+`order_by` accepts `priority`, `tracker_position`, `created_at`, and `identifier`. Keys are applied
+in their listed order, ascending, with null values last. Keys cannot repeat, and `identifier`, when
+specified, must be final. Ensemble always adds `identifier` as the final deterministic tie-breaker
+when it is omitted.
+
 ### steps
 
 Pipeline step definitions. Each step invokes one agent.
@@ -602,8 +682,9 @@ steps:
 | `max_step_parallelism` | integer | `2` | Per-issue worker cap reserved for deferred multi-branch execution |
 
 These limits count live agent workers, not claimed or running issues. Ensemble reserves global,
-per-issue, and any configured `agent.max_concurrent_agents_by_state` slot atomically for each exact
-step worker before publishing the step as running or launching its agent. This describes the
+per-issue, and either the selected scheduler-lane slot or a configured legacy
+`agent.max_concurrent_agents_by_state` slot atomically for each exact step worker before publishing
+the step as running or launching its agent. This describes the
 implemented capacity accounting, not a supported guarantee of parallel execution in the sequential
 MVP. If any limit is full, the ready step remains pending without consuming a retry cycle. Pending
 ready steps in claimed pipelines are reconsidered when worker capacity is released and before new

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -6,6 +6,25 @@ For the first release, sequential list-order pipelines are the supported path. D
 can describe a DAG, but Ensemble does not promise guaranteed parallel execution. Finalization after
 a successful pipeline is recoverable and may create a pull request; a human owns review and merge.
 
+## Named pipeline selection and recovery
+
+A configuration can replace the legacy top-level pipeline with named `pipelines`,
+`scheduler.lanes`, and `workflow_selection` rules. The selector matches normalized issue state,
+labels, and blockers without assigning built-in meanings such as planning or delivery to them.
+The matching rule chooses both the executable pipeline and the live-worker capacity lane.
+
+For fresh work, Ensemble evaluates and orders the candidate snapshot, then refreshes the selected
+issue by stable ID immediately before the existing claim operation. The refreshed issue must still
+match the same rule, pipeline, and lane and the lane must still have capacity. If any of those
+conditions changed, Ensemble does not claim or dispatch it during that tick.
+
+The selected rule, pipeline, and lane are journaled with the run's ownership lease and workspace
+branch identity. Retries, interaction resumes, finalization, and restart recovery use that frozen
+identity rather than selecting again. If the named rule, pipeline, or lane is missing or points at
+a different combination after configuration changes, recovery fails closed for operator action.
+This preserves the orchestrator's single lifecycle authority described by ADR-0012 while keeping
+development-method vocabulary outside the runtime core as required by ADR-0014.
+
 ## Steps and agents
 
 Each step references an agent defined in `config.yaml`:


### PR DESCRIPTION
Fixes #510

Adds configuration-driven named pipelines, scheduler lanes, and deterministic fixed-vocabulary workflow-selection rules. Selected candidates are refreshed and reselected immediately before the existing ownership claim, then persist rule/pipeline/lane identity beside the ownership lease and workspace branch for retry, restart, finalization, and delivery recovery. GitHub native blockers and sub-issues are normalized only for selected mode, preserving legacy dispatch and polling behavior when selection is absent.

Validation:

- Serial full non-desktop workspace suite, including 1,292 core tests
- Product E2E at default stack: 44 passed, 1 live dogfood test ignored
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The exact parallel workspace invocation can still expose the pre-existing shared Git/PATH fixture race (`create_finalize_repo` ENOENT); the deterministic serial full suite passes.
