### PR TITLE
Persist Mission Control preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ non-destructive keyboard shortcuts outside editable controls:
 a reply field. Shortcuts do not run while focus is in an input, textarea, select, or editable-content
 surface; `Esc` is the scoped exception for closing the selected panel.
 
+### Mission Control preferences
+
+Mission Control stores its view mode, selected detail tab, query, status, Attention only filter,
+and desktop detail-panel width in browser-local storage. The desktop width control supports whole
+values from 28 to 48 rem (34 rem by default) and applies only at the `xl` layout; selected issues
+and reply drafts remain transient.
+
 ## Web dashboard security
 
 The web and desktop dashboards control an unauthenticated, single-operator service. `ensemble web`

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { useState } from "react";
@@ -24,6 +24,9 @@ vi.mock("./useIssueRuntime", () => ({ useIssueRuntime: vi.fn() }));
 const VIEW_MODE_KEY = "ensemble.mission-control.view-mode";
 const ACTIVE_TAB_KEY = "ensemble.mission-control.active-tab";
 const ATTENTION_ONLY_KEY = "ensemble.mission-control.attention-only";
+const QUERY_KEY = "ensemble.mission-control.query";
+const STATUS_KEY = "ensemble.mission-control.status";
+const DETAIL_PANEL_WIDTH_KEY = "ensemble.mission-control.detail-panel-width-rem";
 const originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
 const originalScrollIntoView = Object.getOwnPropertyDescriptor(
   HTMLElement.prototype,
@@ -1065,6 +1068,62 @@ describe("Mission Control page", () => {
       }),
     );
     expect(screen.getByRole("tab", { name: "Acceptance" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("restores persisted filters and a supported detail-panel width", () => {
+    window.localStorage.setItem(QUERY_KEY, "clippy");
+    window.localStorage.setItem(STATUS_KEY, "retrying");
+    window.localStorage.setItem(ATTENTION_ONLY_KEY, "true");
+    window.localStorage.setItem(DETAIL_PANEL_WIDTH_KEY, "42");
+
+    renderMissionControl(runtimeSnapshot());
+
+    expect(screen.getByRole("textbox", { name: "Search issues" })).toHaveValue("clippy");
+    expect(screen.getByRole("combobox", { name: "Status" })).toHaveValue("retrying");
+    expect(screen.getByRole("button", { name: "Attention only" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Detail panel width")).toHaveValue("42");
+    expect(screen.getByRole("region", { name: "Issue command panel" }).parentElement).toHaveStyle(
+      "--mission-control-panel-width: 42rem",
+    );
+  });
+
+  it.each(["34.5", "27", "49", "not-a-width"])(
+    "falls back safely from obsolete filter status and invalid panel width %s",
+    (storedWidth) => {
+      window.localStorage.setItem(QUERY_KEY, "saved query");
+      window.localStorage.setItem(STATUS_KEY, "obsolete-status");
+      window.localStorage.setItem(DETAIL_PANEL_WIDTH_KEY, storedWidth);
+
+      renderMissionControl(runtimeSnapshot());
+
+      expect(screen.getByRole("textbox", { name: "Search issues" })).toHaveValue("saved query");
+      expect(screen.getByRole("combobox", { name: "Status" })).toHaveValue("all");
+      expect(screen.getByLabelText("Detail panel width")).toHaveValue("34");
+    },
+  );
+
+  it("persists filters and detail-panel width through a reload", async () => {
+    const user = userEvent.setup();
+    const first = renderMissionControl(runtimeSnapshot());
+    const search = screen.getByRole("textbox", { name: "Search issues" });
+    const width = screen.getByLabelText("Detail panel width");
+
+    await user.type(search, "repo#2");
+    await user.selectOptions(screen.getByRole("combobox", { name: "Status" }), "retrying");
+    fireEvent.change(width, { target: { value: "36" } });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(QUERY_KEY)).toBe("repo#2");
+      expect(window.localStorage.getItem(STATUS_KEY)).toBe("retrying");
+      expect(window.localStorage.getItem(DETAIL_PANEL_WIDTH_KEY)).toBe("36");
+    });
+
+    first.unmount();
+    renderMissionControl(runtimeSnapshot());
+
+    expect(screen.getByRole("textbox", { name: "Search issues" })).toHaveValue("repo#2");
+    expect(screen.getByRole("combobox", { name: "Status" })).toHaveValue("retrying");
+    expect(screen.getByLabelText("Detail panel width")).toHaveValue("36");
   });
 
   it("renders when localStorage access is unavailable", () => {

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 
 import { Button } from "@/components/ui/button";
 import { useRefreshMutation, useStateQuery } from "@/hooks";
@@ -25,6 +25,20 @@ import {
 const VIEW_MODE_KEY = "ensemble.mission-control.view-mode";
 const ACTIVE_TAB_KEY = "ensemble.mission-control.active-tab";
 const ATTENTION_ONLY_KEY = "ensemble.mission-control.attention-only";
+const QUERY_KEY = "ensemble.mission-control.query";
+const STATUS_KEY = "ensemble.mission-control.status";
+const DETAIL_PANEL_WIDTH_KEY = "ensemble.mission-control.detail-panel-width-rem";
+const DETAIL_PANEL_WIDTH_MIN_REM = 28;
+const DETAIL_PANEL_WIDTH_MAX_REM = 48;
+const DEFAULT_DETAIL_PANEL_WIDTH_REM = 34;
+const FILTER_STATUSES: Array<MissionIssueStatus | "all"> = [
+  "all",
+  "running",
+  "retrying",
+  "waiting_on_human",
+  "failed_or_blocked",
+  "completed_recently",
+];
 
 const PANEL_TABS: IssueCommandPanelTab[] = [
   "overview",
@@ -67,6 +81,26 @@ function readAttentionOnly(): boolean {
   return readPreference(ATTENTION_ONLY_KEY) === "true";
 }
 
+function readQuery(): string {
+  return readPreference(QUERY_KEY) ?? "";
+}
+
+function readStatus(): MissionIssueStatus | "all" {
+  const value = readPreference(STATUS_KEY);
+  return FILTER_STATUSES.includes(value as MissionIssueStatus | "all")
+    ? (value as MissionIssueStatus | "all")
+    : "all";
+}
+
+function readDetailPanelWidthRem(): number {
+  const value = Number(readPreference(DETAIL_PANEL_WIDTH_KEY));
+  return Number.isInteger(value) &&
+    value >= DETAIL_PANEL_WIDTH_MIN_REM &&
+    value <= DETAIL_PANEL_WIDTH_MAX_REM
+    ? value
+    : DEFAULT_DETAIL_PANEL_WIDTH_REM;
+}
+
 export default function MissionControl() {
   const { data, isLoading, isError, error } = useStateQuery();
   const refreshMutation = useRefreshMutation();
@@ -79,9 +113,10 @@ export default function MissionControl() {
   const [viewMode, setViewMode] = useState<MissionControlViewMode>(readViewMode);
   const [activeTab, setActiveTab] = useState<IssueCommandPanelTab>(readActiveTab);
   const [shortcutReferenceOpen, setShortcutReferenceOpen] = useState(false);
+  const [detailPanelWidthRem, setDetailPanelWidthRem] = useState(readDetailPanelWidthRem);
   const [filters, setFilters] = useState<MissionControlFilters>(() => ({
-    query: "",
-    status: "all",
+    query: readQuery(),
+    status: readStatus(),
     attentionOnly: readAttentionOnly(),
   }));
 
@@ -90,6 +125,12 @@ export default function MissionControl() {
   useEffect(
     () => writePreference(ATTENTION_ONLY_KEY, String(filters.attentionOnly)),
     [filters.attentionOnly],
+  );
+  useEffect(() => writePreference(QUERY_KEY, filters.query), [filters.query]);
+  useEffect(() => writePreference(STATUS_KEY, filters.status), [filters.status]);
+  useEffect(
+    () => writePreference(DETAIL_PANEL_WIDTH_KEY, String(detailPanelWidthRem)),
+    [detailPanelWidthRem],
   );
 
   const missionState = useMemo(() => (data ? deriveMissionControlState(data) : null), [data]);
@@ -319,7 +360,10 @@ export default function MissionControl() {
         onSelectIssue={selectIssue}
       />
 
-      <div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1fr)_34rem]">
+      <div
+        className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1fr)_var(--mission-control-panel-width)]"
+        style={{ "--mission-control-panel-width": `${detailPanelWidthRem}rem` } as CSSProperties}
+      >
         <section
           ref={operationsRegionRef}
           aria-label="Operations"
@@ -354,6 +398,23 @@ export default function MissionControl() {
           tabIndex={-1}
           className="min-w-0 scroll-mt-4 outline-none [&>aside]:!w-full"
         >
+          <div className="mb-2 hidden items-center gap-2 xl:flex">
+            <label htmlFor="detail-panel-width" className="text-sm text-muted-foreground">
+              Detail panel width
+            </label>
+            <input
+              id="detail-panel-width"
+              type="range"
+              min={DETAIL_PANEL_WIDTH_MIN_REM}
+              max={DETAIL_PANEL_WIDTH_MAX_REM}
+              step="1"
+              value={detailPanelWidthRem}
+              onChange={(event) => setDetailPanelWidthRem(Number(event.target.value))}
+            />
+            <output className="text-sm tabular-nums text-muted-foreground">
+              {detailPanelWidthRem} rem
+            </output>
+          </div>
           <IssueCommandPanel
             identifier={selectedIssueIdentifier}
             activeTab={activeTab}


### PR DESCRIPTION
Closes #410

## Summary
- persist Mission Control query, status, and detail-width preferences in namespaced browser-local storage
- add a labelled 28–48rem desktop detail-width control with safe defaults
- preserve the merged keyboard shortcut behavior and document the preference contract

## Validation
- focused Mission Control tests: 47 passed
- full frontend suite: 321 passed
- TypeScript no-emit and Vite production build
- OpenAPI generation and Orval client generation
- standards/spec, simplify, and ponytail reviews clean