### PR TITLE
Add Mission Control action capabilities

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,12 @@ _Avoid_: Step result, execution result
 A durable question, approval, or handoff that blocks a run until a human resolves it.
 _Avoid_: Prompt, comment
 
+**Action capability**:
+A server-derived snapshot-time statement of whether one named Mission Control operation is currently
+available. Disabled capabilities include an operator-facing reason; enabled capability does not
+reserve the operation, whose endpoint remains authoritative at execution time.
+_Avoid_: Client-side lifecycle inference, permission, reservation
+
 **Operator-attention item**:
 A durable, non-authoritative report from a producer that fresh evidence says a subject needs an operator.
 _Avoid_: Interaction request, action, command

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -7,9 +7,9 @@ use crate::history::model::HistoryRecord;
 use crate::interaction::store::InteractionStore;
 use crate::observability::snapshot::{
     build_issue_snapshot, build_state_snapshot, enrich_issue_snapshot_pending_input,
-    extract_step_detail_state, AttemptInfo, FinalizeSnapshot, IssueDetailSnapshot, IssueSummary,
-    RepoFinalizeSnapshot, RetryRow, RunningDetail, RuntimeSnapshot, StepDetailSnapshot,
-    WorkflowStepInfo, WorkspaceInfo,
+    enrich_runtime_snapshot_interactions, extract_step_detail_state, AttemptInfo, FinalizeSnapshot,
+    IssueDetailSnapshot, IssueSummary, RepoFinalizeSnapshot, RetryRow, RunningDetail,
+    RuntimeSnapshot, StepDetailSnapshot, WorkflowStepInfo, WorkspaceInfo,
 };
 use crate::workspace::key::issue_workspace_key;
 use axum::extract::{Extension, Path, State};
@@ -74,6 +74,14 @@ pub async fn get_state(
     let lock = state.orchestrator_state.read().await;
     let mut snapshot = build_state_snapshot(&lock);
     drop(lock);
+
+    let config_dir = state
+        .config_runtime
+        .config_path
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    enrich_runtime_snapshot_interactions(&mut snapshot, &InteractionStore::new(config_dir)).await;
 
     if exposure == ApiExposure::TrustedLocal {
         let Some(store) = state.history_store.as_ref() else {
@@ -304,6 +312,9 @@ fn issue_snapshot_from_history_record(
                     "passed".to_string()
                 },
                 can_navigate: true,
+                capabilities: crate::observability::capabilities::StepActionCapabilities::for_step(
+                    true,
+                ),
             })
             .collect()
     };
@@ -340,6 +351,9 @@ fn issue_snapshot_from_history_record(
         },
         artifacts,
         acceptance_attempts: record.acceptance_attempts.clone(),
+        capabilities: crate::observability::capabilities::IssueActionCapabilities::for_issue(
+            false, false, false, None,
+        ),
     })
 }
 
