### PR TITLE
Add scheduler lanes and bounded drain

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,17 @@ _Avoid_: Workflow when referring to the executable graph
 A named, configuration-defined live-worker capacity bucket shared by runs selected into that lane.
 _Avoid_: Tracker state, workflow role
 
+**Scheduler resource lease**:
+The exact live-agent reservation of declared resource units and normalized repository-relative paths.
+It is journaled with dispatch and released when the agent is no longer live.
+
+**Parked run**:
+A claimed run retained after configured automatic recovery is exhausted; it has no live-agent lease
+and is reported through durable operator attention until fresh evidence permits resumption.
+
+**Drain outcome**:
+The structured terminal result of bounded scheduler execution: success, waiting for human, or partial drain.
+
 **Step**:
 A named unit of agent or synthesis work within a pipeline.
 _Avoid_: Stage, phase

--- a/crates/ensemble-cli/src/commands/run.rs
+++ b/crates/ensemble-cli/src/commands/run.rs
@@ -14,6 +14,8 @@ use ensemble_core::workspace::finalize::FinalizeMode;
 #[derive(Debug, Clone)]
 pub struct RunArgs {
     pub config_dir: Option<PathBuf>,
+    pub once: bool,
+    pub deadline_ms: Option<u64>,
 }
 
 /// Run the orchestrator in headless mode (terminal output only)
@@ -115,6 +117,50 @@ pub async fn execute(args: RunArgs) -> ExitCode {
         }
     }
 
+    if args.once {
+        watcher.abort();
+        let config = prepared
+            .app_state
+            .config_runtime
+            .document_state
+            .read()
+            .await
+            .active_config
+            .clone()
+            .expect("runnable config has active config");
+        let deadline_ms = args
+            .deadline_ms
+            .unwrap_or(config.scheduler.one_shot.deadline_ms);
+        if deadline_ms == 0 {
+            eprintln!("error: --deadline-ms must be positive");
+            return ExitCode::FAILURE;
+        }
+        let result = match ensemble_core::api::bootstrap::run_orchestrator_once_for_app(
+            &prepared.app_state,
+            std::time::Duration::from_millis(deadline_ms),
+        )
+        .await
+        {
+            Ok(Some(result)) => result,
+            Ok(None) | Err(_) => {
+                eprintln!("error: runnable config did not produce an orchestrator runtime");
+                return ExitCode::FAILURE;
+            }
+        };
+        println!(
+            "{}",
+            serde_json::to_string(&result).expect("drain result serializes")
+        );
+        return if matches!(
+            result.outcome,
+            ensemble_core::orchestrator::DrainOutcome::Success
+        ) {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::FAILURE
+        };
+    }
+
     match start_or_replace_registered_orchestrator(&prepared.app_state).await {
         Ok(true) => {}
         Ok(false) => {
@@ -155,13 +201,19 @@ mod tests {
     fn test_run_args() {
         let args = RunArgs {
             config_dir: Some(PathBuf::from("/tmp/test")),
+            once: false,
+            deadline_ms: None,
         };
         assert_eq!(args.config_dir, Some(PathBuf::from("/tmp/test")));
     }
 
     #[test]
     fn test_run_args_none() {
-        let args = RunArgs { config_dir: None };
+        let args = RunArgs {
+            config_dir: None,
+            once: false,
+            deadline_ms: None,
+        };
         assert!(args.config_dir.is_none());
     }
 }

--- a/crates/ensemble-cli/src/main.rs
+++ b/crates/ensemble-cli/src/main.rs
@@ -33,7 +33,14 @@ enum Command {
     /// Interactively create an ensemble configuration directory.
     Init,
     /// Start the ensemble orchestrator in headless mode.
-    Run,
+    Run {
+        /// Stop after a bounded scheduler drain and emit one JSON result.
+        #[arg(long)]
+        once: bool,
+        /// Override the configured one-shot deadline in milliseconds.
+        #[arg(long)]
+        deadline_ms: Option<u64>,
+    },
     /// Start the ensemble orchestrator with web UI.
     #[cfg(feature = "web-ui")]
     Web {
@@ -139,7 +146,14 @@ async fn main() -> ExitCode {
         Some(Command::Init) => {
             commands::init::execute(commands::init::InitArgs { config_dir }).await
         }
-        Some(Command::Run) => commands::run::execute(commands::run::RunArgs { config_dir }).await,
+        Some(Command::Run { once, deadline_ms }) => {
+            commands::run::execute(commands::run::RunArgs {
+                config_dir,
+                once,
+                deadline_ms,
+            })
+            .await
+        }
         #[cfg(feature = "web-ui")]
         Some(Command::Web {
             host,
@@ -160,7 +174,14 @@ async fn main() -> ExitCode {
             })
             .await
         }
-        None => commands::run::execute(commands::run::RunArgs { config_dir }).await,
+        None => {
+            commands::run::execute(commands::run::RunArgs {
+                config_dir,
+                once: false,
+                deadline_ms: None,
+            })
+            .await
+        }
     }
 }
 
@@ -218,7 +239,9 @@ mod tests {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "run", "--config-dir", "/tmp/ensemble"]);
         match cli.command {
-            Some(Command::Run) => {
+            Some(Command::Run { once, deadline_ms }) => {
+                assert!(!once);
+                assert_eq!(deadline_ms, None);
                 assert_eq!(cli.config.config_dir, Some(PathBuf::from("/tmp/ensemble")))
             }
             other => panic!("expected Run subcommand, got {:?}", other),
@@ -231,9 +254,27 @@ mod tests {
         let (_guard, host, port) = lock_and_clear_env();
         let cli = Cli::parse_from(["ensemble", "run"]);
         match cli.command {
-            Some(Command::Run) => assert_eq!(cli.config.config_dir, None),
+            Some(Command::Run { once, deadline_ms }) => {
+                assert!(!once);
+                assert_eq!(deadline_ms, None);
+                assert_eq!(cli.config.config_dir, None)
+            }
             other => panic!("expected Run subcommand, got {:?}", other),
         }
+        restore_env(host, port);
+    }
+
+    #[test]
+    fn test_cli_parse_bounded_run_options() {
+        let (_guard, host, port) = lock_and_clear_env();
+        let cli = Cli::parse_from(["ensemble", "run", "--once", "--deadline-ms", "25"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Run {
+                once: true,
+                deadline_ms: Some(25)
+            })
+        ));
         restore_env(host, port);
     }
 

--- a/crates/ensemble-core/src/agent/cancellation.rs
+++ b/crates/ensemble-core/src/agent/cancellation.rs
@@ -9,11 +9,13 @@ use tokio_util::sync::CancellationToken;
 
 use crate::agent::events::WorkerIdentity;
 use crate::config::ensemble::normalize_state_worker_cap_key;
+use crate::orchestrator::resources::{paths_conflict, SchedulerReservation};
 
 struct ActiveWorker {
     cancellation: CancellationToken,
     completion: watch::Receiver<bool>,
     capacity_bucket: String,
+    scheduler_reservation: SchedulerReservation,
     reconciliation_owned: bool,
     launched: bool,
 }
@@ -32,6 +34,8 @@ pub(crate) enum WorkerReservationError {
     GlobalCapacityExhausted,
     IssueCapacityExhausted,
     CapacityBucketExhausted,
+    ResourceExhausted,
+    PathConflict,
 }
 
 pub(crate) struct WorkerCapacity<'a> {
@@ -45,7 +49,7 @@ enum CapacitySource<'a> {
     },
     Lane {
         lane: &'a str,
-        capacity: u32,
+        capacity: Option<u32>,
     },
 }
 
@@ -62,7 +66,7 @@ impl<'a> WorkerCapacity<'a> {
         }
     }
 
-    pub(crate) fn lane(lane: &'a str, capacity: u32) -> Self {
+    pub(crate) fn lane(lane: &'a str, capacity: Option<u32>) -> Self {
         Self {
             source: CapacitySource::Lane { lane, capacity },
         }
@@ -78,7 +82,7 @@ impl<'a> WorkerCapacity<'a> {
                 let limit = max_workers_by_state.get(&bucket).copied();
                 (format!("state:{bucket}"), limit)
             }
-            CapacitySource::Lane { lane, capacity } => (format!("lane:{lane}"), Some(capacity)),
+            CapacitySource::Lane { lane, capacity } => (format!("lane:{lane}"), capacity),
         }
     }
 }
@@ -103,12 +107,14 @@ pub fn register_worker(
             cancellation,
             completion,
             capacity_bucket: String::new(),
+            scheduler_reservation: SchedulerReservation::default(),
             reconciliation_owned: false,
             launched: true,
         },
     );
 }
 
