### PR TITLE
Add Mission Control keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,26 @@ The `web` subcommand is available in release builds and source builds installed 
 
 Then open `http://localhost:3000` in your browser.
 
+### Mission Control keyboard shortcuts
+
+Mission Control keeps its pointer and touch controls available while also supporting these
+non-destructive keyboard shortcuts outside editable controls:
+
+| Shortcut | Action |
+| --- | --- |
+| `/` | Focus issue search |
+| `j` / `k` | Select the next / previous issue in the visible view order (board columns left-to-right, then top-to-bottom) |
+| `Esc` | Close the selected issue panel |
+| `r` | Focus the rendered reply field |
+| `b` / `l` | Show Board / List |
+| `a` | Toggle Attention only |
+| `Shift` + `R` | Refresh Mission Control |
+| `?` | Show the in-product shortcut reference |
+
+`Esc` only closes a selected issue panel, and `r` is available only when that panel already renders
+a reply field. Shortcuts do not run while focus is in an input, textarea, select, or editable-content
+surface; `Esc` is the scoped exception for closing the selected panel.
+
 ## Web dashboard security
 
 The web and desktop dashboards control an unauthenticated, single-operator service. `ensemble web`

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
@@ -287,6 +287,12 @@ function renderMissionControl(snapshot?: RuntimeSnapshot) {
   };
 }
 