@@ -417,6 +431,7 @@ async fn build_step_detail_from_history(
             .to_string(),
         dependencies: Vec::new(),
         can_navigate: true,
+        capabilities: crate::observability::capabilities::StepActionCapabilities::for_step(true),
         verdict: if step_idx == Some(last_idx) {
             record.verdict
         } else {
@@ -550,6 +565,9 @@ pub async fn get_step_detail(
         kind: detail_state.kind,
         dependencies: detail_state.dependencies,
         can_navigate: detail_state.can_navigate,
+        capabilities: crate::observability::capabilities::StepActionCapabilities::for_step(
+            detail_state.can_navigate,
+        ),
         verdict: detail_state.verdict,
         run_id: detail_state.run_id,
         transcript,
@@ -805,6 +823,20 @@ mod tests {
         assert_eq!(json["agent_totals"]["input_tokens"], 5000);
         assert_eq!(json["agent_totals"]["output_tokens"], 2400);
         assert_eq!(json["agent_totals"]["total_tokens"], 7400);
+        assert_eq!(
+            json["running"][0]["capabilities"]["inspect"]["enabled"],
+            true
+        );
+        assert_eq!(json["running"][0]["capabilities"]["stop"]["enabled"], true);
+        assert_eq!(
+            json["running"][0]["capabilities"]["retry"]["enabled"],
+            false
+        );
+        assert!(
+            json["running"][0]["capabilities"]["retry"]["disabled_reason"]
+                .as_str()
+                .is_some_and(|reason| !reason.is_empty())
+        );
     }
 
     #[tokio::test]
@@ -832,6 +864,9 @@ mod tests {
 
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
+        assert_eq!(json["capabilities"]["inspect"]["enabled"], true);
+        assert_eq!(json["capabilities"]["stop"]["enabled"], true);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/api/openapi.rs
+++ b/crates/ensemble-core/src/api/openapi.rs
@@ -41,6 +41,9 @@ use utoipa::OpenApi;
     components(schemas(
         // Snapshot types
         crate::observability::snapshot::RuntimeSnapshot,
+        crate::observability::capabilities::ActionCapability,
+        crate::observability::capabilities::IssueActionCapabilities,
+        crate::observability::capabilities::StepActionCapabilities,
         crate::observability::snapshot::SnapshotCounts,
         crate::observability::snapshot::RunningSessionRow,
         crate::observability::snapshot::TokenSnapshot,
@@ -193,6 +196,22 @@ mod tests {
         assert!(spec["paths"]["/api/v1/attention"]["get"].is_object());
         assert!(spec["paths"]["/api/v1/attention"].get("post").is_none());
         assert!(spec["components"]["schemas"]["AttentionHistoryResponse"].is_object());
+    }
+
+    #[test]
+    fn test_openapi_documents_snapshot_action_capabilities() {
+        let spec: serde_json::Value =
+            serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+
+        assert_eq!(
+            spec["components"]["schemas"]["RunningSessionRow"]["properties"]["capabilities"]
+                ["$ref"],
+            "#/components/schemas/IssueActionCapabilities"
+        );
+        assert_eq!(
+            spec["components"]["schemas"]["ActionCapability"]["properties"]["enabled"]["type"],
+            "boolean"
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/observability/capabilities.rs
+++ b/crates/ensemble-core/src/observability/capabilities.rs
@@ -1,0 +1,272 @@
+use crate::interaction::model::{InteractionRequest, InteractionStatus};
+use crate::orchestrator::state::FinalizeStatus;
+use serde::Serialize;
+
+const NOT_AVAILABLE: &str = "This action is not available for the current issue state.";
+const NOT_RUNNING: &str = "This issue is not running.";
+const NOT_RETRYING: &str = "This issue is not retrying.";
+const NO_INTERACTION: &str = "This issue has no interaction awaiting input.";
+const INTERACTION_REFRESHING: &str = "Interaction availability is refreshing.";
+const INTERACTION_UNAVAILABLE: &str = "Interaction is unavailable; refresh and try again.";
+const GUIDE_UNSUPPORTED: &str = "Guidance is not supported in Mission Control.";
+const CLEANUP_UNSUPPORTED: &str = "Manual workspace cleanup is not supported.";
+
+/// One server-derived Mission Control operation state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+pub struct ActionCapability {
+    enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    disabled_reason: Option<String>,
+}
+
+impl ActionCapability {
+    pub fn enabled() -> Self {
+        Self {
+            enabled: true,
+            disabled_reason: None,
+        }
+    }
+
+    pub fn disabled(reason: impl Into<String>) -> Self {
+        Self {
+            enabled: false,
+            disabled_reason: Some(reason.into()),
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn disabled_reason(&self) -> Option<&str> {
+        self.disabled_reason.as_deref()
+    }
+}
+
+/// Fixed set of issue-level operations that Mission Control can describe.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+pub struct IssueActionCapabilities {
+    inspect: ActionCapability,
+    reply: ActionCapability,
+    guide: ActionCapability,
+    cancel: ActionCapability,
+    stop: ActionCapability,
+    retry: ActionCapability,
+    resume: ActionCapability,
+    finalize_approve: ActionCapability,
+    finalize_retry: ActionCapability,
+    cleanup: ActionCapability,
+}
+
+impl IssueActionCapabilities {
+    pub fn for_issue(
+        is_running: bool,
+        is_retrying: bool,
+        has_waiting_interaction: bool,
+        finalize_status: Option<&FinalizeStatus>,
+    ) -> Self {
+        let (finalize_approve, finalize_retry) = match finalize_status {
+            Some(FinalizeStatus::PendingApproval) => (
+                ActionCapability::enabled(),
+                ActionCapability::disabled(NOT_AVAILABLE),
+            ),
+            Some(FinalizeStatus::Failed) => (
+                ActionCapability::disabled(NOT_AVAILABLE),
+                ActionCapability::enabled(),
+            ),
+            _ => (
+                ActionCapability::disabled(NOT_AVAILABLE),
+                ActionCapability::disabled(NOT_AVAILABLE),
+            ),
+        };
+        let interaction = if has_waiting_interaction {
+            ActionCapability::disabled(INTERACTION_REFRESHING)
+        } else {
+            ActionCapability::disabled(NO_INTERACTION)
+        };
+
+        Self {
+            inspect: ActionCapability::enabled(),
+            reply: interaction.clone(),
+            guide: ActionCapability::disabled(GUIDE_UNSUPPORTED),
+            cancel: interaction.clone(),
+            stop: if is_running {
+                ActionCapability::enabled()
+            } else {
+                ActionCapability::disabled(NOT_RUNNING)
+            },
+            retry: if is_retrying {
+                ActionCapability::enabled()
+            } else {
+                ActionCapability::disabled(NOT_RETRYING)
+            },
+            resume: interaction,
+            finalize_approve,
+            finalize_retry,
+            cleanup: ActionCapability::disabled(CLEANUP_UNSUPPORTED),
+        }
+    }
+
+    pub fn apply_interaction(&mut self, interaction: Option<&InteractionRequest>) {
+        let Some(interaction) = interaction else {
+            self.reply = ActionCapability::disabled(INTERACTION_UNAVAILABLE);
+            self.cancel = ActionCapability::disabled(INTERACTION_UNAVAILABLE);
+            self.resume = ActionCapability::disabled(INTERACTION_UNAVAILABLE);
+            return;
+        };
+
+        match interaction.status {
+            InteractionStatus::Open => {
+                self.reply = ActionCapability::enabled();
+                self.cancel = ActionCapability::enabled();
+                self.resume =
+                    ActionCapability::disabled("Resolve the interaction before resuming.");
+            }
+            InteractionStatus::Resolved if interaction.awaiting_resume => {
+                self.reply =
+                    ActionCapability::disabled("The interaction has already been resolved.");
+                self.cancel =
+                    ActionCapability::disabled("The interaction has already been resolved.");
+                self.resume = ActionCapability::enabled();
+            }
+            InteractionStatus::Resolved => {
+                self.reply =
+                    ActionCapability::disabled("The interaction has already been resolved.");
+                self.cancel =
+                    ActionCapability::disabled("The interaction has already been resolved.");
+                self.resume = ActionCapability::disabled(
+                    "The resolved interaction is no longer awaiting resume.",
+                );
+            }
+            InteractionStatus::Cancelled => {
+                self.reply = ActionCapability::disabled("The interaction was cancelled.");
+                self.cancel = ActionCapability::disabled("The interaction was cancelled.");
+                self.resume = ActionCapability::disabled("The interaction was cancelled.");
+            }
+        }
+    }
+
+    pub fn inspect(&self) -> &ActionCapability {
+        &self.inspect
+    }
+
+    pub fn reply(&self) -> &ActionCapability {
+        &self.reply
+    }
+
+    pub fn guide(&self) -> &ActionCapability {
+        &self.guide
+    }
+
+    pub fn cancel(&self) -> &ActionCapability {
+        &self.cancel
+    }
+
+    pub fn stop(&self) -> &ActionCapability {
+        &self.stop
+    }
+
+    pub fn retry(&self) -> &ActionCapability {
+        &self.retry
+    }
+
+    pub fn resume(&self) -> &ActionCapability {
+        &self.resume
+    }
+
+    pub fn finalize_approve(&self) -> &ActionCapability {
+        &self.finalize_approve
+    }
+
+    pub fn finalize_retry(&self) -> &ActionCapability {
+        &self.finalize_retry
+    }
+
+    pub fn cleanup(&self) -> &ActionCapability {
+        &self.cleanup
+    }
+}
+
+/// Fixed step navigation capability for Mission Control.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+pub struct StepActionCapabilities {
+    inspect: ActionCapability,
+}
+
+impl StepActionCapabilities {
+    pub fn for_step(can_inspect: bool) -> Self {
+        Self {
+            inspect: if can_inspect {
+                ActionCapability::enabled()
+            } else {
+                ActionCapability::disabled("No step details are available yet.")
+            },
+        }
+    }
+
+    pub fn inspect(&self) -> &ActionCapability {
+        &self.inspect
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enabled_capability_has_no_disabled_reason() {
+        let capability = ActionCapability::enabled();
+
+        assert!(capability.is_enabled());
+        assert_eq!(capability.disabled_reason(), None);
+    }
+
+    #[test]
+    fn disabled_capability_has_operator_reason() {
+        let capability = ActionCapability::disabled("Unavailable now.");
+
+        assert!(!capability.is_enabled());
+        assert_eq!(capability.disabled_reason(), Some("Unavailable now."));
+    }
+
+    #[test]
+    fn issue_capabilities_follow_runtime_and_finalize_state() {
+        let running = IssueActionCapabilities::for_issue(true, false, false, None);
+        assert!(running.inspect().is_enabled());
+        assert!(running.stop().is_enabled());
+        assert!(!running.retry().is_enabled());
+        assert_eq!(running.retry().disabled_reason(), Some(NOT_RETRYING));
+
+        let retrying = IssueActionCapabilities::for_issue(false, true, false, None);
+        assert!(retrying.retry().is_enabled());
+        assert!(!retrying.stop().is_enabled());
+        assert_eq!(retrying.stop().disabled_reason(), Some(NOT_RUNNING));
+
+        let pending_approval = IssueActionCapabilities::for_issue(
+            false,
+            false,
+            false,
+            Some(&FinalizeStatus::PendingApproval),
+        );
+        assert!(pending_approval.finalize_approve().is_enabled());
+        assert!(!pending_approval.finalize_retry().is_enabled());
+
+        let failed_finalize =
+            IssueActionCapabilities::for_issue(false, false, false, Some(&FinalizeStatus::Failed));
+        assert!(!failed_finalize.finalize_approve().is_enabled());
+        assert!(failed_finalize.finalize_retry().is_enabled());
+    }
+
+    #[test]
+    fn step_inspection_capability_preserves_navigation_availability() {
+        assert!(StepActionCapabilities::for_step(true)
+            .inspect()
+            .is_enabled());
+        let unavailable = StepActionCapabilities::for_step(false);
+        assert!(!unavailable.inspect().is_enabled());
+        assert_eq!(
+            unavailable.inspect().disabled_reason(),
+            Some("No step details are available yet.")
+        );
+    }
+}

--- a/crates/ensemble-core/src/observability/mod.rs
+++ b/crates/ensemble-core/src/observability/mod.rs
@@ -1,3 +1,4 @@
+pub mod capabilities;
 pub mod events;
 pub mod events_contract;
 pub mod logging;

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -2,6 +2,7 @@ use crate::acceptance::AcceptanceAttempt;
 use crate::attention::AttentionItem;
 use crate::history::artifacts::{RunArtifacts, StepTranscriptArtifact};
 use crate::interaction::store::InteractionStore;
+use crate::observability::capabilities::{IssueActionCapabilities, StepActionCapabilities};
 use crate::orchestrator::state::{FinalizeStatus, OrchestratorState, RateLimitSnapshot};
 use crate::pipeline::engine::{PipelineRun, StepState};
 use crate::tracker::model::{RetryEntry, RunningEntry};
@@ -42,6 +43,7 @@ pub struct CompletedRow {
     pub issue_identifier: String,
     pub status: String,
     pub completed_at: DateTime<Utc>,
+    pub capabilities: IssueActionCapabilities,
 }
 
 /// A compact row for an issue currently waiting on human input.
@@ -52,6 +54,7 @@ pub struct WaitingInteractionRow {
     pub interaction_request_id: String,
     pub step_name: String,
     pub requested_at: DateTime<Utc>,
+    pub capabilities: IssueActionCapabilities,
 }
 
 /// Compact issue-detail summary for the current waiting interaction.
@@ -88,6 +91,7 @@ pub struct RunningSessionRow {
     pub started_at: DateTime<Utc>,
     pub last_event_at: Option<DateTime<Utc>>,
     pub tokens: TokenSnapshot,
+    pub capabilities: IssueActionCapabilities,
 }
 
 /// Token counts for a single session.
@@ -106,6 +110,7 @@ pub struct RetryRow {
     pub attempt: u32,
     pub due_at_ms: u64,
     pub error: Option<String>,
+    pub capabilities: IssueActionCapabilities,
 }
 
 /// Aggregate token and runtime totals for the snapshot.
@@ -137,6 +142,7 @@ pub struct IssueDetailSnapshot {
     pub issue: IssueSummary,
     pub artifacts: Option<RunArtifacts>,
     pub acceptance_attempts: Vec<AcceptanceAttempt>,
+    pub capabilities: IssueActionCapabilities,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -164,6 +170,7 @@ pub struct WorkflowStepInfo {
     pub dependencies: Vec<String>,
     pub state: String,
     pub can_navigate: bool,
+    pub capabilities: StepActionCapabilities,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -186,6 +193,7 @@ pub struct StepDetailSnapshot {
     pub kind: String,
     pub dependencies: Vec<String>,
     pub can_navigate: bool,
+    pub capabilities: StepActionCapabilities,
     pub verdict: Option<String>,
     pub run_id: Option<String>,
     pub transcript: Option<StepTranscriptArtifact>,
@@ -264,6 +272,7 @@ pub fn build_state_snapshot(state: &OrchestratorState) -> RuntimeSnapshot {
             issue_identifier: entry.identifier.clone(),
             status: entry.status.clone(),
             completed_at: entry.completed_at,
+            capabilities: IssueActionCapabilities::for_issue(false, false, false, None),
         })
         .collect();
     completed_rows.sort_by_key(|row| std::cmp::Reverse(row.completed_at));
@@ -477,6 +486,7 @@ pub fn build_step_detail_snapshot(
         kind: detail_state.kind,
         dependencies: detail_state.dependencies,
         can_navigate: detail_state.can_navigate,
+        capabilities: StepActionCapabilities::for_step(detail_state.can_navigate),
         verdict: detail_state.verdict,
         run_id: detail_state.run_id,
         transcript: None,
@@ -596,16 +606,18 @@ pub async fn build_issue_snapshot(
 
     let retry_detail = retry_entry.map(retry_entry_to_row);
 
-    let pending_input = if let (Some(entry), Some(store)) = (waiting_entry, interaction_store) {
-        let interaction = store
+    let interaction = if let (Some(entry), Some(store)) = (waiting_entry, interaction_store) {
+        store
             .get(&entry.interaction_request_id)
             .await
             .ok()
-            .flatten();
-        interaction.map(|i| pending_input_summary(entry, &i))
+            .flatten()
     } else {
         None
     };
+    let pending_input = waiting_entry
+        .zip(interaction.as_ref())
+        .map(|(entry, interaction)| pending_input_summary(entry, interaction));
     // Note: store errors are intentionally ignored for best-effort snapshot generation
     let current_interaction = waiting_entry.map(current_interaction_summary);
 
@@ -664,6 +676,11 @@ pub async fn build_issue_snapshot(
                     can_navigate: pipeline_run
                         .map(|r| r.step_states.contains_key(&step.name))
                         .unwrap_or(false),
+                    capabilities: StepActionCapabilities::for_step(
+                        pipeline_run
+                            .map(|r| r.step_states.contains_key(&step.name))
+                            .unwrap_or(false),
+                    ),
                 }
             })
             .collect()
@@ -678,6 +695,7 @@ pub async fn build_issue_snapshot(
                 dependencies: step.dependencies.clone(),
                 state: step.state.clone(),
                 can_navigate: step.can_navigate,
+                capabilities: StepActionCapabilities::for_step(step.can_navigate),
             })
             .collect()
     } else {
@@ -710,6 +728,16 @@ pub async fn build_issue_snapshot(
             url: None,
         });
 
+    let mut capabilities = IssueActionCapabilities::for_issue(
+        running_entry.is_some(),
+        retry_entry.is_some(),
+        waiting_entry.is_some(),
+        finalize_entry.map(|(_, finalize)| &finalize.status),
+    );
+    if waiting_entry.is_some() && interaction_store.is_some() {
+        capabilities.apply_interaction(interaction.as_ref());
+    }
+
     Some(IssueDetailSnapshot {
         issue_identifier,
         issue_id,
@@ -734,6 +762,7 @@ pub async fn build_issue_snapshot(
         acceptance_attempts: pipeline_run
             .map(|run| run.acceptance_attempts.clone())
             .unwrap_or_default(),
+        capabilities,
     })
 }
 
@@ -743,10 +772,6 @@ pub async fn enrich_issue_snapshot_pending_input(
     detail: &mut IssueDetailSnapshot,
     interaction_store: &InteractionStore,
 ) {
-    if detail.pending_input.is_some() {
-        return;
-    }
-
     let Some(current) = detail.current_interaction.as_ref() else {
         return;
     };
@@ -757,8 +782,26 @@ pub async fn enrich_issue_snapshot_pending_input(
         .ok()
         .flatten();
 
-    if let Some(interaction) = interaction {
-        detail.pending_input = Some(pending_input_from_current(current, &interaction));
+    detail.capabilities.apply_interaction(interaction.as_ref());
+    if detail.pending_input.is_none() {
+        if let Some(interaction) = interaction {
+            detail.pending_input = Some(pending_input_from_current(current, &interaction));
+        }
+    }
+}
+
+/// Enrich waiting runtime rows from their durable interaction records after the state lock is released.
+pub async fn enrich_runtime_snapshot_interactions(
+    snapshot: &mut RuntimeSnapshot,
+    interaction_store: &InteractionStore,
+) {
+    for row in &mut snapshot.waiting_on_human {
+        let interaction = interaction_store
+            .get(&row.interaction_request_id)
+            .await
+            .ok()
+            .flatten();
+        row.capabilities.apply_interaction(interaction.as_ref());
     }
 }
 
@@ -792,6 +835,7 @@ fn running_entry_to_row(
             output_tokens: entry.agent_output_tokens,
             total_tokens: entry.agent_total_tokens,
         },
+        capabilities: IssueActionCapabilities::for_issue(true, false, false, None),
     }
 }
 
@@ -803,6 +847,7 @@ fn retry_entry_to_row(entry: &RetryEntry) -> RetryRow {
         attempt: entry.attempt,
         due_at_ms: entry.due_at_ms,
         error: entry.error.clone(),
+        capabilities: IssueActionCapabilities::for_issue(false, true, false, None),
     }
 }
 
@@ -815,6 +860,7 @@ fn waiting_entry_to_row(
         interaction_request_id: entry.interaction_request_id.clone(),
         step_name: entry.step_name.clone(),
         requested_at: entry.requested_at,
+        capabilities: IssueActionCapabilities::for_issue(false, false, true, None),
     }
 }
 
@@ -1102,6 +1148,25 @@ mod tests {
         assert_eq!(row.tokens.input_tokens, 1200);
         assert_eq!(row.tokens.output_tokens, 800);
         assert_eq!(row.tokens.total_tokens, 2000);
+    }
+
+    #[test]
+    fn running_rows_expose_only_stop_and_inspect_as_enabled_actions() {
+        let snapshot = build_state_snapshot(&build_test_state());
+        let capabilities = &snapshot.running[0].capabilities;
+
+        assert!(capabilities.inspect().is_enabled());
+        assert!(capabilities.stop().is_enabled());
+        assert!(!capabilities.retry().is_enabled());
+        assert_eq!(
+            capabilities.retry().disabled_reason(),
+            Some("This issue is not retrying.")
+        );
+        assert!(!capabilities.guide().is_enabled());
+        assert_eq!(
+            capabilities.guide().disabled_reason(),
+            Some("Guidance is not supported in Mission Control."),
+        );
     }
 
     #[test]

--- a/crates/ensemble-ui/src-ui/src/components/InteractionQueue.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/InteractionQueue.test.tsx
@@ -13,6 +13,13 @@ function waitingInteraction(
     issue_identifier: "my-repo#42",
     requested_at: "2026-04-04T10:00:00Z",
     step_name: "review",
+    capabilities: {
+      inspect: { enabled: true }, reply: { enabled: false, disabled_reason: "Unavailable." },
+      guide: { enabled: false, disabled_reason: "Unavailable." }, cancel: { enabled: false, disabled_reason: "Unavailable." },
+      stop: { enabled: false, disabled_reason: "Unavailable." }, retry: { enabled: false, disabled_reason: "Unavailable." },
+      resume: { enabled: false, disabled_reason: "Unavailable." }, finalize_approve: { enabled: false, disabled_reason: "Unavailable." },
+      finalize_retry: { enabled: false, disabled_reason: "Unavailable." }, cleanup: { enabled: false, disabled_reason: "Unavailable." },
+    },
     ...overrides,
   };
 }

--- a/crates/ensemble-ui/src-ui/src/components/WorkflowStepsSidebar.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/WorkflowStepsSidebar.tsx
@@ -1,17 +1,10 @@
 import { Link } from "react-router-dom";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-
-interface WorkflowStep {
-  name: string;
-  agent: string;
-  dependencies: string[];
-  state: string;
-  can_navigate: boolean;
-}
+import type { WorkflowStepInfo } from "@/generated/models";
 
 interface WorkflowStepsSidebarProps {
-  steps: WorkflowStep[];
+  steps: WorkflowStepInfo[];
   issueIdentifier: string;
   currentStep?: string;
 }
@@ -50,15 +43,29 @@ export default function WorkflowStepsSidebar({
           const icon = stateIcons[step.state] ?? "○";
           const color = stateColors[step.state] ?? "text-gray-400";
           
+          const inspect = step.capabilities?.inspect;
+          const disabledReason = inspect?.disabled_reason ?? "Inspection is unavailable; refresh and try again.";
+          const canInspect = inspect?.enabled === true;
+
           return (
             <div key={step.name} className="flex items-center gap-2">
               <span className={`text-lg ${color}`}>{icon}</span>
-              <Link
-                to={`/issue/${encodeURIComponent(issueIdentifier)}/step/${encodeURIComponent(step.name)}`}
-                className={`text-sm hover:underline ${isActive ? 'font-semibold text-primary' : 'text-muted-foreground'}`}
-              >
-                {step.name}
-              </Link>
+              {canInspect ? (
+                <Link
+                  to={`/issue/${encodeURIComponent(issueIdentifier)}/step/${encodeURIComponent(step.name)}`}
+                  className={`text-sm hover:underline ${isActive ? "font-semibold text-primary" : "text-muted-foreground"}`}
+                >
+                  {step.name}
+                </Link>
+              ) : (
+                <span
+                  aria-label={`${step.name}: ${disabledReason}`}
+                  className="text-sm text-muted-foreground"
+                  title={disabledReason}
+                >
+                  {step.name}
+                </span>
+              )}
               <Badge variant="outline" className="text-xs ml-auto">
                 {step.agent}
               </Badge>

--- a/crates/ensemble-ui/src-ui/src/hooks.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/hooks.test.tsx
@@ -128,6 +128,13 @@ function issueDetail(finalizeStatus: string, approvalRequired = false): IssueDet
     running: null,
     status: "completed_succeeded",
     workflow_steps: [],
+    capabilities: {
+      inspect: { enabled: true }, reply: { enabled: false, disabled_reason: "Unavailable." },
+      guide: { enabled: false, disabled_reason: "Unavailable." }, cancel: { enabled: false, disabled_reason: "Unavailable." },
+      stop: { enabled: false, disabled_reason: "Unavailable." }, retry: { enabled: false, disabled_reason: "Unavailable." },
+      resume: { enabled: false, disabled_reason: "Unavailable." }, finalize_approve: { enabled: false, disabled_reason: "Unavailable." },
+      finalize_retry: { enabled: false, disabled_reason: "Unavailable." }, cleanup: { enabled: false, disabled_reason: "Unavailable." },
+    },
     workspace: { path: "/tmp/workspace" },
   };
 }

--- a/crates/ensemble-ui/src-ui/src/pages/Dashboard.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/Dashboard.test.tsx
@@ -6,6 +6,14 @@ import { describe, expect, it } from "vitest";
 import type { RuntimeSnapshot } from "@/generated/models";
 import Dashboard from "./Dashboard";
 
+const capabilities = {
+  inspect: { enabled: true }, reply: { enabled: false, disabled_reason: "Unavailable." },
+  guide: { enabled: false, disabled_reason: "Unavailable." }, cancel: { enabled: false, disabled_reason: "Unavailable." },
+  stop: { enabled: false, disabled_reason: "Unavailable." }, retry: { enabled: false, disabled_reason: "Unavailable." },
+  resume: { enabled: false, disabled_reason: "Unavailable." }, finalize_approve: { enabled: false, disabled_reason: "Unavailable." },
+  finalize_retry: { enabled: false, disabled_reason: "Unavailable." }, cleanup: { enabled: false, disabled_reason: "Unavailable." },
+};
+
 function mockSnapshot(): RuntimeSnapshot {
   return {
     agent_totals: { input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0 },
@@ -42,6 +50,7 @@ function mockSnapshot(): RuntimeSnapshot {
         step_name: "build",
         tokens: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
         turn_count: 3,
+        capabilities: { ...capabilities, stop: { enabled: true } },
       },
     ],
     retrying: [],
@@ -52,6 +61,7 @@ function mockSnapshot(): RuntimeSnapshot {
         issue_identifier: "repo#2",
         requested_at: "2026-07-09T09:10:00Z",
         step_name: "review",
+        capabilities: { ...capabilities, reply: { enabled: true }, cancel: { enabled: true } },
       },
     ],
     completed: [],

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.test.tsx
@@ -59,6 +59,18 @@ const hooksMock = vi.hoisted(() => {
         ],
         pending_input: { ask_id: "ask-1" },
         current_interaction: { interaction_request_id: "ask-1" },
+        capabilities: {
+          inspect: { enabled: true },
+          reply: { enabled: true },
+          guide: { enabled: false, disabled_reason: "Guidance is not supported." },
+          cancel: { enabled: true },
+          stop: { enabled: true },
+          retry: { enabled: false, disabled_reason: "This issue is not retrying." },
+          resume: { enabled: false, disabled_reason: "Resolve the interaction before resuming." },
+          finalize_approve: { enabled: false, disabled_reason: "Finalize approval is not required." },
+          finalize_retry: { enabled: false, disabled_reason: "Finalize retry is not required." },
+          cleanup: { enabled: false, disabled_reason: "Manual cleanup is not supported." },
+        },
       },
       isLoading: false,
       isError: false,
@@ -1195,6 +1207,7 @@ describe("useIssueRuntime lifecycle", () => {
             dependencies: [],
             state: "passed",
             can_navigate: true,
+            capabilities: { inspect: { enabled: true } },
           },
           {
             name: "review",
@@ -1203,6 +1216,7 @@ describe("useIssueRuntime lifecycle", () => {
             dependencies: ["build"],
             state: terminalStepState,
             can_navigate: true,
+            capabilities: { inspect: { enabled: true } },
           },
           {
             name: "publish",
@@ -1211,8 +1225,21 @@ describe("useIssueRuntime lifecycle", () => {
             dependencies: ["review"],
             state: "pending",
             can_navigate: false,
+            capabilities: { inspect: { enabled: false, disabled_reason: "No step details are available yet." } },
           },
         ],
+        capabilities: {
+          inspect: { enabled: true },
+          reply: { enabled: false, disabled_reason: "Unavailable." },
+          guide: { enabled: false, disabled_reason: "Unavailable." },
+          cancel: { enabled: false, disabled_reason: "Unavailable." },
+          stop: { enabled: false, disabled_reason: "Unavailable." },
+          retry: { enabled: false, disabled_reason: "Unavailable." },
+          resume: { enabled: false, disabled_reason: "Unavailable." },
+          finalize_approve: { enabled: false, disabled_reason: "Unavailable." },
+          finalize_retry: { enabled: false, disabled_reason: "Unavailable." },
+          cleanup: { enabled: false, disabled_reason: "Unavailable." },
+        },
       } satisfies IssueDetailSnapshot;
       hooksMock.useIssueDetailQuery.mockReturnValue({
         data: terminalDetail,
@@ -1309,6 +1336,19 @@ describe("useIssueRuntime lifecycle", () => {
 });
 
 describe("IssueDetail", () => {
+  const capabilities = {
+    inspect: { enabled: true },
+    reply: { enabled: true },
+    guide: { enabled: false, disabled_reason: "Guidance is not supported." },
+    cancel: { enabled: true },
+    stop: { enabled: true },
+    retry: { enabled: false, disabled_reason: "This issue is not retrying." },
+    resume: { enabled: false, disabled_reason: "Resolve the interaction before resuming." },
+    finalize_approve: { enabled: false, disabled_reason: "Finalize approval is not required." },
+    finalize_retry: { enabled: false, disabled_reason: "Finalize retry is not required." },
+    cleanup: { enabled: false, disabled_reason: "Manual cleanup is not supported." },
+  };
+
   beforeEach(() => {
     hooksMock.stopMutate.mockClear();
     hooksMock.retryMutate.mockClear();
@@ -1363,6 +1403,7 @@ describe("IssueDetail", () => {
         ],
         pending_input: { ask_id: "ask-1" },
         current_interaction: { interaction_request_id: "ask-1" },
+        capabilities,
       },
       isLoading: false,
       isError: false,
@@ -1613,6 +1654,7 @@ describe("IssueDetail", () => {
         workflow_steps: [],
         pending_input: { ask_id: `ask-${identifier}` },
         current_interaction: { interaction_request_id: `ask-${identifier}` },
+        capabilities,
       },
       isLoading: false,
       isError: false,
@@ -2277,7 +2319,7 @@ describe("IssueDetail", () => {
     expect(screen.getByText("completed build record")).toBeInTheDocument();
   });
 
-  it("renders durable artifacts and keeps workflow steps clickable when can_navigate is false", async () => {
+  it("renders durable artifacts and disables unavailable workflow step inspection", async () => {
     const user = userEvent.setup();
 
     hooksMock.useIssueDetailQuery.mockReturnValue({
@@ -2322,6 +2364,9 @@ describe("IssueDetail", () => {
             dependencies: [],
             state: "passed",
             can_navigate: false,
+            capabilities: {
+              inspect: { enabled: false, disabled_reason: "No step details are available yet." },
+            },
           },
         ],
       } as any,
@@ -2348,10 +2393,8 @@ describe("IssueDetail", () => {
       { wrapper },
     );
 
-    expect(screen.getByRole("link", { name: "deploy" })).toHaveAttribute(
-      "href",
-      "/issue/todo-1/step/deploy",
-    );
+    expect(screen.queryByRole("link", { name: "deploy" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("deploy: No step details are available yet.")).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Artifacts" }));
 
@@ -2392,6 +2435,7 @@ describe("IssueDetail", () => {
           ],
         },
         workflow_steps: [],
+        capabilities: { ...capabilities, finalize_approve: { enabled: true } },
       } as any,
       isLoading: false,
       isError: false,
@@ -2439,7 +2483,17 @@ describe("IssueDetail", () => {
     let finalize = { status: "pending_approval", repos: [pendingRepo] };
     hooksMock.useIssueDetailQuery.mockImplementation(() => ({
       ...current,
-      data: { ...current.data, finalize },
+      data: {
+        ...current.data,
+        finalize,
+        capabilities: {
+          ...capabilities,
+          finalize_approve:
+            finalize.status === "pending_approval"
+              ? { enabled: true }
+              : { enabled: false, disabled_reason: "Finalize approval is not required." },
+        },
+      },
     }));
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -2490,6 +2544,7 @@ describe("IssueDetail", () => {
         workspace: { path: "/tmp/workspace" },
         finalize: { status: "failed", repos: [] },
         workflow_steps: [],
+        capabilities: { ...capabilities, finalize_retry: { enabled: true } },
       } as any,
       isLoading: false,
       isError: false,

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
@@ -14,6 +14,7 @@ import { IssueComposer } from "@/components/issue-detail/IssueComposer";
 import { IssueContextPanel } from "@/components/issue-detail/IssueContextPanel";
 import { RunTranscript } from "@/components/transcript/RunTranscript";
 import { useIssueRuntime } from "./mission-control/useIssueRuntime";
+import type { ActionCapability } from "@/generated/models";
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -23,6 +24,18 @@ function formatTokens(n: number): string {
 
 function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Request failed";
+}
+
+function actionEnabled(capability: ActionCapability | undefined) {
+  return capability?.enabled === true;
+}
+
+function actionReason(capability: ActionCapability | undefined) {
+  return capability?.disabled_reason ?? "Action availability is unavailable; refresh and try again.";
+}
+
+function actionAriaLabel(label: string, capability: ActionCapability | undefined) {
+  return capability?.enabled !== true ? `${label}: ${actionReason(capability)}` : undefined;
 }
 
 export default function IssueDetail() {
@@ -120,6 +133,9 @@ function IssueDetailContent({ identifier }: { identifier: string }) {
   );
 
   const finalizeStatus = data.finalize?.status;
+  const capabilities = data.capabilities;
+  const canApproveFinalize = actionEnabled(capabilities?.finalize_approve);
+  const canRetryFinalize = actionEnabled(capabilities?.finalize_retry);
   const actionError = [
     stopMutation,
     retryMutation,
@@ -129,7 +145,7 @@ function IssueDetailContent({ identifier }: { identifier: string }) {
   ].find((mutation) => mutation.isError)?.error;
   const finalizePanel = finalizeStatus ? (
     <div className="rounded-lg border bg-card p-4 text-sm">
-      {finalizeStatus === "pending_approval" ? (
+      {canApproveFinalize ? (
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <div className="font-medium">Finalize approval required</div>
@@ -138,12 +154,12 @@ function IssueDetailContent({ identifier }: { identifier: string }) {
           <Button
             size="sm"
             onClick={() => setShowFinalizeConfirm(true)}
-            disabled={finalizeApproveMutation.isPending}
+            disabled={finalizeApproveMutation.isPending || !canApproveFinalize}
           >
             Approve finalize
           </Button>
         </div>
-      ) : finalizeStatus === "failed" ? (
+      ) : canRetryFinalize ? (
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <div className="font-medium">Finalize failed</div>
@@ -152,7 +168,7 @@ function IssueDetailContent({ identifier }: { identifier: string }) {
           <Button
             size="sm"
             onClick={() => finalizeRetryMutation.mutate({ identifier })}
-            disabled={finalizeRetryMutation.isPending}
+            disabled={finalizeRetryMutation.isPending || !canRetryFinalize}
           >
             Retry finalize
           </Button>
@@ -202,7 +218,10 @@ function IssueDetailContent({ identifier }: { identifier: string }) {
       onSubmitReply={submitInteractionReply}
       onSubmitFollowUp={() => false}
       onResumeInteraction={resumeInteraction}
-      isSubmitting={interactionSubmitting}
+      isSubmitting={
+        interactionSubmitting ||
+        (!actionEnabled(capabilities?.reply) && !actionEnabled(capabilities?.resume))
+      }
       error={composerError}
     />
   ) : (
@@ -242,16 +261,25 @@ function IssueDetailContent({ identifier }: { identifier: string }) {
           </div>
         </div>
         <div className="flex gap-2">
-          {isLiveRun ? (
-            <Button variant="destructive" size="sm" onClick={() => setShowStopConfirm(true)}>
+          {capabilities ? (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setShowStopConfirm(true)}
+              disabled={!actionEnabled(capabilities.stop)}
+              aria-label={actionAriaLabel("Stop Agent", capabilities.stop)}
+              title={!actionEnabled(capabilities.stop) ? actionReason(capabilities.stop) : undefined}
+            >
               Stop Agent
             </Button>
           ) : null}
-          {data.retry ? (
+          {capabilities ? (
             <Button
               size="sm"
               onClick={() => retryMutation.mutate({ identifier })}
-              disabled={retryMutation.isPending}
+              disabled={retryMutation.isPending || !actionEnabled(capabilities.retry)}
+              aria-label={actionAriaLabel("Retry Now", capabilities.retry)}
+              title={!actionEnabled(capabilities.retry) ? actionReason(capabilities.retry) : undefined}
             >
               Retry Now
             </Button>
@@ -327,7 +355,9 @@ function IssueDetailContent({ identifier }: { identifier: string }) {
                   variant="outline"
                   size="sm"
                   onClick={() => cancelMutation.mutate({ id: interaction.id })}
-                  disabled={cancelMutation.isPending}
+                  disabled={cancelMutation.isPending || !actionEnabled(capabilities?.cancel)}
+                  aria-label={actionAriaLabel("Cancel Request", capabilities?.cancel)}
+                  title={!actionEnabled(capabilities?.cancel) ? actionReason(capabilities?.cancel) : undefined}
                 >
                   Cancel Request
                 </Button>

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import type {
   InteractionDetail,
   InteractionStatus,
+  IssueActionCapabilities,
   IssueDetailSnapshot,
 } from "@/generated/models";
 import { IssueCommandPanel, type IssueCommandPanelTab } from "./IssueCommandPanel";
@@ -25,6 +26,30 @@ const actions = {
   setActiveEntry: vi.fn(),
   setActiveEntryForConversation: vi.fn(),
 };
+
+function capability(enabled: boolean, disabledReason = "Unavailable for this test.") {
+  return enabled ? { enabled } : { enabled, disabled_reason: disabledReason };
+}
+
+function capabilitiesFor(
+  data: Pick<IssueDetailSnapshot, "running" | "retry" | "finalize">,
+  interaction?: InteractionDetail,
+): IssueActionCapabilities {
+  const interactionOpen = interaction?.status === "open";
+  const canResume = interaction?.status === "resolved" && interaction.awaiting_resume;
+  return {
+    inspect: capability(true),
+    reply: capability(interactionOpen ?? true),
+    guide: capability(false),
+    cancel: capability(interactionOpen ?? true),
+    stop: capability(data.running != null),
+    retry: capability(data.retry != null),
+    resume: capability(canResume),
+    finalize_approve: capability(data.finalize.status === "pending_approval"),
+    finalize_retry: capability(data.finalize.status === "failed"),
+    cleanup: capability(false),
+  };
+}
 
 function mockMutation<T>(mutate: ReturnType<typeof vi.fn>, overrides: Record<string, unknown> = {}) {
   return {
@@ -73,6 +98,7 @@ const issue = {
       dependencies: [],
       state: "running",
       can_navigate: true,
+      capabilities: { inspect: { enabled: true } },
     },
   ],
   artifacts: null,
@@ -101,6 +127,11 @@ const issue = {
       ],
     },
   ],
+  capabilities: capabilitiesFor({
+    running: {} as IssueDetailSnapshot["running"],
+    retry: null,
+    finalize: { status: "not_required", repos: [] },
+  }),
 } satisfies IssueDetailSnapshot;
 
 const openInteraction = {
@@ -119,13 +150,23 @@ const openInteraction = {
 } satisfies InteractionDetail;
 
 function runtimeFixture(overrides: Partial<IssueRuntimeState> = {}): IssueRuntimeState {
+  const { data: dataOverride, interaction, ...runtimeOverrides } = overrides;
+  const data = dataOverride
+    ? {
+        ...dataOverride,
+        capabilities:
+          dataOverride.capabilities && dataOverride.capabilities !== issue.capabilities
+            ? dataOverride.capabilities
+            : capabilitiesFor(dataOverride, interaction),
+      }
+    : { ...issue, capabilities: capabilitiesFor(issue, interaction) };
   return {
     identifier: "repo#1",
-    data: issue,
+    data,
     isLoading: false,
     isError: false,
     error: null,
-    interaction: undefined,
+    interaction: interaction ?? undefined,
     interactionIsLoading: false,
     interactionIsError: false,
     interactionError: null,
@@ -158,7 +199,7 @@ function runtimeFixture(overrides: Partial<IssueRuntimeState> = {}): IssueRuntim
     submitFollowUpInput: vi.fn(),
     setActiveEntryIdForConversationIndex: actions.setActiveEntryForConversation,
     setActiveEntryId: actions.setActiveEntry,
-    ...overrides,
+    ...runtimeOverrides,
   };
 }
 
@@ -211,6 +252,25 @@ describe("IssueCommandPanel", () => {
       "true",
     );
     expect(screen.getAllByRole("tab")).toHaveLength(7);
+  });
+
+  it("uses server capability reasons instead of inferring a disabled action locally", () => {
+    vi.mocked(useIssueRuntime).mockReturnValue(
+      runtimeFixture({
+        data: {
+          ...issue,
+          capabilities: {
+            ...issue.capabilities,
+            stop: { enabled: false, disabled_reason: "The run has already stopped." },
+          },
+        },
+      }),
+    );
+    renderPanel();
+
+    const stop = screen.getByRole("button", { name: "Stop: The run has already stopped." });
+    expect(stop).toBeDisabled();
+    expect(stop).toHaveAttribute("title", "The run has already stopped.");
   });
 
   it("renders tabs in contract order and activates them with roving keyboard focus", async () => {
@@ -455,6 +515,7 @@ describe("IssueCommandPanel", () => {
             error: "step failed",
             issue_id: "issue-1",
             issue_identifier: "repo#1",
+            capabilities: capabilitiesFor({ running: null, retry: {} as IssueDetailSnapshot["retry"], finalize: issue.finalize }),
           },
         },
         isLiveRun: false,
@@ -649,7 +710,9 @@ describe("IssueCommandPanel", () => {
       renderPanel();
 
       expect(screen.getByText(finalizeStatus)).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: /finalize/i })).not.toBeInTheDocument();
+      for (const button of screen.getAllByRole("button", { name: /finalize/i })) {
+        expect(button).toBeDisabled();
+      }
     },
   );
 

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.tsx
@@ -11,6 +11,7 @@ import WorkflowStepsSidebar from "@/components/WorkflowStepsSidebar";
 import { IssueComposer } from "@/components/issue-detail/IssueComposer";
 import { RunTranscript } from "@/components/transcript/RunTranscript";
 import { Button } from "@/components/ui/button";
+import type { ActionCapability } from "@/generated/models";
 import { cn } from "@/lib/utils";
 import { useIssueRuntime } from "./useIssueRuntime";
 
@@ -57,6 +58,18 @@ function PanelCloseButton({ onClose }: { onClose: () => void }) {
       <X className="h-4 w-4" />
     </Button>
   );
+}
+
+function capabilityDisabled(capability: ActionCapability | undefined, isPending = false) {
+  return isPending || capability?.enabled !== true;
+}
+
+function capabilityReason(capability: ActionCapability | undefined) {
+  return capability?.disabled_reason ?? "Action availability is unavailable; refresh and try again.";
+}
+
+function actionAriaLabel(label: string, capability: ActionCapability | undefined) {
+  return capability?.enabled !== true ? `${label}: ${capabilityReason(capability)}` : undefined;
 }
 
 export function IssueCommandPanel({
@@ -175,6 +188,7 @@ function IssueCommandPanelContent({
   }
 
   const finalizeStatus = data.finalize.status;
+  const capabilities = data.capabilities;
   const actionError = [
     stopMutation,
     retryMutation,
@@ -323,15 +337,25 @@ function IssueCommandPanelContent({
                 <p className="mt-1 text-muted-foreground">{errorMessage(interactionError)}</p>
               </div>
             ) : pendingQuestion ? (
+              <div className="space-y-2">
               <IssueComposer
                 key={`${identifier}:${pendingQuestion.interactionId}`}
                 pendingQuestion={pendingQuestion}
                 onSubmitReply={submitInteractionReply}
                 onSubmitFollowUp={() => false}
                 onResumeInteraction={resumeInteraction}
-                isSubmitting={interactionSubmitting}
+                isSubmitting={
+                  interactionSubmitting ||
+                  capabilityDisabled(capabilities?.reply) && capabilityDisabled(capabilities?.resume)
+                }
                 error={composerError}
               />
+              {capabilityDisabled(capabilities?.reply) && capabilityDisabled(capabilities?.resume) ? (
+                <p className="text-sm text-muted-foreground">
+                  {capabilityReason(capabilities?.reply)}
+                </p>
+              ) : null}
+              </div>
             ) : (
               <div className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
                 No response is currently available. Use Transcript or Steps to inspect the issue.
@@ -342,7 +366,9 @@ function IssueCommandPanelContent({
                 variant="outline"
                 size="sm"
                 onClick={() => cancelMutation.mutate({ id: interaction.id })}
-                disabled={cancelMutation.isPending}
+              disabled={capabilityDisabled(capabilities?.cancel, cancelMutation.isPending)}
+                aria-label={actionAriaLabel("Cancel Request", capabilities?.cancel)}
+                title={capabilityDisabled(capabilities?.cancel) ? capabilityReason(capabilities?.cancel) : undefined}
               >
                 Cancel Request
               </Button>
@@ -436,38 +462,47 @@ function IssueCommandPanelContent({
         </div>
 
         <div className="mt-3 flex flex-wrap items-center gap-2">
-          {isLiveRun ? (
+          {capabilities ? (
             <Button
               variant="destructive"
               size="sm"
               onClick={() => setStopConfirmationIdentifier(identifier)}
+              disabled={capabilityDisabled(capabilities?.stop)}
+              aria-label={actionAriaLabel("Stop", capabilities?.stop)}
+              title={capabilityDisabled(capabilities?.stop) ? capabilityReason(capabilities?.stop) : undefined}
             >
               Stop
             </Button>
           ) : null}
-          {data.retry ? (
+          {capabilities ? (
             <Button
               size="sm"
               onClick={() => retryMutation.mutate({ identifier })}
-              disabled={retryMutation.isPending}
+              disabled={capabilityDisabled(capabilities?.retry, retryMutation.isPending)}
+              aria-label={actionAriaLabel("Retry", capabilities?.retry)}
+              title={capabilityDisabled(capabilities?.retry) ? capabilityReason(capabilities?.retry) : undefined}
             >
               Retry
             </Button>
           ) : null}
-          {finalizeStatus === "pending_approval" ? (
+          {capabilities ? (
             <Button
               size="sm"
               onClick={() => setShowFinalizeConfirm(true)}
-              disabled={finalizeApproveMutation.isPending}
+              disabled={capabilityDisabled(capabilities?.finalize_approve, finalizeApproveMutation.isPending)}
+              aria-label={actionAriaLabel("Approve finalize", capabilities?.finalize_approve)}
+              title={capabilityDisabled(capabilities?.finalize_approve) ? capabilityReason(capabilities?.finalize_approve) : undefined}
             >
               Approve finalize
             </Button>
           ) : null}
-          {finalizeStatus === "failed" ? (
+          {capabilities ? (
             <Button
               size="sm"
               onClick={() => finalizeRetryMutation.mutate({ identifier })}
-              disabled={finalizeRetryMutation.isPending}
+              disabled={capabilityDisabled(capabilities?.finalize_retry, finalizeRetryMutation.isPending)}
+              aria-label={actionAriaLabel("Retry finalize", capabilities?.finalize_retry)}
+              title={capabilityDisabled(capabilities?.finalize_retry) ? capabilityReason(capabilities?.finalize_retry) : undefined}
             >
               Retry finalize
             </Button>

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/MissionControl.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { postRefresh } from "@/generated/api/controls/controls";
 import { getState } from "@/generated/api/state/state";
-import type { IssueDetailSnapshot, RuntimeSnapshot } from "@/generated/models";
+import type { IssueActionCapabilities, IssueDetailSnapshot, RuntimeSnapshot } from "@/generated/models";
 import { AttentionQueue } from "./AttentionQueue";
 import MissionControl from "./MissionControl";
 import { MissionControlToolbar } from "./MissionControlToolbar";
@@ -100,6 +100,19 @@ const attentionItems: MissionAttentionItem[] = [
   },
 ];
 
+const capabilities: IssueActionCapabilities = {
+  inspect: { enabled: true },
+  reply: { enabled: false, disabled_reason: "No interaction is awaiting input." },
+  guide: { enabled: false, disabled_reason: "Guidance is not supported." },
+  cancel: { enabled: false, disabled_reason: "No interaction is awaiting input." },
+  stop: { enabled: false, disabled_reason: "This issue is not running." },
+  retry: { enabled: false, disabled_reason: "This issue is not retrying." },
+  resume: { enabled: false, disabled_reason: "No interaction is awaiting input." },
+  finalize_approve: { enabled: false, disabled_reason: "Finalize approval is not required." },
+  finalize_retry: { enabled: false, disabled_reason: "Finalize retry is not required." },
+  cleanup: { enabled: false, disabled_reason: "Manual cleanup is not supported." },
+};
+
 function issue(overrides: Partial<MissionIssueSummary> = {}): MissionIssueSummary {
   return {
     id: "issue-1",
@@ -115,6 +128,7 @@ function issue(overrides: Partial<MissionIssueSummary> = {}): MissionIssueSummar
     tokenTotal: 150,
     turnCount: 3,
     attention: false,
+    capabilities,
     source: {} as MissionIssueSummary["source"],
     ...overrides,
   };
@@ -174,6 +188,7 @@ function runtimeSnapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnaps
         step_name: "build",
         tokens: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
         turn_count: 3,
+        capabilities: { ...capabilities, stop: { enabled: true } },
       },
     ],
     retrying: [
@@ -183,6 +198,7 @@ function runtimeSnapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnaps
         attempt: 2,
         due_at_ms: 1000,
         error: "clippy failed",
+        capabilities: { ...capabilities, retry: { enabled: true } },
       },
     ],
     waiting_on_human: [
@@ -192,6 +208,7 @@ function runtimeSnapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnaps
         issue_identifier: "repo#3",
         requested_at: "2026-07-09T09:10:00Z",
         step_name: "review",
+        capabilities: { ...capabilities, reply: { enabled: true }, cancel: { enabled: true } },
       },
     ],
     completed: [
@@ -200,6 +217,7 @@ function runtimeSnapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnaps
         issue_identifier: "repo#4",
         completed_at: "2026-07-09T09:20:00Z",
         status: "completed_succeeded",
+        capabilities,
       },
     ],
     ...overrides,
@@ -234,6 +252,7 @@ function runtimeFixture(identifier: string): IssueRuntimeState {
     last_error: null,
     pending_input: null,
     current_interaction: null,
+    capabilities,
   } satisfies IssueDetailSnapshot;
 
   return {
@@ -929,12 +948,14 @@ describe("Mission Control page", () => {
           issue_identifier: "repo#halted",
           requested_at: "2026-07-09T09:15:00Z",
           step_name: "review",
+          capabilities,
         }],
         completed: [{
           issue_id: "issue-failed",
           issue_identifier: "repo#failed",
           completed_at: "2026-07-09T09:25:00Z",
           status: "completed_failed",
+          capabilities,
         }],
       }),
     );

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/OperationsBoard.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/OperationsBoard.tsx
@@ -31,12 +31,18 @@ function IssueTile({
   onSelect: () => void;
 }) {
   const updatedText = formatUpdatedAt(issue.updatedAt);
+  const inspect = issue.capabilities.inspect;
+  const disabled = !inspect.enabled;
+  const disabledReason = inspect.disabled_reason ?? "Inspection is unavailable; refresh and try again.";
 
   return (
     <button
       type="button"
       aria-current={selected ? "true" : undefined}
       onClick={onSelect}
+      disabled={disabled}
+      aria-label={disabled ? `${issue.identifier}: ${disabledReason}` : undefined}
+      title={disabled ? disabledReason : undefined}
       className={cn(
         "w-full rounded-lg border bg-background p-3 text-left shadow-sm transition hover:border-primary/50 hover:bg-muted/30",
         issue.attention && "border-amber-400/70 bg-amber-50/50 dark:bg-amber-950/15",

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/OperationsList.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/OperationsList.tsx
@@ -42,6 +42,9 @@ export function OperationsList({ issues, selectedIssueIdentifier, onSelectIssue 
             {issues.map((issue) => {
               const selected = selectedIssueIdentifier === issue.identifier;
               const updatedText = formatUpdatedAt(issue.updatedAt);
+              const inspect = issue.capabilities.inspect;
+              const disabled = !inspect.enabled;
+              const disabledReason = inspect.disabled_reason ?? "Inspection is unavailable; refresh and try again.";
 
               return (
                 <button
@@ -49,6 +52,9 @@ export function OperationsList({ issues, selectedIssueIdentifier, onSelectIssue 
                   type="button"
                   aria-current={selected ? "true" : undefined}
                   onClick={() => onSelectIssue(issue.identifier)}
+                  disabled={disabled}
+                  aria-label={disabled ? `${issue.identifier}: ${disabledReason}` : undefined}
+                  title={disabled ? disabledReason : undefined}
                   className={cn(
                     "grid w-full grid-cols-[minmax(10rem,1.1fr)_8rem_minmax(10rem,1fr)_8rem] items-center gap-3 px-4 py-3 text-left text-sm transition hover:bg-muted/30",
                     selected && "bg-primary/5 ring-1 ring-primary/30 ring-inset",

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/model.test.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AttentionItem, RuntimeSnapshot } from "@/generated/models";
+import type { AttentionItem, IssueActionCapabilities, RuntimeSnapshot } from "@/generated/models";
 import {
   deriveMissionControlState,
   filterMissionControlIssues,
@@ -30,6 +30,19 @@ function attentionItem(overrides: Partial<AttentionItem> = {}): AttentionItem {
   };
 }
 
+const capabilities: IssueActionCapabilities = {
+  inspect: { enabled: true },
+  reply: { enabled: false, disabled_reason: "No interaction is awaiting input." },
+  guide: { enabled: false, disabled_reason: "Guidance is not supported." },
+  cancel: { enabled: false, disabled_reason: "No interaction is awaiting input." },
+  stop: { enabled: false, disabled_reason: "This issue is not running." },
+  retry: { enabled: false, disabled_reason: "This issue is not retrying." },
+  resume: { enabled: false, disabled_reason: "No interaction is awaiting input." },
+  finalize_approve: { enabled: false, disabled_reason: "Finalize approval is not required." },
+  finalize_retry: { enabled: false, disabled_reason: "Finalize retry is not required." },
+  cleanup: { enabled: false, disabled_reason: "Manual cleanup is not supported." },
+};
+
 function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
   return {
     agent_totals: {
@@ -57,6 +70,7 @@ function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
         step_name: "build",
         tokens: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
         turn_count: 3,
+        capabilities: { ...capabilities, stop: { enabled: true } },
       },
     ],
     retrying: [
@@ -66,6 +80,7 @@ function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
         attempt: 2,
         due_at_ms: 1000,
         error: "clippy failed",
+        capabilities: { ...capabilities, retry: { enabled: true } },
       },
     ],
     waiting_on_human: [
@@ -75,6 +90,7 @@ function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
         issue_identifier: "repo#3",
         requested_at: "2026-07-09T09:10:00Z",
         step_name: "review",
+        capabilities: { ...capabilities, reply: { enabled: true }, cancel: { enabled: true } },
       },
     ],
     completed: [
@@ -83,6 +99,7 @@ function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
         issue_identifier: "repo#4",
         completed_at: "2026-07-09T09:20:00Z",
         status: "completed_succeeded",
+        capabilities,
       },
     ],
     ...overrides,
@@ -167,6 +184,36 @@ describe("mission-control model", () => {
     });
   });
 
+  it("uses the matching issue inspect capability for attention navigation", () => {
+    const state = deriveMissionControlState(
+      snapshot({
+        attention_items: [
+          attentionItem({
+            identity: {
+              producer_key: "runtime.interaction",
+              subject_ref: "repo#1",
+              kind: "runtime.interaction.awaiting_input",
+            },
+          }),
+        ],
+        running: [
+          {
+            ...snapshot().running[0]!,
+            capabilities: {
+              ...capabilities,
+              inspect: { enabled: false, disabled_reason: "Issue inspection is unavailable." },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(state.attentionItems[0]).toMatchObject({
+      issueIdentifier: "repo#1",
+      canNavigate: false,
+    });
+  });
+
   it("classifies synthetic halted waits as blocked failures instead of human input", () => {
     const state = deriveMissionControlState(
       snapshot({
@@ -180,6 +227,7 @@ describe("mission-control model", () => {
             issue_identifier: "repo#halted",
             requested_at: "2026-07-09T09:15:00Z",
             step_name: "review",
+            capabilities,
           },
         ],
         completed: [],
@@ -308,12 +356,14 @@ describe("mission-control model", () => {
             issue_identifier: "repo#failed",
             completed_at: "2026-07-09T09:25:00Z",
             status: "completed_failed",
+            capabilities,
           },
           {
             issue_id: "issue-succeeded",
             issue_identifier: "repo#succeeded",
             completed_at: "2026-07-09T09:20:00Z",
             status: "completed_succeeded",
+            capabilities,
           },
         ],
       }),
@@ -342,6 +392,7 @@ describe("mission-control model", () => {
             issue_identifier: "repo#failed",
             completed_at: "2026-07-09T09:25:00Z",
             status: "completed_failed",
+            capabilities,
           },
         ],
       }),
@@ -370,6 +421,7 @@ describe("mission-control model", () => {
             issue_identifier: "repo#unknown",
             completed_at: "2026-07-09T09:25:00Z",
             status: "retry_exhausted",
+            capabilities,
           },
         ],
       }),

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/model.ts
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/model.ts
@@ -1,6 +1,7 @@
 import type {
   AttentionItem,
   CompletedRow,
+  IssueActionCapabilities,
   RetryRow,
   RunningSessionRow,
   RuntimeSnapshot,
@@ -29,6 +30,7 @@ export interface MissionIssueSummary {
   tokenTotal: number | null;
   turnCount: number | null;
   attention: boolean;
+  capabilities: IssueActionCapabilities;
   source: RunningSessionRow | RetryRow | WaitingInteractionRow | CompletedRow;
 }
 
@@ -127,6 +129,7 @@ function runningIssue(row: RunningSessionRow): MissionIssueSummary {
     turnCount: row.turn_count,
     attention: false,
     source: row,
+    capabilities: row.capabilities,
   };
 }
 
@@ -146,6 +149,7 @@ function retryIssue(row: RetryRow): MissionIssueSummary {
     turnCount: null,
     attention: false,
     source: row,
+    capabilities: row.capabilities,
   };
 }
 
@@ -166,6 +170,7 @@ function waitingIssue(row: WaitingInteractionRow): MissionIssueSummary {
     turnCount: null,
     attention: false,
     source: row,
+    capabilities: row.capabilities,
   };
 }
 
@@ -186,6 +191,7 @@ function completedIssue(row: CompletedRow): MissionIssueSummary {
     turnCount: null,
     attention: false,
     source: row,
+    capabilities: row.capabilities,
   };
 }
 
@@ -207,12 +213,16 @@ export function deriveMissionControlState(snapshot: RuntimeSnapshot): MissionCon
     ...issue,
     attention: attentionBySubject.has(issue.identifier),
   }));
-  const issueIdentifiers = new Set(issues.map((issue) => issue.identifier));
+  const inspectByIssueIdentifier = new Map(
+    issues.map((issue) => [issue.identifier, issue.capabilities.inspect.enabled]),
+  );
 
   return {
     issues: issuesWithAttention,
     groups: regroupMissionControlIssues(issuesWithAttention),
-    attentionItems: snapshot.attention_items.map((item) => missionAttentionItem(item, issueIdentifiers)),
+    attentionItems: snapshot.attention_items.map((item) =>
+      missionAttentionItem(item, inspectByIssueIdentifier),
+    ),
     stats: {
       running: snapshot.counts.running,
       retrying: snapshot.counts.retrying,
@@ -231,7 +241,7 @@ export function deriveMissionControlState(snapshot: RuntimeSnapshot): MissionCon
 
 function missionAttentionItem(
   item: AttentionItem,
-  issueIdentifiers: Set<string>,
+  inspectByIssueIdentifier: Map<string, boolean>,
 ): MissionAttentionItem {
   return {
     id: JSON.stringify([
@@ -245,7 +255,7 @@ function missionAttentionItem(
     detail: item.presentation.remedy,
     references: item.presentation.references,
     requestedAt: item.opened_at,
-    canNavigate: issueIdentifiers.has(item.identity.subject_ref),
+    canNavigate: inspectByIssueIdentifier.get(item.identity.subject_ref) === true,
   };
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2609,6 +2609,10 @@ Minimum endpoints:
     ```
 
   - Includes `attention_items`, containing only open records read from the shared history database.
+  - Every issue row includes `capabilities`: a fixed, server-derived set of `inspect`, `reply`,
+    `guide`, `cancel`, `stop`, `retry`, `resume`, `finalize_approve`, `finalize_retry`, and
+    `cleanup` operation states. Each state has `enabled`; a disabled state also carries a nonempty
+    `disabled_reason`. Clients use these states rather than inferring lifecycle predicates locally.
 
 - `GET /api/v1/<issue_identifier>`
   - Returns issue-specific runtime/debug details for the identified issue, including any information
@@ -2628,6 +2632,13 @@ Minimum endpoints:
     artifacts and the `delivery_observation_updated` WebSocket event expose the same repository-
     keyed schema; neither endpoint performs GitHub reconciliation on demand.
   - Includes matching open `attention_items` from the same shared history database.
+  - Includes the same issue `capabilities` as state rows and a separate step `capabilities.inspect`
+    state. `workflow_steps[].can_navigate` remains the compatibility/navigation fact for the
+    existing step-detail link; it does not determine issue actions.
+  - Capability availability is advisory and snapshot-time only. Control and interaction endpoints
+    validate their authoritative state again when invoked, so a concurrent transition can still
+    reject a previously enabled operation. When durable interaction lookup is absent, stale, or
+    unavailable, `reply`, `cancel`, and `resume` are disabled without exposing interaction content.
   - Suggested response shape:
 
     ```json
@@ -2707,7 +2718,7 @@ Minimum endpoints:
   - Returns bounded, read-only operator-attention lifecycle history with optional `subject_ref`,
     lifecycle `state`, cursor, and limit filters. Terminal evidence is included only when requested.
   - It has no action or mutation counterpart; selecting an attention item may navigate only to
-    existing issue detail.
+    existing issue detail when that issue row's `capabilities.inspect` is enabled.
 
 - `POST /api/v1/interactions/{id}/respond`
   - Attempts to resolve a specific open human interaction. The body is typed by interaction kind and


### PR DESCRIPTION
Closes #299

## Summary
- Add server-derived issue and workflow-step action capability DTOs with invariant-preserving disabled reasons.
- Enrich interaction capabilities outside the orchestrator state lock and expose the contract through OpenAPI and generated clients.
- Make Mission Control and issue-detail action/navigation surfaces fail closed on server capabilities while preserving existing mutations, shortcuts, and preferences.
- Document snapshot-time capability authority and its race boundary.

## Validation
- cargo test --workspace --exclude ensemble-desktop -- --test-threads=1
- Product E2E: 44 passed, 1 ignored
- Web UI feature check
- Workspace Clippy with warnings denied
- cargo fmt check
- Frontend: 323 tests and production build