+#[cfg(test)]
 pub(crate) fn try_reserve_worker(
     registry: &CancellationRegistry,
     identity: WorkerIdentity,
@@ -117,6 +123,31 @@ pub(crate) fn try_reserve_worker(
     max_global_workers: u32,
     max_issue_workers: u32,
     capacity: WorkerCapacity<'_>,
+) -> Result<(), WorkerReservationError> {
+    try_reserve_scheduler_worker(
+        registry,
+        identity,
+        cancellation,
+        completion,
+        max_global_workers,
+        max_issue_workers,
+        capacity,
+        &BTreeMap::new(),
+        SchedulerReservation::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_reserve_scheduler_worker(
+    registry: &CancellationRegistry,
+    identity: WorkerIdentity,
+    cancellation: CancellationToken,
+    completion: watch::Receiver<bool>,
+    max_global_workers: u32,
+    max_issue_workers: u32,
+    capacity: WorkerCapacity<'_>,
+    resource_capacities: &BTreeMap<String, u32>,
+    scheduler_reservation: SchedulerReservation,
 ) -> Result<(), WorkerReservationError> {
     let mut workers = registry_guard(registry);
     if workers.contains_key(&identity) {
@@ -137,12 +168,38 @@ pub(crate) fn try_reserve_worker(
     if !capacity_available(&workers, &capacity_bucket, limit) {
         return Err(WorkerReservationError::CapacityBucketExhausted);
     }
+    for (resource, units) in &scheduler_reservation.resources {
+        let used = workers
+            .values()
+            .filter_map(|worker| worker.scheduler_reservation.resources.get(resource))
+            .sum::<u32>();
+        if resource_capacities
+            .get(resource)
+            .copied()
+            .unwrap_or_default()
+            < used.saturating_add(*units)
+        {
+            return Err(WorkerReservationError::ResourceExhausted);
+        }
+    }
+    if scheduler_reservation.paths.iter().any(|path| {
+        workers.values().any(|worker| {
+            worker
+                .scheduler_reservation
+                .paths
+                .iter()
+                .any(|active| paths_conflict(active, path))
+        })
+    }) {
+        return Err(WorkerReservationError::PathConflict);
+    }
     workers.insert(
         identity,
         ActiveWorker {
             cancellation,
             completion,
             capacity_bucket,
+            scheduler_reservation,
             reconciliation_owned: false,
             launched: false,
         },
@@ -170,10 +227,10 @@ pub(crate) fn has_available_state_worker_capacity(
 pub(crate) fn has_available_lane_worker_capacity(
     registry: &CancellationRegistry,
     lane: &str,
-    capacity: u32,
+    capacity: Option<u32>,
 ) -> bool {
     let bucket = format!("lane:{lane}");
-    capacity_available(&registry_guard(registry), &bucket, Some(capacity))
+    capacity_available(&registry_guard(registry), &bucket, capacity)
 }
 
 fn capacity_available(
@@ -949,11 +1006,13 @@ mod tests {
             lane_completion,
             4,
             1,
-            WorkerCapacity::lane("delivery", 1),
+            WorkerCapacity::lane("delivery", Some(1)),
         )
         .unwrap();
         assert!(!has_available_lane_worker_capacity(
-            &registry, "delivery", 1
+            &registry,
+            "delivery",
+            Some(1)
         ));
 
         let (_, blocked_completion) = watch::channel(false);
@@ -968,12 +1027,16 @@ mod tests {
                 blocked_completion,
                 4,
                 1,
-                WorkerCapacity::lane("delivery", 1),
+                WorkerCapacity::lane("delivery", Some(1)),
             ),
             Err(WorkerReservationError::CapacityBucketExhausted)
         );
 
         assert!(rollback_worker_reservation(&registry, &lane_identity));
-        assert!(has_available_lane_worker_capacity(&registry, "delivery", 1));
+        assert!(has_available_lane_worker_capacity(
+            &registry,
+            "delivery",
+            Some(1)
+        ));
     }
 }

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -405,6 +405,22 @@ pub async fn start_orchestrator_for_app(
         .map(launch_orchestrator_runtime))
 }
 
+/// Build the standard runtime components and drive their scheduler once without
+/// spawning the daemon host loop.
+pub async fn run_orchestrator_once_for_app(
+    app_state: &AppState,
+    deadline: Duration,
+) -> Result<Option<crate::orchestrator::DrainResult>, EnsembleError> {
+    let candidate = app_state.config_runtime.document_state.read().await.clone();
+    let Some(prepared) = prepare_orchestrator_runtime(app_state, &candidate).await? else {
+        return Ok(None);
+    };
+    let PreparedOrchestratorRuntime {
+        mut orchestrator, ..
+    } = prepared;
+    Ok(Some(orchestrator.run_once(deadline).await))
+}
+
 pub fn take_registered_orchestrator(app_state: &AppState) -> Option<OrchestratorRuntime> {
     registered_orchestrator_guard(app_state)
         .take()

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -1019,6 +1019,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }])
         .unwrap();
 

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -66,13 +66,69 @@ pub struct PipelineConfig {
 pub struct SchedulerConfig {
     #[serde(default)]
     pub lanes: BTreeMap<String, SchedulerLaneConfig>,
+    #[serde(default)]
+    pub resources: BTreeMap<String, SchedulerResourceConfig>,
+    #[serde(default)]
+    pub recovery: Option<SchedulerRecoveryConfig>,
+    #[serde(default)]
+    pub one_shot: SchedulerOneShotConfig,
 }
 
-/// A positive-capacity worker bucket shared by selected runs in one lane.
+/// A precedence-ordered worker bucket shared by selected runs in one lane.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SchedulerLaneConfig {
+    #[serde(default = "default_lane_precedence")]
+    pub precedence: u32,
+    #[serde(default)]
+    pub idle_only: bool,
+    #[serde(default)]
+    pub capacity: Option<u32>,
+}
+
+fn default_lane_precedence() -> u32 {
+    1
+}
+
+/// A named scheduler resource with a positive number of fungible units.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SchedulerResourceConfig {
+    #[serde(default = "default_resource_capacity")]
     pub capacity: u32,
+}
+
+fn default_resource_capacity() -> u32 {
+    1
+}
+
+/// Bounded automatic recovery for retained scheduler runs.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SchedulerRecoveryConfig {
+    pub max_attempts: u32,
+    #[serde(default)]
+    pub max_backoff_ms: Option<u64>,
+}
+
+/// The default deadline for bounded scheduler execution.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SchedulerOneShotConfig {
+    #[serde(default = "default_one_shot_deadline_ms")]
+    pub deadline_ms: u64,
+}
+
+fn default_one_shot_deadline_ms() -> u64 {
+    300_000
+}
+
+impl Default for SchedulerOneShotConfig {
+    fn default() -> Self {
+        Self {
+            deadline_ms: default_one_shot_deadline_ms(),
+        }
+    }
 }
 
 /// A precedence-ordered rule over normalized tracker fields.
@@ -584,6 +640,18 @@ pub struct StepConfig {
     pub on_failure: OnFailure,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fixup_agent: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub resource_requests: BTreeMap<String, u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub affected_paths: Option<AffectedPathSource>,
+}
+
+/// A validated string-array selected from one direct dependency's step output.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AffectedPathSource {
+    pub step: String,
+    pub pointer: String,
 }
 
 /// Concurrency limits for the pipeline orchestrator.
@@ -1359,6 +1427,7 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         });
     }
 
+    let mut lane_precedences = std::collections::HashSet::new();
     for (name, lane) in &config.scheduler.lanes {
         if name.trim().is_empty() {
             return Err(PipelineError::InvalidSchedulerLane {
@@ -1366,12 +1435,43 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
                 reason: "name must not be blank".to_string(),
             });
         }
-        if lane.capacity == 0 {
+        if lane.precedence == 0 || !lane_precedences.insert(lane.precedence) {
             return Err(PipelineError::InvalidSchedulerLane {
                 lane: name.clone(),
-                reason: "capacity must be greater than 0".to_string(),
+                reason: "precedence must be positive and unique".to_string(),
             });
         }
+        if lane.capacity == Some(0) {
+            return Err(PipelineError::InvalidSchedulerLane {
+                lane: name.clone(),
+                reason: "capacity must be greater than 0 when supplied".to_string(),
+            });
+        }
+    }
+    for (name, resource) in &config.scheduler.resources {
+        if name.trim().is_empty() || resource.capacity == 0 {
+            return Err(PipelineError::InvalidSchedulerLane {
+                lane: name.clone(),
+                reason: "resource names and capacities must be non-blank and positive".to_string(),
+            });
+        }
+    }
+    if config
+        .scheduler
+        .recovery
+        .as_ref()
+        .is_some_and(|recovery| recovery.max_attempts == 0 || recovery.max_backoff_ms == Some(0))
+    {
+        return Err(PipelineError::InvalidSchedulerLane {
+            lane: "recovery".to_string(),
+            reason: "recovery max_attempts and max_backoff_ms must be positive".to_string(),
+        });
+    }
+    if config.scheduler.one_shot.deadline_ms == 0 {
+        return Err(PipelineError::InvalidSchedulerLane {
+            lane: "one_shot".to_string(),
+            reason: "one_shot deadline_ms must be positive".to_string(),
+        });
     }
 
     let mut rule_names = std::collections::HashSet::new();
@@ -1857,19 +1957,76 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
                     reason: "synthesis steps require explicit non-empty depends".to_string(),
                 });
             }
+            for (resource, units) in &step.resource_requests {
+                let Some(configured) = config.scheduler.resources.get(resource) else {
+                    return Err(PipelineError::InvalidStepConfig {
+                        step: step.name.clone(),
+                        reason: format!("resource request '{resource}' is not configured"),
+                    });
+                };
+                if resource.trim().is_empty() || *units == 0 || *units > configured.capacity {
+                    return Err(PipelineError::InvalidStepConfig {
+                        step: step.name.clone(),
+                        reason: format!("resource request '{resource}' must be positive and within configured capacity"),
+                    });
+                }
+            }
+            if let Some(source) = &step.affected_paths {
+                if source.step.trim().is_empty() || !is_valid_json_pointer(&source.pointer) {
+                    return Err(PipelineError::InvalidStepConfig {
+                        step: step.name.clone(),
+                        reason: "affected_paths requires a non-blank direct dependency and valid non-empty JSON Pointer".to_string(),
+                    });
+                }
+            }
         }
-        if selected_mode {
+        let dag = if selected_mode {
             crate::pipeline::dag::build_dag(steps).map_err(|error| {
                 PipelineError::InvalidNamedPipeline {
                     pipeline: pipeline_name.to_string(),
                     reason: error.to_string(),
                 }
-            })?;
+            })?
         } else {
-            crate::pipeline::dag::build_dag(steps)?;
+            crate::pipeline::dag::build_dag(steps)?
+        };
+        for step in &dag.steps {
+            let Some(source) = &steps
+                .iter()
+                .find(|configured| configured.name == step.name)
+                .and_then(|configured| configured.affected_paths.as_ref())
+            else {
+                continue;
+            };
+            if !step
+                .depends
+                .iter()
+                .any(|dependency| dependency == &source.step)
+            {
+                return Err(PipelineError::InvalidStepConfig {
+                    step: step.name.clone(),
+                    reason: format!(
+                        "affected_paths step '{}' must be a direct dependency",
+                        source.step
+                    ),
+                });
+            }
         }
     }
     Ok(())
+}
+
+fn is_valid_json_pointer(pointer: &str) -> bool {
+    pointer.starts_with('/')
+        && pointer.split('/').skip(1).all(|segment| {
+            let mut characters = segment.chars();
+            while let Some(character) = characters.next() {
+                if character == '~' && !matches!(characters.next(), Some('0' | '1')) {
+                    return false;
+                }
+            }
+            true
+        })
 }
 
 #[cfg(test)]
@@ -1995,7 +2152,7 @@ workflow_selection:
 
         assert!(config.steps.is_empty());
         assert_eq!(config.pipelines["delivery"].steps[0].name, "build");
-        assert_eq!(config.scheduler.lanes["delivery"].capacity, 2);
+        assert_eq!(config.scheduler.lanes["delivery"].capacity, Some(2));
         assert_eq!(config.workflow_selection[0].name, "ready");
         assert_eq!(
             config.workflow_selection[0].order_by,
@@ -2070,11 +2227,133 @@ workflow_selection:
         ));
 
         let mut config = parse_config(selected).unwrap();
-        config.scheduler.lanes.get_mut("main").unwrap().capacity = 0;
+        config.scheduler.lanes.get_mut("main").unwrap().capacity = Some(0);
         assert!(matches!(
             validate_config(&config),
             Err(PipelineError::InvalidSchedulerLane { .. })
         ));