+function dispatchShortcut(key: string, options: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key, ...options });
+  act(() => window.dispatchEvent(event));
+  return event;
+}
+
 function missionGroups(overrides: Partial<Record<MissionGroup["id"], MissionIssueSummary[]>> = {}): MissionGroup[] {
   return [
     { id: "running", title: "Running", issues: overrides.running ?? [issue()] },
@@ -729,6 +735,104 @@ describe("Mission Control page", () => {
     expect(within(operations).getByText("Activity")).toBeInTheDocument();
     expect(within(operations).getByText("repo#4")).toBeInTheDocument();
     expect(within(operations).queryByText("repo#1")).not.toBeInTheDocument();
+  });
+
+  it("focuses search and cycles filtered issue selection from the keyboard", async () => {
+    renderMissionControl(runtimeSnapshot());
+    const search = screen.getByRole("textbox", { name: "Search issues" });
+
+    const focusSearch = dispatchShortcut("/");
+    expect(focusSearch.defaultPrevented).toBe(true);
+    expect(search).toHaveFocus();
+
+    search.blur();
+    const next = dispatchShortcut("j");
+    expect(next.defaultPrevented).toBe(true);
+    expect(await screen.findByRole("heading", { name: "repo#1" })).toBeInTheDocument();
+
+    dispatchShortcut("j");
+    expect(await screen.findByRole("heading", { name: "repo#2" })).toBeInTheDocument();
+
+    dispatchShortcut("k");
+    expect(await screen.findByRole("heading", { name: "repo#1" })).toBeInTheDocument();
+  });
+
+  it("handles non-destructive toolbar shortcuts and renders their shared reference", async () => {
+    renderMissionControl(runtimeSnapshot());
+
+    dispatchShortcut("l");
+    expect(screen.getByRole("button", { name: "List" })).toHaveAttribute("aria-pressed", "true");
+    dispatchShortcut("b");
+    expect(screen.getByRole("button", { name: "Board" })).toHaveAttribute("aria-pressed", "true");
+    dispatchShortcut("a");
+    expect(screen.getByRole("button", { name: "Attention only" })).toHaveAttribute("aria-pressed", "true");
+
+    const refresh = dispatchShortcut("R", { shiftKey: true });
+    expect(refresh.defaultPrevented).toBe(true);
+    await waitFor(() => expect(postRefresh).toHaveBeenCalledTimes(1));
+
+    const reference = dispatchShortcut("?", { shiftKey: true });
+    expect(reference.defaultPrevented).toBe(true);
+    expect(await screen.findByText("Focus issue search")).toBeInTheDocument();
+    expect(screen.getByText("Shift + R")).toBeInTheDocument();
+    expect(screen.getByText("Reply field required")).toBeInTheDocument();
+  });
+
+  it("does not steal editable input or unavailable shortcuts, but closes a selected panel with Escape", async () => {
+    renderMissionControl(runtimeSnapshot());
+    const search = screen.getByRole("textbox", { name: "Search issues" });
+    search.focus();
+
+    const typedShortcut = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "j",
+    });
+    act(() => search.dispatchEvent(typedShortcut));
+    expect(typedShortcut.defaultPrevented).toBe(false);
+    expect(screen.getByText("Select an issue")).toBeInTheDocument();
+
+    const unavailableReply = dispatchShortcut("r");
+    expect(unavailableReply.defaultPrevented).toBe(false);
+
+    const composing = dispatchShortcut("j", { isComposing: true });
+    expect(composing.defaultPrevented).toBe(false);
+    expect(screen.getByText("Select an issue")).toBeInTheDocument();
+
+    dispatchShortcut("j");
+    expect(await screen.findByRole("heading", { name: "repo#1" })).toBeInTheDocument();
+    const close = dispatchShortcut("Escape");
+    expect(close.defaultPrevented).toBe(true);
+    expect(await screen.findByText("Select an issue")).toBeInTheDocument();
+  });
+
+  it("focuses an already rendered reply surface without changing the active tab", async () => {
+    vi.mocked(useIssueRuntime).mockImplementation((identifier) => ({
+      ...runtimeFixture(identifier || "unselected"),
+      pendingQuestion: {
+        interactionId: "ask-1",
+        kind: "question",
+        status: "open",
+        awaitingResume: false,
+        question: "Proceed?",
+        whyBlocked: "A decision is required.",
+        suggestedAnswer: null,
+        stepName: "review",
+      },
+    }));
+    const user = userEvent.setup();
+    renderMissionControl(runtimeSnapshot());
+
+    dispatchShortcut("j");
+    expect(await screen.findByRole("heading", { name: "repo#1" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Respond" }));
+    const composer = screen.getByRole("textbox", { name: "Reply" });
+    expect(composer).not.toHaveFocus();
+
+    const focusReply = dispatchShortcut("r");
+    expect(focusReply.defaultPrevented).toBe(true);
+    expect(composer).toHaveFocus();
+    expect(screen.getByRole("tab", { name: "Respond" })).toHaveAttribute("aria-selected", "true");
   });
 
   it("exposes operations as a named section without adding a nested main landmark", () => {

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
@@ -4,12 +4,19 @@ import { Button } from "@/components/ui/button";
 import { useRefreshMutation, useStateQuery } from "@/hooks";
 import { AttentionQueue } from "./AttentionQueue";
 import { IssueCommandPanel, type IssueCommandPanelTab } from "./IssueCommandPanel";
+import {
+  isEditableTarget,
+  isShortcutAvailable,
+  keyboardShortcuts,
+  matchesShortcut,
+} from "./keyboardShortcuts";
 import { MissionControlToolbar, type MissionControlViewMode } from "./MissionControlToolbar";
 import { OperationsBoard } from "./OperationsBoard";
 import { OperationsList } from "./OperationsList";
 import {
   deriveMissionControlState,
   filterMissionControlIssues,
+  issuesInGroupOrder,
   regroupMissionControlIssues,
   type MissionControlFilters,
   type MissionIssueStatus,
@@ -65,11 +72,13 @@ export default function MissionControl() {
   const refreshMutation = useRefreshMutation();
   const operationsRegionRef = useRef<HTMLElement>(null);
   const panelRegionRef = useRef<HTMLElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const selectionTriggerRef = useRef<HTMLElement | null>(null);
   const restoreSelectionFocusRef = useRef(false);
   const [selectedIssueIdentifier, setSelectedIssueIdentifier] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<MissionControlViewMode>(readViewMode);
   const [activeTab, setActiveTab] = useState<IssueCommandPanelTab>(readActiveTab);
+  const [shortcutReferenceOpen, setShortcutReferenceOpen] = useState(false);
   const [filters, setFilters] = useState<MissionControlFilters>(() => ({
     query: "",
     status: "all",
@@ -91,6 +100,10 @@ export default function MissionControl() {
   const filteredGroups = useMemo(
     () => regroupMissionControlIssues(filteredIssues),
     [filteredIssues],
+  );
+  const navigationIssues = useMemo(
+    () => (viewMode === "board" ? issuesInGroupOrder(filteredGroups) : filteredIssues),
+    [filteredGroups, filteredIssues, viewMode],
   );
 
   useEffect(() => {
@@ -124,6 +137,87 @@ export default function MissionControl() {
     panelRegionRef.current?.focus({ preventScroll: true });
     panelRegionRef.current?.scrollIntoView?.({ behavior: "smooth", block: "start" });
   }, [selectedIssueIdentifier]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.isComposing) return;
+
+      const shortcut = keyboardShortcuts.find((candidate) => matchesShortcut(event, candidate));
+      if (!shortcut) return;
+      if (isEditableTarget(event.target) && shortcut.id !== "close-panel") return;
+
+      const replySurface = document.getElementById("issue-composer");
+      const hasReplySurface = replySurface instanceof HTMLTextAreaElement;
+      if (
+        !isShortcutAvailable(shortcut, {
+          hasSelectedIssue: selectedIssueIdentifier !== null,
+          hasReplySurface,
+        })
+      ) {
+        return;
+      }
+
+      let handled = false;
+      switch (shortcut.id) {
+        case "focus-search":
+          searchInputRef.current?.focus({ preventScroll: true });
+          handled = searchInputRef.current !== null;
+          break;
+        case "next-issue":
+        case "previous-issue": {
+          if (navigationIssues.length === 0) break;
+          const selectedIndex = navigationIssues.findIndex(
+            (issue) => issue.identifier === selectedIssueIdentifier,
+          );
+          const offset = shortcut.id === "next-issue" ? 1 : -1;
+          const index =
+            selectedIndex === -1
+              ? (offset === 1 ? 0 : navigationIssues.length - 1)
+              : (selectedIndex + offset + navigationIssues.length) % navigationIssues.length;
+          selectIssue(navigationIssues[index]!.identifier);
+          handled = true;
+          break;
+        }
+        case "close-panel":
+          closePanel();
+          handled = true;
+          break;
+        case "focus-reply":
+          if (replySurface instanceof HTMLTextAreaElement) {
+            replySurface.focus({ preventScroll: true });
+            handled = true;
+          }
+          break;
+        case "board":
+          setViewMode("board");
+          handled = true;
+          break;
+        case "list":
+          setViewMode("list");
+          handled = true;
+          break;
+        case "toggle-attention":
+          setFilters((current) => ({ ...current, attentionOnly: !current.attentionOnly }));
+          handled = true;
+          break;
+        case "refresh":
+          if (!refreshMutation.isPending) {
+            refreshMutation.mutate();
+            handled = true;
+          }
+          break;
+        case "show-shortcuts":
+          setShortcutReferenceOpen(true);
+          handled = true;
+          break;
+      }
+
+      if (handled) event.preventDefault();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [navigationIssues, refreshMutation, selectedIssueIdentifier]);
 
   function selectIssue(identifier: string) {
     selectionTriggerRef.current =
@@ -176,6 +270,9 @@ export default function MissionControl() {
         }
         onViewModeChange={setViewMode}
         onRefresh={() => refreshMutation.mutate()}
+        searchInputRef={searchInputRef}
+        shortcutReferenceOpen={shortcutReferenceOpen}
+        onShortcutReferenceOpenChange={setShortcutReferenceOpen}
       />
 
       {isError ? (

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControlToolbar.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControlToolbar.tsx
@@ -1,7 +1,14 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type Ref } from "react";
 
 import {
   getSystemFreshness,
@@ -10,6 +17,7 @@ import {
   type MissionIssueStatus,
   type MissionSystemStats,
 } from "./model";
+import { keyboardShortcuts, shortcutAvailabilityLabel } from "./keyboardShortcuts";
 
 export type MissionControlViewMode = "board" | "list";
 
@@ -22,6 +30,9 @@ interface MissionControlToolbarProps extends MissionControlFilters {
   onAttentionOnlyChange: (value: boolean) => void;
   onViewModeChange: (value: MissionControlViewMode) => void;
   onRefresh: () => void;
+  searchInputRef?: Ref<HTMLInputElement>;
+  shortcutReferenceOpen?: boolean;
+  onShortcutReferenceOpenChange?: (open: boolean) => void;
 }
 
 const STATUS_OPTIONS: Array<{ value: MissionIssueStatus | "all"; label: string }> = [
@@ -57,6 +68,9 @@ export function MissionControlToolbar({
   onAttentionOnlyChange,
   onViewModeChange,
   onRefresh,
+  searchInputRef,
+  shortcutReferenceOpen,
+  onShortcutReferenceOpenChange,
 }: MissionControlToolbarProps) {
   const [clockMs, setClockMs] = useState(() => Date.now());
 
@@ -117,6 +131,7 @@ export function MissionControlToolbar({
 
         <div className="flex flex-col gap-2 lg:flex-row lg:items-center">
           <Input
+            ref={searchInputRef}
             aria-label="Search issues"
             value={query}
             onChange={(event) => onQueryChange(event.target.value)}
@@ -162,6 +177,33 @@ export function MissionControlToolbar({
           <Button size="sm" onClick={onRefresh} disabled={isRefreshing}>
             {isRefreshing ? "Refreshing..." : "Refresh"}
           </Button>
+          <Popover open={shortcutReferenceOpen} onOpenChange={onShortcutReferenceOpenChange}>
+            <PopoverTrigger
+              render={<Button variant="outline" size="sm" aria-label="Keyboard shortcuts" />}
+            >
+              Keyboard shortcuts
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-80 gap-3 p-4">
+              <PopoverHeader>
+                <PopoverTitle>Keyboard shortcuts</PopoverTitle>
+              </PopoverHeader>
+              <ul className="space-y-2">
+                {keyboardShortcuts.map((shortcut) => (
+                  <li key={shortcut.id} className="flex items-center justify-between gap-4">
+                    <span>
+                      <span className="block text-muted-foreground">{shortcut.description}</span>
+                      <span className="block text-xs text-muted-foreground">
+                        {shortcutAvailabilityLabel(shortcut)}
+                      </span>
+                    </span>
+                    <kbd className="shrink-0 rounded border bg-muted px-1.5 py-0.5 text-xs font-medium">
+                      {shortcut.keys}
+                    </kbd>
+                  </li>
+                ))}
+              </ul>
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
     </header>

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/keyboardShortcuts.test.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/keyboardShortcuts.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  keyboardShortcuts,
+  isEditableTarget,
+  isShortcutAvailable,
+  matchesShortcut,
+  shortcutAvailabilityLabel,
+} from "./keyboardShortcuts";
+
+describe("Mission Control keyboard shortcuts", () => {
+  it("defines the approved shortcuts in their rendered order", () => {
+    expect(keyboardShortcuts.map((shortcut) => [shortcut.id, shortcut.keys])).toEqual([
+      ["focus-search", "/"],
+      ["next-issue", "J"],
+      ["previous-issue", "K"],
+      ["close-panel", "Esc"],
+      ["focus-reply", "R"],
+      ["board", "B"],
+      ["list", "L"],
+      ["toggle-attention", "A"],
+      ["refresh", "Shift + R"],
+      ["show-shortcuts", "?"],
+    ]);
+    expect(shortcutAvailabilityLabel(keyboardShortcuts.find((shortcut) => shortcut.id === "focus-reply")!)).toBe(
+      "Reply field required",
+    );
+  });
+
+  it("matches only the exact unmodified key binding", () => {
+    const refresh = keyboardShortcuts.find((shortcut) => shortcut.id === "refresh")!;
+    const search = keyboardShortcuts.find((shortcut) => shortcut.id === "focus-search")!;
+
+    expect(matchesShortcut(new KeyboardEvent("keydown", { key: "R", shiftKey: true }), refresh)).toBe(true);
+    expect(matchesShortcut(new KeyboardEvent("keydown", { key: "r" }), refresh)).toBe(false);
+    expect(matchesShortcut(new KeyboardEvent("keydown", { key: "/" }), search)).toBe(true);
+    expect(matchesShortcut(new KeyboardEvent("keydown", { key: "/", ctrlKey: true }), search)).toBe(false);
+  });
+
+  it("suppresses global shortcuts from every editable surface", () => {
+    const input = document.createElement("input");
+    const textarea = document.createElement("textarea");
+    const select = document.createElement("select");
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    const nonEditable = document.createElement("div");
+    nonEditable.setAttribute("contenteditable", "false");
+    const child = document.createElement("span");
+    editable.append(child);
+    document.body.append(input, textarea, select, editable, nonEditable);
+
+    expect(isEditableTarget(input)).toBe(true);
+    expect(isEditableTarget(textarea)).toBe(true);
+    expect(isEditableTarget(select)).toBe(true);
+    expect(isEditableTarget(child)).toBe(true);
+    expect(isEditableTarget(nonEditable)).toBe(false);
+    expect(isEditableTarget(document.body)).toBe(false);
+
+    editable.remove();
+    input.remove();
+    textarea.remove();
+    select.remove();
+    nonEditable.remove();
+  });
+
+  it("advertises selected-panel and rendered-reply availability", () => {
+    const closePanel = keyboardShortcuts.find((shortcut) => shortcut.id === "close-panel")!;
+    const focusReply = keyboardShortcuts.find((shortcut) => shortcut.id === "focus-reply")!;
+
+    expect(isShortcutAvailable(closePanel, { hasSelectedIssue: false, hasReplySurface: false })).toBe(false);
+    expect(isShortcutAvailable(closePanel, { hasSelectedIssue: true, hasReplySurface: false })).toBe(true);
+    expect(isShortcutAvailable(focusReply, { hasSelectedIssue: true, hasReplySurface: false })).toBe(false);
+    expect(isShortcutAvailable(focusReply, { hasSelectedIssue: true, hasReplySurface: true })).toBe(true);
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/keyboardShortcuts.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/keyboardShortcuts.ts
@@ -1,0 +1,140 @@
+export type KeyboardShortcutId =
+  | "focus-search"
+  | "next-issue"
+  | "previous-issue"
+  | "close-panel"
+  | "focus-reply"
+  | "board"
+  | "list"
+  | "toggle-attention"
+  | "refresh"
+  | "show-shortcuts";
+
+type ShortcutAvailability = "always" | "selected-issue" | "reply-surface";
+
+export interface KeyboardShortcut {
+  id: KeyboardShortcutId;
+  key: string;
+  keys: string;
+  description: string;
+  availability: ShortcutAvailability;
+  requiresShift?: boolean;
+}
+
+export interface ShortcutAvailabilityContext {
+  hasSelectedIssue: boolean;
+  hasReplySurface: boolean;
+}
+
+export const keyboardShortcuts: KeyboardShortcut[] = [
+  {
+    id: "focus-search",
+    key: "/",
+    keys: "/",
+    description: "Focus issue search",
+    availability: "always",
+  },
+  {
+    id: "next-issue",
+    key: "j",
+    keys: "J",
+    description: "Select next issue",
+    availability: "always",
+  },
+  {
+    id: "previous-issue",
+    key: "k",
+    keys: "K",
+    description: "Select previous issue",
+    availability: "always",
+  },
+  {
+    id: "close-panel",
+    key: "Escape",
+    keys: "Esc",
+    description: "Close selected issue",
+    availability: "selected-issue",
+  },
+  {
+    id: "focus-reply",
+    key: "r",
+    keys: "R",
+    description: "Focus reply",
+    availability: "reply-surface",
+  },
+  {
+    id: "board",
+    key: "b",
+    keys: "B",
+    description: "Show board",
+    availability: "always",
+  },
+  {
+    id: "list",
+    key: "l",
+    keys: "L",
+    description: "Show list",
+    availability: "always",
+  },
+  {
+    id: "toggle-attention",
+    key: "a",
+    keys: "A",
+    description: "Toggle Attention only",
+    availability: "always",
+  },
+  {
+    id: "refresh",
+    key: "R",
+    keys: "Shift + R",
+    description: "Refresh Mission Control",
+    availability: "always",
+    requiresShift: true,
+  },
+  {
+    id: "show-shortcuts",
+    key: "?",
+    keys: "?",
+    description: "Show keyboard shortcuts",
+    availability: "always",
+    requiresShift: true,
+  },
+];
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+
+  return target.closest("input, textarea, select, [contenteditable]:not([contenteditable='false'])") !== null;
+}
+
+export function matchesShortcut(event: KeyboardEvent, shortcut: KeyboardShortcut): boolean {
+  if (event.altKey || event.ctrlKey || event.metaKey) return false;
+  if (Boolean(shortcut.requiresShift) !== event.shiftKey) return false;
+
+  return event.key === shortcut.key;
+}
+
+export function isShortcutAvailable(
+  shortcut: KeyboardShortcut,
+  { hasSelectedIssue, hasReplySurface }: ShortcutAvailabilityContext,
+): boolean {
+  switch (shortcut.availability) {
+    case "always":
+      return true;
+    case "selected-issue":
+      return hasSelectedIssue;
+    case "reply-surface":
+      return hasReplySurface;
+  }
+}
+
+export function shortcutAvailabilityLabel(shortcut: KeyboardShortcut): string {
+  switch (shortcut.availability) {
+    case "always":
+      return "Always available";
+    case "selected-issue":
+      return "Selected issue required";
+    case "reply-surface":
+      return "Reply field required";
+  }
+}

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/model.test.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/model.test.ts
@@ -4,6 +4,7 @@ import {
   deriveMissionControlState,
   filterMissionControlIssues,
   getSystemFreshness,
+  issuesInGroupOrder,
   isRateLimitLow,
   regroupMissionControlIssues,
   type MissionControlFilters,
@@ -280,6 +281,17 @@ describe("mission-control model", () => {
       ["waiting_on_human", 0],
       ["failed_or_blocked", 0],
       ["completed_recently", 0],
+    ]);
+  });
+
+  it("uses the rendered group order for board navigation", () => {
+    const state = deriveMissionControlState(snapshot());
+    const [running, retrying, waiting] = state.groups;
+
+    expect(issuesInGroupOrder([running!, waiting!, retrying!]).map((issue) => issue.identifier)).toEqual([
+      "repo#1",
+      "repo#3",
+      "repo#2",
     ]);
   });
 

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/model.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/model.ts
@@ -273,3 +273,8 @@ export function regroupMissionControlIssues(issues: MissionIssueSummary[]): Miss
     issues: issues.filter((issue) => issue.status === id),
   }));
 }
+
+/** Returns issues in the same left-to-right, top-to-bottom order as the rendered board. */
+export function issuesInGroupOrder(groups: MissionGroup[]): MissionIssueSummary[] {
+  return groups.flatMap((group) => group.issues);
+}


### PR DESCRIPTION
Fixes #409\n\n## Summary\n- add one authoritative Mission Control shortcut registry\n- route guarded global keyboard commands through existing actions\n- render an accessible shortcut reference without removing pointer or touch controls\n\n## Verification\n- 314 frontend tests\n- TypeScript no-emit check\n- Vite production build\n- correctness/standards, simplify, and over-engineering reviews\n\n## Residual risk\n- shortcuts are intentionally fixed rather than user-configurable\n- destructive lifecycle actions remain excluded from global bindings