### PR TITLE
Add durable operator attention

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,10 @@ _Avoid_: Step result, execution result
 A durable question, approval, or handoff that blocks a run until a human resolves it.
 _Avoid_: Prompt, comment
 
+**Operator-attention item**:
+A durable, non-authoritative report from a producer that fresh evidence says a subject needs an operator.
+_Avoid_: Interaction request, action, command
+
 **Finalization**:
 The recoverable post-pipeline phase that performs configured repository publication, if any, before an issue is considered complete.
 _Avoid_: Completion, cleanup

--- a/crates/ensemble-core/src/api/attention_handler.rs
+++ b/crates/ensemble-core/src/api/attention_handler.rs
@@ -1,0 +1,138 @@
+use crate::api::handlers::{api_error, ApiError};
+use crate::api::router::AppState;
+use crate::api::security::ApiExposure;
+use crate::attention::{AttentionHistoryResponse, AttentionLifecycleState};
+use axum::extract::{Extension, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize, utoipa::IntoParams)]
+pub struct AttentionHistoryQuery {
+    pub subject_ref: Option<String>,
+    pub state: Option<AttentionLifecycleState>,
+    pub cursor: Option<usize>,
+    pub limit: Option<usize>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/attention",
+    operation_id = "getAttentionHistory",
+    params(AttentionHistoryQuery),
+    responses(
+        (status = 200, description = "Operator-attention lifecycle history", body = AttentionHistoryResponse),
+        (status = 404, description = "Unavailable for remotely exposed APIs", body = ApiError),
+        (status = 503, description = "Attention history unavailable", body = ApiError)
+    ),
+    tag = "attention"
+)]
+pub async fn get_attention_history(
+    State(state): State<AppState>,
+    Extension(exposure): Extension<ApiExposure>,
+    Query(query): Query<AttentionHistoryQuery>,
+) -> impl IntoResponse {
+    if exposure == ApiExposure::UnsafeRemote {
+        return (
+            StatusCode::NOT_FOUND,
+            api_error("not_found", "API endpoint not found"),
+        )
+            .into_response();
+    }
+
+    let Some(store) = state.history_store.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            api_error(
+                "attention_history_unavailable",
+                "attention history store is unavailable",
+            ),
+        )
+            .into_response();
+    };
+
+    match store
+        .read_attention_history(query.subject_ref, query.state, query.cursor, query.limit)
+        .await
+    {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            api_error(
+                "attention_history_unavailable",
+                format!("failed to read attention history: {error}"),
+            ),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::extract::Extension;
+
+    use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
+    use crate::attention::{
+        AttentionEvidence, AttentionIdentity, AttentionPresentation, AttentionReporter,
+        AttentionUpsert,
+    };
+
+    use super::*;
+
+    fn observation() -> AttentionUpsert {
+        AttentionUpsert::new(
+            AttentionIdentity::new("producer-1", "issue-514", "runtime.awaiting_input").unwrap(),
+            AttentionPresentation::new(
+                "Awaiting input",
+                "Resolve the request",
+                vec!["request-1".into()],
+            )
+            .unwrap(),
+            AttentionEvidence::new("open-v1").unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn trusted_local_history_returns_persisted_events_with_subject_filter() {
+        let state = app_state_with_document_state(parsed_document_state());
+        let reporter = AttentionReporter::new(state.history_store.clone().unwrap());
+        reporter.upsert_open(observation()).await.unwrap();
+
+        let response = get_attention_history(
+            State(state),
+            Extension(ApiExposure::TrustedLocal),
+            Query(AttentionHistoryQuery {
+                subject_ref: Some("issue-514".into()),
+                state: None,
+                cursor: None,
+                limit: None,
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["events"].as_array().unwrap().iter().any(|event| {
+            event["identity"]["producer_key"] == "producer-1"
+                && event["identity"]["subject_ref"] == "issue-514"
+        }));
+    }
+
+    #[tokio::test]
+    async fn unsafe_remote_history_route_is_hidden() {
+        let response = get_attention_history(
+            State(app_state_with_document_state(parsed_document_state())),
+            Extension(ApiExposure::UnsafeRemote),
+            Query(AttentionHistoryQuery::default()),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -1,4 +1,5 @@
 use crate::api::router::AppState;
+use crate::api::security::ApiExposure;
 use crate::config::draft::ConfigDocumentState;
 use crate::config::ensemble::{EnsembleConfig, StepKind};
 use crate::history::artifacts::StepTranscriptArtifact;
@@ -11,7 +12,7 @@ use crate::observability::snapshot::{
     WorkflowStepInfo, WorkspaceInfo,
 };
 use crate::workspace::key::issue_workspace_key;
-use axum::extract::{Path, State};
+use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
@@ -61,16 +62,34 @@ impl ApiError {
     path = "/api/v1/state",
     operation_id = "getState",
     responses(
-        (status = 200, description = "Runtime snapshot", body = RuntimeSnapshot)
+        (status = 200, description = "Runtime snapshot", body = RuntimeSnapshot),
+        (status = 503, description = "Attention history unavailable", body = ApiError)
     ),
     tag = "state"
 )]
-pub async fn get_state(State(state): State<AppState>) -> (StatusCode, Json<RuntimeSnapshot>) {
+pub async fn get_state(
+    State(state): State<AppState>,
+    Extension(exposure): Extension<ApiExposure>,
+) -> impl IntoResponse {
     let lock = state.orchestrator_state.read().await;
-    let snapshot = build_state_snapshot(&lock);
+    let mut snapshot = build_state_snapshot(&lock);
     drop(lock);
 
-    (StatusCode::OK, Json(snapshot))
+    if exposure == ApiExposure::TrustedLocal {
+        let Some(store) = state.history_store.as_ref() else {
+            return attention_history_unavailable("attention history store is unavailable");
+        };
+        match store.read_open_attention().await {
+            Ok(attention_items) => snapshot.attention_items = attention_items,
+            Err(error) => {
+                return attention_history_unavailable(format!(
+                    "failed to read attention history: {error}"
+                ));
+            }
+        }
+    }
+
+    (StatusCode::OK, Json(snapshot)).into_response()
 }
 
 /// GET /api/v1/{identifier}
@@ -86,12 +105,14 @@ pub async fn get_state(State(state): State<AppState>) -> (StatusCode, Json<Runti
     ),
     responses(
         (status = 200, description = "Issue detail", body = IssueDetailSnapshot),
-        (status = 404, description = "Issue not found", body = ApiError)
+        (status = 404, description = "Issue not found", body = ApiError),
+        (status = 503, description = "Attention history unavailable", body = ApiError)
     ),
     tag = "issues"
 )]
 pub async fn get_issue_detail(
     State(state): State<AppState>,
+    Extension(exposure): Extension<ApiExposure>,
     Path(identifier): Path<String>,
 ) -> impl IntoResponse {
     let config_dir = state
@@ -111,7 +132,10 @@ pub async fn get_issue_detail(
         enrich_issue_snapshot_pending_input(detail, &interaction_store).await;
     }
 
-    if let Some(detail) = live_detail {
+    if let Some(mut detail) = live_detail {
+        if let Err(response) = enrich_issue_attention(&state, exposure, &mut detail).await {
+            return response;
+        }
         return (StatusCode::OK, Json(detail)).into_response();
     }
 
@@ -134,7 +158,12 @@ pub async fn get_issue_detail(
     };
 
     match detail {
-        Some(detail) => (StatusCode::OK, Json(detail)).into_response(),
+        Some(mut detail) => {
+            if let Err(response) = enrich_issue_attention(&state, exposure, &mut detail).await {
+                return response;
+            }
+            (StatusCode::OK, Json(detail)).into_response()
+        }
         None => {
             let error = ApiError::new(
                 "issue_not_found",
@@ -146,6 +175,36 @@ pub async fn get_issue_detail(
             (StatusCode::NOT_FOUND, Json(error)).into_response()
         }
     }
+}
+
+async fn enrich_issue_attention(
+    state: &AppState,
+    exposure: ApiExposure,
+    detail: &mut IssueDetailSnapshot,
+) -> Result<(), axum::response::Response> {
+    if exposure == ApiExposure::UnsafeRemote {
+        return Ok(());
+    }
+    let Some(store) = state.history_store.as_ref() else {
+        return Err(attention_history_unavailable(
+            "attention history store is unavailable",
+        ));
+    };
+    detail.attention_items = store
+        .read_open_attention_for_subject(&detail.issue_identifier)
+        .await
+        .map_err(|error| {
+            attention_history_unavailable(format!("failed to read attention history: {error}"))
+        })?;
+    Ok(())
+}
+
+fn attention_history_unavailable(message: impl Into<String>) -> axum::response::Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        api_error("attention_history_unavailable", message),
+    )
+        .into_response()
 }
 
 /// Build a name → step kind map from the active config so that
@@ -265,6 +324,7 @@ fn issue_snapshot_from_history_record(
         retry: Option::<RetryRow>::None,
         pending_input: None,
         current_interaction: None,
+        attention_items: vec![],
         last_error: record.last_error.clone(),
         finalize: FinalizeSnapshot {
             status: "not_required".to_string(),
@@ -563,6 +623,17 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use tempfile::NamedTempFile;
 
+    fn trusted_local() -> Extension<ApiExposure> {
+        Extension(ApiExposure::TrustedLocal)
+    }
+
+    async fn response_json(response: axum::response::Response) -> serde_json::Value {
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
     fn test_issue() -> Issue {
         Issue {
             id: "NODE_123".to_string(),
@@ -723,11 +794,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_state_returns_json() {
         let app_state = build_populated_state();
-        let (status, Json(snapshot)) = get_state(State(app_state)).await;
+        let response = get_state(State(app_state), trusted_local())
+            .await
+            .into_response();
 
-        assert_eq!(status, StatusCode::OK);
-
-        let json = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
         assert_eq!(json["counts"]["running"], 1);
         assert_eq!(json["counts"]["retrying"], 1);
         assert_eq!(json["agent_totals"]["input_tokens"], 5000);
@@ -738,11 +810,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_state_empty() {
         let app_state = build_empty_state();
-        let (status, Json(snapshot)) = get_state(State(app_state)).await;
+        let response = get_state(State(app_state), trusted_local())
+            .await
+            .into_response();
 
-        assert_eq!(status, StatusCode::OK);
-
-        let json = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
         assert_eq!(json["counts"]["running"], 0);
         assert_eq!(json["counts"]["retrying"], 0);
     }
@@ -750,7 +823,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_issue_detail_found() {
         let app_state = build_populated_state();
-        let response = get_issue_detail(State(app_state), Path("my-repo#42".to_string())).await;
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("my-repo#42".to_string()),
+        )
+        .await;
 
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::OK);
@@ -759,8 +837,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_issue_detail_not_found() {
         let app_state = build_populated_state();
-        let response =
-            get_issue_detail(State(app_state), Path("nonexistent#999".to_string())).await;
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("nonexistent#999".to_string()),
+        )
+        .await;
 
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -769,9 +851,13 @@ mod tests {
     #[tokio::test]
     async fn test_get_issue_detail_not_found_message_mentions_waiting_issues() {
         let app_state = build_empty_state();
-        let response = get_issue_detail(State(app_state), Path("nonexistent#999".to_string()))
-            .await
-            .into_response();
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("nonexistent#999".to_string()),
+        )
+        .await
+        .into_response();
 
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
@@ -828,7 +914,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_issue_detail_retrying_issue() {
         let app_state = build_populated_state();
-        let response = get_issue_detail(State(app_state), Path("my-repo#99".to_string())).await;
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("my-repo#99".to_string()),
+        )
+        .await;
 
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::OK);
@@ -867,9 +958,13 @@ mod tests {
             .await
             .unwrap();
 
-        let response = get_issue_detail(State(app_state), Path("todo-0".to_string()))
-            .await
-            .into_response();
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("todo-0".to_string()),
+        )
+        .await
+        .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
     }
@@ -907,9 +1002,13 @@ mod tests {
             .await
             .unwrap();
 
-        let response = get_issue_detail(State(app_state), Path("history#419".to_string()))
-            .await
-            .into_response();
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("history#419".to_string()),
+        )
+        .await
+        .into_response();
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
@@ -953,9 +1052,13 @@ mod tests {
             .await
             .unwrap();
 
-        let response = get_issue_detail(State(app_state), Path("history#empty".to_string()))
-            .await
-            .into_response();
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("history#empty".to_string()),
+        )
+        .await
+        .into_response();
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
@@ -970,9 +1073,13 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         app_state.history_path = temp_dir.path().to_path_buf();
 
-        let response = get_issue_detail(State(app_state), Path("todo-0".to_string()))
-            .await
-            .into_response();
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("todo-0".to_string()),
+        )
+        .await
+        .into_response();
 
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
@@ -1010,7 +1117,7 @@ mod tests {
             .await
             .unwrap();
 
-        let response = get_issue_detail(State(app_state), Path(".".to_string()))
+        let response = get_issue_detail(State(app_state), trusted_local(), Path(".".to_string()))
             .await
             .into_response();
 
@@ -1102,9 +1209,13 @@ on_failure: Failed
             .await
             .unwrap();
 
-        let response = get_issue_detail(State(app_state), Path("synth-1".to_string()))
-            .await
-            .into_response();
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("synth-1".to_string()),
+        )
+        .await
+        .into_response();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
@@ -1171,7 +1282,12 @@ on_failure: Failed
         app_state.history_path = history_path;
         app_state.workspace_root = tmp.path().display().to_string();
 
-        let response = get_issue_detail(State(app_state), Path("repo#77".to_string())).await;
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("repo#77".to_string()),
+        )
+        .await;
         let body = axum::body::to_bytes(response.into_response().into_body(), usize::MAX)
             .await
             .unwrap();

--- a/crates/ensemble-core/src/api/interactions.rs
+++ b/crates/ensemble-core/src/api/interactions.rs
@@ -1,5 +1,7 @@
 use crate::api::handlers::ApiError;
 use crate::api::router::AppState;
+use crate::attention::interaction::interaction_attention_close;
+use crate::attention::AttentionReporter;
 use crate::interaction::error::InteractionError;
 use crate::interaction::model::{
     AcceptedInteractionCommand, InteractionKind, InteractionRequest, InteractionResponse,
@@ -14,6 +16,7 @@ use axum::Json;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
+use tracing::warn;
 
 static LOCAL_API_INPUT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -255,15 +258,26 @@ pub async fn respond_to_interaction(
         received_at,
     };
 
-    match interaction_store(&state)
-        .accept_response(&id, command, response)
-        .await
-    {
-        Ok(InteractionAcceptance::Accepted(interaction)) => (
-            StatusCode::OK,
-            Json(serde_json::to_value(interaction).unwrap()),
-        )
-            .into_response(),
+    let store = interaction_store(&state);
+    let before = match store.get(&id).await {
+        Ok(Some(interaction)) => interaction,
+        Ok(None) => {
+            return interaction_error_response(InteractionError::NotFound { id }).into_response();
+        }
+        Err(error) => return interaction_error_response(error).into_response(),
+    };
+
+    match store.accept_response(&id, command, response).await {
+        Ok(InteractionAcceptance::Accepted(interaction)) => {
+            if let Err(error) = retire_attention(&state, &before, &interaction).await {
+                warn!(interaction_id = %interaction.id, error, "interaction attention retirement will reconcile on a later tick");
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::to_value(interaction).unwrap()),
+            )
+                .into_response()
+        }
         Ok(InteractionAcceptance::Ignored(interaction)) => {
             let error = if interaction.status == InteractionStatus::Cancelled {
                 InteractionError::AlreadyCancelled { id }
@@ -308,12 +322,138 @@ pub async fn cancel_interaction(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match interaction_store(&state).cancel(&id).await {
-        Ok(interaction) => (
-            StatusCode::OK,
-            Json(serde_json::to_value(interaction).unwrap()),
-        )
-            .into_response(),
+    let store = interaction_store(&state);
+    let before = match store.get(&id).await {
+        Ok(Some(interaction)) => interaction,
+        Ok(None) => {
+            return interaction_error_response(InteractionError::NotFound { id }).into_response();
+        }
+        Err(error) => return interaction_error_response(error).into_response(),
+    };
+    match store.cancel(&id).await {
+        Ok(interaction) => {
+            if let Err(error) = retire_attention(&state, &before, &interaction).await {
+                warn!(interaction_id = %interaction.id, error, "interaction attention retirement will reconcile on a later tick");
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::to_value(interaction).unwrap()),
+            )
+                .into_response()
+        }
         Err(error) => interaction_error_response(error).into_response(),
+    }
+}
+
+async fn retire_attention(
+    state: &AppState,
+    before: &InteractionRequest,
+    after: &InteractionRequest,
+) -> Result<(), String> {
+    let Some(history_store) = state.history_store.clone() else {
+        return Err("attention history store is unavailable".into());
+    };
+    let close = interaction_attention_close(before, after)
+        .map_err(|error| format!("failed to derive attention close evidence: {error}"))?;
+    AttentionReporter::new(history_store)
+        .resolve(close)
+        .await
+        .map_err(|error| format!("failed to retire interaction attention: {error}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::test_helpers::{app_state_with_document_state, parsed_document_state};
+    use crate::interaction::InteractionResumeStrategy;
+
+    fn request(id: &str) -> InteractionRequest {
+        InteractionRequest {
+            id: id.into(),
+            schema_version: 1,
+            issue_id: "issue-514".into(),
+            issue_identifier: "repo#514".into(),
+            pipeline_cycle: 1,
+            completed_steps: vec![],
+            step_name: "build".into(),
+            agent_name: "solver".into(),
+            step_depends: vec![],
+            step_tracker_state: None,
+            kind: InteractionKind::Question,
+            status: InteractionStatus::Open,
+            blocking: true,
+            awaiting_resume: true,
+            resume_strategy: InteractionResumeStrategy::RerunStep,
+            title: "Need input".into(),
+            body: "Choose an option".into(),
+            options: vec![],
+            artifacts: vec![],
+            thread_root_comment_id: None,
+            thread_root_comment_url: None,
+            last_processed_comment_id: None,
+            accepted_command: None,
+            ignored_commands: vec![],
+            response: None,
+            waiting_started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: Utc::now(),
+            resolved_at: None,
+        }
+    }
+
+    fn state_without_attention_history(config_path: std::path::PathBuf) -> AppState {
+        let mut state = app_state_with_document_state(parsed_document_state());
+        state.config_runtime.config_path = config_path;
+        state.history_store = None;
+        state
+    }
+
+    #[tokio::test]
+    async fn response_keeps_committed_resolution_when_attention_retirement_is_unavailable() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        let state = state_without_attention_history(config_path);
+        let store = interaction_store(&state);
+        store.create(request("response-1")).await.unwrap();
+
+        let response = respond_to_interaction(
+            State(state),
+            Path("response-1".into()),
+            Ok(Json(InteractionResponseBody::Question {
+                response_schema_version: 1,
+                text: "Proceed".into(),
+                selected_option: None,
+            })),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            store.get("response-1").await.unwrap().unwrap().status,
+            InteractionStatus::Resolved
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_keeps_committed_cancellation_when_attention_retirement_is_unavailable() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        let state = state_without_attention_history(config_path);
+        let store = interaction_store(&state);
+        store.create(request("cancel-1")).await.unwrap();
+
+        let response = cancel_interaction(State(state), Path("cancel-1".into()))
+            .await
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            store.get("cancel-1").await.unwrap().unwrap().status,
+            InteractionStatus::Cancelled
+        );
     }
 }

--- a/crates/ensemble-core/src/api/mod.rs
+++ b/crates/ensemble-core/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod attention_handler;
 pub mod bootstrap;
 pub mod config_edit_handler;
 pub mod config_handler;

--- a/crates/ensemble-core/src/api/openapi.rs
+++ b/crates/ensemble-core/src/api/openapi.rs
@@ -13,6 +13,7 @@ use utoipa::OpenApi;
         crate::api::handlers::get_step_detail,
         crate::api::handlers::post_refresh,
         crate::api::history_handler::get_history,
+        crate::api::attention_handler::get_attention_history,
         crate::api::timeline_handler::get_timeline,
         crate::api::config_handler::get_config,
         crate::api::config_edit_handler::validate_yaml,
@@ -138,6 +139,13 @@ use utoipa::OpenApi;
         crate::history::model::HistoryRecord,
         crate::history::model::TokenTotals,
         crate::history::reader::HistoryResponse,
+        crate::attention::AttentionIdentity,
+        crate::attention::AttentionPresentation,
+        crate::attention::AttentionEvidence,
+        crate::attention::AttentionLifecycleState,
+        crate::attention::AttentionItem,
+        crate::attention::AttentionEvent,
+        crate::attention::AttentionHistoryResponse,
         // Timeline types
         crate::timeline::model::TimelineEventRecord,
         crate::timeline::TimelineResponse,
@@ -156,6 +164,7 @@ use utoipa::OpenApi;
         (name = "controls", description = "Agent control"),
         (name = "interactions", description = "Human interaction requests"),
         (name = "history", description = "Completion history"),
+        (name = "attention", description = "Trusted-local operator-attention history"),
         (name = "config", description = "Configuration"),
         (name = "conversation", description = "Agent conversation logs"),
         (name = "filesystem", description = "File browser"),
@@ -174,6 +183,16 @@ mod tests {
         assert!(spec.contains("Ensemble API"));
         assert!(spec.contains("HumanInteractionConfig"));
         assert!(spec.contains("HumanResumeMode"));
+    }
+
+    #[test]
+    fn test_openapi_documents_read_only_attention_history() {
+        let spec: serde_json::Value =
+            serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+
+        assert!(spec["paths"]["/api/v1/attention"]["get"].is_object());
+        assert!(spec["paths"]["/api/v1/attention"].get("post").is_none());
+        assert!(spec["components"]["schemas"]["AttentionHistoryResponse"].is_object());
     }
 
     #[test]

--- a/crates/ensemble-core/src/api/router.rs
+++ b/crates/ensemble-core/src/api/router.rs
@@ -2,8 +2,8 @@ use crate::agent::cancellation::CancellationRegistry;
 use crate::api::interactions;
 use crate::api::security::ApiExposure;
 use crate::api::{
-    config_edit_handler, config_handler, controls, conversation, fs_handler, handlers,
-    history_handler, timeline_handler, ws,
+    attention_handler, config_edit_handler, config_handler, controls, conversation, fs_handler,
+    handlers, history_handler, timeline_handler, ws,
 };
 use crate::config::draft::ConfigDocumentState;
 use crate::history_store::store::HistoryStore;
@@ -73,6 +73,7 @@ pub struct AppState {
 /// - `GET /api/v1/state` — runtime snapshot
 /// - `POST /api/v1/refresh` — trigger immediate poll+reconcile
 /// - `GET /api/v1/history` — query history records
+/// - `GET /api/v1/attention` — query operator-attention history on trusted-local hosts
 /// - `GET /api/v1/{identifier}` — issue-specific detail
 /// - `GET /api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation` — paginated step transcript records
 /// - `GET /api/v1/{identifier}/runs/{run_id}/steps/{step_name}/conversation/{sequence}` — single transcript record
@@ -99,6 +100,7 @@ pub fn create_api_router(state: AppState, exposure: ApiExposure) -> Router {
                 .patch(handlers::method_not_allowed),
         )
         .route("/history", get(history_handler::get_history))
+        .route("/attention", get(attention_handler::get_attention_history))
         .route("/interactions", get(interactions::list_open_interactions))
         .route(
             "/interactions/{id}",

--- a/crates/ensemble-core/src/attention/error.rs
+++ b/crates/ensemble-core/src/attention/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AttentionError {
+    #[error("invalid attention {field}: {reason}")]
+    InvalidField { field: &'static str, reason: String },
+    #[error("attention storage error: {reason}")]
+    Storage { reason: String },
+}
+
+impl From<std::io::Error> for AttentionError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Storage {
+            reason: value.to_string(),
+        }
+    }
+}

--- a/crates/ensemble-core/src/attention/interaction.rs
+++ b/crates/ensemble-core/src/attention/interaction.rs
@@ -1,0 +1,248 @@
+use sha2::{Digest, Sha256};
+
+use crate::interaction::InteractionRequest;
+
+use super::{
+    AttentionClose, AttentionError, AttentionEvidence, AttentionIdentity, AttentionItem,
+    AttentionLifecycleState, AttentionPresentation, AttentionUpsert,
+};
+
+pub const AWAITING_INPUT_KIND: &str = "runtime.interaction.awaiting_input";
+const MAX_REFERENCE_COUNT: usize = 16;
+const MAX_REFERENCE_BYTES: usize = 1024;
+
+pub fn awaiting_interaction_observation(
+    interaction: &InteractionRequest,
+) -> Result<AttentionUpsert, AttentionError> {
+    Ok(AttentionUpsert::new(
+        interaction_attention_identity(interaction)?,
+        AttentionPresentation::new(
+            bounded_interaction_text(&interaction.title, 512, "Operator input required"),
+            bounded_interaction_text(&interaction.body, 1024, "Review the interaction request."),
+            interaction_attention_references(interaction),
+        )?,
+        AttentionEvidence::new(interaction_attention_fingerprint(interaction))?,
+    ))
+}
+
+pub fn interaction_attention_close(
+    before: &InteractionRequest,
+    after: &InteractionRequest,
+) -> Result<AttentionClose, AttentionError> {
+    AttentionClose::new(
+        interaction_attention_identity(before)?,
+        interaction_attention_fingerprint(before),
+        AttentionEvidence::new(interaction_attention_fingerprint(after))?,
+    )
+}
+
+/// Rebuilds a conditional close from the latest durable open observation.
+///
+/// This lets startup reconciliation retire an interaction after its lifecycle transition was
+/// persisted but the original attention write was interrupted.
+pub fn interaction_attention_close_from_open(
+    open_item: &AttentionItem,
+    interaction: &InteractionRequest,
+) -> Result<Option<AttentionClose>, AttentionError> {
+    let identity = interaction_attention_identity(interaction)?;
+    if open_item.state != AttentionLifecycleState::Open || open_item.identity != identity {
+        return Ok(None);
+    }
+    AttentionClose::new(
+        identity,
+        open_item.evidence.fingerprint.clone(),
+        AttentionEvidence::new(interaction_attention_fingerprint(interaction))?,
+    )
+    .map(Some)
+}
+
+pub fn interaction_attention_identity(
+    interaction: &InteractionRequest,
+) -> Result<AttentionIdentity, AttentionError> {
+    AttentionIdentity::new(
+        &interaction.id,
+        &interaction.issue_identifier,
+        AWAITING_INPUT_KIND,
+    )
+}
+
+pub fn interaction_attention_fingerprint(interaction: &InteractionRequest) -> String {
+    let relevant_state = serde_json::json!({
+        "id": interaction.id,
+        "issue_id": interaction.issue_id,
+        "issue_identifier": interaction.issue_identifier,
+        "status": interaction.status,
+        "awaiting_resume": interaction.awaiting_resume,
+        "title": interaction.title,
+        "body": interaction.body,
+        "artifacts": interaction.artifacts,
+        "requested_at": interaction.requested_at,
+        "resolved_at": interaction.resolved_at,
+    });
+    let encoded = serde_json::to_vec(&relevant_state)
+        .expect("serialized interaction attention state contains only serializable fields");
+    format!("sha256:{:x}", Sha256::digest(encoded))
+}
+
+fn interaction_attention_references(interaction: &InteractionRequest) -> Vec<String> {
+    let mut references = vec![bounded_interaction_text(
+        &format!("interaction:{}", interaction.id),
+        MAX_REFERENCE_BYTES,
+        "interaction:unknown",
+    )];
+    references.extend(
+        interaction
+            .artifacts
+            .iter()
+            .filter(|reference| valid_reference(reference))
+            .cloned(),
+    );
+    references.sort();
+    references.dedup();
+    references.truncate(MAX_REFERENCE_COUNT);
+    references
+}
+
+fn valid_reference(value: &str) -> bool {
+    !value.is_empty() && value.len() <= MAX_REFERENCE_BYTES && !value.chars().any(char::is_control)
+}
+
+fn bounded_interaction_text(value: &str, max_bytes: usize, fallback: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim();
+    let value = if normalized.is_empty() {
+        fallback
+    } else {
+        normalized
+    };
+    let mut end = value.len().min(max_bytes);
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use crate::interaction::{InteractionKind, InteractionResumeStrategy, InteractionStatus};
+
+    use super::*;
+
+    fn interaction(status: InteractionStatus) -> InteractionRequest {
+        InteractionRequest {
+            id: "request-1".into(),
+            schema_version: 1,
+            issue_id: "issue-id".into(),
+            issue_identifier: "issue-514".into(),
+            pipeline_cycle: 1,
+            completed_steps: vec![],
+            step_name: "build".into(),
+            agent_name: "solver".into(),
+            step_depends: vec![],
+            step_tracker_state: None,
+            kind: InteractionKind::Question,
+            status,
+            blocking: true,
+            awaiting_resume: true,
+            resume_strategy: InteractionResumeStrategy::RerunStep,
+            title: "Awaiting input".into(),
+            body: "Resolve the question".into(),
+            options: vec![],
+            artifacts: vec!["artifact:1".into()],
+            thread_root_comment_id: None,
+            thread_root_comment_url: None,
+            last_processed_comment_id: None,
+            accepted_command: None,
+            ignored_commands: vec![],
+            response: None,
+            waiting_started_at: None,
+            agent_input_tokens: 0,
+            agent_output_tokens: 0,
+            agent_total_tokens: 0,
+            requested_at: Utc::now(),
+            resolved_at: None,
+        }
+    }
+
+    #[test]
+    fn observation_uses_interaction_identity_and_opaque_kind() {
+        let observation =
+            awaiting_interaction_observation(&interaction(InteractionStatus::Open)).unwrap();
+        assert_eq!(observation.identity.producer_key, "request-1");
+        assert_eq!(observation.identity.subject_ref, "issue-514");
+        assert_eq!(observation.identity.kind, AWAITING_INPUT_KIND);
+    }
+
+    #[test]
+    fn close_requires_evidence_that_differs_after_resolution() {
+        let before = interaction(InteractionStatus::Open);
+        let mut after = before.clone();
+        after.status = InteractionStatus::Resolved;
+        after.resolved_at = Some(Utc::now());
+        let close = interaction_attention_close(&before, &after).unwrap();
+        assert_ne!(
+            close.expected_fingerprint,
+            close.closing_evidence.fingerprint
+        );
+    }
+
+    #[test]
+    fn close_from_open_observation_uses_its_latest_fingerprint() {
+        let before = interaction(InteractionStatus::Open);
+        let observation = awaiting_interaction_observation(&before).unwrap();
+        let open_item = AttentionItem {
+            identity: observation.identity,
+            presentation: observation.presentation,
+            evidence: AttentionEvidence::new("latest-open-fingerprint").unwrap(),
+            state: AttentionLifecycleState::Open,
+            opened_at: before.requested_at,
+            updated_at: before.requested_at,
+            closed_at: None,
+            superseding_identity: None,
+        };
+        let mut resolved = before;
+        resolved.status = InteractionStatus::Resolved;
+        resolved.resolved_at = Some(Utc::now());
+
+        let close = interaction_attention_close_from_open(&open_item, &resolved)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(close.expected_fingerprint, "latest-open-fingerprint");
+        assert_ne!(
+            close.expected_fingerprint,
+            close.closing_evidence.fingerprint
+        );
+    }
+
+    #[test]
+    fn observation_bounds_and_filters_interaction_artifact_references() {
+        let mut request = interaction(InteractionStatus::Open);
+        request.artifacts = (0..20).map(|index| format!("artifact:{index}")).collect();
+        request.artifacts.push("bad\u{0000}artifact".into());
+        request.artifacts.push("x".repeat(1025));
+
+        let observation = awaiting_interaction_observation(&request).unwrap();
+
+        assert_eq!(
+            observation.presentation.references.len(),
+            MAX_REFERENCE_COUNT
+        );
+        assert!(!observation
+            .presentation
+            .references
+            .iter()
+            .any(|reference| reference.contains('\u{0000}')));
+    }
+}

--- a/crates/ensemble-core/src/attention/mod.rs
+++ b/crates/ensemble-core/src/attention/mod.rs
@@ -1,0 +1,12 @@
+pub mod error;
+pub mod interaction;
+pub mod model;
+pub mod reporter;
+
+pub use error::AttentionError;
+pub use model::{
+    AttentionClose, AttentionEvent, AttentionEvidence, AttentionHistoryResponse, AttentionIdentity,
+    AttentionItem, AttentionLifecycleState, AttentionPresentation, AttentionSupersede,
+    AttentionUpsert,
+};
+pub use reporter::AttentionReporter;

--- a/crates/ensemble-core/src/attention/model.rs
+++ b/crates/ensemble-core/src/attention/model.rs
@@ -1,0 +1,362 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use super::AttentionError;
+
+const PRODUCER_KEY_MAX_BYTES: usize = 128;
+const SUBJECT_REF_MAX_BYTES: usize = 512;
+const KIND_MAX_BYTES: usize = 128;
+const SUMMARY_MAX_BYTES: usize = 512;
+const REMEDY_MAX_BYTES: usize = 1024;
+const FINGERPRINT_MAX_BYTES: usize = 256;
+const REFERENCE_MAX_COUNT: usize = 16;
+const REFERENCE_MAX_BYTES: usize = 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+pub struct AttentionIdentity {
+    pub producer_key: String,
+    pub subject_ref: String,
+    pub kind: String,
+}
+
+impl AttentionIdentity {
+    pub fn new(
+        producer_key: impl Into<String>,
+        subject_ref: impl Into<String>,
+        kind: impl Into<String>,
+    ) -> Result<Self, AttentionError> {
+        let identity = Self {
+            producer_key: producer_key.into(),
+            subject_ref: subject_ref.into(),
+            kind: kind.into(),
+        };
+        identity.validate()?;
+        Ok(identity)
+    }
+
+    pub fn validate(&self) -> Result<(), AttentionError> {
+        validate_text("producer_key", &self.producer_key, PRODUCER_KEY_MAX_BYTES)?;
+        validate_text("subject_ref", &self.subject_ref, SUBJECT_REF_MAX_BYTES)?;
+        validate_text("kind", &self.kind, KIND_MAX_BYTES)?;
+        if !is_namespaced_kind(&self.kind) {
+            return Err(AttentionError::InvalidField {
+                field: "kind",
+                reason: "must contain non-empty namespace segments separated by '.'".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct AttentionPresentation {
+    pub summary: String,
+    pub remedy: String,
+    pub references: Vec<String>,
+}
+
+impl AttentionPresentation {
+    pub fn new(
+        summary: impl Into<String>,
+        remedy: impl Into<String>,
+        references: Vec<String>,
+    ) -> Result<Self, AttentionError> {
+        let presentation = Self {
+            summary: summary.into(),
+            remedy: remedy.into(),
+            references,
+        };
+        presentation.validate()?;
+        Ok(presentation)
+    }
+
+    pub fn validate(&self) -> Result<(), AttentionError> {
+        validate_text("summary", &self.summary, SUMMARY_MAX_BYTES)?;
+        validate_text("remedy", &self.remedy, REMEDY_MAX_BYTES)?;
+        if self.references.len() > REFERENCE_MAX_COUNT {
+            return Err(AttentionError::InvalidField {
+                field: "references",
+                reason: format!("must contain at most {REFERENCE_MAX_COUNT} entries"),
+            });
+        }
+        for reference in &self.references {
+            validate_text("reference", reference, REFERENCE_MAX_BYTES)?;
+        }
+        let mut unique = self.references.clone();
+        unique.sort();
+        unique.dedup();
+        if unique.len() != self.references.len() {
+            return Err(AttentionError::InvalidField {
+                field: "references",
+                reason: "must not contain duplicate entries".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct AttentionEvidence {
+    pub fingerprint: String,
+}
+
+impl AttentionEvidence {
+    pub fn new(fingerprint: impl Into<String>) -> Result<Self, AttentionError> {
+        let evidence = Self {
+            fingerprint: fingerprint.into(),
+        };
+        validate_text("fingerprint", &evidence.fingerprint, FINGERPRINT_MAX_BYTES)?;
+        Ok(evidence)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct AttentionUpsert {
+    pub identity: AttentionIdentity,
+    pub presentation: AttentionPresentation,
+    pub evidence: AttentionEvidence,
+}
+
+impl AttentionUpsert {
+    pub fn new(
+        identity: AttentionIdentity,
+        presentation: AttentionPresentation,
+        evidence: AttentionEvidence,
+    ) -> Self {
+        Self {
+            identity,
+            presentation,
+            evidence,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), AttentionError> {
+        self.identity.validate()?;
+        self.presentation.validate()?;
+        AttentionEvidence::new(&self.evidence.fingerprint)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AttentionLifecycleState {
+    Open,
+    Resolved,
+    Superseded,
+}
+
+impl AttentionLifecycleState {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Resolved => "resolved",
+            Self::Superseded => "superseded",
+        }
+    }
+
+    pub(crate) fn parse(value: &str) -> Result<Self, AttentionError> {
+        match value {
+            "open" => Ok(Self::Open),
+            "resolved" => Ok(Self::Resolved),
+            "superseded" => Ok(Self::Superseded),
+            _ => Err(AttentionError::Storage {
+                reason: format!("unknown attention lifecycle state: {value}"),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct AttentionItem {
+    pub identity: AttentionIdentity,
+    pub presentation: AttentionPresentation,
+    pub evidence: AttentionEvidence,
+    pub state: AttentionLifecycleState,
+    pub opened_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub closed_at: Option<DateTime<Utc>>,
+    pub superseding_identity: Option<AttentionIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct AttentionEvent {
+    pub sequence: u64,
+    pub identity: AttentionIdentity,
+    pub state: AttentionLifecycleState,
+    pub evidence: AttentionEvidence,
+    pub timestamp: DateTime<Utc>,
+    pub superseding_identity: Option<AttentionIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct AttentionHistoryResponse {
+    pub events: Vec<AttentionEvent>,
+    pub total: usize,
+    pub next_cursor: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct AttentionClose {
+    pub identity: AttentionIdentity,
+    pub expected_fingerprint: String,
+    pub closing_evidence: AttentionEvidence,
+}
+
+impl AttentionClose {
+    pub fn new(
+        identity: AttentionIdentity,
+        expected_fingerprint: impl Into<String>,
+        closing_evidence: AttentionEvidence,
+    ) -> Result<Self, AttentionError> {
+        let close = Self {
+            identity,
+            expected_fingerprint: expected_fingerprint.into(),
+            closing_evidence,
+        };
+        close.validate()?;
+        Ok(close)
+    }
+
+    pub fn validate(&self) -> Result<(), AttentionError> {
+        self.identity.validate()?;
+        validate_text(
+            "expected_fingerprint",
+            &self.expected_fingerprint,
+            FINGERPRINT_MAX_BYTES,
+        )?;
+        AttentionEvidence::new(&self.closing_evidence.fingerprint)?;
+        if self.expected_fingerprint == self.closing_evidence.fingerprint {
+            return Err(AttentionError::InvalidField {
+                field: "closing_evidence",
+                reason: "must differ from the open observation fingerprint".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct AttentionSupersede {
+    pub close: AttentionClose,
+    pub superseding_identity: AttentionIdentity,
+}
+
+impl AttentionSupersede {
+    pub fn new(
+        close: AttentionClose,
+        superseding_identity: AttentionIdentity,
+    ) -> Result<Self, AttentionError> {
+        let request = Self {
+            close,
+            superseding_identity,
+        };
+        request.close.validate()?;
+        request.superseding_identity.validate()?;
+        Ok(request)
+    }
+}
+
+fn validate_text(field: &'static str, value: &str, max_bytes: usize) -> Result<(), AttentionError> {
+    if value.is_empty() {
+        return Err(AttentionError::InvalidField {
+            field,
+            reason: "must not be empty".into(),
+        });
+    }
+    if value.len() > max_bytes {
+        return Err(AttentionError::InvalidField {
+            field,
+            reason: format!("must not exceed {max_bytes} UTF-8 bytes"),
+        });
+    }
+    if value.chars().any(char::is_control) {
+        return Err(AttentionError::InvalidField {
+            field,
+            reason: "must not contain control characters".into(),
+        });
+    }
+    Ok(())
+}
+
+fn is_namespaced_kind(kind: &str) -> bool {
+    let mut segments = kind.split('.');
+    let first = segments.next();
+    first.is_some_and(is_kind_segment)
+        && segments.next().is_some_and(is_kind_segment)
+        && segments.all(is_kind_segment)
+}
+
+fn is_kind_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_' || byte == b'-'
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attention_observation_preserves_opaque_namespaced_identity() {
+        let observation = AttentionUpsert::new(
+            AttentionIdentity::new(
+                "interaction:request-1",
+                "issue-514",
+                "runtime.interaction.awaiting_input",
+            )
+            .expect("namespaced identity is valid"),
+            AttentionPresentation::new(
+                "Awaiting operator input",
+                "Resolve the interaction",
+                vec!["request-1".into()],
+            )
+            .expect("bounded presentation is valid"),
+            AttentionEvidence::new("interaction-open:v1").expect("bounded evidence is valid"),
+        );
+
+        assert_eq!(
+            observation.identity.kind,
+            "runtime.interaction.awaiting_input"
+        );
+    }
+
+    #[test]
+    fn attention_observation_rejects_an_unnamespaced_kind() {
+        let result = AttentionIdentity::new("producer", "subject", "awaiting_input");
+
+        assert!(matches!(
+            result,
+            Err(AttentionError::InvalidField { field: "kind", .. })
+        ));
+    }
+
+    #[test]
+    fn attention_presentation_rejects_duplicate_references() {
+        let result =
+            AttentionPresentation::new("summary", "remedy", vec!["one".into(), "one".into()]);
+
+        assert!(matches!(
+            result,
+            Err(AttentionError::InvalidField {
+                field: "references",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn attention_identity_rejects_control_characters() {
+        let result = AttentionIdentity::new("producer\nkey", "subject", "runtime.waiting");
+
+        assert!(matches!(
+            result,
+            Err(AttentionError::InvalidField {
+                field: "producer_key",
+                ..
+            })
+        ));
+    }
+}

--- a/crates/ensemble-core/src/attention/reporter.rs
+++ b/crates/ensemble-core/src/attention/reporter.rs
@@ -1,0 +1,89 @@
+use crate::history_store::store::HistoryStore;
+
+use super::{
+    AttentionClose, AttentionError, AttentionHistoryResponse, AttentionIdentity, AttentionItem,
+    AttentionLifecycleState, AttentionSupersede, AttentionUpsert,
+};
+
+/// Bounded, non-authoritative access to durable operator-attention records.
+#[derive(Debug, Clone)]
+pub struct AttentionReporter {
+    store: HistoryStore,
+}
+
+impl AttentionReporter {
+    pub fn new(store: HistoryStore) -> Self {
+        Self { store }
+    }
+
+    pub async fn upsert_open(
+        &self,
+        observation: AttentionUpsert,
+    ) -> Result<AttentionItem, AttentionError> {
+        observation.validate()?;
+        self.store
+            .upsert_attention_open(observation)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn resolve(
+        &self,
+        request: AttentionClose,
+    ) -> Result<Option<AttentionItem>, AttentionError> {
+        request.validate()?;
+        self.store
+            .resolve_attention(request)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn supersede(
+        &self,
+        request: AttentionSupersede,
+    ) -> Result<Option<AttentionItem>, AttentionError> {
+        request.close.validate()?;
+        request.superseding_identity.validate()?;
+        self.store
+            .supersede_attention(request)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn open_items(&self) -> Result<Vec<AttentionItem>, AttentionError> {
+        self.store.read_open_attention().await.map_err(Into::into)
+    }
+
+    pub async fn items_for_subject(
+        &self,
+        subject_ref: &str,
+    ) -> Result<Vec<AttentionItem>, AttentionError> {
+        self.store
+            .read_open_attention_for_subject(subject_ref)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn open_item(
+        &self,
+        identity: &AttentionIdentity,
+    ) -> Result<Option<AttentionItem>, AttentionError> {
+        self.store
+            .read_open_attention_item(identity)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn history(
+        &self,
+        subject_ref: Option<String>,
+        state: Option<AttentionLifecycleState>,
+        cursor: Option<usize>,
+        limit: Option<usize>,
+    ) -> Result<AttentionHistoryResponse, AttentionError> {
+        self.store
+            .read_attention_history(subject_ref, state, cursor, limit)
+            .await
+            .map_err(Into::into)
+    }
+}

--- a/crates/ensemble-core/src/history_store/attention.rs
+++ b/crates/ensemble-core/src/history_store/attention.rs
@@ -1,0 +1,505 @@
+use std::io;
+
+use chrono::{DateTime, Utc};
+use rusqlite::types::Value;
+use rusqlite::{
+    params, params_from_iter, Connection, OptionalExtension, Transaction, TransactionBehavior,
+};
+
+use crate::attention::{
+    AttentionClose, AttentionHistoryResponse, AttentionIdentity, AttentionItem,
+    AttentionLifecycleState, AttentionSupersede, AttentionUpsert,
+};
+
+use super::store::HistoryStore;
+
+impl HistoryStore {
+    pub async fn upsert_attention_open(
+        &self,
+        observation: AttentionUpsert,
+    ) -> Result<AttentionItem, io::Error> {
+        let path = self.db_path.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = Connection::open(path).map_err(io::Error::other)?;
+            super::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(io::Error::other)?;
+            let current = select_item(&tx, &observation.identity)?;
+            let unchanged = current.as_ref().is_some_and(|item| {
+                item.state == AttentionLifecycleState::Open
+                    && item.presentation == observation.presentation
+                    && item.evidence == observation.evidence
+            });
+            if !unchanged {
+                let now = Utc::now();
+                tx.execute(
+                    r#"
+                    INSERT INTO attention_items (
+                        producer_key, subject_ref, kind, summary, remedy, references_json,
+                        fingerprint, state, opened_at, updated_at, closed_at, superseding_identity_json
+                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'open', ?8, ?8, NULL, NULL)
+                    ON CONFLICT(producer_key, subject_ref, kind) DO UPDATE SET
+                        summary = excluded.summary,
+                        remedy = excluded.remedy,
+                        references_json = excluded.references_json,
+                        fingerprint = excluded.fingerprint,
+                        state = 'open',
+                        updated_at = excluded.updated_at,
+                        closed_at = NULL,
+                        superseding_identity_json = NULL
+                    "#,
+                    params![
+                        observation.identity.producer_key,
+                        observation.identity.subject_ref,
+                        observation.identity.kind,
+                        observation.presentation.summary,
+                        observation.presentation.remedy,
+                        serde_json::to_string(&observation.presentation.references)
+                            .map_err(io::Error::other)?,
+                        observation.evidence.fingerprint,
+                        now.to_rfc3339(),
+                    ],
+                )
+                .map_err(io::Error::other)?;
+                insert_event(
+                    &tx,
+                    &observation.identity,
+                    AttentionLifecycleState::Open,
+                    &observation.evidence.fingerprint,
+                    now,
+                    None,
+                )?;
+            }
+            let item = select_item(&tx, &observation.identity)?.ok_or_else(|| {
+                io::Error::other("attention upsert did not retain its item")
+            })?;
+            tx.commit().map_err(io::Error::other)?;
+            Ok(item)
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    pub async fn resolve_attention(
+        &self,
+        request: AttentionClose,
+    ) -> Result<Option<AttentionItem>, io::Error> {
+        self.close_attention(request, None).await
+    }
+
+    pub async fn supersede_attention(
+        &self,
+        request: AttentionSupersede,
+    ) -> Result<Option<AttentionItem>, io::Error> {
+        self.close_attention(request.close, Some(request.superseding_identity))
+            .await
+    }
+
+    async fn close_attention(
+        &self,
+        request: AttentionClose,
+        superseding_identity: Option<AttentionIdentity>,
+    ) -> Result<Option<AttentionItem>, io::Error> {
+        let path = self.db_path.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = Connection::open(path).map_err(io::Error::other)?;
+            super::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(io::Error::other)?;
+            let Some(current) = select_item(&tx, &request.identity)? else {
+                return Ok(None);
+            };
+            if current.state != AttentionLifecycleState::Open
+                || current.evidence.fingerprint != request.expected_fingerprint
+            {
+                return Ok(None);
+            }
+            let now = Utc::now();
+            let state = if superseding_identity.is_some() {
+                AttentionLifecycleState::Superseded
+            } else {
+                AttentionLifecycleState::Resolved
+            };
+            let superseding_identity_json = superseding_identity
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()
+                .map_err(io::Error::other)?;
+            tx.execute(
+                "UPDATE attention_items SET fingerprint = ?1, state = ?2, updated_at = ?3, closed_at = ?3, superseding_identity_json = ?4 WHERE producer_key = ?5 AND subject_ref = ?6 AND kind = ?7",
+                params![
+                    request.closing_evidence.fingerprint,
+                    state.as_str(),
+                    now.to_rfc3339(),
+                    superseding_identity_json,
+                    request.identity.producer_key,
+                    request.identity.subject_ref,
+                    request.identity.kind,
+                ],
+            )
+            .map_err(io::Error::other)?;
+            insert_event(
+                &tx,
+                &request.identity,
+                state,
+                &request.closing_evidence.fingerprint,
+                now,
+                superseding_identity.as_ref(),
+            )?;
+            let item = select_item(&tx, &request.identity)?;
+            tx.commit().map_err(io::Error::other)?;
+            Ok(item)
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    pub async fn read_open_attention(&self) -> Result<Vec<AttentionItem>, io::Error> {
+        self.list_open_attention(None).await
+    }
+
+    pub async fn read_open_attention_for_subject(
+        &self,
+        subject_ref: &str,
+    ) -> Result<Vec<AttentionItem>, io::Error> {
+        self.list_open_attention(Some(subject_ref.to_string()))
+            .await
+    }
+
+    pub async fn read_open_attention_item(
+        &self,
+        identity: &AttentionIdentity,
+    ) -> Result<Option<AttentionItem>, io::Error> {
+        let path = self.db_path.clone();
+        let identity = identity.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = Connection::open(path).map_err(io::Error::other)?;
+            super::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            conn.query_row(
+                "SELECT * FROM attention_items WHERE producer_key = ?1 AND subject_ref = ?2 AND kind = ?3 AND state = 'open'",
+                params![identity.producer_key, identity.subject_ref, identity.kind],
+                super::model::row_to_attention_item,
+            )
+            .optional()
+            .map_err(io::Error::other)
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    async fn list_open_attention(
+        &self,
+        subject_ref: Option<String>,
+    ) -> Result<Vec<AttentionItem>, io::Error> {
+        let path = self.db_path.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = Connection::open(path).map_err(io::Error::other)?;
+            super::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            let sql = if subject_ref.is_some() {
+                "SELECT * FROM attention_items WHERE state = 'open' AND subject_ref = ?1 ORDER BY updated_at DESC, producer_key, kind"
+            } else {
+                "SELECT * FROM attention_items WHERE state = 'open' ORDER BY updated_at DESC, producer_key, subject_ref, kind"
+            };
+            let mut statement = conn.prepare(sql).map_err(io::Error::other)?;
+            let rows = match subject_ref {
+                Some(subject_ref) => statement.query_map(params![subject_ref], super::model::row_to_attention_item),
+                None => statement.query_map([], super::model::row_to_attention_item),
+            }
+            .map_err(io::Error::other)?;
+            rows.map(|row| row.map_err(io::Error::other)).collect()
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+
+    pub async fn read_attention_history(
+        &self,
+        subject_ref: Option<String>,
+        state: Option<AttentionLifecycleState>,
+        cursor: Option<usize>,
+        limit: Option<usize>,
+    ) -> Result<AttentionHistoryResponse, io::Error> {
+        let path = self.db_path.clone();
+        let include_terminal = state.is_some();
+        let cursor = cursor.unwrap_or(0);
+        let limit = limit.unwrap_or(50).min(200);
+        tokio::task::spawn_blocking(move || {
+            let conn = Connection::open(path).map_err(io::Error::other)?;
+            super::schema::apply_pragmas(&conn).map_err(io::Error::other)?;
+            let mut clauses = Vec::new();
+            let mut values = Vec::new();
+            if let Some(subject_ref) = subject_ref {
+                clauses.push("attention_events.subject_ref = ?");
+                values.push(Value::from(subject_ref));
+            }
+            let from = if include_terminal {
+                if let Some(state) = state {
+                    clauses.push("attention_events.state = ?");
+                    values.push(Value::from(state.as_str().to_string()));
+                }
+                "attention_events"
+            } else {
+                clauses.push("attention_items.state = 'open'");
+                "attention_events INNER JOIN attention_items USING (producer_key, subject_ref, kind)"
+            };
+            let where_sql = if clauses.is_empty() { String::new() } else { format!(" WHERE {}", clauses.join(" AND ")) };
+            let total: usize = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM {from}{where_sql}"),
+                    params_from_iter(values.clone()),
+                    |row| row.get(0),
+                )
+                .map_err(io::Error::other)?;
+            let mut page_values = values;
+            page_values.push(Value::from(i64::try_from(limit).map_err(io::Error::other)?));
+            page_values.push(Value::from(i64::try_from(cursor).map_err(io::Error::other)?));
+            let mut statement = conn
+                .prepare(&format!(
+                    "SELECT attention_events.sequence, attention_events.producer_key, attention_events.subject_ref, attention_events.kind, attention_events.state, attention_events.fingerprint, attention_events.timestamp, attention_events.superseding_identity_json FROM {from}{where_sql} ORDER BY attention_events.sequence DESC LIMIT ? OFFSET ?"
+                ))
+                .map_err(io::Error::other)?;
+            let events = statement
+                .query_map(params_from_iter(page_values), super::model::row_to_attention_event)
+                .map_err(io::Error::other)?
+                .map(|row| row.map_err(io::Error::other))
+                .collect::<Result<Vec<_>, _>>()?;
+            let next_cursor = (cursor + events.len() < total).then_some(cursor + events.len());
+            Ok(AttentionHistoryResponse { events, total, next_cursor })
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+}
+
+fn select_item(
+    tx: &Transaction<'_>,
+    identity: &AttentionIdentity,
+) -> Result<Option<AttentionItem>, io::Error> {
+    tx.query_row(
+        "SELECT * FROM attention_items WHERE producer_key = ?1 AND subject_ref = ?2 AND kind = ?3",
+        params![identity.producer_key, identity.subject_ref, identity.kind],
+        super::model::row_to_attention_item,
+    )
+    .optional()
+    .map_err(io::Error::other)
+}
+
+fn insert_event(
+    tx: &Transaction<'_>,
+    identity: &AttentionIdentity,
+    state: AttentionLifecycleState,
+    fingerprint: &str,
+    timestamp: DateTime<Utc>,
+    superseding_identity: Option<&AttentionIdentity>,
+) -> Result<(), io::Error> {
+    tx.execute(
+        "INSERT INTO attention_events (producer_key, subject_ref, kind, state, fingerprint, timestamp, superseding_identity_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            identity.producer_key,
+            identity.subject_ref,
+            identity.kind,
+            state.as_str(),
+            fingerprint,
+            timestamp.to_rfc3339(),
+            superseding_identity.map(serde_json::to_string).transpose().map_err(io::Error::other)?,
+        ],
+    )
+    .map_err(io::Error::other)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::attention::{
+        AttentionClose, AttentionEvidence, AttentionIdentity, AttentionPresentation,
+        AttentionReporter, AttentionUpsert,
+    };
+
+    use super::HistoryStore;
+
+    fn observation(fingerprint: &str) -> AttentionUpsert {
+        AttentionUpsert::new(
+            AttentionIdentity::new("producer-a", "issue-514", "runtime.awaiting_input").unwrap(),
+            AttentionPresentation::new(
+                "Awaiting input",
+                "Resolve the request",
+                vec!["request-1".into()],
+            )
+            .unwrap(),
+            AttentionEvidence::new(fingerprint).unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn history_retains_one_event_for_an_idempotent_observation() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let reporter = AttentionReporter::new(
+            HistoryStore::new(dir.path().join(".ensemble/history.db"))
+                .await
+                .unwrap(),
+        );
+        let observation = observation("open-v1");
+
+        reporter.upsert_open(observation.clone()).await.unwrap();
+        reporter.upsert_open(observation).await.unwrap();
+
+        let history = reporter.history(None, None, None, None).await.unwrap();
+        assert_eq!(history.events.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_close_cannot_retire_newer_attention() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let reporter = AttentionReporter::new(
+            HistoryStore::new(dir.path().join(".ensemble/history.db"))
+                .await
+                .unwrap(),
+        );
+        reporter.upsert_open(observation("open-v1")).await.unwrap();
+        reporter.upsert_open(observation("open-v2")).await.unwrap();
+
+        let result = reporter
+            .resolve(
+                AttentionClose::new(
+                    AttentionIdentity::new("producer-a", "issue-514", "runtime.awaiting_input")
+                        .unwrap(),
+                    "open-v1",
+                    AttentionEvidence::new("closed-v1").unwrap(),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolved_attention_is_retained_in_filtered_history_but_absent_from_open_items() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let reporter = AttentionReporter::new(
+            HistoryStore::new(dir.path().join(".ensemble/history.db"))
+                .await
+                .unwrap(),
+        );
+        let observation = observation("open-v1");
+        reporter.upsert_open(observation.clone()).await.unwrap();
+        reporter
+            .resolve(
+                AttentionClose::new(
+                    observation.identity.clone(),
+                    "open-v1",
+                    AttentionEvidence::new("resolved-v1").unwrap(),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let open = reporter.open_items().await.unwrap();
+        let resolved = reporter
+            .history(
+                None,
+                Some(crate::attention::AttentionLifecycleState::Resolved),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(open.is_empty());
+        assert_eq!(resolved.events.len(), 1);
+        assert_eq!(resolved.events[0].evidence.fingerprint, "resolved-v1");
+    }
+
+    #[tokio::test]
+    async fn history_defaults_to_open_events_until_terminal_state_is_requested() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let reporter = AttentionReporter::new(
+            HistoryStore::new(dir.path().join(".ensemble/history.db"))
+                .await
+                .unwrap(),
+        );
+        let observation = observation("open-v1");
+        reporter.upsert_open(observation.clone()).await.unwrap();
+        reporter
+            .resolve(
+                AttentionClose::new(
+                    observation.identity,
+                    "open-v1",
+                    AttentionEvidence::new("resolved-v1").unwrap(),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(reporter
+            .history(None, None, None, None)
+            .await
+            .unwrap()
+            .events
+            .is_empty());
+        assert_eq!(
+            reporter
+                .history(
+                    None,
+                    Some(crate::attention::AttentionLifecycleState::Resolved),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+                .events
+                .len(),
+            1,
+        );
+    }
+
+    #[tokio::test]
+    async fn tuple_identity_allows_distinct_producers_for_one_subject() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let reporter = AttentionReporter::new(
+            HistoryStore::new(dir.path().join(".ensemble/history.db"))
+                .await
+                .unwrap(),
+        );
+        reporter
+            .upsert_open(observation("producer-a-v1"))
+            .await
+            .unwrap();
+        let second = AttentionUpsert::new(
+            AttentionIdentity::new("producer-b", "issue-514", "runtime.awaiting_input").unwrap(),
+            AttentionPresentation::new(
+                "Different producer",
+                "Resolve it",
+                vec!["request-2".into()],
+            )
+            .unwrap(),
+            AttentionEvidence::new("producer-b-v1").unwrap(),
+        );
+        reporter.upsert_open(second).await.unwrap();
+
+        let open = reporter.items_for_subject("issue-514").await.unwrap();
+
+        assert_eq!(open.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn open_item_lookup_targets_an_identity() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let reporter = AttentionReporter::new(
+            HistoryStore::new(dir.path().join(".ensemble/history.db"))
+                .await
+                .unwrap(),
+        );
+        let observation = observation("open-v1");
+        reporter.upsert_open(observation.clone()).await.unwrap();
+
+        let item = reporter.open_item(&observation.identity).await.unwrap();
+
+        assert_eq!(item.unwrap().identity, observation.identity);
+    }
+}

--- a/crates/ensemble-core/src/history_store/mod.rs
+++ b/crates/ensemble-core/src/history_store/mod.rs
@@ -1,3 +1,4 @@
+pub mod attention;
 pub mod model;
 pub mod schema;
 pub mod store;

--- a/crates/ensemble-core/src/history_store/model.rs
+++ b/crates/ensemble-core/src/history_store/model.rs
@@ -1,3 +1,7 @@
+use crate::attention::{
+    AttentionError, AttentionEvent, AttentionEvidence, AttentionIdentity, AttentionItem,
+    AttentionLifecycleState, AttentionPresentation,
+};
 use crate::history::model::{HistoryRecord, TokenTotals};
 use crate::timeline::model::TimelineEventRecord;
 use chrono::{DateTime, Utc};
@@ -9,6 +13,40 @@ fn parse_utc(ts: &str) -> rusqlite::Result<DateTime<Utc>> {
         .map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
         })
+}
+
+pub(crate) fn row_to_attention_event(row: &Row<'_>) -> rusqlite::Result<AttentionEvent> {
+    let state: String = row.get("state")?;
+    let timestamp: String = row.get("timestamp")?;
+    let superseding_identity_json: Option<String> = row.get("superseding_identity_json")?;
+    let superseding_identity = superseding_identity_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(sql_conversion_error)?;
+    let evidence = AttentionEvidence {
+        fingerprint: row.get("fingerprint")?,
+    };
+    AttentionEvidence::new(&evidence.fingerprint).map_err(attention_conversion_error)?;
+    let sequence: i64 = row.get("sequence")?;
+    Ok(AttentionEvent {
+        sequence: u64::try_from(sequence).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Integer,
+                Box::new(error),
+            )
+        })?,
+        identity: AttentionIdentity {
+            producer_key: row.get("producer_key")?,
+            subject_ref: row.get("subject_ref")?,
+            kind: row.get("kind")?,
+        },
+        state: AttentionLifecycleState::parse(&state).map_err(attention_conversion_error)?,
+        evidence,
+        timestamp: parse_utc(&timestamp)?,
+        superseding_identity,
+    })
 }
 
 pub(crate) fn row_to_history_record(row: &Row<'_>) -> rusqlite::Result<HistoryRecord> {
@@ -73,4 +111,56 @@ pub(crate) fn row_to_timeline_record(row: &Row<'_>) -> rusqlite::Result<Timeline
         verdict: row.get("verdict")?,
         tool_name: row.get("tool_name")?,
     })
+}
+
+pub(crate) fn row_to_attention_item(row: &Row<'_>) -> rusqlite::Result<AttentionItem> {
+    let references_json: String = row.get("references_json")?;
+    let references = serde_json::from_str(&references_json).map_err(sql_conversion_error)?;
+    let superseding_identity_json: Option<String> = row.get("superseding_identity_json")?;
+    let superseding_identity = superseding_identity_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(sql_conversion_error)?;
+    let identity = AttentionIdentity {
+        producer_key: row.get("producer_key")?,
+        subject_ref: row.get("subject_ref")?,
+        kind: row.get("kind")?,
+    };
+    identity.validate().map_err(attention_conversion_error)?;
+    let presentation = AttentionPresentation {
+        summary: row.get("summary")?,
+        remedy: row.get("remedy")?,
+        references,
+    };
+    presentation
+        .validate()
+        .map_err(attention_conversion_error)?;
+    let evidence = AttentionEvidence {
+        fingerprint: row.get("fingerprint")?,
+    };
+    AttentionEvidence::new(&evidence.fingerprint).map_err(attention_conversion_error)?;
+    let state: String = row.get("state")?;
+    let opened_at: String = row.get("opened_at")?;
+    let updated_at: String = row.get("updated_at")?;
+    let closed_at: Option<String> = row.get("closed_at")?;
+
+    Ok(AttentionItem {
+        identity,
+        presentation,
+        evidence,
+        state: AttentionLifecycleState::parse(&state).map_err(attention_conversion_error)?,
+        opened_at: parse_utc(&opened_at)?,
+        updated_at: parse_utc(&updated_at)?,
+        closed_at: closed_at.as_deref().map(parse_utc).transpose()?,
+        superseding_identity,
+    })
+}
+
+fn sql_conversion_error(error: serde_json::Error) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+}
+
+fn attention_conversion_error(error: AttentionError) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
 }

--- a/crates/ensemble-core/src/history_store/schema.rs
+++ b/crates/ensemble-core/src/history_store/schema.rs
@@ -47,6 +47,40 @@ pub fn bootstrap_schema(conn: &Connection) -> rusqlite::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_run_events_run_sequence ON run_events(run_id, sequence);
         CREATE INDEX IF NOT EXISTS idx_runs_identifier_completed_at ON runs(issue_identifier, completed_at);
         CREATE INDEX IF NOT EXISTS idx_runs_outcome_completed_at ON runs(outcome, completed_at);
+
+        CREATE TABLE IF NOT EXISTS attention_items (
+            producer_key TEXT NOT NULL,
+            subject_ref TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            remedy TEXT NOT NULL,
+            references_json TEXT NOT NULL,
+            fingerprint TEXT NOT NULL,
+            state TEXT NOT NULL,
+            opened_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            closed_at TEXT,
+            superseding_identity_json TEXT,
+            PRIMARY KEY (producer_key, subject_ref, kind)
+        );
+
+        CREATE TABLE IF NOT EXISTS attention_events (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            producer_key TEXT NOT NULL,
+            subject_ref TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            state TEXT NOT NULL,
+            fingerprint TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            superseding_identity_json TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_attention_items_open_updated
+            ON attention_items(state, updated_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_attention_items_subject_open
+            ON attention_items(subject_ref, state, updated_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_attention_events_identity_sequence
+            ON attention_events(producer_key, subject_ref, kind, sequence);
         "#,
     )?;
     add_column_if_missing(conn, "runs", "artifacts", "TEXT")?;

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -11,7 +11,7 @@ use crate::timeline::{TimelineQuery, TimelineResponse};
 
 #[derive(Debug, Clone)]
 pub struct HistoryStore {
-    db_path: PathBuf,
+    pub(crate) db_path: PathBuf,
 }
 
 impl HistoryStore {

--- a/crates/ensemble-core/src/interaction/store.rs
+++ b/crates/ensemble-core/src/interaction/store.rs
@@ -430,7 +430,7 @@ impl InteractionStore {
         self.write_interaction(replacement).await
     }
 
-    async fn list_all(&self) -> Result<Vec<InteractionRequest>, InteractionError> {
+    pub(crate) async fn list_all(&self) -> Result<Vec<InteractionRequest>, InteractionError> {
         let dir = self.interactions_dir();
         let mut entries = match tokio::fs::read_dir(&dir).await {
             Ok(entries) => entries,

--- a/crates/ensemble-core/src/lib.rs
+++ b/crates/ensemble-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod acceptance;
 pub mod agent;
 pub mod api;
+pub mod attention;
 pub mod config;
 pub mod config_watcher;
 pub mod error;

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -1,4 +1,5 @@
 use crate::acceptance::AcceptanceAttempt;
+use crate::attention::AttentionItem;
 use crate::history::artifacts::{RunArtifacts, StepTranscriptArtifact};
 use crate::interaction::store::InteractionStore;
 use crate::orchestrator::state::{FinalizeStatus, OrchestratorState, RateLimitSnapshot};
@@ -17,6 +18,7 @@ pub struct RuntimeSnapshot {
     pub running: Vec<RunningSessionRow>,
     pub retrying: Vec<RetryRow>,
     pub waiting_on_human: Vec<WaitingInteractionRow>,
+    pub attention_items: Vec<AttentionItem>,
     pub completed: Vec<CompletedRow>,
     pub agent_totals: AgentTotalsSnapshot,
     pub rate_limits: Option<RateLimitSnapshot>,
@@ -128,6 +130,7 @@ pub struct IssueDetailSnapshot {
     pub pending_input: Option<PendingInputSummary>,
     /// Deprecated compatibility field. Prefer `pending_input`.
     pub current_interaction: Option<CurrentInteractionSummary>,
+    pub attention_items: Vec<AttentionItem>,
     pub last_error: Option<String>,
     pub finalize: FinalizeSnapshot,
     pub workflow_steps: Vec<WorkflowStepInfo>,
@@ -288,6 +291,7 @@ pub fn build_state_snapshot(state: &OrchestratorState) -> RuntimeSnapshot {
         running: running_rows,
         retrying: retry_rows,
         waiting_on_human: waiting_rows,
+        attention_items: vec![],
         completed: completed_rows,
         agent_totals: AgentTotalsSnapshot {
             input_tokens: state.agent_totals.input_tokens,
@@ -721,6 +725,7 @@ pub async fn build_issue_snapshot(
         retry: retry_detail,
         pending_input,
         current_interaction,
+        attention_items: vec![],
         last_error,
         finalize,
         workflow_steps,

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -43,6 +43,13 @@ use crate::agent::events::{
     WorkerEvent, WorkerFailureKind, WorkerIdentity, WorkerResult,
 };
 use crate::agent::{AgentRunRequest, AgentRunner, InteractionResponseEnvelope};
+use crate::attention::{
+    interaction::{
+        awaiting_interaction_observation, interaction_attention_close_from_open,
+        interaction_attention_identity,
+    },
+    AttentionReporter,
+};
 use crate::config::ensemble::{EnsembleConfig, OnFailure, StepKind};
 use crate::error::{AgentError, EnsembleError};
 use crate::history::artifacts::{finalize_mode_name, RunArtifacts};
@@ -54,7 +61,7 @@ use crate::interaction::model::{
 };
 use crate::interaction::{
     parse_scoped_interaction_command, InteractionAcceptance, InteractionCommand,
-    InteractionResumeStrategy, InteractionStatus, InteractionStore,
+    InteractionRequest, InteractionResumeStrategy, InteractionStatus, InteractionStore,
     ParseScopedInteractionCommandError,
 };
 use crate::observability::events::{EventBus, PipelineEvent};
@@ -455,6 +462,8 @@ pub struct Orchestrator {
     cancellation_registry: CancellationRegistry,
     history_write_lock: Arc<tokio::sync::Mutex<()>>,
     history_store: Option<HistoryStore>,
+    attention_reporter: Option<AttentionReporter>,
+    attention_reconciled_on_startup: AtomicBool,
     pipeline_journal: PipelineRunJournal,
     pipeline_journal_restored: AtomicBool,
     pending_run_started_transitions:
@@ -623,6 +632,7 @@ impl Orchestrator {
         let (worker_tx, worker_rx) = mpsc::channel(1000);
         let (command_tx, command_rx) = mpsc::channel(100);
         let timeline_persistence = history_store.clone().map(TimelinePersistence::new);
+        let attention_reporter = history_store.clone().map(AttentionReporter::new);
 
         Self {
             state: parts.state,
@@ -637,6 +647,8 @@ impl Orchestrator {
             cancellation_registry: parts.cancellation_registry,
             history_write_lock: Arc::new(tokio::sync::Mutex::new(())),
             history_store,
+            attention_reporter,
+            attention_reconciled_on_startup: AtomicBool::new(false),
             pipeline_journal: PipelineRunJournal::new(config_dir.to_path_buf()),
             pipeline_journal_restored: AtomicBool::new(false),
             pending_run_started_transitions: Box::new(std::sync::Mutex::new(HashMap::new())),
@@ -5409,6 +5421,7 @@ impl Orchestrator {
         interaction.agent_output_tokens = waiting_output_tokens;
         interaction.agent_total_tokens = waiting_total_tokens;
         self.interaction_store.create(interaction.clone()).await?;
+        self.report_awaiting_interaction(&interaction).await;
         let root_body = format_interaction_thread_root_comment(&interaction);
         match self
             .tracker
@@ -5650,6 +5663,7 @@ impl Orchestrator {
         interaction.agent_output_tokens = waiting_output_tokens;
         interaction.agent_total_tokens = waiting_total_tokens;
         self.interaction_store.create(interaction.clone()).await?;
+        self.report_awaiting_interaction(&interaction).await;
 
         let root_body = format_interaction_thread_root_comment(&interaction);
         match self
@@ -6066,7 +6080,8 @@ impl Orchestrator {
                 .retire_waiting_state(&interaction.id)
                 .await
             {
-                Ok(_) => {
+                Ok((_, retired)) => {
+                    self.reconcile_interaction_attention(&retired).await;
                     warn!(
                         issue_id = %interaction.issue_id,
                         interaction_id = %interaction.id,
@@ -6201,14 +6216,97 @@ impl Orchestrator {
         true
     }
 
+    async fn report_awaiting_interaction(&self, interaction: &InteractionRequest) -> bool {
+        if interaction.status != InteractionStatus::Open || !interaction.awaiting_resume {
+            return true;
+        }
+        let Some(reporter) = &self.attention_reporter else {
+            return true;
+        };
+        let observation = match awaiting_interaction_observation(interaction) {
+            Ok(observation) => observation,
+            Err(error) => {
+                warn!(interaction_id = %interaction.id, error = %error, "interaction could not be represented as operator attention");
+                return false;
+            }
+        };
+        if let Err(error) = reporter.upsert_open(observation).await {
+            warn!(
+                interaction_id = %interaction.id,
+                error = %error,
+                "failed to persist operator attention; startup reconciliation will retry"
+            );
+            return false;
+        }
+        true
+    }
+
+    async fn reconcile_interaction_attention(&self, interaction: &InteractionRequest) -> bool {
+        if interaction.status == InteractionStatus::Open {
+            return self.report_awaiting_interaction(interaction).await;
+        }
+        let Some(reporter) = &self.attention_reporter else {
+            return true;
+        };
+        let identity = match interaction_attention_identity(interaction) {
+            Ok(identity) => identity,
+            Err(error) => {
+                warn!(interaction_id = %interaction.id, error = %error, "interaction could not be reconciled as operator attention");
+                return false;
+            }
+        };
+        let open_item = match reporter.open_item(&identity).await {
+            Ok(item) => item,
+            Err(error) => {
+                warn!(interaction_id = %interaction.id, error = %error, "failed to read operator attention during reconciliation");
+                return false;
+            }
+        };
+        let Some(open_item) = open_item else {
+            return true;
+        };
+        let close = match interaction_attention_close_from_open(&open_item, interaction) {
+            Ok(Some(close)) => close,
+            Ok(None) => return true,
+            Err(error) => {
+                warn!(interaction_id = %interaction.id, error = %error, "failed to derive operator attention close during reconciliation");
+                return false;
+            }
+        };
+        if let Err(error) = reporter.resolve(close).await {
+            warn!(
+                interaction_id = %interaction.id,
+                error = %error,
+                "failed to reconcile resolved operator attention; startup reconciliation will retry"
+            );
+            return false;
+        }
+        true
+    }
+
     async fn hydrate_waiting_on_human_from_store(&self) {
-        let mut interactions = match self.interaction_store.list_awaiting_resume().await {
+        let reconcile_all = !self.attention_reconciled_on_startup.load(Ordering::Acquire);
+        let mut interactions = match if reconcile_all {
+            self.interaction_store.list_all().await
+        } else {
+            self.interaction_store.list_awaiting_resume().await
+        } {
             Ok(interactions) => interactions,
             Err(error) => {
                 warn!(error = %error, "failed to hydrate waiting interactions from store");
                 return;
             }
         };
+        let mut attention_reconciled = true;
+        for interaction in &interactions {
+            attention_reconciled &= self.reconcile_interaction_attention(interaction).await;
+        }
+        if reconcile_all && attention_reconciled {
+            self.attention_reconciled_on_startup
+                .store(true, Ordering::Release);
+        }
+        interactions.retain(|interaction| interaction.blocking && interaction.awaiting_resume);
+        interactions.sort_by_key(|interaction| interaction.requested_at);
         if !interactions.is_empty() {
             let live_records = match self.pipeline_journal.latest_live_records().await {
                 Ok(records) => records
@@ -6239,7 +6337,8 @@ impl Orchestrator {
                         .retire_waiting_state(&interaction.id)
                         .await
                     {
-                        Ok(_) => {
+                        Ok((_, retired)) => {
+                            self.reconcile_interaction_attention(&retired).await;
                             let mut state = self.state.write().await;
                             state.remove_waiting_on_human(&interaction.issue_id);
                             state.clear_resume_request(&interaction.issue_id);
@@ -7229,16 +7328,21 @@ impl Orchestrator {
             return;
         };
 
-        if let Err(error) = self
+        match self
             .interaction_store
-            .clear_waiting_state(&interaction_request_id)
+            .retire_waiting_state(&interaction_request_id)
             .await
         {
-            warn!(
-                interaction_request_id = %interaction_request_id,
-                error = %error,
-                "failed to clear interaction waiting state during waiting-issue cleanup"
-            );
+            Ok((_, retired)) => {
+                self.reconcile_interaction_attention(&retired).await;
+            }
+            Err(error) => {
+                warn!(
+                    interaction_request_id = %interaction_request_id,
+                    error = %error,
+                    "failed to clear interaction waiting state during waiting-issue cleanup"
+                );
+            }
         }
     }
 
@@ -13173,6 +13277,44 @@ agent:
             accepted_command: None,
             ignored_commands: Vec::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn startup_attention_reconciliation_retries_terminal_records_after_a_read_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let cfg = make_config();
+        let issue = test_issue("attention-retry", "Todo");
+        let (mut orchestrator, _) = make_restart_test_orchestrator(&temp, &cfg, &issue);
+        let mut interaction = test_question_interaction(&issue, 1, "attention-retry");
+        let reporter = AttentionReporter::new(orchestrator.history_store.clone().unwrap());
+        reporter
+            .upsert_open(awaiting_interaction_observation(&interaction).unwrap())
+            .await
+            .unwrap();
+        interaction.status = InteractionStatus::Resolved;
+        interaction.resolved_at = Some(Utc::now());
+        orchestrator
+            .interaction_store
+            .create(interaction)
+            .await
+            .unwrap();
+
+        orchestrator.attention_reporter = Some(AttentionReporter::new(HistoryStore {
+            db_path: temp.path().join("missing/history.db"),
+        }));
+        orchestrator.hydrate_waiting_on_human_from_store().await;
+
+        assert!(!orchestrator
+            .attention_reconciled_on_startup
+            .load(Ordering::Acquire));
+
+        orchestrator.attention_reporter = Some(reporter.clone());
+        orchestrator.hydrate_waiting_on_human_from_store().await;
+
+        assert!(orchestrator
+            .attention_reconciled_on_startup
+            .load(Ordering::Acquire));
+        assert!(reporter.open_items().await.unwrap().is_empty());
     }
 
     fn make_retry_step_config() -> EnsembleConfig {

--- a/crates/ensemble-ui/src-ui/src/hooks.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/hooks.test.tsx
@@ -103,6 +103,7 @@ function interaction(status: InteractionDetail["status"]): InteractionDetail {
 function issueDetail(finalizeStatus: string, approvalRequired = false): IssueDetailSnapshot {
   return {
     acceptance_attempts: [],
+    attention_items: [],
     artifacts: null,
     attempts: { restart_count: 0, current_retry_attempt: null },
     current_interaction: null,

--- a/crates/ensemble-ui/src-ui/src/pages/Dashboard.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/Dashboard.test.tsx
@@ -9,6 +9,22 @@ import Dashboard from "./Dashboard";
 function mockSnapshot(): RuntimeSnapshot {
   return {
     agent_totals: { input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0 },
+    attention_items: [{
+      identity: {
+        producer_key: "runtime.interaction",
+        subject_ref: "repo#2",
+        kind: "runtime.interaction.awaiting_input",
+      },
+      presentation: {
+        summary: "Agent needs a decision",
+        remedy: "Reply in the issue panel.",
+        references: ["interaction:ask-1"],
+      },
+      evidence: { fingerprint: "ask-1" },
+      state: "open",
+      opened_at: "2026-07-09T09:10:00Z",
+      updated_at: "2026-07-09T09:10:00Z",
+    }],
     counts: { running: 1, retrying: 0, waiting_on_human: 1, completed: 0 },
     generated_at: "2026-07-09T09:30:00Z",
     last_tick_at: "2026-07-09T09:29:58Z",

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
@@ -1165,6 +1165,7 @@ describe("useIssueRuntime lifecycle", () => {
     async (status, terminalStepState) => {
       const terminalDetail = {
         acceptance_attempts: [],
+        attention_items: [],
         issue_identifier: "todo-1",
         issue_id: "NODE_1",
         status,

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/AttentionQueue.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/AttentionQueue.tsx
@@ -8,9 +8,7 @@ interface AttentionQueueProps {
   onSelectIssue: (identifier: string) => void;
 }
 
-function formatAge(value: string | null): string {
-  if (!value) return "scheduled";
-
+function formatAge(value: string): string {
   const minutes = Math.max(0, Math.floor((Date.now() - new Date(value).getTime()) / 60_000));
   if (minutes < 1) return "just now";
   if (minutes < 60) return `${minutes}m ago`;
@@ -21,12 +19,6 @@ function formatAge(value: string | null): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
-function kindLabel(item: MissionAttentionItem): string {
-  if (item.stepName) return item.stepName;
-  if (item.kind === "human_input") return "human input";
-  return item.kind === "failure" ? "failure" : "retry";
-}
-
 export function AttentionQueue({ items, selectedIssueIdentifier, onSelectIssue }: AttentionQueueProps) {
   return (
     <section className="rounded-xl border bg-card p-4 shadow-sm">
@@ -35,7 +27,7 @@ export function AttentionQueue({ items, selectedIssueIdentifier, onSelectIssue }
           <h2 className="text-sm font-semibold tracking-wide text-muted-foreground uppercase">
             Needs Attention
           </h2>
-          <p className="text-sm text-muted-foreground">Human questions and recovery paths.</p>
+          <p className="text-sm text-muted-foreground">Reported operator interventions.</p>
         </div>
         <span className="rounded-full bg-muted px-2 py-1 text-xs font-medium">{items.length}</span>
       </div>
@@ -48,34 +40,43 @@ export function AttentionQueue({ items, selectedIssueIdentifier, onSelectIssue }
         <div className="grid gap-2 lg:grid-cols-2 xl:grid-cols-3">
           {items.map((item) => {
             const selected = selectedIssueIdentifier === item.issueIdentifier;
+            const content = <>
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-semibold">{item.issueIdentifier}</div>
+                  <div className="mt-1 text-sm text-foreground">{item.title}</div>
+                  <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">{item.detail}</div>
+                </div>
+                <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-xs font-medium text-muted-foreground">
+                  {item.kind}
+                </span>
+              </div>
+              <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                <span className="truncate">
+                  {item.references.length} {item.references.length === 1 ? "reference" : "references"}
+                </span>
+                <span className="shrink-0">{formatAge(item.requestedAt)}</span>
+              </div>
+            </>;
 
-            return (
+            return item.canNavigate ? (
               <button
                 key={item.id}
                 type="button"
                 aria-current={selected ? "true" : undefined}
-                aria-label={`${item.primaryAction} to ${item.issueIdentifier}`}
+                aria-label={`Open ${item.issueIdentifier}`}
                 onClick={() => onSelectIssue(item.issueIdentifier)}
                 className={cn(
                   "rounded-lg border p-3 text-left transition hover:border-primary/50 hover:bg-muted/40",
                   selected && "border-primary bg-primary/5 ring-1 ring-primary/30",
                 )}
               >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-semibold">{item.issueIdentifier}</div>
-                    <div className="mt-1 text-sm text-foreground">{item.title}</div>
-                    <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">{item.detail}</div>
-                  </div>
-                  <span className="shrink-0 rounded-full bg-primary px-2 py-1 text-xs font-medium text-primary-foreground">
-                    {item.primaryAction}
-                  </span>
-                </div>
-                <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
-                  <span className="truncate">{kindLabel(item)}</span>
-                  <span className="shrink-0">{formatAge(item.requestedAt)}</span>
-                </div>
+                {content}
               </button>
+            ) : (
+              <div key={item.id} className="rounded-lg border border-dashed p-3 text-left">
+                {content}
+              </div>
             );
           })}
         </div>

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
@@ -49,6 +49,7 @@ function mockMutation<T>(mutate: ReturnType<typeof vi.fn>, overrides: Record<str
 }
 
 const issue = {
+  attention_items: [],
   issue_identifier: "repo#1",
   issue_id: "issue-1",
   status: "running",

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
@@ -87,14 +87,13 @@ const stats: MissionSystemStats = {
 const attentionItems: MissionAttentionItem[] = [
   {
     id: "ask-1",
-    issueId: "issue-1",
     issueIdentifier: "repo#1",
-    kind: "human_input",
-    title: "Agent needs input",
-    detail: "Waiting in review",
-    stepName: "review",
+    kind: "runtime.interaction.awaiting_input",
+    title: "Agent needs a decision",
+    detail: "Reply in the issue panel.",
+    references: ["interaction:ask-1"],
     requestedAt: "2026-07-09T09:10:00Z",
-    primaryAction: "Reply",
+    canNavigate: true,
   },
 ];
 
@@ -121,6 +120,40 @@ function issue(overrides: Partial<MissionIssueSummary> = {}): MissionIssueSummar
 function runtimeSnapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
   return {
     agent_totals: { input_tokens: 100, output_tokens: 50, total_tokens: 150, seconds_running: 60 },
+    attention_items: [
+      {
+        identity: {
+          producer_key: "runtime.interaction",
+          subject_ref: "repo#3",
+          kind: "runtime.interaction.awaiting_input",
+        },
+        presentation: {
+          summary: "Agent needs a decision",
+          remedy: "Reply in the issue panel.",
+          references: ["interaction:ask-1"],
+        },
+        evidence: { fingerprint: "ask-1" },
+        state: "open",
+        opened_at: "2026-07-09T09:10:00Z",
+        updated_at: "2026-07-09T09:10:00Z",
+      },
+      {
+        identity: {
+          producer_key: "adapter.policy",
+          subject_ref: "repo#2",
+          kind: "adapter.policy.escalation",
+        },
+        presentation: {
+          summary: "Retry scheduling needs review",
+          remedy: "Inspect the policy record.",
+          references: ["policy:retry-2"],
+        },
+        evidence: { fingerprint: "retry-2" },
+        state: "open",
+        opened_at: "2026-07-09T09:11:00Z",
+        updated_at: "2026-07-09T09:11:00Z",
+      },
+    ],
     counts: { running: 1, retrying: 1, waiting_on_human: 1, completed: 1 },
     generated_at: "2026-07-09T09:30:00Z",
     last_tick_at: "2026-07-09T09:29:58Z",
@@ -183,6 +216,7 @@ function mockMutation<T>(): T {
 function runtimeFixture(identifier: string): IssueRuntimeState {
   const data = {
     acceptance_attempts: [],
+    attention_items: [],
     issue_identifier: identifier,
     issue_id: `id:${identifier}`,
     status: "running",
@@ -473,7 +507,7 @@ describe("Mission Control shell components", () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole("button", { name: /Reply to repo#1/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Open repo#1" }));
 
     expect(onSelectIssue).toHaveBeenCalledWith("repo#1");
   });
@@ -488,25 +522,23 @@ describe("Mission Control shell components", () => {
           ...attentionItems,
           {
             id: "retry:issue-2",
-            issueId: "issue-2",
             issueIdentifier: "repo#2",
-            kind: "retry",
-            title: "Retry scheduled",
-            detail: "clippy failed",
-            stepName: null,
-            requestedAt: null,
-            primaryAction: "Inspect",
+            kind: "adapter.policy.escalation",
+            title: "Policy review required",
+            detail: "A retry needs policy review.",
+            references: ["policy:retry-2", "run:7"],
+            requestedAt: "2026-07-09T09:20:00Z",
+            canNavigate: true,
           },
           {
             id: "failure:issue-3",
-            issueId: "issue-3",
             issueIdentifier: "repo#failed",
-            kind: "failure",
-            title: "Run failed",
-            detail: "completed_failed",
-            stepName: null,
+            kind: "integration.release.decision",
+            title: "Release decision required",
+            detail: "Check the release record.",
+            references: [],
             requestedAt: "2026-07-09T09:30:00Z",
-            primaryAction: "Inspect",
+            canNavigate: true,
           },
         ]}
         selectedIssueIdentifier="repo#1"
@@ -515,18 +547,19 @@ describe("Mission Control shell components", () => {
     );
 
     expect(screen.getByText("repo#1")).toBeInTheDocument();
-    expect(screen.getByText("Agent needs input")).toBeInTheDocument();
-    expect(screen.getByText("Waiting in review")).toBeInTheDocument();
-    expect(screen.getByText("review")).toBeInTheDocument();
-    expect(screen.getByText("Reply")).toBeInTheDocument();
+    expect(screen.getByText("Agent needs a decision")).toBeInTheDocument();
+    expect(screen.getByText("Reply in the issue panel.")).toBeInTheDocument();
+    expect(screen.getByText("runtime.interaction.awaiting_input")).toBeInTheDocument();
+    expect(screen.getByText("1 reference")).toBeInTheDocument();
     expect(screen.getByText("32m ago")).toBeInTheDocument();
     expect(screen.getByText("repo#2")).toBeInTheDocument();
-    expect(screen.getAllByText("Inspect")).toHaveLength(2);
-    expect(screen.getByText("scheduled")).toBeInTheDocument();
+    expect(screen.getByText("adapter.policy.escalation")).toBeInTheDocument();
+    expect(screen.getByText("2 references")).toBeInTheDocument();
     expect(screen.getByText("repo#failed")).toBeInTheDocument();
-    expect(screen.getByText("Run failed")).toBeInTheDocument();
-    expect(screen.getByText("failure")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Reply to repo#1/i })).toHaveAttribute(
+    expect(screen.getByText("Release decision required")).toBeInTheDocument();
+    expect(screen.getByText("integration.release.decision")).toBeInTheDocument();
+    expect(screen.getByText("0 references")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open repo#1" })).toHaveAttribute(
       "aria-current",
       "true",
     );
@@ -540,6 +573,19 @@ describe("Mission Control shell components", () => {
     expect(screen.getByText("Needs Attention")).toBeInTheDocument();
     expect(screen.getByText("0")).toBeInTheDocument();
     expect(screen.getByText("Nothing needs intervention right now.")).toBeInTheDocument();
+  });
+
+  it("renders an orphan attention item without a navigation action", () => {
+    render(
+      <AttentionQueue
+        items={[{ ...attentionItems[0]!, issueIdentifier: "repo#orphan", canNavigate: false }]}
+        selectedIssueIdentifier={null}
+        onSelectIssue={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("repo#orphan")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open repo#orphan" })).not.toBeInTheDocument();
   });
 });
 
@@ -706,7 +752,7 @@ describe("Mission Control page", () => {
     expect(within(operations).getByText("repo#2")).toBeInTheDocument();
     expect(within(operations).getByText("repo#3")).toBeInTheDocument();
     expect(within(operations).queryByText("repo#1")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Reply to repo#3" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open repo#3" })).toBeInTheDocument();
   });
 
   it("shows one filtered-empty state in board mode", async () => {
@@ -751,67 +797,45 @@ describe("Mission Control page", () => {
     await waitFor(() => expect(trigger).toHaveFocus());
   });
 
-  it("opens human attention on Respond and preserves the current tab for retry attention", async () => {
+  it("opens a canonical attention record without changing the selected panel tab", async () => {
     const user = userEvent.setup();
     renderMissionControl(runtimeSnapshot());
 
-    await user.click(screen.getByRole("button", { name: "Reply to repo#3" }));
+    await user.click(screen.getByRole("button", { name: "Open repo#3" }));
     expect(screen.getByRole("heading", { name: "repo#3" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Respond" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
 
-    await user.click(screen.getByRole("button", { name: "Inspect to repo#2" }));
+    await user.click(screen.getByRole("button", { name: "Open repo#2" }));
     expect(screen.getByRole("heading", { name: "repo#2" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Respond" })).toHaveAttribute("aria-selected", "true");
-  });
-
-  it("does not force Respond when opening an ordinary or retrying issue", async () => {
-    const user = userEvent.setup();
-    renderMissionControl(runtimeSnapshot());
-    const operations = screen.getByRole("region", { name: "Operations" });
-
-    await user.click(within(operations).getByRole("button", { name: /Open\s*repo#1/i }));
-    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
-
-    await user.click(screen.getByRole("button", { name: "Close issue panel" }));
-    await user.click(screen.getByRole("button", { name: "Inspect to repo#2" }));
     expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
   });
 
-  it("switches from Respond to Overview when opening halted attention for inspection", async () => {
-    const user = userEvent.setup();
+  it("does not infer attention from waiting, retrying, halted, or failed runtime rows", () => {
     renderMissionControl(
       runtimeSnapshot({
-        counts: { running: 0, retrying: 0, waiting_on_human: 2, completed: 0 },
+        attention_items: [],
+        counts: { running: 0, retrying: 1, waiting_on_human: 1, completed: 1 },
         running: [],
-        retrying: [],
-        waiting_on_human: [
-          {
-            interaction_request_id: "ask-human",
-            issue_id: "issue-human",
-            issue_identifier: "repo#human",
-            requested_at: "2026-07-09T09:10:00Z",
-            step_name: "build",
-          },
-          {
-            interaction_request_id: "halted:issue-halted:review",
-            issue_id: "issue-halted",
-            issue_identifier: "repo#halted",
-            requested_at: "2026-07-09T09:15:00Z",
-            step_name: "review",
-          },
-        ],
-        completed: [],
+        waiting_on_human: [{
+          interaction_request_id: "halted:issue-halted:review",
+          issue_id: "issue-halted",
+          issue_identifier: "repo#halted",
+          requested_at: "2026-07-09T09:15:00Z",
+          step_name: "review",
+        }],
+        completed: [{
+          issue_id: "issue-failed",
+          issue_identifier: "repo#failed",
+          completed_at: "2026-07-09T09:25:00Z",
+          status: "completed_failed",
+        }],
       }),
     );
 
-    await user.click(screen.getByRole("button", { name: "Reply to repo#human" }));
-    expect(screen.getByRole("tab", { name: "Respond" })).toHaveAttribute("aria-selected", "true");
-
-    expect(screen.queryByRole("button", { name: "Reply to repo#halted" })).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Inspect to repo#halted" }));
-
-    expect(screen.getByRole("heading", { name: "repo#halted" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Nothing needs intervention right now.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open repo#2" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open repo#halted" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open repo#failed" })).not.toBeInTheDocument();
   });
 
   it("closes the panel and focuses Operations when a refreshed snapshot removes the selected issue", async () => {
@@ -987,6 +1011,7 @@ describe("Mission Control page", () => {
   it("shows a true empty operational state", () => {
     renderMissionControl(
       runtimeSnapshot({
+        attention_items: [],
         counts: { running: 0, retrying: 0, waiting_on_human: 0, completed: 0 },
         running: [],
         retrying: [],

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
@@ -129,17 +129,6 @@ export default function MissionControl() {
     selectionTriggerRef.current =
       document.activeElement instanceof HTMLButtonElement ? document.activeElement : null;
     setSelectedIssueIdentifier(identifier);
-    const attentionItem = missionState?.attentionItems.find(
-      (item) => item.issueIdentifier === identifier,
-    );
-    if (attentionItem?.kind === "human_input") {
-      setActiveTab("respond");
-    } else if (
-      attentionItem?.kind === "failure" &&
-      (attentionItem.primaryAction === "Inspect" || attentionItem.primaryAction === "Open")
-    ) {
-      setActiveTab("overview");
-    }
   }
 
   function closePanel() {

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/model.test.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { RuntimeSnapshot } from "@/generated/models";
+import type { AttentionItem, RuntimeSnapshot } from "@/generated/models";
 import {
   deriveMissionControlState,
   filterMissionControlIssues,
@@ -9,6 +9,26 @@ import {
   type MissionControlFilters,
 } from "./model";
 
+function attentionItem(overrides: Partial<AttentionItem> = {}): AttentionItem {
+  return {
+    identity: {
+      producer_key: "runtime.interaction",
+      subject_ref: "repo#3",
+      kind: "runtime.interaction.awaiting_input",
+    },
+    presentation: {
+      summary: "Agent needs a decision",
+      remedy: "Reply in the issue panel.",
+      references: ["interaction:ask-1"],
+    },
+    evidence: { fingerprint: "abc123" },
+    state: "open",
+    opened_at: "2026-07-09T09:10:00Z",
+    updated_at: "2026-07-09T09:10:00Z",
+    ...overrides,
+  };
+}
+
 function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
   return {
     agent_totals: {
@@ -17,6 +37,7 @@ function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
       total_tokens: 3500,
       seconds_running: 95,
     },
+    attention_items: [],
     counts: { running: 1, retrying: 1, waiting_on_human: 1, completed: 1 },
     generated_at: "2026-07-09T09:30:00Z",
     last_tick_at: "2026-07-09T09:29:58Z",
@@ -80,13 +101,69 @@ describe("mission-control model", () => {
     ]);
   });
 
-  it("promotes human questions and retry recovery into attention items", () => {
-    const state = deriveMissionControlState(snapshot());
+  it("uses only persisted attention records, including unknown kinds and multiple producers", () => {
+    const state = deriveMissionControlState(
+      snapshot({
+        attention_items: [
+          attentionItem(),
+          attentionItem({
+            identity: {
+              producer_key: "adapter.policy",
+              subject_ref: "repo#3",
+              kind: "adapter.policy.escalation",
+            },
+            presentation: {
+              summary: "External approval is required",
+              remedy: "Review the linked policy record.",
+              references: ["policy:42", "run:run-7"],
+            },
+            opened_at: "2026-07-09T09:12:00Z",
+          }),
+        ],
+      }),
+    );
 
-    expect(state.attentionItems.map((item) => [item.issueIdentifier, item.kind, item.primaryAction])).toEqual([
-      ["repo#3", "human_input", "Reply"],
-      ["repo#2", "retry", "Inspect"],
+    expect(state.attentionItems).toMatchObject([
+      {
+        issueIdentifier: "repo#3",
+        kind: "runtime.interaction.awaiting_input",
+        title: "Agent needs a decision",
+        detail: "Reply in the issue panel.",
+        references: ["interaction:ask-1"],
+        requestedAt: "2026-07-09T09:10:00Z",
+        canNavigate: true,
+      },
+      {
+        issueIdentifier: "repo#3",
+        kind: "adapter.policy.escalation",
+        title: "External approval is required",
+        detail: "Review the linked policy record.",
+        references: ["policy:42", "run:run-7"],
+        requestedAt: "2026-07-09T09:12:00Z",
+        canNavigate: true,
+      },
     ]);
+    expect(state.issues.find((issue) => issue.identifier === "repo#2")?.attention).toBe(false);
+    expect(state.issues.find((issue) => issue.identifier === "repo#3")?.attention).toBe(true);
+  });
+
+  it("keeps persisted orphan attention visible but not navigable", () => {
+    const state = deriveMissionControlState(
+      snapshot({
+        attention_items: [attentionItem({
+          identity: {
+            producer_key: "adapter.policy",
+            subject_ref: "repo#orphan",
+            kind: "adapter.policy.escalation",
+          },
+        })],
+      }),
+    );
+
+    expect(state.attentionItems[0]).toMatchObject({
+      issueIdentifier: "repo#orphan",
+      canNavigate: false,
+    });
   });
 
   it("classifies synthetic halted waits as blocked failures instead of human input", () => {
@@ -114,18 +191,10 @@ describe("mission-control model", () => {
         identifier: "repo#halted",
         statusLabel: "Halted",
         activity: "Pipeline halted after review failed",
-        attention: true,
+        attention: false,
       }),
     ]);
-    expect(state.attentionItems).toEqual([
-      expect.objectContaining({
-        issueIdentifier: "repo#halted",
-        kind: "failure",
-        title: "Pipeline halted",
-        detail: "Blocked after review failed",
-        primaryAction: "Inspect",
-      }),
-    ]);
+    expect(state.attentionItems).toEqual([]);
     expect(state.stats).toMatchObject({ waitingOnHuman: 0, failed: 1 });
   });
 
@@ -173,18 +242,19 @@ describe("mission-control model", () => {
     ]);
   });
 
-  it("filters to attention-only issues", () => {
-    const state = deriveMissionControlState(snapshot());
+  it("filters to issues with persisted attention only", () => {
+    const state = deriveMissionControlState(
+      snapshot({ attention_items: [attentionItem()] }),
+    );
     const filters: MissionControlFilters = { query: "", status: "all", attentionOnly: true };
 
     expect(filterMissionControlIssues(state.issues, filters).map((issue) => issue.identifier)).toEqual([
-      "repo#2",
       "repo#3",
     ]);
   });
 
   it("searches status label, step name, and activity", () => {
-    const state = deriveMissionControlState(snapshot());
+    const state = deriveMissionControlState(snapshot({ attention_items: [attentionItem()] }));
 
     expect(
       filterMissionControlIssues(state.issues, { query: "completed_succeeded", status: "all", attentionOnly: false })
@@ -206,8 +276,8 @@ describe("mission-control model", () => {
 
     expect(regroupMissionControlIssues(filteredIssues).map((group) => [group.id, group.issues.length])).toEqual([
       ["running", 0],
-      ["retrying", 1],
-      ["waiting_on_human", 1],
+      ["retrying", 0],
+      ["waiting_on_human", 0],
       ["failed_or_blocked", 0],
       ["completed_recently", 0],
     ]);
@@ -238,22 +308,16 @@ describe("mission-control model", () => {
     );
 
     expect(state.groups.find((group) => group.id === "failed_or_blocked")?.issues).toEqual([
-      expect.objectContaining({ identifier: "repo#failed", attention: true }),
+      expect.objectContaining({ identifier: "repo#failed", attention: false }),
     ]);
     expect(state.groups.find((group) => group.id === "completed_recently")?.issues).toEqual([
       expect.objectContaining({ identifier: "repo#succeeded", attention: false }),
     ]);
-    expect(state.attentionItems).toContainEqual(
-      expect.objectContaining({
-        issueIdentifier: "repo#failed",
-        kind: "failure",
-        primaryAction: "Inspect",
-      }),
-    );
+    expect(state.attentionItems).toEqual([]);
     expect(state.stats).toMatchObject({ completed: 2, failed: 1 });
   });
 
-  it("includes completed_failed in failed and attention-only filters", () => {
+  it("keeps completed_failed in failed filters without inferring attention", () => {
     const state = deriveMissionControlState(
       snapshot({
         counts: { running: 0, retrying: 0, waiting_on_human: 0, completed: 1 },
@@ -278,13 +342,11 @@ describe("mission-control model", () => {
         attentionOnly: false,
       }).map((issue) => issue.identifier),
     ).toEqual(["repo#failed"]);
-    expect(
-      filterMissionControlIssues(state.issues, {
-        query: "",
-        status: "all",
-        attentionOnly: true,
-      }).map((issue) => issue.identifier),
-    ).toEqual(["repo#failed"]);
+    expect(filterMissionControlIssues(state.issues, {
+      query: "",
+      status: "all",
+      attentionOnly: true,
+    })).toEqual([]);
   });
 
   it("does not infer retry exhaustion from unspecified completed statuses", () => {

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/model.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/model.ts
@@ -1,4 +1,5 @@
 import type {
+  AttentionItem,
   CompletedRow,
   RetryRow,
   RunningSessionRow,
@@ -13,8 +14,6 @@ export type MissionIssueStatus =
   | "waiting_on_human"
   | "failed_or_blocked"
   | "completed_recently";
-export type MissionAttentionKind = "human_input" | "retry" | "failure";
-export type MissionPrimaryAction = "Reply" | "Inspect" | "Open";
 
 export interface MissionIssueSummary {
   id: string;
@@ -41,14 +40,13 @@ export interface MissionGroup {
 
 export interface MissionAttentionItem {
   id: string;
-  issueId: string;
   issueIdentifier: string;
-  kind: MissionAttentionKind;
+  kind: string;
   title: string;
   detail: string;
-  stepName: string | null;
-  requestedAt: string | null;
-  primaryAction: MissionPrimaryAction;
+  references: string[];
+  requestedAt: string;
+  canNavigate: boolean;
 }
 
 export interface MissionSystemStats {
@@ -146,7 +144,7 @@ function retryIssue(row: RetryRow): MissionIssueSummary {
     retryAttempt: row.attempt,
     tokenTotal: null,
     turnCount: null,
-    attention: true,
+    attention: false,
     source: row,
   };
 }
@@ -166,7 +164,7 @@ function waitingIssue(row: WaitingInteractionRow): MissionIssueSummary {
     retryAttempt: null,
     tokenTotal: null,
     turnCount: null,
-    attention: true,
+    attention: false,
     source: row,
   };
 }
@@ -186,7 +184,7 @@ function completedIssue(row: CompletedRow): MissionIssueSummary {
     retryAttempt: null,
     tokenTotal: null,
     turnCount: null,
-    attention: failed,
+    attention: false,
     source: row,
   };
 }
@@ -202,60 +200,19 @@ export function deriveMissionControlState(snapshot: RuntimeSnapshot): MissionCon
     ...snapshot.waiting_on_human.map(waitingIssue),
     ...snapshot.completed.map(completedIssue),
   ];
+  const attentionBySubject = new Set(
+    snapshot.attention_items.map((item) => item.identity.subject_ref),
+  );
+  const issuesWithAttention = issues.map((issue) => ({
+    ...issue,
+    attention: attentionBySubject.has(issue.identifier),
+  }));
+  const issueIdentifiers = new Set(issues.map((issue) => issue.identifier));
 
   return {
-    issues,
-    groups: regroupMissionControlIssues(issues),
-    attentionItems: [
-      ...snapshot.waiting_on_human.map(
-        (row): MissionAttentionItem =>
-          isSyntheticHaltedInteractionId(row.interaction_request_id)
-            ? {
-                id: row.interaction_request_id,
-                issueId: row.issue_id,
-                issueIdentifier: row.issue_identifier,
-                kind: "failure",
-                title: "Pipeline halted",
-                detail: `Blocked after ${row.step_name} failed`,
-                stepName: row.step_name,
-                requestedAt: row.requested_at,
-                primaryAction: "Inspect",
-              }
-            : {
-                id: row.interaction_request_id,
-                issueId: row.issue_id,
-                issueIdentifier: row.issue_identifier,
-                kind: "human_input",
-                title: "Agent needs input",
-                detail: `Waiting in ${row.step_name}`,
-                stepName: row.step_name,
-                requestedAt: row.requested_at,
-                primaryAction: "Reply",
-              },
-      ),
-      ...snapshot.retrying.map((row): MissionAttentionItem => ({
-        id: `retry:${row.issue_id}`,
-        issueId: row.issue_id,
-        issueIdentifier: row.issue_identifier,
-        kind: "retry",
-        title: "Retry scheduled",
-        detail: row.error ?? `Attempt ${row.attempt} is waiting to retry`,
-        stepName: null,
-        requestedAt: null,
-        primaryAction: "Inspect",
-      })),
-      ...failedRows.map((row): MissionAttentionItem => ({
-        id: `failure:${row.issue_id}`,
-        issueId: row.issue_id,
-        issueIdentifier: row.issue_identifier,
-        kind: "failure",
-        title: "Run failed",
-        detail: row.status,
-        stepName: null,
-        requestedAt: row.completed_at,
-        primaryAction: "Inspect",
-      })),
-    ],
+    issues: issuesWithAttention,
+    groups: regroupMissionControlIssues(issuesWithAttention),
+    attentionItems: snapshot.attention_items.map((item) => missionAttentionItem(item, issueIdentifiers)),
     stats: {
       running: snapshot.counts.running,
       retrying: snapshot.counts.retrying,
@@ -269,6 +226,26 @@ export function deriveMissionControlState(snapshot: RuntimeSnapshot): MissionCon
       rateLimitLimit: snapshot.rate_limits?.limit ?? null,
       rateLimitResetAt: snapshot.rate_limits?.reset_at ?? null,
     },
+  };
+}
+
+function missionAttentionItem(
+  item: AttentionItem,
+  issueIdentifiers: Set<string>,
+): MissionAttentionItem {
+  return {
+    id: JSON.stringify([
+      item.identity.producer_key,
+      item.identity.subject_ref,
+      item.identity.kind,
+    ]),
+    issueIdentifier: item.identity.subject_ref,
+    kind: item.identity.kind,
+    title: item.presentation.summary,
+    detail: item.presentation.remedy,
+    references: item.presentation.references,
+    requestedAt: item.opened_at,
+    canNavigate: issueIdentifiers.has(item.identity.subject_ref),
   };
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1929,6 +1929,20 @@ across repeated restarts. Failure to read the durable maximum prevents that jour
 being restored under a potentially reused sequence; the issue remains undispatched rather than
 falling back to a fresh run.
 
+The same shared database stores durable operator-attention records separately from run history.
+An attention item has stable `(producer_key, subject_ref, kind)` identity, an opaque namespaced
+kind, bounded presentation (summary, remedy, ordered references), an evidence fingerprint, and
+`open`, `resolved`, or `superseded` lifecycle state. Equal open observations are no-ops; fresh
+evidence refreshes the retained item. Resolution and supersession compare the prior fingerprint and
+require distinct closing evidence, so stale observations cannot close newer records and a missing
+transient poll never closes one. Each effective transition appends immutable lifecycle evidence;
+terminal records remain queryable for restart and completed-history audit.
+
+Attention is observational: it does not pause/resume a run, grant tracker/control authority, or
+substitute for an interaction request. The first producer maps durable interactions awaiting resume
+to `runtime.interaction.awaiting_input`; retries, failures, and synthetic halted waits do not become
+attention merely through inference.
+
 For each pipeline step, Ensemble persists a typed JSONL transcript at:
 
 ```text
@@ -2582,6 +2596,8 @@ Minimum endpoints:
     }
     ```
 
+  - Includes `attention_items`, containing only open records read from the shared history database.
+
 - `GET /api/v1/<issue_identifier>`
   - Returns issue-specific runtime/debug details for the identified issue, including any information
     the implementation tracks that is useful for debugging.
@@ -2599,6 +2615,7 @@ Minimum endpoints:
   - Each finalized repository may include the stored version-1 delivery observation. History
     artifacts and the `delivery_observation_updated` WebSocket event expose the same repository-
     keyed schema; neither endpoint performs GitHub reconciliation on demand.
+  - Includes matching open `attention_items` from the same shared history database.
   - Suggested response shape:
 
     ```json
@@ -2673,6 +2690,12 @@ Minimum endpoints:
   - Repeated persistence of the same `(run_id, sequence)` is idempotent.
   - The endpoint and runtime persistence must use the same canonical
     `{workspace}/.ensemble/history.db`; per-run timeline JSONL is not a fallback source.
+
+- `GET /api/v1/attention`
+  - Returns bounded, read-only operator-attention lifecycle history with optional `subject_ref`,
+    lifecycle `state`, cursor, and limit filters. Terminal evidence is included only when requested.
+  - It has no action or mutation counterpart; selecting an attention item may navigate only to
+    existing issue detail.
 
 - `POST /api/v1/interactions/{id}/respond`
   - Attempts to resolve a specific open human interaction. The body is typed by interaction kind and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,10 @@
 
 ## First-release configuration boundary
 
+Operator-attention reporting is a runtime primitive backed by the shared workspace history
+database. This release adds no `config.yaml` routing, kind, or development-method vocabulary for
+attention; configured branch adapters may use the generic reporter in a later change.
+
 Configuration serves one trusted local operator. ACPX-backed agents and sequential pipelines are
 the supported first-release path. `agent.max_turns` is not a supported field and is rejected.
 Changes to `workspace.root` or the ordered `repos` list persist but require an Ensemble restart


### PR DESCRIPTION
## Summary
- persist generic operator-attention records and lifecycle evidence in the shared history database
- expose trusted-local read-only state, detail, and history projections
- render canonical attention records in Mission Control without inferred action authority

## Validation
- cargo test --workspace --exclude ensemble-desktop --no-fail-fast --quiet
- product E2E: 44 passed, 1 ignored
- frontend: 306 tests; codegen and production build passed
- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Risk
- API exposure is gated to trusted-local clients; unsafe-remote requests receive no attention payload
- attention remains observational and cannot authorize tracker, interaction, retry, or other mutations

Fixes #514