+    }
+
+    #[test]
+    fn selected_scheduler_parses_neutral_lane_resource_and_path_policy() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+repos:
+  - path: /tmp/ensemble
+    branch: main
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: build
+pipelines:
+  main:
+    steps:
+      - name: produce
+        agent: build
+      - name: consume
+        agent: build
+        depends: [produce]
+        resource_requests: { database: 2 }
+        affected_paths: { step: produce, pointer: /data/paths }
+    on_success: Done
+    on_failure: Failed
+scheduler:
+  lanes:
+    primary: { precedence: 10, capacity: 2 }
+    background: { precedence: 20, idle_only: true }
+  resources:
+    database: { capacity: 2 }
+  recovery: { max_attempts: 3, max_backoff_ms: 1000 }
+  one_shot: { deadline_ms: 2000 }
+workflow_selection:
+  - name: ready
+    precedence: 1
+    pipeline: main
+    lane: primary
+    order_by: [identifier]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.scheduler.lanes["primary"].precedence, 10);
+        assert_eq!(config.scheduler.lanes["primary"].capacity, Some(2));
+        assert!(config.scheduler.lanes["background"].idle_only);
+        assert_eq!(config.scheduler.resources["database"].capacity, 2);
+        assert_eq!(config.scheduler.recovery.as_ref().unwrap().max_attempts, 3);
+        assert_eq!(config.scheduler.one_shot.deadline_ms, 2_000);
+        assert_eq!(
+            config.pipelines["main"].steps[1]
+                .affected_paths
+                .as_ref()
+                .unwrap()
+                .pointer,
+            "/data/paths"
+        );
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn selected_scheduler_rejects_impossible_lane_resource_and_path_policy() {
+        let source = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+repos:
+  - path: /tmp/ensemble
+    branch: main
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: build
+pipelines:
+  main:
+    steps:
+      - name: produce
+        agent: build
+      - name: consume
+        agent: build
+        depends: [produce]
+    on_success: Done
+    on_failure: Failed
+scheduler:
+  lanes:
+    primary: { precedence: 10, capacity: 1 }
+  resources:
+    database: {}
+workflow_selection:
+  - name: ready
+    precedence: 1
+    pipeline: main
+    lane: primary
+    order_by: [identifier]
+"#;
+
+        let mut config = parse_config(source).unwrap();
+        config
+            .scheduler
+            .lanes
+            .get_mut("primary")
+            .unwrap()
+            .precedence = 0;
+        assert!(validate_config(&config).is_err());
+
+        let mut config = parse_config(source).unwrap();
+        config.pipelines.get_mut("main").unwrap().steps[1].resource_requests =
+            BTreeMap::from([("missing".to_string(), 1)]);
+        assert!(validate_config(&config).is_err());
+
+        let mut config = parse_config(source).unwrap();
+        config.pipelines.get_mut("main").unwrap().steps[1].affected_paths =
+            Some(AffectedPathSource {
+                step: "produce".to_string(),
+                pointer: "not-a-pointer".to_string(),
+            });
+        assert!(validate_config(&config).is_err());
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -857,7 +857,9 @@ fn build_setup_dag(steps: &[SetupStep]) -> Result<crate::pipeline::dag::StepDag,
                 approval: None,
                 on_failure: OnFailure::RetryIssue,
                 fixup_agent: None,
-            })
+            resource_requests: Default::default(),
+            affected_paths: None,
+})
         })
         .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -1007,6 +1007,8 @@ mod tests {
                     approval: None,
                     on_failure: OnFailure::RetryIssue,
                     fixup_agent: None,
+                    resource_requests: Default::default(),
+                    affected_paths: None,
                 },
                 StepConfig {
                     name: "review".to_string(),
@@ -1018,6 +1020,8 @@ mod tests {
                     approval: None,
                     on_failure: OnFailure::RetryIssue,
                     fixup_agent: None,
+                    resource_requests: Default::default(),
+                    affected_paths: None,
                 },
             ],
             on_success: "finalize".to_string(),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod delivery;
 pub mod delivery_observation;
 pub mod pipeline_journal;
 pub mod reconciler;
+pub mod resources;
 pub mod retry;
 pub mod scheduler;
 pub mod selection;
@@ -35,8 +36,8 @@ use crate::agent::cancellation::{
     has_available_state_worker_capacity, is_reconciliation_owned, live_worker_count,
     mark_all_for_drain, mark_issue_for_drain, mark_worker_launched, new_cancellation_registry,
     pending_reconciliation_issue_ids, remove_completed_worker, remove_drained_workers,
-    rollback_worker_reservation, try_reserve_worker, CancellationRegistry, WorkerCapacity,
-    WorkerDrainHandle, WorkerReservationError,
+    rollback_worker_reservation, try_reserve_scheduler_worker, CancellationRegistry,
+    WorkerCapacity, WorkerDrainHandle, WorkerReservationError,
 };
 use crate::agent::events::{
     AgentEvent, InteractionRequestDraft, OrchestratorWorkerEvent, StepApprovalRequestDraft,
@@ -48,9 +49,10 @@ use crate::attention::{
         awaiting_interaction_observation, interaction_attention_close_from_open,
         interaction_attention_identity,
     },
-    AttentionReporter,
+    AttentionEvidence, AttentionIdentity, AttentionPresentation, AttentionReporter,
+    AttentionUpsert,
 };
-use crate::config::ensemble::{EnsembleConfig, OnFailure, StepKind};
+use crate::config::ensemble::{repository_key, EnsembleConfig, OnFailure, StepKind};
 use crate::error::{AgentError, EnsembleError};
 use crate::history::artifacts::{finalize_mode_name, RunArtifacts};
 use crate::history::model::{HistoryRecord, TokenTotals};
@@ -79,6 +81,7 @@ use crate::orchestrator::pipeline_journal::{
     PendingTerminalTransition, PipelineRunJournal, PipelineTransitionInput, PipelineTransitionKind,
     PipelineTransitionRecord, TerminalOutcome,
 };
+use crate::orchestrator::resources::{resolve_output_paths, SchedulerReservation};
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{
     DispatchRequest, PipelineAction, PipelineRun, PipelineRunSnapshot, SelectedWorkflowSnapshot,
@@ -111,8 +114,8 @@ use scheduler::{
 };
 use selection::{sort_selected_candidates, SelectedWorkflow, WorkflowSelector};
 use state::{
-    FinalizeStatus, IssueFinalizeState, OrchestratorState, PendingTerminalEntry, RepoFinalizeState,
-    WaitingOnHumanEntry,
+    FinalizeStatus, IssueFinalizeState, OrchestratorState, ParkedRunEntry, PendingTerminalEntry,
+    RepoFinalizeState, WaitingOnHumanEntry,
 };
 
 struct StepDispatchContext<'a> {
@@ -211,8 +214,22 @@ struct ExhaustedRetryTerminal {
     history_record: Option<HistoryRecord>,
 }
 
+struct ParkedRecoveryRequest<'a> {
+    issue_id: &'a str,
+    entry: &'a RunningEntry,
+    step: &'a str,
+    attempt: u32,
+    reason: &'a str,
+}
+
 enum WholeIssueFailureRetry {
     Scheduled(Option<Box<PipelineTransitionInput>>),
+    Parked {
+        transition: Option<Box<PipelineTransitionInput>>,
+        identifier: String,
+        attempt: u32,
+        reason: String,
+    },
     Exhausted(Box<ExhaustedRetryTerminal>),
 }
 
@@ -494,6 +511,32 @@ pub(crate) struct QuiescingLatch(Arc<std::sync::Mutex<bool>>);
 
 struct DispatchPermit;
 
