### PR TITLE
Add Mission Control review gate

### DIFF
--- a/crates/ensemble-core/tests/openapi_spec.rs
+++ b/crates/ensemble-core/tests/openapi_spec.rs
@@ -210,6 +210,39 @@ fn openapi_documents_versioned_delivery_observations() {
 }
 
 #[test]
+fn openapi_keeps_review_gate_evidence_on_issue_detail() {
+    let spec: serde_json::Value =
+        serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap()).unwrap();
+    let schemas = &spec["components"]["schemas"];
+    let issue_detail = &schemas["IssueDetailSnapshot"];
+
+    assert_eq!(
+        issue_detail["properties"]["acceptance_attempts"]["items"]["$ref"],
+        "#/components/schemas/AcceptanceAttempt"
+    );
+    assert_eq!(
+        issue_detail["properties"]["artifacts"]["oneOf"][1]["$ref"],
+        "#/components/schemas/RunArtifacts"
+    );
+    assert_eq!(
+        issue_detail["properties"]["capabilities"]["$ref"],
+        "#/components/schemas/IssueActionCapabilities"
+    );
+    assert_eq!(
+        issue_detail["properties"]["workflow_steps"]["items"]["$ref"],
+        "#/components/schemas/WorkflowStepInfo"
+    );
+    assert_eq!(
+        schemas["RunArtifacts"]["properties"]["artifact_snapshots"]["items"]["$ref"],
+        "#/components/schemas/ArtifactSnapshot"
+    );
+    assert_eq!(
+        schemas["RepoFinalizeSnapshot"]["properties"]["observation"]["oneOf"][1]["$ref"],
+        "#/components/schemas/DeliveryObservation"
+    );
+}
+
+#[test]
 #[ignore = "writes generated OpenAPI output for frontend codegen"]
 fn write_openapi_spec() {
     let spec = ApiDoc::openapi().to_pretty_json().unwrap();

--- a/crates/ensemble-ui/src-ui/src/components/ArtifactsPanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ArtifactsPanel.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { RunArtifacts } from "@/generated/models";
+import ArtifactsPanel from "./ArtifactsPanel";
+
+const artifacts = {
+  run_id: "run-303",
+  workspace_path: "/tmp/workspace",
+  repos: [],
+  transcripts: [],
+  artifact_snapshots: [
+    {
+      identity: "snapshot-identity",
+      run_id: "run-303",
+      cycle: 2,
+      producer_step: "review",
+      attempt: 1,
+      output_digest: "output-digest",
+      repositories: [
+        {
+          repository: "chrisbanes/ensemble",
+          head: "524e233",
+          index_digest: "index-digest",
+          tracked_worktree_digest: "worktree-digest",
+          untracked_paths: ["report.txt"],
+        },
+      ],
+    },
+  ],
+} satisfies RunArtifacts;
+
+describe("ArtifactsPanel", () => {
+  it("shows content-free snapshot identity and links its producer step", () => {
+    render(
+      <MemoryRouter>
+        <ArtifactsPanel
+          identifier="ensemble#303"
+          workspacePath="/tmp/workspace"
+          artifacts={artifacts}
+          workflowSteps={[
+            {
+              name: "review",
+              agent: "reviewer",
+              kind: "agent",
+              dependencies: [],
+              state: "passed",
+              can_navigate: true,
+              capabilities: { inspect: { enabled: true } },
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Artifact snapshots")).toBeInTheDocument();
+    expect(screen.getByText("snapshot-identity")).toBeInTheDocument();
+    expect(screen.getByText("output-digest")).toBeInTheDocument();
+    expect(screen.getByText(/chrisbanes\/ensemble/)).toBeInTheDocument();
+    expect(screen.getByText("524e233")).toBeInTheDocument();
+    expect(screen.getByText("index-digest")).toBeInTheDocument();
+    expect(screen.getByText("worktree-digest")).toBeInTheDocument();
+    expect(screen.getByText(/Untracked: report\.txt/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Producer step: review" })).toHaveAttribute(
+      "href",
+      "/issue/ensemble%23303/step/review",
+    );
+    expect(screen.queryByText("source contents")).not.toBeInTheDocument();
+  });
+
+  it("fails closed when the producer step cannot be inspected", () => {
+    render(
+      <MemoryRouter>
+        <ArtifactsPanel
+          identifier="ensemble#303"
+          workspacePath="/tmp/workspace"
+          artifacts={artifacts}
+          workflowSteps={[
+            {
+              name: "review",
+              agent: "reviewer",
+              kind: "agent",
+              dependencies: [],
+              state: "passed",
+              can_navigate: false,
+              capabilities: { inspect: { enabled: false, disabled_reason: "Step details are unavailable." } },
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("link", { name: "Producer step: review" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Step details are unavailable/)).toBeInTheDocument();
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/components/ArtifactsPanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ArtifactsPanel.tsx
@@ -3,22 +3,25 @@ import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import type { RunArtifacts } from "@/generated/models";
+import type { RunArtifacts, WorkflowStepInfo } from "@/generated/models";
 
 interface ArtifactsPanelProps {
   identifier: string;
   workspacePath: string;
   artifacts?: RunArtifacts | null;
+  workflowSteps: WorkflowStepInfo[];
 }
 
 export default function ArtifactsPanel({
   identifier,
   workspacePath,
   artifacts,
+  workflowSteps,
 }: ArtifactsPanelProps) {
   const effectiveWorkspace = artifacts?.workspace_path ?? workspacePath;
   const repos = artifacts?.repos ?? [];
   const transcripts = artifacts?.transcripts ?? [];
+  const snapshots = artifacts?.artifact_snapshots ?? [];
 
   return (
     <div className="space-y-3 text-sm">
@@ -83,6 +86,53 @@ export default function ArtifactsPanel({
           ) : null}
         </div>
       ))}
+
+      {snapshots.length > 0 ? (
+        <div className="rounded-lg border bg-muted/20 p-3">
+          <div className="font-medium">Artifact snapshots</div>
+          <div className="mt-2 space-y-3">
+            {snapshots.map((snapshot) => {
+              const inspect = workflowSteps.find(
+                (step) => step.name === snapshot.producer_step,
+              )?.capabilities.inspect;
+              return (
+                <section key={snapshot.identity} className="rounded border bg-background p-2 text-xs">
+                  {inspect?.enabled ? (
+                    <Link
+                      to={`/issue/${encodeURIComponent(identifier)}/step/${encodeURIComponent(snapshot.producer_step)}`}
+                      aria-label={`Producer step: ${snapshot.producer_step}`}
+                      className="font-medium text-primary underline"
+                    >
+                      {snapshot.producer_step}
+                    </Link>
+                  ) : (
+                    <div className="font-medium text-muted-foreground">
+                      {snapshot.producer_step}: {inspect?.disabled_reason ?? "Step inspection is unavailable."}
+                    </div>
+                  )}
+                  <dl className="mt-2 grid gap-1 text-muted-foreground">
+                    <div>Identity: <code className="text-foreground">{snapshot.identity}</code></div>
+                    <div>Output digest: <code className="text-foreground">{snapshot.output_digest}</code></div>
+                    <div>Cycle {snapshot.cycle}, attempt {snapshot.attempt}</div>
+                    {snapshot.repositories.map((repository) => (
+                      <div key={repository.repository} className="rounded bg-muted/30 p-1">
+                        <div>
+                          {repository.repository}: <span className="text-foreground">{repository.head}</span>
+                        </div>
+                        <div>Index digest: <code className="text-foreground">{repository.index_digest}</code></div>
+                        <div>Worktree digest: <code className="text-foreground">{repository.tracked_worktree_digest}</code></div>
+                        {repository.untracked_paths.length > 0 ? (
+                          <div>Untracked: {repository.untracked_paths.join(", ")}</div>
+                        ) : null}
+                      </div>
+                    ))}
+                  </dl>
+                </section>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
 
       {transcripts.length > 0 ? (
         <div className="rounded-lg border bg-muted/20 p-3">

--- a/crates/ensemble-ui/src-ui/src/components/ReviewGatePanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ReviewGatePanel.test.tsx
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { IssueDetailSnapshot } from "@/generated/models";
+import { ReviewGatePanel } from "./ReviewGatePanel";
+
+type ReviewGateData = Pick<
+  IssueDetailSnapshot,
+  "issue_identifier" | "finalize" | "workflow_steps" | "acceptance_attempts" | "artifacts" | "workspace"
+>;
+
+const reviewData: ReviewGateData = {
+  issue_identifier: "ensemble#303",
+  finalize: {
+    status: "pending_approval",
+    repos: [
+      {
+        approval_required: true,
+        last_error: null,
+        mode: "push_and_pr",
+        repo: "chrisbanes/ensemble",
+        status: "pending_approval",
+        observation: {
+          schema_version: 1,
+          freshness: "fresh",
+          observed_at: "2026-08-13T12:00:00Z",
+          last_attempt_at: "2026-08-13T12:00:00Z",
+          retry: null,
+          failure: null,
+          facts: {
+            pull_request_number: 535,
+            pull_request_url: "https://github.com/chrisbanes/ensemble/pull/535",
+            head_sha: "524e233",
+            matches_delivery: true,
+            head_diverged: false,
+            terminal_state: "open",
+            mergeability: "mergeable",
+            base_freshness: "up_to_date",
+            checks: [{ name: "CI", status: "completed", conclusion: "failure" }],
+            check_summary: "failing",
+            review_decision: "changes_requested",
+          },
+        },
+      },
+    ],
+  },
+  workflow_steps: [
+    {
+      name: "review",
+      agent: "reviewer",
+      kind: "agent",
+      dependencies: [],
+      state: "failed",
+      can_navigate: true,
+      capabilities: { inspect: { enabled: true } },
+    },
+  ],
+  acceptance_attempts: [],
+  artifacts: null,
+  workspace: { path: "/tmp/workspace" },
+};
+
+describe("ReviewGatePanel", () => {
+  it("renders failing CI and requested changes from the structured delivery observation", () => {
+    render(
+      <MemoryRouter>
+        <ReviewGatePanel data={reviewData} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Delivery review")).toBeInTheDocument();
+    expect(screen.getByText("failing")).toBeInTheDocument();
+    expect(screen.getByText("changes_requested")).toBeInTheDocument();
+    expect(screen.getByText("CI: failure")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "PR #535" })).toHaveAttribute(
+      "href",
+      "https://github.com/chrisbanes/ensemble/pull/535",
+    );
+    expect(screen.getByRole("link", { name: "Review step: review" })).toHaveAttribute(
+      "href",
+      "/issue/ensemble%23303/step/review",
+    );
+    expect(screen.getByText("Acceptance evidence")).toBeInTheDocument();
+    expect(screen.getByText("No acceptance evidence has been recorded.")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["stale", null, "Delivery observation is stale. No readiness outcome is implied."],
+    ["fresh", { kind: "transport", message: "GitHub is unavailable." }, /GitHub is unavailable.*No readiness outcome is implied/],
+  ] as const)("does not infer readiness from %s incomplete delivery evidence", (freshness, failure, expected) => {
+    const data = {
+      ...reviewData,
+      finalize: {
+        ...reviewData.finalize,
+        repos: [
+          {
+              ...reviewData.finalize.repos[0]!,
+              observation: {
+              ...reviewData.finalize.repos[0]!.observation!,
+              freshness,
+              facts: null,
+              failure,
+            },
+          },
+        ],
+      },
+    };
+    render(
+      <MemoryRouter>
+        <ReviewGatePanel data={data} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+    expect(screen.queryByText("ready")).not.toBeInTheDocument();
+  });
+
+  it("fails closed when the server disables review-step inspection", () => {
+    const data = {
+      ...reviewData,
+      workflow_steps: [
+        {
+          ...reviewData.workflow_steps[0]!,
+          capabilities: { inspect: { enabled: false, disabled_reason: "Step details are unavailable." } },
+        },
+      ],
+    };
+    render(
+      <MemoryRouter>
+        <ReviewGatePanel data={data} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("link", { name: "Review step: review" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Step details are unavailable/)).toBeInTheDocument();
+  });
+
+  it("uses the retained artifact observation for a historical delivery", () => {
+    const data: ReviewGateData = {
+      ...reviewData,
+      finalize: { status: "not_required", repos: [] },
+      artifacts: {
+        run_id: "run-303",
+        workspace_path: "/tmp/workspace",
+        transcripts: [],
+        artifact_snapshots: [],
+        repos: [
+          {
+            repo: "chrisbanes/ensemble",
+            worktree_path: "/tmp/workspace",
+            base_branch: "main",
+            branch: "review-gate",
+            head_sha: "524e233",
+            changed_files: [],
+            finalize_mode: "push_and_pr",
+            finalize_status: "succeeded",
+            pushed_ref: null,
+            pr_number: 535,
+            pr_url: "https://github.com/chrisbanes/ensemble/pull/535",
+            review_state: null,
+            review_projection: null,
+            last_error: null,
+            observation: {
+              ...reviewData.finalize.repos[0]!.observation!,
+              facts: {
+                ...reviewData.finalize.repos[0]!.observation!.facts!,
+                terminal_state: "merged",
+              },
+            },
+          },
+        ],
+      },
+    };
+    render(
+      <MemoryRouter>
+        <ReviewGatePanel data={data} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Pull request is merged.")).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "ready evidence",
+      {
+        check_summary: "passing",
+        review_decision: "approved",
+        terminal_state: "open",
+        mergeability: "mergeable",
+        base_freshness: "up_to_date",
+        head_diverged: false,
+        matches_delivery: true,
+      },
+      "Delivery evidence is current. No readiness outcome is implied.",
+    ],
+    [
+      "merged delivery",
+      { terminal_state: "merged" },
+      "Pull request is merged.",
+    ],
+    [
+      "closed delivery",
+      { terminal_state: "closed_without_merge" },
+      "Pull request closed without merge.",
+    ],
+    [
+      "diverged delivery",
+      { head_diverged: true, matches_delivery: false },
+      "Delivery head diverged. No readiness outcome is implied.",
+    ],
+  ] as const)("renders %s from explicit delivery facts", (_name, factsOverride, expected) => {
+    const data: ReviewGateData = {
+      ...reviewData,
+      finalize: {
+        ...reviewData.finalize,
+        repos: [
+          {
+            ...reviewData.finalize.repos[0]!,
+            observation: {
+              ...reviewData.finalize.repos[0]!.observation!,
+              facts: { ...reviewData.finalize.repos[0]!.observation!.facts!, ...factsOverride },
+            },
+          },
+        ],
+      },
+    };
+    render(
+      <MemoryRouter>
+        <ReviewGatePanel data={data} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it("labels a missing repository observation without hiding the observed evidence", () => {
+    const data: ReviewGateData = {
+      ...reviewData,
+      finalize: {
+        ...reviewData.finalize,
+        repos: [
+          reviewData.finalize.repos[0]!,
+          {
+            approval_required: false,
+            last_error: null,
+            mode: "push_and_pr",
+            repo: "chrisbanes/docs",
+            status: "succeeded",
+            observation: null,
+          },
+        ],
+      },
+    };
+    render(
+      <MemoryRouter>
+        <ReviewGatePanel data={data} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText("chrisbanes/ensemble delivery review")).toBeInTheDocument();
+    expect(screen.getByLabelText("chrisbanes/docs delivery review")).toHaveTextContent(
+      "Delivery observation is unavailable. No readiness outcome is implied.",
+    );
+  });
+});

--- a/crates/ensemble-ui/src-ui/src/components/ReviewGatePanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ReviewGatePanel.tsx
@@ -1,0 +1,180 @@
+import { Link } from "react-router-dom";
+import type { IssueDetailSnapshot } from "@/generated/models";
+import { AcceptanceEvidencePanel } from "./AcceptanceEvidencePanel";
+import ArtifactsPanel from "./ArtifactsPanel";
+
+type ReviewGateData = Pick<
+  IssueDetailSnapshot,
+  | "issue_identifier"
+  | "finalize"
+  | "workflow_steps"
+  | "acceptance_attempts"
+  | "artifacts"
+  | "workspace"
+>;
+
+function safeExternalUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+function deliverySummary(observation: NonNullable<ReviewGateData["finalize"]["repos"][number]["observation"]>): string {
+  const facts = observation.facts;
+  if (observation.freshness === "stale") {
+    return "Delivery observation is stale. No readiness outcome is implied.";
+  }
+  if (observation.failure) {
+    return `${observation.failure.message} No readiness outcome is implied.`;
+  }
+  if (!facts) {
+    return "Delivery observation is unavailable. No readiness outcome is implied.";
+  }
+  if (facts.terminal_state === "merged") return "Pull request is merged.";
+  if (facts.terminal_state === "closed_without_merge") return "Pull request closed without merge.";
+  if (facts.head_diverged || !facts.matches_delivery) {
+    return "Delivery head diverged. No readiness outcome is implied.";
+  }
+  if (facts.check_summary === "failing") return "Checks are failing.";
+  if (facts.review_decision === "changes_requested") return "Changes were requested.";
+  if (facts.mergeability === "conflicting") return "Pull request has merge conflicts.";
+  if (facts.base_freshness === "behind") return "Pull request branch is behind its base.";
+  return "Delivery evidence is current. No readiness outcome is implied.";
+}
+
+function DeliveryObservation({ data }: { data: ReviewGateData }) {
+  const finalizedRepositories = data.finalize.repos.map((repo) => ({
+    repo: repo.repo,
+    status: repo.status,
+    observation: repo.observation,
+  }));
+  const finalizedRepositoryNames = new Set(finalizedRepositories.map((repo) => repo.repo));
+  const artifactRepositories = (data.artifacts?.repos ?? [])
+    .filter((repo) => !finalizedRepositoryNames.has(repo.repo))
+    .map((repo) => ({
+      repo: repo.repo,
+      status: repo.finalize_status,
+      observation: repo.observation,
+    }));
+  const deliveryRepositories = [...finalizedRepositories, ...artifactRepositories];
+
+  if (deliveryRepositories.length === 0) {
+    return (
+      <p className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+        Delivery observation is unavailable. No readiness outcome is implied.
+      </p>
+    );
+  }
+
+  return deliveryRepositories.map((repo) => {
+    const observation = repo.observation;
+    if (!observation) {
+      return (
+        <section key={repo.repo} className="space-y-2 rounded-lg border p-3" aria-label={`${repo.repo} delivery review`}>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h3 className="font-medium">{repo.repo}</h3>
+            <span className="text-sm text-muted-foreground">Finalize: {repo.status}</span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Delivery observation is unavailable. No readiness outcome is implied.
+          </p>
+        </section>
+      );
+    }
+    const facts = observation.facts;
+    const pullRequestUrl = facts ? safeExternalUrl(facts.pull_request_url) : null;
+
+    return (
+      <section key={repo.repo} className="space-y-2 rounded-lg border p-3" aria-label={`${repo.repo} delivery review`}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-medium">{repo.repo}</h3>
+          <span className="text-sm text-muted-foreground">Finalize: {repo.status}</span>
+        </div>
+        <dl className="grid gap-1 text-sm text-muted-foreground">
+          <div>Observation: <span className="text-foreground">{observation.freshness}</span></div>
+          <div className="text-amber-700 dark:text-amber-400">{deliverySummary(observation)}</div>
+          {facts ? (
+            <>
+              <div>Checks: <span className="text-foreground">{facts.check_summary}</span></div>
+              <div>Review: <span className="text-foreground">{facts.review_decision}</span></div>
+              <div>Merge: <span className="text-foreground">{facts.terminal_state}</span></div>
+              <div>Mergeability: <span className="text-foreground">{facts.mergeability}</span></div>
+              <div>Base: <span className="text-foreground">{facts.base_freshness}</span></div>
+              {facts.checks.map((check) => (
+                <div key={check.name}>{check.name}: {check.conclusion ?? check.status}</div>
+              ))}
+              {pullRequestUrl ? (
+                <a className="text-primary underline" href={pullRequestUrl} target="_blank" rel="noreferrer">
+                  PR #{facts.pull_request_number}
+                </a>
+              ) : null}
+            </>
+          ) : null}
+          {observation.failure ? <div className="text-destructive">{observation.failure.message}</div> : null}
+          {observation.retry ? <div>Retry due: {new Date(observation.retry.due_at).toLocaleString()}</div> : null}
+        </dl>
+      </section>
+    );
+  });
+}
+
+function WorkflowVerdicts({ data }: { data: ReviewGateData }) {
+  return (
+    <section className="space-y-2" aria-labelledby="workflow-verdicts-heading">
+      <h3 id="workflow-verdicts-heading" className="font-medium">Workflow verdicts</h3>
+      {data.workflow_steps.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No workflow verdicts are available.</p>
+      ) : (
+        data.workflow_steps.map((step) => {
+          const inspect = step.capabilities.inspect;
+          const detail = `${step.name}: ${step.state}`;
+          return inspect.enabled ? (
+            <Link
+              key={step.name}
+              to={`/issue/${encodeURIComponent(data.issue_identifier)}/step/${encodeURIComponent(step.name)}`}
+              aria-label={`Review step: ${step.name}`}
+              className="flex justify-between rounded-lg border p-3 text-sm hover:bg-muted"
+            >
+              <span>{detail}</span>
+              <span className="text-muted-foreground">View detail</span>
+            </Link>
+          ) : (
+            <div key={step.name} className="rounded-lg border p-3 text-sm text-muted-foreground">
+              {detail}: {inspect.disabled_reason ?? "Step inspection is unavailable."}
+            </div>
+          );
+        })
+      )}
+    </section>
+  );
+}
+
+export function ReviewGatePanel({ data }: { data: ReviewGateData }) {
+  return (
+    <div className="space-y-4">
+      <section className="space-y-2" aria-labelledby="delivery-review-heading">
+        <h2 id="delivery-review-heading" className="font-semibold">Delivery review</h2>
+        <DeliveryObservation data={data} />
+      </section>
+      <WorkflowVerdicts data={data} />
+      <section className="space-y-2" aria-labelledby="acceptance-evidence-heading">
+        <h3 id="acceptance-evidence-heading" className="font-medium">Acceptance evidence</h3>
+        <AcceptanceEvidencePanel attempts={data.acceptance_attempts} />
+      </section>
+      {data.artifacts ? (
+        <section className="space-y-2" aria-labelledby="artifact-context-heading">
+          <h3 id="artifact-context-heading" className="font-medium">Artifact context</h3>
+          <ArtifactsPanel
+            identifier={data.issue_identifier}
+            workspacePath={data.workspace.path}
+            artifacts={data.artifacts}
+            workflowSteps={data.workflow_steps}
+          />
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/IssueDetail.tsx
@@ -127,6 +127,7 @@ function IssueDetailContent({ identifier }: { identifier: string }) {
         identifier={identifier}
         workspacePath={data.workspace.path}
         artifacts={data.artifacts ?? null}
+        workflowSteps={data.workflow_steps}
       />
       {data.issue ? <IssueInfoSection issue={data.issue} /> : null}
     </div>

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.test.tsx
@@ -221,6 +221,37 @@ function renderPanel(
 }
 
 describe("IssueCommandPanel", () => {
+  it("provides a keyboard-navigable Review gate tab without deriving a finalize action", async () => {
+    function ControlledPanel() {
+      const [activeTab, setActiveTab] = useState<IssueCommandPanelTab>("overview");
+      return (
+        <IssueCommandPanel
+          identifier="repo#1"
+          activeTab={activeTab}
+          onActiveTabChange={setActiveTab}
+          onClose={() => {}}
+        />
+      );
+    }
+
+    render(
+      <MemoryRouter>
+        <ControlledPanel />
+      </MemoryRouter>,
+    );
+
+    const reviewGate = screen.getByRole("tab", { name: "Review gate" });
+    reviewGate.focus();
+    await userEvent.keyboard("{Enter}");
+
+    expect(screen.getByRole("tab", { name: "Review gate" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Delivery observation is unavailable. No readiness outcome is implied.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Approve finalize:/ })).toBeDisabled();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     actions.submitReply.mockResolvedValue(true);
@@ -251,7 +282,7 @@ describe("IssueCommandPanel", () => {
       "aria-selected",
       "true",
     );
-    expect(screen.getAllByRole("tab")).toHaveLength(7);
+    expect(screen.getAllByRole("tab")).toHaveLength(8);
   });
 
   it("uses server capability reasons instead of inferring a disabled action locally", () => {
@@ -302,6 +333,7 @@ describe("IssueCommandPanel", () => {
       "Transcript",
       "Logs",
       "Acceptance",
+      "Review gate",
       "Artifacts",
     ]);
     const controlledPanelIds = screen
@@ -330,6 +362,8 @@ describe("IssueCommandPanel", () => {
     expect(screen.getByRole("tab", { name: "Overview" })).toHaveFocus();
     await user.keyboard("{ArrowLeft}");
     expect(screen.getByRole("tab", { name: "Artifacts" })).toHaveFocus();
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("tab", { name: "Review gate" })).toHaveFocus();
     await user.keyboard("{ArrowLeft}");
     expect(screen.getByRole("tab", { name: "Acceptance" })).toHaveFocus();
   });

--- a/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/pages/mission-control/IssueCommandPanel.tsx
@@ -6,6 +6,7 @@ import ConfirmDialog from "@/components/ConfirmDialog";
 import FinalizeApprovalDialog from "@/components/FinalizeApprovalDialog";
 import EventTimeline from "@/components/EventTimeline";
 import IssueInfoSection from "@/components/IssueInfoSection";
+import { ReviewGatePanel } from "@/components/ReviewGatePanel";
 import StatusBadge from "@/components/StatusBadge";
 import WorkflowStepsSidebar from "@/components/WorkflowStepsSidebar";
 import { IssueComposer } from "@/components/issue-detail/IssueComposer";
@@ -22,6 +23,7 @@ export type IssueCommandPanelTab =
   | "transcript"
   | "logs"
   | "acceptance"
+  | "review_gate"
   | "artifacts";
 
 interface IssueCommandPanelProps {
@@ -38,6 +40,7 @@ const TABS: Array<{ id: IssueCommandPanelTab; label: string }> = [
   { id: "transcript", label: "Transcript" },
   { id: "logs", label: "Logs" },
   { id: "acceptance", label: "Acceptance" },
+  { id: "review_gate", label: "Review gate" },
   { id: "artifacts", label: "Artifacts" },
 ];
 
@@ -427,6 +430,8 @@ function IssueCommandPanelContent({
         );
       case "acceptance":
         return <AcceptanceEvidencePanel attempts={data.acceptance_attempts} />;
+      case "review_gate":
+        return <ReviewGatePanel data={data} />;
       case "artifacts":
         return (
           <div className="space-y-3">
@@ -435,6 +440,7 @@ function IssueCommandPanelContent({
                 identifier={identifier}
                 workspacePath={data.workspace.path}
                 artifacts={data.artifacts}
+                workflowSteps={data.workflow_steps}
               />
             ) : (
               <div className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2639,6 +2639,11 @@ Minimum endpoints:
     validate their authoritative state again when invoked, so a concurrent transition can still
     reject a previously enabled operation. When durable interaction lookup is absent, stale, or
     unavailable, `reply`, `cancel`, and `resume` are disabled without exposing interaction content.
+  - Mission Control's read-only review gate composes the persisted workflow verdict links,
+    `acceptance_attempts`, content-free artifact snapshots, and per-repository delivery observation.
+    It labels stale, unavailable, unknown, and divergent delivery evidence without inferring a
+    readiness outcome or triggering reconciliation. Finalization controls remain capability-driven,
+    and raw transcripts remain available only through their separate inspection views.
   - Suggested response shape:
 
     ```json


### PR DESCRIPTION
Closes #303

## Summary
- Add a read-only Mission Control review gate over existing structured delivery observations, workflow verdicts, acceptance evidence, and artifact snapshots.
- Preserve backend capability authority for every action and navigation affordance.
- Render stale, failed, divergent, terminal, and unavailable evidence explicitly without deriving a readiness outcome.
- Document the trusted-local review-gate contract and guard its existing OpenAPI inputs.

## Validation
- Frontend: 336 tests and production build
- Serial non-desktop workspace tests
- Product E2E: 44 passed, 1 ignored
- Web UI feature check
- Workspace Clippy with warnings denied
- cargo fmt and diff checks