+/// The terminal result of a bounded scheduler run.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DrainOutcome {
+    Success,
+    WaitingForHuman,
+    PartialDrain,
+}
+
+/// Stable summary of residual scheduler ownership at a bounded-run boundary.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ResidualWorkSummary {
+    pub runnable: Vec<String>,
+    pub retrying: Vec<String>,
+    pub externally_waiting: Vec<String>,
+    pub delivery_or_finalization: Vec<String>,
+    pub parked: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct DrainResult {
+    pub outcome: DrainOutcome,
+    #[serde(default)]
+    pub residual: ResidualWorkSummary,
+}
+
 impl QuiescingLatch {
     pub(crate) fn request(&self) {
         *self
@@ -552,6 +595,131 @@ struct WaitingHistoryRecordInput<'a> {
 }
 
 impl Orchestrator {
+    fn drain_snapshot(state: &OrchestratorState) -> ResidualWorkSummary {
+        let mut summary = ResidualWorkSummary {
+            runnable: state.running.keys().cloned().collect(),
+            retrying: state.retry_attempts.keys().cloned().collect(),
+            externally_waiting: state.waiting_on_human.keys().cloned().collect(),
+            delivery_or_finalization: state
+                .delivery
+                .keys()
+                .chain(state.finalize.keys())
+                .cloned()
+                .collect(),
+            parked: state.parked_runs.keys().cloned().collect(),
+        };
+        summary.runnable.sort();
+        summary.retrying.sort();
+        summary.externally_waiting.sort();
+        summary.delivery_or_finalization.sort();
+        summary.delivery_or_finalization.dedup();
+        summary.parked.sort();
+        summary
+    }
+
+    /// Drive the same tick loop without installing the daemon watcher.
+    pub async fn run_once(&mut self, deadline: Duration) -> DrainResult {
+        {
+            let config = self.config.read().await;
+            let mut state = self.state.write().await;
+            state.poll_interval_ms = config.polling.interval_ms;
+            state.max_concurrent_agents = config.concurrency.max_concurrent_agents;
+            state.init_state_lists(&config);
+        }
+        let started = std::time::Instant::now();
+        let mut consecutive_empty = 0_u8;
+        loop {
+            self.handle_tick().await;
+            while let Ok(event) = self.worker_rx.lock().await.try_recv() {
+                self.handle_worker_event(event).await;
+            }
+            self.handle_retry_fires().await;
+            let state = self.state.read().await;
+            let summary = Self::drain_snapshot(&state);
+            drop(state);
+            if summary.runnable.is_empty()
+                && summary.retrying.is_empty()
+                && summary.externally_waiting.is_empty()
+                && summary.delivery_or_finalization.is_empty()
+                && summary.parked.is_empty()
+            {
+                consecutive_empty = consecutive_empty.saturating_add(1);
+                if consecutive_empty == 2 {
+                    return DrainResult {
+                        outcome: DrainOutcome::Success,
+                        residual: summary,
+                    };
+                }
+            } else {
+                consecutive_empty = 0;
+                if !summary.externally_waiting.is_empty()
+                    && summary.runnable.is_empty()
+                    && summary.retrying.is_empty()
+                    && summary.delivery_or_finalization.is_empty()
+                    && summary.parked.is_empty()
+                {
+                    return DrainResult {
+                        outcome: DrainOutcome::WaitingForHuman,
+                        residual: summary,
+                    };
+                }
+            }
+            if started.elapsed() >= deadline {
+                return DrainResult {
+                    outcome: DrainOutcome::PartialDrain,
+                    residual: summary,
+                };
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    fn park_exhausted_recovery(
+        state: &mut OrchestratorState,
+        config: &EnsembleConfig,
+        request: ParkedRecoveryRequest<'_>,
+        transitions: &mut Vec<PipelineTransitionInput>,
+    ) -> Option<(String, u32, String)> {
+        config.scheduler.recovery.as_ref()?;
+        state.parked_runs.insert(
+            request.issue_id.to_string(),
+            ParkedRunEntry {
+                issue_id: request.issue_id.to_string(),
+                identifier: request.entry.identifier.clone(),
+                condition_key: "runtime.scheduler.recovery_exhausted".to_string(),
+                attempt: request.attempt,
+                reason: request.reason.to_string(),
+                parked_at: Utc::now(),
+            },
+        );
+        state.add_runtime_seconds(request.entry);
+        if let Some(input) = Self::transition_input_for_run(
+            state,
+            request.issue_id,
+            &request.entry.identifier,
+            PipelineTransitionKind::RunParked,
+            Some(request.step.to_string()),
+            Some(request.reason.to_string()),
+            None,
+        ) {
+            transitions.push(input);
+        }
+        Some((
+            request.entry.identifier.clone(),
+            request.attempt,
+            request.reason.to_string(),
+        ))
+    }
+
+    fn automatic_recovery_max_attempts(config: &EnsembleConfig) -> u32 {
+        config
+            .scheduler
+            .recovery
+            .as_ref()
+            .map(|recovery| recovery.max_attempts)
+            .unwrap_or(config.max_cycles)
+    }
+
     fn effective_step_timeout_ms(timeout_ms: Option<u64>, config: &EnsembleConfig) -> u64 {
         timeout_ms.unwrap_or(config.agent.turn_timeout_ms)
     }
@@ -827,6 +995,7 @@ impl Orchestrator {
         }
 
         self.restore_pipeline_runs_from_journal().await;
+        self.reconcile_parked_recovery_attention().await;
         self.reconcile_pending_terminal_transitions().await;
 
         // Startup terminal workspace cleanup
@@ -983,6 +1152,7 @@ impl Orchestrator {
         Box::pin(self.reconcile_pending_run_started_transitions()).await;
         self.reconcile_pending_acceptance_transitions().await;
         self.restore_pipeline_runs_from_journal().await;
+        self.reconcile_parked_recovery_attention().await;
         self.reconcile_pending_terminal_transitions().await;
         self.hydrate_waiting_on_human_from_store().await;
         self.process_interaction_thread_commands().await;
@@ -1234,6 +1404,9 @@ impl Orchestrator {
         {
             let config = self.config.read().await;
             let capacity_available = if let Some(selected) = selected.as_ref() {
+                if selected.lane_idle_only && live_worker_count(&self.cancellation_registry) > 0 {
+                    return;
+                }
                 has_available_lane_worker_capacity(
                     &self.cancellation_registry,
                     &selected.lane,
@@ -3010,7 +3183,49 @@ impl Orchestrator {
                 &config_snapshot.agent.max_concurrent_agents_by_state,
             )
         };
-        match try_reserve_worker(
+        let scheduler_reservation = {
+            let (resource_requests, affected_paths, outputs) = {
+                let state = self.state.read().await;
+                let run =
+                    state
+                        .get_pipeline_run(&issue.id)
+                        .ok_or_else(|| AgentError::PromptError {
+                            reason: format!(
+                                "cannot dispatch step '{}' without a pipeline run",
+                                dispatch.step_name
+                            ),
+                        })?;
+                let (resource_requests, affected_paths) = run
+                    .scheduler_requirements_for(dispatch.step_name)
+                    .ok_or_else(|| AgentError::PromptError {
+                        reason: format!("pipeline run has no step '{}'", dispatch.step_name),
+                    })?;
+                (resource_requests, affected_paths, run.step_outputs.clone())
+            };
+            let repositories = config_snapshot
+                .repos
+                .iter()
+                .enumerate()
+                .map(|(index, repo)| repository_key(repo, index))
+                .collect();
+            let paths = affected_paths
+                .as_ref()
+                .map(|source| resolve_output_paths(source, &outputs, &repositories))
+                .transpose()
+                .map_err(|reason| AgentError::PromptError { reason })?
+                .unwrap_or_default();
+            SchedulerReservation {
+                resources: resource_requests,
+                paths,
+            }
+        };
+        let resource_capacities = config_snapshot
+            .scheduler
+            .resources
+            .iter()
+            .map(|(name, config)| (name.clone(), config.capacity))
+            .collect();
+        match try_reserve_scheduler_worker(
             &self.cancellation_registry,
             worker_identity.clone(),
             cancel_token.clone(),
@@ -3018,12 +3233,16 @@ impl Orchestrator {
             config_snapshot.concurrency.max_concurrent_agents,
             config_snapshot.concurrency.max_step_parallelism,
             worker_capacity,
+            &resource_capacities,
+            scheduler_reservation.clone(),
         ) {
             Ok(()) => {}
             Err(
                 WorkerReservationError::GlobalCapacityExhausted
                 | WorkerReservationError::IssueCapacityExhausted
-                | WorkerReservationError::CapacityBucketExhausted,
+                | WorkerReservationError::CapacityBucketExhausted
+                | WorkerReservationError::ResourceExhausted
+                | WorkerReservationError::PathConflict,
             ) => {
                 debug!(
                     issue_id = %issue.id,
@@ -3153,6 +3372,7 @@ impl Orchestrator {
                 "{}-{}-{}",
                 issue.id, dispatch.step_name, dispatch.agent_name
             );
+            run.set_active_scheduler_reservation(dispatch.step_name, scheduler_reservation);
             run.mark_running(dispatch.step_name, running_session_id.clone());
             let transition = Self::transition_input_for_run(
                 &state,
@@ -3193,13 +3413,12 @@ impl Orchestrator {
                             })
                         {
                             if let Some(previous_step_state) = previous_step_state {
-                                state
-                                    .get_pipeline_run_mut(&issue.id)
-                                    .expect(
-                                        "pipeline run was present while validating dispatch rollback",
-                                    )
-                                    .step_states
+                                let run = state.get_pipeline_run_mut(&issue.id).expect(
+                                    "pipeline run was present while validating dispatch rollback",
+                                );
+                                run.step_states
                                     .insert(dispatch.step_name.to_string(), previous_step_state);
+                                run.clear_active_scheduler_reservation(dispatch.step_name);
                             }
                         }
                         return Err(AgentError::PromptError {
@@ -3248,6 +3467,7 @@ impl Orchestrator {
                             if let Some(previous_step_state) = previous_step_state.clone() {
                                 run.step_states
                                     .insert(dispatch.step_name.to_string(), previous_step_state);
+                                run.clear_active_scheduler_reservation(dispatch.step_name);
                             }
                         }
                     }
@@ -4358,6 +4578,7 @@ impl Orchestrator {
                             let mut history_record = None;
                             let mut terminal_issue = None;
                             let mut rejection_comment = None;
+                            let mut parked_recovery = None;
                             let mut post_failure_transitions = Vec::new();
                             if let Some(input) = step_transition {
                                 post_failure_transitions.push(input);
@@ -4389,13 +4610,33 @@ impl Orchestrator {
                                                 max_backoff_ms: config_snapshot
                                                     .agent
                                                     .max_retry_backoff_ms,
-                                                max_cycles: config_snapshot.max_cycles,
+                                                max_cycles: config_snapshot
+                                                    .scheduler
+                                                    .recovery
+                                                    .as_ref()
+                                                    .map(|recovery| recovery.max_attempts)
+                                                    .unwrap_or(config_snapshot.max_cycles),
                                                 error: &reason,
                                                 retry_from_step: Some(step.clone()),
                                                 with_fixup: false,
                                             },
                                         );
                                         final_failure = retry_scheduled.is_exhausted();
+                                        if final_failure {
+                                            parked_recovery = Self::park_exhausted_recovery(
+                                                &mut state,
+                                                &config_snapshot,
+                                                ParkedRecoveryRequest {
+                                                    issue_id,
+                                                    entry: &entry,
+                                                    step: &step,
+                                                    attempt,
+                                                    reason: &reason,
+                                                },
+                                                &mut post_failure_transitions,
+                                            );
+                                            final_failure = parked_recovery.is_none();
+                                        }
                                         if final_failure {
                                             history_record =
                                                 state.get_pipeline_run(issue_id).map(|run| {
@@ -4473,13 +4714,33 @@ impl Orchestrator {
                                                 max_backoff_ms: config_snapshot
                                                     .agent
                                                     .max_retry_backoff_ms,
-                                                max_cycles: config_snapshot.max_cycles,
+                                                max_cycles: config_snapshot
+                                                    .scheduler
+                                                    .recovery
+                                                    .as_ref()
+                                                    .map(|recovery| recovery.max_attempts)
+                                                    .unwrap_or(config_snapshot.max_cycles),
                                                 error: &reason,
                                                 retry_from_step: Some(step.clone()),
                                                 with_fixup: true,
                                             },
                                         );
                                         final_failure = retry_scheduled.is_exhausted();
+                                        if final_failure {
+                                            parked_recovery = Self::park_exhausted_recovery(
+                                                &mut state,
+                                                &config_snapshot,
+                                                ParkedRecoveryRequest {
+                                                    issue_id,
+                                                    entry: &entry,
+                                                    step: &step,
+                                                    attempt,
+                                                    reason: &reason,
+                                                },
+                                                &mut post_failure_transitions,
+                                            );
+                                            final_failure = parked_recovery.is_none();
+                                        }
                                         if final_failure {
                                             history_record =
                                                 state.get_pipeline_run(issue_id).map(|run| {
@@ -4581,13 +4842,32 @@ impl Orchestrator {
                                                 max_backoff_ms: config_snapshot
                                                     .agent
                                                     .max_retry_backoff_ms,
-                                                max_cycles: config_snapshot.max_cycles,
+                                                max_cycles: Self::automatic_recovery_max_attempts(
+                                                    &config_snapshot,
+                                                ),
                                                 error: &reason,
                                                 retry_from_step: None,
                                                 with_fixup: false,
                                             },
                                         );
                                         final_failure = retry_scheduled.is_exhausted();
+                                        if final_failure {
+                                            parked_recovery = Self::park_exhausted_recovery(
+                                                &mut state,
+                                                &config_snapshot,
+                                                ParkedRecoveryRequest {
+                                                    issue_id,
+                                                    entry: &entry,
+                                                    step: &step,
+                                                    attempt,
+                                                    reason: &reason,
+                                                },
+                                                &mut post_failure_transitions,
+                                            );
+                                        }
+                                        if parked_recovery.is_some() {
+                                            final_failure = false;
+                                        }
                                         if final_failure {
                                             history_record =
                                                 state.get_pipeline_run(issue_id).map(|run| {
@@ -4635,6 +4915,16 @@ impl Orchestrator {
                             drop(state);
                             for input in post_failure_transitions {
                                 self.append_pipeline_transition(input).await;
+                            }
+                            if let Some((identifier, attempt, reason)) = parked_recovery {
+                                self.report_recovery_exhausted_attention(
+                                    issue_id,
+                                    &identifier,
+                                    attempt,
+                                    &reason,
+                                )
+                                .await;
+                                return;
                             }
                             if final_failure {
                                 if let Some((step_name, summary)) = rejection_comment {
@@ -4795,6 +5085,8 @@ impl Orchestrator {
                 let mut history_record = None;
                 let mut terminal_issue = None;
                 let mut retry_transition = None;
+                let mut parked_recovery = None;
+                let mut parked_transitions = Vec::new();
 
                 if let Some(entry) = state.running.get(issue_id).cloned() {
                     terminal_issue = Some(entry.issue.clone());
@@ -4808,7 +5100,7 @@ impl Orchestrator {
                                 identifier: &entry.identifier,
                                 attempt: next_attempt(entry.retry_attempt),
                                 max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
-                                max_cycles: config_snapshot.max_cycles,
+                                max_cycles: Self::automatic_recovery_max_attempts(&config_snapshot),
                                 error: &error,
                                 retry_from_step: None,
                                 with_fixup: false,
@@ -4818,6 +5110,22 @@ impl Orchestrator {
                     final_failure = retry_scheduled
                         .as_ref()
                         .is_none_or(FailureRetryDisposition::is_exhausted);
+                    if final_failure && retry_scheduled.is_some() {
+                        let attempt = next_attempt(entry.retry_attempt);
+                        parked_recovery = Self::park_exhausted_recovery(
+                            &mut state,
+                            &config_snapshot,
+                            ParkedRecoveryRequest {
+                                issue_id,
+                                entry: &entry,
+                                step: step_name,
+                                attempt,
+                                reason: &error,
+                            },
+                            &mut parked_transitions,
+                        );
+                        final_failure = parked_recovery.is_none();
+                    }
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             self.build_history_record(RunningHistoryRecordInput {
@@ -4851,6 +5159,19 @@ impl Orchestrator {
                 if let Some(input) = retry_transition {
                     self.append_pipeline_transition(input).await;
                 }
+                for input in parked_transitions {
+                    self.append_pipeline_transition(input).await;
+                }
+                if let Some((identifier, attempt, reason)) = parked_recovery {
+                    self.report_recovery_exhausted_attention(
+                        issue_id,
+                        &identifier,
+                        attempt,
+                        &reason,
+                    )
+                    .await;
+                    return;
+                }
                 if final_failure {
                     if let Some(issue) = terminal_issue {
                         self.begin_terminal_transition(
@@ -4882,7 +5203,7 @@ impl Orchestrator {
                 identifier: &entry.identifier,
                 attempt: next_attempt(entry.retry_attempt),
                 max_backoff_ms: config.agent.max_retry_backoff_ms,
-                max_cycles: config.max_cycles,
+                max_cycles: Self::automatic_recovery_max_attempts(config),
                 error,
                 retry_from_step: None,
                 with_fixup: false,
@@ -4915,6 +5236,29 @@ impl Orchestrator {
                 WholeIssueFailureRetry::Scheduled(transition.map(Box::new))
             }
             FailureRetryDisposition::Exhausted => {
+                if config.scheduler.recovery.is_some() {
+                    let mut transitions = Vec::new();
+                    let attempt = next_attempt(entry.retry_attempt);
+                    let parked = Self::park_exhausted_recovery(
+                        state,
+                        config,
+                        ParkedRecoveryRequest {
+                            issue_id: &issue_id,
+                            entry: &entry,
+                            step: "runtime",
+                            attempt,
+                            reason: error,
+                        },
+                        &mut transitions,
+                    )
+                    .expect("configured recovery parks exhausted automatic retries");
+                    return WholeIssueFailureRetry::Parked {
+                        transition: transitions.pop().map(Box::new),
+                        identifier: parked.0,
+                        attempt: parked.1,
+                        reason: parked.2,
+                    };
+                }
                 state.running.insert(issue_id.clone(), entry.clone());
                 let history_record = state.get_pipeline_run(&issue_id).map(|run| {
                     self.build_history_record(RunningHistoryRecordInput {
@@ -5010,6 +5354,22 @@ impl Orchestrator {
                 )
                 .await;
             }
+            Some(WholeIssueFailureRetry::Parked {
+                transition,
+                identifier,
+                attempt,
+                reason,
+            }) => {
+                let issue_id = transition
+                    .as_ref()
+                    .map(|input| input.issue_id.clone())
+                    .unwrap_or_else(|| identifier.clone());
+                if let Some(input) = transition {
+                    self.append_pipeline_transition(*input).await;
+                }
+                self.report_recovery_exhausted_attention(&issue_id, &identifier, attempt, &reason)
+                    .await;
+            }
             Some(WholeIssueFailureRetry::Scheduled(None)) | None => {}
         }
     }
@@ -5046,6 +5406,7 @@ impl Orchestrator {
         let mut history_record = None;
         let mut terminal_issue = None;
         let mut rejection_comment = None;
+        let mut parked_recovery = None;
         let mut post_failure_transitions = Vec::new();
         if let Some(input) = step_failed_transition {
             post_failure_transitions.push(input);
@@ -5077,13 +5438,28 @@ impl Orchestrator {
                             identifier: &entry.identifier,
                             attempt,
                             max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
-                            max_cycles: config_snapshot.max_cycles,
+                            max_cycles: Self::automatic_recovery_max_attempts(&config_snapshot),
                             error: &reason,
                             retry_from_step: Some(step_name.clone()),
                             with_fixup: false,
                         },
                     );
                     final_failure = retry_scheduled.is_exhausted();
+                    if final_failure {
+                        parked_recovery = Self::park_exhausted_recovery(
+                            &mut state,
+                            &config_snapshot,
+                            ParkedRecoveryRequest {
+                                issue_id,
+                                entry: &entry,
+                                step,
+                                attempt,
+                                reason: &reason,
+                            },
+                            &mut post_failure_transitions,
+                        );
+                        final_failure = parked_recovery.is_none();
+                    }
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             rejection_comment = Self::rejection_comment_for_step(run, step);
@@ -5148,13 +5524,28 @@ impl Orchestrator {
                             identifier: &entry.identifier,
                             attempt,
                             max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
-                            max_cycles: config_snapshot.max_cycles,
+                            max_cycles: Self::automatic_recovery_max_attempts(&config_snapshot),
                             error: &reason,
                             retry_from_step: Some(step_name.clone()),
                             with_fixup: true,
                         },
                     );
                     final_failure = retry_scheduled.is_exhausted();
+                    if final_failure {
+                        parked_recovery = Self::park_exhausted_recovery(
+                            &mut state,
+                            &config_snapshot,
+                            ParkedRecoveryRequest {
+                                issue_id,
+                                entry: &entry,
+                                step,
+                                attempt,
+                                reason: &reason,
+                            },
+                            &mut post_failure_transitions,
+                        );
+                        final_failure = parked_recovery.is_none();
+                    }
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             rejection_comment = Self::rejection_comment_for_step(run, step);
@@ -5243,13 +5634,28 @@ impl Orchestrator {
                             identifier: &entry.identifier,
                             attempt,
                             max_backoff_ms: config_snapshot.agent.max_retry_backoff_ms,
-                            max_cycles: config_snapshot.max_cycles,
+                            max_cycles: Self::automatic_recovery_max_attempts(&config_snapshot),
                             error: &reason,
                             retry_from_step: None,
                             with_fixup: false,
                         },
                     );
                     final_failure = retry_scheduled.is_exhausted();
+                    if final_failure {
+                        parked_recovery = Self::park_exhausted_recovery(
+                            &mut state,
+                            &config_snapshot,
+                            ParkedRecoveryRequest {
+                                issue_id,
+                                entry: &entry,
+                                step,
+                                attempt,
+                                reason: &reason,
+                            },
+                            &mut post_failure_transitions,
+                        );
+                        final_failure = parked_recovery.is_none();
+                    }
                     if final_failure {
                         history_record = state.get_pipeline_run(issue_id).map(|run| {
                             rejection_comment = Self::rejection_comment_for_step(run, step);
@@ -5288,6 +5694,11 @@ impl Orchestrator {
         drop(state);
         for input in post_failure_transitions {
             self.append_pipeline_transition(input).await;
+        }
+        if let Some((identifier, attempt, reason)) = parked_recovery {
+            self.report_recovery_exhausted_attention(issue_id, &identifier, attempt, &reason)
+                .await;
+            return;
         }
         if final_failure {
             if let Some((step_name, summary)) = rejection_comment {
@@ -6241,6 +6652,58 @@ impl Orchestrator {
         true
     }
 
+    async fn report_recovery_exhausted_attention(
+        &self,
+        issue_id: &str,
+        identifier: &str,
+        attempt: u32,
+        reason: &str,
+    ) -> bool {
+        let Some(reporter) = &self.attention_reporter else {
+            return true;
+        };
+        let observation: Result<AttentionUpsert, crate::attention::AttentionError> = (|| {
+            Ok(AttentionUpsert::new(
+                AttentionIdentity::new(
+                    "runtime.scheduler",
+                    issue_id,
+                    "runtime.scheduler.recovery_exhausted",
+                )?,
+                AttentionPresentation::new(
+                    format!("{identifier} exhausted automatic recovery"),
+                    "Provide fresh evidence, then explicitly resume the retained run.",
+                    vec![],
+                )?,
+                AttentionEvidence::new(format!("attempt:{attempt}:{reason}"))?,
+            ))
+        })();
+        let Ok(observation) = observation else {
+            return false;
+        };
+        if let Err(error) = reporter.upsert_open(observation).await {
+            warn!(issue_id, error = %error, "failed to persist exhausted-recovery attention");
+            return false;
+        }
+        true
+    }
+
+    /// Retry durable attention projection for retained runs without changing their ownership.
+    async fn reconcile_parked_recovery_attention(&self) {
+        let parked = {
+            let state = self.state.read().await;
+            state.parked_runs.values().cloned().collect::<Vec<_>>()
+        };
+        for entry in parked {
+            self.report_recovery_exhausted_attention(
+                &entry.issue_id,
+                &entry.identifier,
+                entry.attempt,
+                &entry.reason,
+            )
+            .await;
+        }
+    }
+
     async fn reconcile_interaction_attention(&self, interaction: &InteractionRequest) -> bool {
         if interaction.status == InteractionStatus::Open {
             return self.report_awaiting_interaction(interaction).await;
@@ -6639,6 +7102,23 @@ impl Orchestrator {
                 run_id: record.run_id.clone(),
                 issue: issues_by_id.get(&record.issue_id).cloned(),
             });
+        }
+
+        if record.kind == PipelineTransitionKind::RunParked {
+            state
+                .parked_runs
+                .entry(record.issue_id.clone())
+                .or_insert_with(|| ParkedRunEntry {
+                    issue_id: record.issue_id.clone(),
+                    identifier: record.identifier.clone(),
+                    condition_key: "runtime.scheduler.recovery_exhausted".to_string(),
+                    attempt: record.cycle.max(1),
+                    reason: record
+                        .reason
+                        .clone()
+                        .unwrap_or_else(|| "automatic recovery exhausted".to_string()),
+                    parked_at: record.written_at,
+                });
         }
 
         Ok(())
@@ -9646,6 +10126,7 @@ fn validate_acceptance_attempts(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::cancellation::try_reserve_worker;
     use crate::agent::events::{
         AgentEvent, InteractionRequestDraft, OrchestratorWorkerEvent, StepApprovalRequestDraft,
         WorkerEvent, WorkerIdentity, WorkerResult,
@@ -13406,6 +13887,100 @@ agent:
         (orchestrator, state)
     }
 
+    #[tokio::test]
+    async fn one_shot_requires_two_fresh_empty_snapshots() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = make_config();
+        let issue = test_issue("1", "Done");
+        let (mut orchestrator, state) = make_restart_test_orchestrator(&temp, &config, &issue);
+
+        let result = orchestrator.run_once(Duration::from_millis(100)).await;
+
+        assert_eq!(result.outcome, DrainOutcome::Success);
+        assert!(result.residual.runnable.is_empty());
+        assert!(state.read().await.running.is_empty());
+    }
+
+    #[tokio::test]
+    async fn one_shot_reports_attention_only_wait_as_waiting_for_human() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = make_config();
+        let issue = test_issue("1", "Todo");
+        let (mut orchestrator, state) = make_restart_test_orchestrator(&temp, &config, &issue);
+        state
+            .write()
+            .await
+            .add_waiting_on_human(WaitingOnHumanEntry {
+                issue_id: "1".to_string(),
+                identifier: issue.identifier.clone(),
+                interaction_request_id: "ask-1".to_string(),
+                step_name: "build".to_string(),
+                kind: InteractionKind::Question,
+                prompt: "Need input".to_string(),
+                agent_name: "builder".to_string(),
+                retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: Utc::now(),
+                run_id: None,
+                issue: Some(issue),
+            });
+
+        let result = orchestrator.run_once(Duration::from_millis(100)).await;
+
+        assert_eq!(result.outcome, DrainOutcome::WaitingForHuman);
+        assert_eq!(result.residual.externally_waiting, vec!["1"]);
+    }
+
+    #[tokio::test]
+    async fn one_shot_deadline_reports_parked_residual() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = make_config();
+        let issue = test_issue("1", "Todo");
+        let (mut orchestrator, state) = make_restart_test_orchestrator(&temp, &config, &issue);
+        state.write().await.parked_runs.insert(
+            "1".to_string(),
+            ParkedRunEntry {
+                issue_id: "1".to_string(),
+                identifier: issue.identifier,
+                condition_key: "runtime.scheduler.recovery_exhausted".to_string(),
+                attempt: 1,
+                reason: "network".to_string(),
+                parked_at: Utc::now(),
+            },
+        );
+
+        let result = orchestrator.run_once(Duration::from_millis(1)).await;
+
+        assert_eq!(result.outcome, DrainOutcome::PartialDrain);
+        assert_eq!(result.residual.parked, vec!["1"]);
+    }
+
+    #[tokio::test]
+    async fn one_shot_deadline_keeps_retry_residual_without_consuming_a_worker_slot() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = make_config();
+        let issue = test_issue("retrying", "Todo");
+        let (mut orchestrator, state) = make_restart_test_orchestrator(&temp, &config, &issue);
+        state.write().await.add_retry(RetryEntry {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            attempt: 1,
+            due_at_ms: current_time_ms() + 60_000,
+            error: Some("transient".to_string()),
+            retry_from_step: None,
+            with_fixup: false,
+        });
+
+        let result = orchestrator.run_once(Duration::from_millis(1)).await;
+
+        assert_eq!(result.outcome, DrainOutcome::PartialDrain);
+        assert_eq!(result.residual.retrying, vec![issue.id]);
+        assert_eq!(live_worker_count(&orchestrator.cancellation_registry), 0);
+    }
+
     fn make_acceptance_test_orchestrator(
         temp: &tempfile::TempDir,
         cfg: &EnsembleConfig,
@@ -14577,6 +15152,55 @@ agent:
         assert!(lock.get_pipeline_run(&issue.id).is_some());
         assert!(lock.is_claimed(&issue.id));
         assert!(lock.is_waiting_on_human(&issue.id));
+    }
+
+    #[tokio::test]
+    async fn restore_pipeline_run_preserves_parked_owner_and_reconciles_attention() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut cfg = make_config();
+        cfg.scheduler.recovery = Some(crate::config::ensemble::SchedulerRecoveryConfig {
+            max_attempts: 1,
+            max_backoff_ms: None,
+        });
+        let issue = test_issue("parked-restart", "Todo");
+        let (orchestrator, state) = make_restart_test_orchestrator(&temp, &cfg, &issue);
+        let run = PipelineRun::new(issue.id.clone(), 2, build_dag(&cfg.steps).unwrap());
+        orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::RunParked,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-parked".to_string()),
+                cycle: 2,
+                step: Some("build".to_string()),
+                reason: Some("retry budget exhausted".to_string()),
+                retry: None,
+                snapshot: Some(run.to_snapshot()),
+                terminal_transition: None,
+                delivery: None,
+            })
+            .await
+            .unwrap();
+
+        orchestrator.restore_pipeline_runs_from_journal().await;
+        orchestrator.reconcile_parked_recovery_attention().await;
+
+        let state = state.read().await;
+        let parked = state.parked_runs.get(&issue.id).unwrap();
+        assert_eq!(parked.attempt, 2);
+        assert_eq!(parked.reason, "retry budget exhausted");
+        assert!(state.is_claimed(&issue.id));
+        assert!(state.get_pipeline_run(&issue.id).is_some());
+        drop(state);
+        let items = orchestrator
+            .attention_reporter
+            .as_ref()
+            .unwrap()
+            .items_for_subject(&issue.id)
+            .await
+            .unwrap();
+        assert_eq!(items.len(), 1);
     }
 
     #[tokio::test]
@@ -16233,6 +16857,8 @@ agent:
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }])
         .unwrap();
         let stale_run = PipelineRun::new(issue.id.clone(), 1, stale_dag);
@@ -21435,7 +22061,15 @@ agent:
             },
         );
         config.scheduler = SchedulerConfig {
-            lanes: BTreeMap::from([("delivery".to_string(), SchedulerLaneConfig { capacity: 1 })]),
+            lanes: BTreeMap::from([(
+                "delivery".to_string(),
+                SchedulerLaneConfig {
+                    precedence: 1,
+                    idle_only: false,
+                    capacity: Some(1),
+                },
+            )]),
+            ..SchedulerConfig::default()
         };
         config.workflow_selection = vec![WorkflowSelectionRuleConfig {
             name: "ready".to_string(),

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -113,6 +113,7 @@ pub enum PipelineTransitionKind {
     AcceptanceCheckCompleted,
     StepRetryScheduled,
     FixupRetryScheduled,
+    RunParked,
     PipelineHalted,
     PipelineSucceeded,
     PipelineFailed,
@@ -636,6 +637,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }
     }
 

--- a/crates/ensemble-core/src/orchestrator/resources.rs
+++ b/crates/ensemble-core/src/orchestrator/resources.rs
@@ -1,0 +1,219 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+#[cfg(test)]
+use crate::agent::events::WorkerIdentity;
+use crate::config::ensemble::AffectedPathSource;
+use crate::pipeline::verdict::StepOutput;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct NormalizedPath {
+    pub repository: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SchedulerReservation {
+    #[serde(default)]
+    pub resources: BTreeMap<String, u32>,
+    #[serde(default)]
+    pub paths: Vec<NormalizedPath>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReservationConflict {
+    Resource(String),
+    Path(NormalizedPath),
+}
+
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct ReservationBook {
+    reservations: HashMap<WorkerIdentity, SchedulerReservation>,
+}
+
+#[cfg(test)]
+impl ReservationBook {
+    pub(crate) fn try_reserve(
+        &mut self,
+        worker: WorkerIdentity,
+        capacities: &BTreeMap<String, u32>,
+        reservation: SchedulerReservation,
+    ) -> Result<(), ReservationConflict> {
+        for (resource, units) in &reservation.resources {
+            let used = self
+                .reservations
+                .values()
+                .filter_map(|active| active.resources.get(resource))
+                .sum::<u32>();
+            if capacities.get(resource).copied().unwrap_or_default() < used.saturating_add(*units) {
+                return Err(ReservationConflict::Resource(resource.clone()));
+            }
+        }
+        for path in &reservation.paths {
+            if self
+                .reservations
+                .values()
+                .flat_map(|active| &active.paths)
+                .any(|active| paths_conflict(active, path))
+            {
+                return Err(ReservationConflict::Path(path.clone()));
+            }
+        }
+        self.reservations.insert(worker, reservation);
+        Ok(())
+    }
+
+    pub(crate) fn release(&mut self, worker: &WorkerIdentity) -> bool {
+        self.reservations.remove(worker).is_some()
+    }
+}
+
+pub(crate) fn normalize_declared_path(
+    value: &str,
+    repositories: &HashSet<String>,
+) -> Result<NormalizedPath, String> {
+    let (repository, raw_path) = value
+        .split_once(':')
+        .ok_or_else(|| "path declaration must be '<repository>:<path>'".to_string())?;
+    if !repositories.contains(repository) {
+        return Err(format!("unknown repository key '{repository}'"));
+    }
+    if raw_path.is_empty()
+        || raw_path.starts_with('/')
+        || raw_path.contains('\\')
+        || raw_path.chars().any(char::is_control)
+    {
+        return Err("path must be a non-empty repository-relative slash path".to_string());
+    }
+    let segments = raw_path.split('/').collect::<Vec<_>>();
+    if segments
+        .iter()
+        .any(|segment| segment.is_empty() || matches!(*segment, "." | ".."))
+    {
+        return Err("path must not contain empty, '.' or '..' segments".to_string());
+    }
+    Ok(NormalizedPath {
+        repository: repository.to_string(),
+        path: segments.join("/"),
+    })
+}
+
+pub(crate) fn resolve_output_paths(
+    source: &AffectedPathSource,
+    outputs: &HashMap<String, StepOutput>,
+    repositories: &HashSet<String>,
+) -> Result<Vec<NormalizedPath>, String> {
+    let output = outputs
+        .get(&source.step)
+        .and_then(|output| output.output.as_ref())
+        .ok_or_else(|| format!("dependency '{}' has no output", source.step))?;
+    let value = output.pointer(&source.pointer).ok_or_else(|| {
+        format!(
+            "dependency '{}' output has no '{}'",
+            source.step, source.pointer
+        )
+    })?;
+    let values = value
+        .as_array()
+        .ok_or_else(|| "affected path output must be a string array".to_string())?;
+    let mut paths = values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| "affected path output must contain only strings".to_string())
+                .and_then(|value| normalize_declared_path(value, repositories))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    paths.sort_by(|left, right| {
+        left.repository
+            .cmp(&right.repository)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    paths.dedup();
+    Ok(paths)
+}
+
+pub(crate) fn paths_conflict(left: &NormalizedPath, right: &NormalizedPath) -> bool {
+    left.repository == right.repository
+        && (left.path == right.path
+            || left.path.starts_with(&(right.path.clone() + "/"))
+            || right.path.starts_with(&(left.path.clone() + "/")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn worker(step: &str) -> WorkerIdentity {
+        WorkerIdentity {
+            issue_id: "issue-1".to_string(),
+            run_id: "run-1".to_string(),
+            cycle: 1,
+            step_name: step.to_string(),
+            started_at: Utc.timestamp_opt(0, 0).unwrap(),
+        }
+    }
+
+    fn repos() -> HashSet<String> {
+        HashSet::from(["app".to_string(), "docs".to_string()])
+    }
+
+    #[test]
+    fn resource_units_are_atomic_and_release_by_exact_identity() {
+        let mut book = ReservationBook::default();
+        let capacities = BTreeMap::from([("db".to_string(), 2), ("cache".to_string(), 1)]);
+        let first = SchedulerReservation {
+            resources: BTreeMap::from([("db".to_string(), 2)]),
+            paths: vec![],
+        };
+        book.try_reserve(worker("first"), &capacities, first)
+            .unwrap();
+        let rejected = SchedulerReservation {
+            resources: BTreeMap::from([("cache".to_string(), 1), ("db".to_string(), 1)]),
+            paths: vec![],
+        };
+        assert_eq!(
+            book.try_reserve(worker("second"), &capacities, rejected),
+            Err(ReservationConflict::Resource("db".to_string()))
+        );
+        assert!(book.release(&worker("first")));
+        assert!(!book.release(&worker("first")));
+        book.try_reserve(
+            worker("second"),
+            &capacities,
+            SchedulerReservation {
+                resources: BTreeMap::from([("db".to_string(), 1)]),
+                paths: vec![],
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn path_conflicts_are_only_component_normalized_within_one_repository() {
+        let source = normalize_declared_path("app:src", &repos()).unwrap();
+        let descendant = normalize_declared_path("app:src/main.rs", &repos()).unwrap();
+        let sibling = normalize_declared_path("app:src2/main.rs", &repos()).unwrap();
+        let other_repo = normalize_declared_path("docs:src/main.rs", &repos()).unwrap();
+        assert!(paths_conflict(&source, &descendant));
+        assert!(!paths_conflict(&source, &sibling));
+        assert!(!paths_conflict(&source, &other_repo));
+    }
+
+    #[test]
+    fn declared_paths_reject_ambiguous_or_unsafe_values() {
+        for value in [
+            "src/main.rs",
+            "missing:src/main.rs",
+            "app:/src",
+            "app:a//b",
+            "app:a/../b",
+            "app:a\\b",
+        ] {
+            assert!(normalize_declared_path(value, &repos()).is_err(), "{value}");
+        }
+    }
+}

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -858,6 +858,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }])
         .unwrap();
         state.pipeline_runs.insert(

--- a/crates/ensemble-core/src/orchestrator/selection.rs
+++ b/crates/ensemble-core/src/orchestrator/selection.rs
@@ -10,7 +10,9 @@ pub struct SelectedWorkflow {
     pub rule: String,
     pub pipeline: String,
     pub lane: String,
-    pub lane_capacity: u32,
+    pub lane_capacity: Option<u32>,
+    pub lane_idle_only: bool,
+    lane_precedence: u32,
     precedence: u32,
     order_by: Vec<WorkflowOrderKey>,
 }
@@ -37,10 +39,9 @@ impl WorkflowSelector {
     ) -> Result<Self, PipelineError> {
         let mut compiled = Vec::with_capacity(rules.len());
         for rule in rules {
-            let lane_capacity =
+            let lane =
                 lanes
                     .get(&rule.lane)
-                    .map(|lane| lane.capacity)
                     .ok_or_else(|| PipelineError::InvalidSchedulerLane {
                         lane: rule.lane.clone(),
                         reason: "referenced by a workflow-selection rule but not configured"
@@ -55,7 +56,9 @@ impl WorkflowSelector {
                     rule: rule.name.clone(),
                     pipeline: rule.pipeline.clone(),
                     lane: rule.lane.clone(),
-                    lane_capacity,
+                    lane_capacity: lane.capacity,
+                    lane_idle_only: lane.idle_only,
+                    lane_precedence: lane.precedence,
                     precedence: rule.precedence,
                     order_by,
                 },
@@ -118,8 +121,9 @@ fn normalize(value: &str) -> String {
 
 pub fn sort_selected_candidates(candidates: &mut [(Issue, SelectedWorkflow)]) {
     candidates.sort_by(|(left_issue, left), (right_issue, right)| {
-        left.precedence
-            .cmp(&right.precedence)
+        left.lane_precedence
+            .cmp(&right.lane_precedence)
+            .then_with(|| left.precedence.cmp(&right.precedence))
             .then_with(|| {
                 if left.rule == right.rule {
                     compare_by_rule(left_issue, right_issue, &left.order_by)
@@ -194,6 +198,42 @@ mod tests {
         assert_eq!(selected.rule, "higher");
         assert_eq!(selected.pipeline, "higher-pipeline");
         assert_eq!(selected.lane, "higher-lane");
+    }
+
+    #[test]
+    fn candidate_order_uses_lane_precedence_before_rule_ordering() {
+        let mut candidates = vec![
+            (
+                test_issue("lower", "ready"),
+                SelectedWorkflow {
+                    rule: "lower".to_string(),
+                    pipeline: "main".to_string(),
+                    lane: "lower-lane".to_string(),
+                    lane_capacity: Some(1),
+                    lane_idle_only: false,
+                    lane_precedence: 20,
+                    precedence: 1,
+                    order_by: vec![WorkflowOrderKey::Identifier],
+                },
+            ),
+            (
+                test_issue("higher", "ready"),
+                SelectedWorkflow {
+                    rule: "higher".to_string(),
+                    pipeline: "main".to_string(),
+                    lane: "higher-lane".to_string(),
+                    lane_capacity: Some(1),
+                    lane_idle_only: false,
+                    lane_precedence: 10,
+                    precedence: 99,
+                    order_by: vec![WorkflowOrderKey::Identifier],
+                },
+            ),
+        ];
+
+        sort_selected_candidates(&mut candidates);
+
+        assert_eq!(candidates[0].1.lane, "higher-lane");
     }
 
     #[test]
@@ -340,7 +380,16 @@ mod tests {
             ("urgent-lane".to_string(), 1),
         ]
         .into_iter()
-        .map(|(name, capacity)| (name, SchedulerLaneConfig { capacity }))
+        .map(|(name, capacity)| {
+            (
+                name,
+                SchedulerLaneConfig {
+                    precedence: 1,
+                    idle_only: false,
+                    capacity: Some(capacity),
+                },
+            )
+        })
         .collect()
     }
 }

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -56,6 +56,17 @@ pub struct WaitingOnHumanEntry {
     pub issue: Option<Issue>,
 }
 
+/// A retained run whose configured automatic recovery bound was reached.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParkedRunEntry {
+    pub issue_id: String,
+    pub identifier: String,
+    pub condition_key: String,
+    pub attempt: u32,
+    pub reason: String,
+    pub parked_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone)]
 pub struct CompletedEntry {
     pub issue_id: String,
@@ -139,6 +150,8 @@ pub struct OrchestratorState {
     pub retry_attempts: HashMap<String, RetryEntry>,
     /// Issues blocked waiting for a human response: issue_id -> waiting entry.
     pub waiting_on_human: HashMap<String, WaitingOnHumanEntry>,
+    /// Retained runs that need fresh external evidence before they are requeued.
+    pub parked_runs: HashMap<String, ParkedRunEntry>,
     /// Explicit resume requests queued by the API/UI: issue IDs.
     pub resume_requested: HashSet<String>,
     /// Completed issues: issue_id -> CompletedEntry.
@@ -195,6 +208,7 @@ impl OrchestratorState {
             claimed: HashSet::new(),
             retry_attempts: HashMap::new(),
             waiting_on_human: HashMap::new(),
+            parked_runs: HashMap::new(),
             resume_requested: HashSet::new(),
             completed: HashMap::new(),
             completed_expiry_secs: config.completed_expiry_secs,
@@ -385,6 +399,7 @@ impl OrchestratorState {
         self.running.remove(issue_id);
         self.retry_attempts.remove(issue_id);
         self.waiting_on_human.remove(issue_id);
+        self.parked_runs.remove(issue_id);
         self.resume_requested.remove(issue_id);
         self.pipeline_configs.remove(issue_id);
         self.finalize.remove(issue_id);
@@ -1173,5 +1188,37 @@ mod tests {
         assert_eq!(state.completed.len(), 2);
         assert!(state.completed.contains_key("issue-1"));
         assert!(state.completed.contains_key("issue-2"));
+    }
+
+    #[test]
+    fn release_claim_removes_parked_recovery_without_touching_other_owners() {
+        let mut state = OrchestratorState::new(30_000, &ConcurrencyConfig::default());
+        state.parked_runs.insert(
+            "issue-1".to_string(),
+            ParkedRunEntry {
+                issue_id: "issue-1".to_string(),
+                identifier: "repo#issue-1".to_string(),
+                condition_key: "runtime.scheduler.recovery_exhausted".to_string(),
+                attempt: 2,
+                reason: "network".to_string(),
+                parked_at: Utc::now(),
+            },
+        );
+        state.parked_runs.insert(
+            "issue-2".to_string(),
+            ParkedRunEntry {
+                issue_id: "issue-2".to_string(),
+                identifier: "repo#issue-2".to_string(),
+                condition_key: "runtime.scheduler.recovery_exhausted".to_string(),
+                attempt: 2,
+                reason: "network".to_string(),
+                parked_at: Utc::now(),
+            },
+        );
+
+        state.release_claim("issue-1");
+
+        assert!(!state.parked_runs.contains_key("issue-1"));
+        assert!(state.parked_runs.contains_key("issue-2"));
     }
 }

--- a/crates/ensemble-core/src/pipeline/dag.rs
+++ b/crates/ensemble-core/src/pipeline/dag.rs
@@ -1,8 +1,10 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::ensemble::{OnFailure, StepApprovalConfig, StepConfig, StepKind};
+use crate::config::ensemble::{
+    AffectedPathSource, OnFailure, StepApprovalConfig, StepConfig, StepKind,
+};
 use crate::error::PipelineError;
 
 /// A single step in the resolved DAG, with its explicit dependency list.
@@ -17,6 +19,10 @@ pub struct DagStep {
     pub approval: Option<StepApprovalConfig>,
     pub on_failure: OnFailure,
     pub fixup_agent: Option<String>,
+    #[serde(default)]
+    pub resource_requests: BTreeMap<String, u32>,
+    #[serde(default)]
+    pub affected_paths: Option<AffectedPathSource>,
     pub depends: Vec<String>,
 }
 
@@ -116,6 +122,8 @@ pub fn build_dag(steps: &[StepConfig]) -> Result<StepDag, PipelineError> {
             approval: step.approval.clone(),
             on_failure: step.on_failure,
             fixup_agent: step.fixup_agent.clone(),
+            resource_requests: step.resource_requests.clone(),
+            affected_paths: step.affected_paths.clone(),
             depends: deps,
         });
     }
@@ -209,6 +217,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }
     }
 
@@ -223,6 +233,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }
     }
 
@@ -378,6 +390,8 @@ mod tests {
                 approval: None,
                 on_failure: OnFailure::RetryIssue,
                 fixup_agent: None,
+                resource_requests: Default::default(),
+                affected_paths: None,
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -389,6 +403,8 @@ mod tests {
                 approval: None,
                 on_failure: OnFailure::RetryIssue,
                 fixup_agent: None,
+                resource_requests: Default::default(),
+                affected_paths: None,
             },
         ];
 
@@ -414,6 +430,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }];
 
         let dag = build_dag(&steps).unwrap();
@@ -436,6 +454,8 @@ mod tests {
             }),
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }];
 
         let dag = build_dag(&steps).unwrap();
@@ -464,6 +484,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::Fixup,
             fixup_agent: Some("fixer".to_string()),
+            resource_requests: Default::default(),
+            affected_paths: None,
         }];
 
         let dag = build_dag(&steps).unwrap();

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -3,7 +3,8 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::acceptance::AcceptanceAttempt;
-use crate::config::ensemble::{OnFailure, StepKind};
+use crate::config::ensemble::{AffectedPathSource, OnFailure, StepKind};
+use crate::orchestrator::resources::SchedulerReservation;
 use crate::pipeline::dag::{DagStep, StepDag};
 use crate::pipeline::verdict::{StepOutput, StepResult};
 use crate::tracker::OwnershipLease;
@@ -135,6 +136,8 @@ pub struct PipelineRun {
     workspace_branch_name: Option<String>,
     /// Configured workflow identity frozen before ownership is journaled.
     selected_workflow: Option<SelectedWorkflowSnapshot>,
+    /// Concrete scheduler leases captured with running dispatch transitions, by step.
+    active_scheduler_reservations: HashMap<String, SchedulerReservation>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -162,6 +165,8 @@ pub struct PipelineRunSnapshot {
     pub workspace_branch_name: Option<String>,
     #[serde(default)]
     pub selected_workflow: Option<SelectedWorkflowSnapshot>,
+    #[serde(default)]
+    pub active_scheduler_reservations: HashMap<String, SchedulerReservation>,
 }
 
 impl PipelineRun {
@@ -185,6 +190,7 @@ impl PipelineRun {
             ownership_lease: None,
             workspace_branch_name: None,
             selected_workflow: None,
+            active_scheduler_reservations: HashMap::new(),
         }
     }
 
@@ -201,7 +207,35 @@ impl PipelineRun {
             ownership_lease: self.ownership_lease.clone(),
             workspace_branch_name: self.workspace_branch_name.clone(),
             selected_workflow: self.selected_workflow.clone(),
+            active_scheduler_reservations: self.active_scheduler_reservations.clone(),
         }
+    }
+
+    pub(crate) fn scheduler_requirements_for(
+        &self,
+        step_name: &str,
+    ) -> Option<(
+        std::collections::BTreeMap<String, u32>,
+        Option<AffectedPathSource>,
+    )> {
+        self.dag
+            .steps
+            .iter()
+            .find(|step| step.name == step_name)
+            .map(|step| (step.resource_requests.clone(), step.affected_paths.clone()))
+    }
+
+    pub(crate) fn set_active_scheduler_reservation(
+        &mut self,
+        step_name: &str,
+        reservation: SchedulerReservation,
+    ) {
+        self.active_scheduler_reservations
+            .insert(step_name.to_string(), reservation);
+    }
+
+    pub(crate) fn clear_active_scheduler_reservation(&mut self, step_name: &str) {
+        self.active_scheduler_reservations.remove(step_name);
     }
 
     pub fn from_snapshot(
@@ -222,6 +256,7 @@ impl PipelineRun {
             ownership_lease: snapshot.ownership_lease,
             workspace_branch_name: snapshot.workspace_branch_name,
             selected_workflow: snapshot.selected_workflow,
+            active_scheduler_reservations: snapshot.active_scheduler_reservations,
         })
     }
 
@@ -255,10 +290,15 @@ impl PipelineRun {
     }
 
     pub fn normalize_stale_running_steps(&mut self) {
+        let mut normalized = false;
         for state in self.step_states.values_mut() {
             if matches!(state, StepState::Running { .. }) {
                 *state = StepState::Pending;
+                normalized = true;
             }
+        }
+        if normalized {
+            self.active_scheduler_reservations.clear();
         }
     }
 
@@ -292,6 +332,7 @@ impl PipelineRun {
         output: StepOutput,
         approval_requested: bool,
     ) -> PipelineAction {
+        self.clear_active_scheduler_reservation(step_name);
         let result = output.result.clone();
         self.step_outputs.insert(step_name.to_string(), output);
         match result {
@@ -527,6 +568,8 @@ impl PipelineRun {
                         approval: None,
                         on_failure: OnFailure::Halt,
                         fixup_agent: None,
+                        resource_requests: Default::default(),
+                        affected_paths: None,
                         depends: original_deps,
                     },
                 );
@@ -838,6 +881,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }
     }
 
@@ -852,6 +897,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }
     }
 
@@ -925,6 +972,51 @@ mod tests {
                 lane: "delivery".to_string(),
             })
         );
+    }
+
+    #[test]
+    fn stale_running_snapshot_releases_durable_scheduler_reservation() {
+        let mut run = make_run(&[make_step("build", "builder", &[])]);
+        run.set_active_scheduler_reservation(
+            "build",
+            SchedulerReservation {
+                resources: std::collections::BTreeMap::from([("database".to_string(), 1)]),
+                paths: vec![crate::orchestrator::resources::NormalizedPath {
+                    repository: "app".to_string(),
+                    path: "src/main.rs".to_string(),
+                }],
+            },
+        );
+        run.mark_running("build", "session".to_string());
+
+        let mut restored = PipelineRun::from_snapshot(run.to_snapshot()).unwrap();
+        restored.normalize_stale_running_steps();
+
+        assert!(restored.active_scheduler_reservations.is_empty());
+        assert_eq!(restored.step_states["build"], StepState::Pending);
+    }
+
+    #[test]
+    fn completing_one_parallel_step_keeps_the_other_durable_reservation() {
+        let mut run = make_run(&[
+            make_step("left", "builder", &[]),
+            make_step("right", "builder", &[]),
+        ]);
+        run.set_active_scheduler_reservation("left", SchedulerReservation::default());
+        run.set_active_scheduler_reservation(
+            "right",
+            SchedulerReservation {
+                resources: std::collections::BTreeMap::from([("database".to_string(), 1)]),
+                paths: vec![],
+            },
+        );
+        run.mark_running("left", "left-session".to_string());
+        run.mark_running("right", "right-session".to_string());
+
+        run.step_completed("left", approve_output(), false);
+
+        assert!(!run.active_scheduler_reservations.contains_key("left"));
+        assert!(run.active_scheduler_reservations.contains_key("right"));
     }
 
     #[test]
@@ -1057,6 +1149,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }];
         let run = make_run(&steps);
 
@@ -1088,6 +1182,8 @@ mod tests {
             approval: None,
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }
     }
 
@@ -1116,6 +1212,8 @@ mod tests {
             }),
             on_failure: OnFailure::RetryIssue,
             fixup_agent: None,
+            resource_requests: Default::default(),
+            affected_paths: None,
         }
     }
 
@@ -1860,6 +1958,8 @@ mod tests {
                 approval: None,
                 on_failure: OnFailure::RetryIssue,
                 fixup_agent: None,
+                resource_requests: Default::default(),
+                affected_paths: None,
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -1871,6 +1971,8 @@ mod tests {
                 approval: None,
                 on_failure: OnFailure::RetryIssue,
                 fixup_agent: None,
+                resource_requests: Default::default(),
+                affected_paths: None,
             },
         ];
         let mut run = make_run(&steps);

--- a/crates/ensemble-core/tests/step_output_templates.rs
+++ b/crates/ensemble-core/tests/step_output_templates.rs
@@ -39,6 +39,8 @@ fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
         approval: None,
         on_failure: OnFailure::RetryIssue,
         fixup_agent: None,
+        resource_requests: Default::default(),
+        affected_paths: None,
     }
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -677,7 +677,14 @@ Pipeline mode rules:
   forbids the legacy pipeline fields.
 - Every named pipeline is independently DAG-validated and supplies its own `steps`, `on_success`,
   and `on_failure`.
-- Every scheduler lane has a positive live-worker `capacity`.
+- Every scheduler lane has unique positive `precedence`, optional positive live-worker `capacity`,
+  and optional `idle_only` admission. Named scheduler resources have positive capacity.
+- A worker atomically reserves its global/per-issue/lane capacity together with named resource
+  units and normalized repository-relative output paths before `StepRunning` is journaled. The
+  effective reservation is snapshot-persisted; stale restored workers release it before retry.
+- `scheduler.recovery.max_attempts` bounds every automatic recovery route. Exhaustion journals a
+  retained parked owner, keeps its workspace and claim, and idempotently projects generic operator
+  attention. `scheduler.one_shot.deadline_ms` configures bounded `ensemble run --once` execution.
 - Selection rules have unique normalized names and unique positive precedence values, reference an
   existing pipeline and lane, and may constrain normalized `states`, `labels_all`, `labels_any`,
   `labels_none`, and `require_unblocked`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -567,9 +567,20 @@ pipelines:
 scheduler:
   lanes:
     delivery:
+      precedence: 10
       capacity: 3
     planning:
+      precedence: 20
       capacity: 1
+      idle_only: true
+  resources:
+    shared-sandbox:
+      capacity: 1
+  recovery:
+    max_attempts: 3
+    max_backoff_ms: 300000
+  one_shot:
+    deadline_ms: 300000
 
 workflow_selection:
   - name: ready-delivery
@@ -609,8 +620,13 @@ non-empty and contain no blank or normalized-duplicate values.
 
 Rules are evaluated by ascending positive `precedence`; the first matching rule selects one named
 pipeline and one scheduler lane. Rule names and precedence values must be unique, and every
-pipeline and lane reference must exist. Lane capacity must be a positive integer. Every named
-pipeline is validated as a complete DAG with non-blank terminal transitions.
+pipeline and lane reference must exist. Lanes have unique positive `precedence`; `capacity`, when
+set, is a positive live-worker cap, while `idle_only` admits the lane only when no worker is live.
+Named resources are positive-capacity unit pools. `scheduler.recovery.max_attempts` bounds all
+automatic recovery paths; exhaustion retains the claimed run and asks an operator to provide fresh
+evidence before resuming it. `scheduler.one_shot.deadline_ms` supplies the default deadline for
+`ensemble run --once`. Every named pipeline is validated as a complete DAG with non-blank terminal
+transitions.
 
 `order_by` accepts `priority`, `tracker_position`, `created_at`, and `identifier`. Keys are applied
 in their listed order, ascending, with null values last. Keys cannot repeat, and `identifier`, when
@@ -631,6 +647,8 @@ Pipeline step definitions. Each step invokes one agent.
 | `timeout_ms` | integer | inherits `agent.turn_timeout_ms` | Optional maximum time for each runtime prompt or turn in this step |
 | `approval.mode` | string | — | Optional post-step approval policy: `always` or `when_requested_by_agent` |
 | `approval.state` | string | — | Optional tracker state to mirror while waiting for approval |
+| `resource_requests` | map of string to integer | `{}` | Named scheduler resource units required atomically before the step starts |
+| `affected_paths` | object | — | Output path source with `step` (direct dependency) and JSON `pointer`; normalized repository-relative paths are leased while the worker is live |
 
 See [Pipeline Guide](pipelines.md) for details on DAG construction and execution.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -25,6 +25,31 @@ a different combination after configuration changes, recovery fails closed for o
 This preserves the orchestrator's single lifecycle authority described by ADR-0012 while keeping
 development-method vocabulary outside the runtime core as required by ADR-0014.
 
+## Scheduler leases and bounded execution
+
+Selected lanes have a unique positive `precedence`, optional live-agent `capacity`, and may be
+`idle_only`. Lower precedence runs first; idle-only fresh work waits until recovered and eligible
+non-idle work has had an admission opportunity. Omitted lane capacity adds no further cap beyond
+the global and per-issue worker limits.
+
+Steps may request configured named resource units and may select a direct dependency's validated
+string-array output with a JSON Pointer as their affected-path declaration. Paths use the strict
+`repository:path` form, are repository-relative slash paths, and conflict only when equal or when
+one is a component ancestor of another in the same repository. Every live dispatch reserves worker,
+lane, resources, and paths atomically; its effective lease is journaled before `StepRunning` and is
+cleared when a stale running step is restored to pending after restart.
+
+`scheduler.recovery.max_attempts` bounds automatic retry recovery. Once exhausted, Ensemble keeps
+the claim, workspace, run state, and completed steps as a parked run, releases live-agent leases,
+and reports the generic `runtime.scheduler.recovery_exhausted` operator-attention item. Parking
+does not add tracker or dashboard mutation authority.
+
+`ensemble run --once [--deadline-ms N]` drives the same scheduler without starting the daemon
+watcher and emits one JSON result. It returns `success` after two fresh empty snapshots,
+`waiting_for_human` only when open interactions are the sole residual, and `partial_drain` on the
+configured/overridden deadline with a deterministic residual summary. Non-success results exit
+nonzero.
+
 ## Steps and agents
 
 Each step references an agent defined in `config.yaml`:


### PR DESCRIPTION
## Summary
- add neutral lane precedence, idle-only admission, optional lane capacity, named resource capacity, and declared affected-path conflicts
- persist per-step scheduler reservations and parked recovery across restart, with bounded operator-attention reporting
- add a shared one-shot scheduler path through `ensemble run --once` with structured terminal outcomes and residual work

## Validation
- orchestrator: 211 passed
- config: 93 passed; selection: 6 passed; resources: 3 passed
- workspace/core serial validation passed; product E2E: 44 passed, 1 ignored
- web feature check, clippy, fmt, and diff check passed

## Risk
- scheduler conflicts depend only on configured resources and validated declared paths; no prose inference
- parked recovery retains claim/workspace and reports observational attention without granting mutation authority
- rebased over non-overlapping shadcn dependency-only main drift and reran orchestrator/clippy gates

Fixes #516