### PR TITLE
Add immutable artifact consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +609,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +940,25 @@ name = "crossbeam-channel"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1360,11 +1427,14 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "cap-fs-ext",
+ "cap-std",
  "chrono",
  "dirs",
  "dotenvy",
  "futures",
  "futures-util",
+ "ignore",
  "jsonschema",
  "libc",
  "liquid",
@@ -1373,6 +1443,7 @@ dependencies = [
  "pulldown-cmark",
  "reqwest 0.13.4",
  "rusqlite",
+ "rustix",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1598,6 +1669,17 @@ checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1979,6 +2061,19 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2395,6 +2490,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2570,22 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "ipnet"
@@ -2941,6 +3068,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -4229,6 +4362,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -6739,6 +6882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.1",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ async-trait = "0.1.92"
 reqwest = { version = "0.13.4", features = ["json"] }
 futures = "0.3.34"
 libc = "0.2.189"
+rustix = "1.1.4"
+ignore = "0.4.23"
+cap-std = "3.4.5"
+cap-fs-ext = "3.4.5"
 wiremock = "0.6.5"
 axum = { version = "0.8.9", features = ["ws"] }
 futures-util = "0.3.34"

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -248,6 +248,90 @@ async fn missing_file_and_handoff_are_durable_acceptance_failures() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn immutable_artifact_postattempt_mutation_halts() {
+    let fixture = TestFixture::new_with_immutable_consumer().expect("fixture setup");
+    let port = reserve_local_port().expect("reserve local port");
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_E2E_MUTATE_IMMUTABLE_INPUT", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let child = command.spawn().expect("spawn ensemble web");
+    let _guard = ChildGuard::new(child);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+
+    let detail = wait_for_halted_immutable_issue(&client, &base_url)
+        .await
+        .expect("post-attempt mutation should halt the pipeline");
+    assert_eq!(detail["status"], "waiting_on_human");
+    assert_eq!(detail["retry"], Value::Null);
+    assert_eq!(detail["current_interaction"]["step_name"], "review");
+    let steps = detail["workflow_steps"]
+        .as_array()
+        .expect("workflow steps should be public");
+    assert!(steps
+        .iter()
+        .any(|step| step["name"] == "produce" && step["state"] == "passed"));
+    assert!(steps
+        .iter()
+        .any(|step| step["name"] == "review" && step["state"] == "failed"));
+    assert!(steps
+        .iter()
+        .any(|step| step["name"] == "publish" && step["state"] == "pending"));
+
+    let workspace = PathBuf::from(detail["workspace"]["path"].as_str().unwrap());
+    let source = fs::read_dir(workspace.join("source"))
+        .expect("preserved source worktree directory")
+        .next()
+        .expect("one source worktree")
+        .expect("source worktree entry")
+        .path();
+    assert_eq!(
+        fs::read_to_string(source.join("README.md")).expect("mutated tracked file"),
+        "mutated after capture\n"
+    );
+
+    let journal = read_halted_pipeline_journal(fixture.config_dir.path())
+        .expect("halted pipeline journal should be durable");
+    let violation = &journal["snapshot"]["artifact_integrity_violations"][0];
+    assert_eq!(violation["consumer_step"], "review");
+    assert_eq!(violation["producer_step"], "produce");
+    assert_eq!(violation["repository"], "source");
+    assert!(violation["expected_digest"].as_str().is_some());
+    assert!(violation["observed_digest"].as_str().is_some());
+    assert_ne!(violation["expected_digest"], violation["observed_digest"]);
+    assert!(
+        violation["changed_paths"]
+            .as_array()
+            .is_some_and(|paths| paths.contains(&serde_json::json!("README.md"))),
+        "the durable evidence must identify the consumer mutation: {violation:#?}"
+    );
+    assert_eq!(violation["omitted_changed_path_count"], 0);
+    assert!(
+        !journal.to_string().contains("mutated after capture"),
+        "durable violation evidence must remain content-free: {journal:#?}"
+    );
+
+    let acpx_log = fs::read_to_string(&fixture.acpx_log_path).expect("read mock acpx log");
+    assert!(acpx_log.contains("Immutable consumer"));
+    assert!(
+        !acpx_log.contains("Downstream publisher"),
+        "the downstream step must not launch after an immutable input violation: {acpx_log}"
+    );
+}
+
 struct TestFixture {
     config_dir: TempDir,
     todo_path: PathBuf,
@@ -277,6 +361,40 @@ impl TestFixture {
         fs::write(
             root.join("config.yaml"),
             config_yaml(&todo_path, &workspace_root, &repo_path, acceptance_run),
+        )?;
+        fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(mock_bin_dir.join("acpx"), fs::Permissions::from_mode(0o755))?;
+        }
+
+        Ok(Self {
+            config_dir,
+            todo_path,
+            workspace_root,
+            acpx_log_path,
+            mock_bin_dir,
+        })
+    }
+
+    fn new_with_immutable_consumer() -> io::Result<Self> {
+        let config_dir = TempDir::new()?;
+        let root = config_dir.path();
+        let todo_path = root.join("TODO.md");
+        let workspace_root = root.join("workspaces");
+        let repo_path = root.join("source");
+        let mock_bin_dir = root.join("bin");
+        let acpx_log_path = root.join("mock-acpx.log");
+
+        fs::create_dir_all(&workspace_root)?;
+        fs::create_dir_all(&mock_bin_dir)?;
+        init_git_repo(&repo_path)?;
+        fs::write(&todo_path, todo_fixture())?;
+        fs::write(
+            root.join("config.yaml"),
+            immutable_consumer_config_yaml(&todo_path, &workspace_root, &repo_path),
         )?;
         fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
 
@@ -378,6 +496,74 @@ agent:
     )
 }
 
+fn immutable_consumer_config_yaml(
+    todo_path: &Path,
+    workspace_root: &Path,
+    repo_path: &Path,
+) -> String {
+    format!(
+        r#"
+tracker:
+  kind: todo_file
+  path: {}
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+workspace:
+  root: {}
+repos:
+  - path: {}
+    branch: main
+agents:
+  producer:
+    acpx_agent: builder
+    prompt: "Produce immutable artifact for {{{{ issue.identifier }}}}"
+  consumer:
+    acpx_agent: builder
+    prompt: "Immutable consumer for {{{{ issue.identifier }}}}"
+  publisher:
+    acpx_agent: builder
+    prompt: "Downstream publisher for {{{{ issue.identifier }}}}"
+steps:
+  - name: produce
+    agent: producer
+    tracker_state: In Progress
+    artifact_snapshot:
+      repositories:
+        - source
+  - name: review
+    agent: consumer
+    depends:
+      - produce
+    artifact_inputs:
+      - produce
+    artifact_access: immutable
+    on_failure: retry_issue
+  - name: publish
+    agent: publisher
+    depends:
+      - review
+on_success: Done
+on_failure: Failed
+max_cycles: 3
+polling:
+  interval_ms: 100
+concurrency:
+  max_concurrent_agents: 1
+  max_step_parallelism: 1
+agent:
+  read_timeout_ms: 5000
+  turn_timeout_ms: 10000
+  max_retry_backoff_ms: 100
+"#,
+        yaml_quote(&todo_path.display().to_string()),
+        yaml_quote(&workspace_root.display().to_string()),
+        yaml_quote(&repo_path.display().to_string()),
+    )
+}
+
 fn init_git_repo(repo_path: &Path) -> io::Result<()> {
     fs::create_dir_all(repo_path)?;
     let run = |args: &[&str]| -> io::Result<()> {
@@ -435,6 +621,59 @@ async fn wait_for_failed_history_record(
     }
 }
 
+async fn wait_for_halted_immutable_issue(
+    client: &reqwest::Client,
+    base_url: &str,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let url = format!("{base_url}/api/v1/{ISSUE_ID}");
+    loop {
+        let response = client.get(&url).send().await.map_err(|e| e.to_string())?;
+        if response.status().is_success() {
+            let detail = response.json::<Value>().await.map_err(|e| e.to_string())?;
+            if detail["status"] == "waiting_on_human"
+                && detail["current_interaction"]["step_name"] == "review"
+            {
+                return Ok(detail);
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "immutable consumer did not halt before timeout: {detail:#?}"
+                ));
+            }
+        } else if Instant::now() >= deadline {
+            return Err(format!(
+                "issue detail endpoint returned {}",
+                response.status()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn read_halted_pipeline_journal(config_dir: &Path) -> Result<Value, String> {
+    let journal_dir = config_dir.join("state").join("pipeline-runs");
+    let entries = fs::read_dir(&journal_dir).map_err(|error| error.to_string())?;
+    for entry in entries {
+        let path = entry.map_err(|error| error.to_string())?.path();
+        let contents = fs::read_to_string(&path).map_err(|error| error.to_string())?;
+        let record = contents
+            .lines()
+            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+            .last();
+        if record
+            .as_ref()
+            .is_some_and(|record| record["kind"] == "pipeline_halted")
+        {
+            return Ok(record.expect("checked above"));
+        }
+    }
+    Err(format!(
+        "no durable pipeline_halted record under {}",
+        journal_dir.display()
+    ))
+}
+
 fn yaml_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
@@ -469,6 +708,8 @@ if [[ " $* " == *" prompt "* ]]; then
     exit 2
   fi
 
+  prompt="$(cat)"
+  printf ' prompt-input=%s\n' "$prompt" >> "$log"
   mkdir -p "$cwd/.ensemble"
   cat > "$cwd/.ensemble/mock-prompt.txt"
   if [[ "${ENSEMBLE_E2E_MISSING_HANDOFF:-}" == "1" ]]; then
@@ -479,6 +720,9 @@ if [[ " $* " == *" prompt "* ]]; then
   if [[ "${ENSEMBLE_E2E_SKIP_REQUIRED_FILE:-}" != "1" ]]; then
     repo_worktree="$(find "$cwd/source" -mindepth 1 -maxdepth 1 -type d -print -quit)"
     printf 'artifact\n' > "$repo_worktree/acceptance.txt"
+  fi
+  if [[ "${ENSEMBLE_E2E_MUTATE_IMMUTABLE_INPUT:-}" == "1" && "$prompt" == *"Immutable consumer"* ]]; then
+    printf 'mutated after capture\n' > "$repo_worktree/README.md"
   fi
 
   printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"mock agent completed"}}}}'

--- a/crates/ensemble-core/Cargo.toml
+++ b/crates/ensemble-core/Cargo.toml
@@ -21,6 +21,8 @@ async-trait = { workspace = true }
 reqwest = { workspace = true }
 futures = { workspace = true }
 libc = { workspace = true }
+rustix = { workspace = true }
+ignore = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
 futures-util = { workspace = true }
@@ -38,7 +40,12 @@ tempfile = { workspace = true }
 shell-words = { workspace = true }
 jsonschema = { workspace = true }
 
+[target.'cfg(not(unix))'.dependencies]
+cap-std = { workspace = true }
+cap-fs-ext = { workspace = true }
+
 [dev-dependencies]
+cap-std = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 wiremock = { workspace = true }
 tower = { workspace = true }

--- a/crates/ensemble-core/src/agent/acpx_runtime.rs
+++ b/crates/ensemble-core/src/agent/acpx_runtime.rs
@@ -14,7 +14,7 @@ use crate::observability::events_contract::{
 use super::acpx_cli::{AcpxCli, AcpxCommandOptions, AcpxPromptRequest, PromptVisibility};
 use super::events::{AgentEvent, WorkerEvent, WorkerResult};
 use super::{detect_worker_result_with_output, AgentRunRequest};
-use crate::config::ensemble::PermissionMode;
+use crate::config::ensemble::{ArtifactAccess, PermissionMode};
 
 /// Agent runtime backed by the `acpx` CLI tool.
 ///
@@ -88,6 +88,14 @@ impl AcpxRuntime {
                 })
             })
             .transpose()?;
+        let permission_mode = if request.artifact_access == ArtifactAccess::Immutable {
+            match permission_mode {
+                Some(PermissionMode::DenyAll) => Some(PermissionMode::DenyAll),
+                _ => Some(PermissionMode::ApproveReads),
+            }
+        } else {
+            permission_mode
+        };
         const MAX_SESSION_NAME_LEN: usize = 128;
 
         let id_comp = sanitize_session_component(&request.issue.id);
@@ -597,13 +605,35 @@ on_failure: Failed
     #[tokio::test]
     async fn acpx_runtime_passes_permission_mode_to_every_lifecycle_command() {
         let cases = [
-            (Some("approve_all"), Some("--approve-all")),
-            (Some("approve_reads"), Some("--approve-reads")),
-            (Some("deny_all"), Some("--deny-all")),
-            (None, None),
+            (
+                Some("approve_all"),
+                ArtifactAccess::Mutable,
+                Some("--approve-all"),
+            ),
+            (
+                Some("approve_reads"),
+                ArtifactAccess::Mutable,
+                Some("--approve-reads"),
+            ),
+            (
+                Some("deny_all"),
+                ArtifactAccess::Mutable,
+                Some("--deny-all"),
+            ),
+            (None, ArtifactAccess::Mutable, None),
+            (
+                Some("approve_all"),
+                ArtifactAccess::Immutable,
+                Some("--approve-reads"),
+            ),
+            (
+                Some("deny_all"),
+                ArtifactAccess::Immutable,
+                Some("--deny-all"),
+            ),
         ];
 
-        for (permission_mode, expected_flag) in cases {
+        for (permission_mode, artifact_access, expected_flag) in cases {
             let workspace = tempfile::TempDir::new().unwrap();
             let args_path = workspace.path().join("args.txt");
             let script_path = write_mock_acpx_script(
@@ -634,6 +664,7 @@ exit 1
                 agent_name: "builder",
                 step_name: "build",
                 step_kind: StepKind::Agent,
+                artifact_access,
                 attempt: None,
                 timeout_ms: TEST_TIMEOUT_MS,
                 interaction_response: None,
@@ -686,6 +717,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -745,6 +777,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -841,6 +874,7 @@ exit 1
             agent_name: "builder",
             step_name: "build-a",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: Some(1),
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -855,6 +889,7 @@ exit 1
             agent_name: "builder",
             step_name: "build-b",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: Some(2),
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -869,6 +904,7 @@ exit 1
             agent_name: "builder",
             step_name: "build-c",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: Some(3),
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -995,6 +1031,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: Some(1),
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1009,6 +1046,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: Some(2),
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1023,6 +1061,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: Some(3),
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1134,6 +1173,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1202,6 +1242,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1281,6 +1322,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1376,6 +1418,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1471,6 +1514,7 @@ on_failure: Failed
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1530,6 +1574,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1587,6 +1632,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1646,6 +1692,7 @@ exit 1
             agent_name: "builder",
             step_name: "build/review",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: Some(2),
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1705,6 +1752,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -1787,6 +1835,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             interaction_response: None,
             workspace_path: workspace.path(),
@@ -1874,6 +1923,7 @@ exit 1
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             interaction_response: None,
             workspace_path: workspace.path(),
@@ -1983,6 +2033,7 @@ exit 1
             agent_name: "builder",
             step_name: &long_step,
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: Some(99),
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -2055,6 +2106,7 @@ exit 1
             agent_name: "builder",
             step_name: "$%^",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,
@@ -2118,6 +2170,7 @@ exit 1
             agent_name: "builder",
             step_name: &bad_chars,
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: Some(1),
             timeout_ms: TEST_TIMEOUT_MS,
             interaction_response: None,

--- a/crates/ensemble-core/src/agent/cancellation.rs
+++ b/crates/ensemble-core/src/agent/cancellation.rs
@@ -1,10 +1,11 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 #[cfg(test)]
 use chrono::{TimeZone, Utc};
-use tokio::sync::watch;
+use tokio::sync::{watch, Notify};
 use tokio_util::sync::CancellationToken;
 
 use crate::agent::events::WorkerIdentity;
@@ -16,6 +17,7 @@ struct ActiveWorker {
     completion: watch::Receiver<bool>,
     capacity_bucket: String,
     scheduler_reservation: SchedulerReservation,
+    exclusive_issue_workspace: bool,
     reconciliation_owned: bool,
     launched: bool,
 }
@@ -26,7 +28,53 @@ pub struct WorkerDrainHandle {
 }
 
 #[derive(Clone, Default)]
-pub struct CancellationRegistry(Arc<Mutex<HashMap<WorkerIdentity, ActiveWorker>>>);
+pub struct CancellationRegistry {
+    state: Arc<Mutex<RegistryState>>,
+    workspace_capture_released: Arc<Notify>,
+}
+
+#[derive(Default)]
+struct RegistryState {
+    workers: HashMap<WorkerIdentity, ActiveWorker>,
+    workspace_captures: HashSet<String>,
+}
+
+impl Deref for RegistryState {
+    type Target = HashMap<WorkerIdentity, ActiveWorker>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.workers
+    }
+}
+
+impl DerefMut for RegistryState {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.workers
+    }
+}
+
+pub(crate) struct IssueWorkspaceCaptureGuard {
+    registry: CancellationRegistry,
+    issue_id: String,
+}
+
+impl std::fmt::Debug for IssueWorkspaceCaptureGuard {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("IssueWorkspaceCaptureGuard")
+            .field("issue_id", &self.issue_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for IssueWorkspaceCaptureGuard {
+    fn drop(&mut self) {
+        let mut state = registry_guard(&self.registry);
+        state.workspace_captures.remove(&self.issue_id);
+        drop(state);
+        self.registry.workspace_capture_released.notify_waiters();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WorkerReservationError {
@@ -36,6 +84,7 @@ pub(crate) enum WorkerReservationError {
     CapacityBucketExhausted,
     ResourceExhausted,
     PathConflict,
+    IssueWorkspaceExclusive,
 }
 
 pub(crate) struct WorkerCapacity<'a> {
@@ -94,6 +143,52 @@ pub fn new_cancellation_registry() -> CancellationRegistry {
     CancellationRegistry::default()
 }
 
+/// Prevent new same-issue workers from starting while a producer captures a stable workspace.
+/// Existing workers remain registered so the caller can drain them before observing the snapshot.
+pub(crate) async fn acquire_issue_workspace_capture(
+    registry: &CancellationRegistry,
+    issue_id: &str,
+) -> IssueWorkspaceCaptureGuard {
+    loop {
+        let notified = registry.workspace_capture_released.notified();
+        tokio::pin!(notified);
+        let acquired = {
+            let mut state = registry_guard(registry);
+            // Arm the waiter while the release path is excluded by the same lock.
+            // A capture guard therefore cannot release after this check without
+            // waking this waiter.
+            notified.as_mut().enable();
+            state.workspace_captures.insert(issue_id.to_string())
+        };
+        if acquired {
+            return IssueWorkspaceCaptureGuard {
+                registry: registry.clone(),
+                issue_id: issue_id.to_string(),
+            };
+        }
+        notified.await;
+    }
+}
+
+pub(crate) fn worker_uses_exclusive_issue_workspace(
+    registry: &CancellationRegistry,
+    identity: &WorkerIdentity,
+) -> bool {
+    registry_guard(registry)
+        .get(identity)
+        .is_some_and(|worker| worker.exclusive_issue_workspace)
+}
+
+#[cfg(test)]
+pub(crate) fn issue_workspace_capture_is_active(
+    registry: &CancellationRegistry,
+    issue_id: &str,
+) -> bool {
+    registry_guard(registry)
+        .workspace_captures
+        .contains(issue_id)
+}
+
 #[cfg(test)]
 pub fn register_worker(
     registry: &CancellationRegistry,
@@ -108,6 +203,7 @@ pub fn register_worker(
             completion,
             capacity_bucket: String::new(),
             scheduler_reservation: SchedulerReservation::default(),
+            exclusive_issue_workspace: false,
             reconciliation_owned: false,
             launched: true,
         },
@@ -124,7 +220,7 @@ pub(crate) fn try_reserve_worker(
     max_issue_workers: u32,
     capacity: WorkerCapacity<'_>,
 ) -> Result<(), WorkerReservationError> {
-    try_reserve_scheduler_worker(
+    try_reserve_scheduler_worker_with_workspace_exclusivity(
         registry,
         identity,
         cancellation,
@@ -134,11 +230,12 @@ pub(crate) fn try_reserve_worker(
         capacity,
         &BTreeMap::new(),
         SchedulerReservation::default(),
+        false,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn try_reserve_scheduler_worker(
+pub(crate) fn try_reserve_scheduler_worker_with_workspace_exclusivity(
     registry: &CancellationRegistry,
     identity: WorkerIdentity,
     cancellation: CancellationToken,
@@ -148,8 +245,12 @@ pub(crate) fn try_reserve_scheduler_worker(
     capacity: WorkerCapacity<'_>,
     resource_capacities: &BTreeMap<String, u32>,
     scheduler_reservation: SchedulerReservation,
+    exclusive_issue_workspace: bool,
 ) -> Result<(), WorkerReservationError> {
     let mut workers = registry_guard(registry);
+    if workers.workspace_captures.contains(&identity.issue_id) {
+        return Err(WorkerReservationError::IssueWorkspaceExclusive);
+    }
     if workers.contains_key(&identity) {
         return Err(WorkerReservationError::DuplicateIdentity);
     }
@@ -163,6 +264,12 @@ pub(crate) fn try_reserve_scheduler_worker(
         >= max_issue_workers as usize
     {
         return Err(WorkerReservationError::IssueCapacityExhausted);
+    }
+    if workers.iter().any(|(active, worker)| {
+        active.issue_id == identity.issue_id
+            && (worker.exclusive_issue_workspace || exclusive_issue_workspace)
+    }) {
+        return Err(WorkerReservationError::IssueWorkspaceExclusive);
     }
     let (capacity_bucket, limit) = capacity.bucket_and_limit();
     if !capacity_available(&workers, &capacity_bucket, limit) {
@@ -200,6 +307,7 @@ pub(crate) fn try_reserve_scheduler_worker(
             completion,
             capacity_bucket,
             scheduler_reservation,
+            exclusive_issue_workspace,
             reconciliation_owned: false,
             launched: false,
         },
@@ -453,11 +561,9 @@ fn issue_tokens(registry: &CancellationRegistry, issue_id: &str) -> Vec<Cancella
         .collect()
 }
 
-fn registry_guard(
-    registry: &CancellationRegistry,
-) -> MutexGuard<'_, HashMap<WorkerIdentity, ActiveWorker>> {
+fn registry_guard(registry: &CancellationRegistry) -> MutexGuard<'_, RegistryState> {
     registry
-        .0
+        .state
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
@@ -766,6 +872,191 @@ mod tests {
             .filter(|outcome| outcome.is_err())
             .all(|outcome| *outcome == Err(WorkerReservationError::GlobalCapacityExhausted)));
         assert_eq!(live_worker_count(&racing_registry), 1);
+    }
+
+    #[test]
+    fn issue_workspace_exclusive_reservation_defers_same_issue_workers_without_blocking_others() {
+        let registry = new_cancellation_registry();
+        let ordinary = identity("build", 1);
+        let immutable = identity("review", 2);
+        let other_issue = WorkerIdentity {
+            issue_id: "issue-2".to_string(),
+            ..identity("build", 3)
+        };
+        let (_, ordinary_completion) = watch::channel(false);
+        let (_, immutable_completion) = watch::channel(false);
+        let (_, other_completion) = watch::channel(false);
+
+        try_reserve_scheduler_worker_with_workspace_exclusivity(
+            &registry,
+            ordinary.clone(),
+            CancellationToken::new(),
+            ordinary_completion,
+            4,
+            4,
+            WorkerCapacity::lane("default", None),
+            &BTreeMap::new(),
+            SchedulerReservation::default(),
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            try_reserve_scheduler_worker_with_workspace_exclusivity(
+                &registry,
+                immutable.clone(),
+                CancellationToken::new(),
+                immutable_completion,
+                4,
+                4,
+                WorkerCapacity::lane("default", None),
+                &BTreeMap::new(),
+                SchedulerReservation::default(),
+                true,
+            ),
+            Err(WorkerReservationError::IssueWorkspaceExclusive)
+        );
+        assert_eq!(
+            try_reserve_scheduler_worker_with_workspace_exclusivity(
+                &registry,
+                other_issue,
+                CancellationToken::new(),
+                other_completion,
+                4,
+                4,
+                WorkerCapacity::lane("default", None),
+                &BTreeMap::new(),
+                SchedulerReservation::default(),
+                true,
+            ),
+            Ok(())
+        );
+
+        assert!(rollback_worker_reservation(&registry, &ordinary));
+        let (_, immutable_completion) = watch::channel(false);
+        try_reserve_scheduler_worker_with_workspace_exclusivity(
+            &registry,
+            immutable.clone(),
+            CancellationToken::new(),
+            immutable_completion,
+            4,
+            4,
+            WorkerCapacity::lane("default", None),
+            &BTreeMap::new(),
+            SchedulerReservation::default(),
+            true,
+        )
+        .unwrap();
+        let (_, ordinary_completion) = watch::channel(false);
+        assert_eq!(
+            try_reserve_scheduler_worker_with_workspace_exclusivity(
+                &registry,
+                ordinary.clone(),
+                CancellationToken::new(),
+                ordinary_completion,
+                4,
+                4,
+                WorkerCapacity::lane("default", None),
+                &BTreeMap::new(),
+                SchedulerReservation::default(),
+                false,
+            ),
+            Err(WorkerReservationError::IssueWorkspaceExclusive)
+        );
+
+        assert!(rollback_worker_reservation(&registry, &immutable));
+        let (_, restored_completion) = watch::channel(false);
+        assert_eq!(
+            try_reserve_scheduler_worker_with_workspace_exclusivity(
+                &registry,
+                ordinary,
+                CancellationToken::new(),
+                restored_completion,
+                4,
+                4,
+                WorkerCapacity::lane("default", None),
+                &BTreeMap::new(),
+                SchedulerReservation::default(),
+                false,
+            ),
+            Ok(())
+        );
+    }
+
+    #[tokio::test]
+    async fn producer_capture_excludes_new_same_issue_workers_until_released() {
+        let registry = new_cancellation_registry();
+        let capture = acquire_issue_workspace_capture(&registry, "issue-1").await;
+        let same_issue = identity("writer", 1);
+        let other_issue = WorkerIdentity {
+            issue_id: "issue-2".to_string(),
+            ..identity("writer", 2)
+        };
+        let (_, same_completion) = watch::channel(false);
+        assert_eq!(
+            try_reserve_scheduler_worker_with_workspace_exclusivity(
+                &registry,
+                same_issue.clone(),
+                CancellationToken::new(),
+                same_completion,
+                4,
+                4,
+                WorkerCapacity::lane("default", None),
+                &BTreeMap::new(),
+                SchedulerReservation::default(),
+                false,
+            ),
+            Err(WorkerReservationError::IssueWorkspaceExclusive)
+        );
+        let (_, other_completion) = watch::channel(false);
+        assert!(try_reserve_scheduler_worker_with_workspace_exclusivity(
+            &registry,
+            other_issue.clone(),
+            CancellationToken::new(),
+            other_completion,
+            4,
+            4,
+            WorkerCapacity::lane("default", None),
+            &BTreeMap::new(),
+            SchedulerReservation::default(),
+            false,
+        )
+        .is_ok());
+
+        drop(capture);
+        let (_, same_completion) = watch::channel(false);
+        assert!(try_reserve_scheduler_worker_with_workspace_exclusivity(
+            &registry,
+            same_issue,
+            CancellationToken::new(),
+            same_completion,
+            4,
+            4,
+            WorkerCapacity::lane("default", None),
+            &BTreeMap::new(),
+            SchedulerReservation::default(),
+            false,
+        )
+        .is_ok());
+        assert!(rollback_worker_reservation(&registry, &other_issue));
+    }
+
+    #[tokio::test]
+    async fn waiting_producer_capture_acquires_after_the_holder_releases() {
+        let registry = new_cancellation_registry();
+        let first_capture = acquire_issue_workspace_capture(&registry, "issue-1").await;
+        let waiting_registry = registry.clone();
+        let waiting_capture = tokio::spawn(async move {
+            acquire_issue_workspace_capture(&waiting_registry, "issue-1").await
+        });
+
+        tokio::task::yield_now().await;
+        drop(first_capture);
+
+        let second_capture = tokio::time::timeout(Duration::from_secs(1), waiting_capture)
+            .await
+            .expect("the released capture wakes its armed waiter")
+            .unwrap();
+        drop(second_capture);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/agent/events.rs
+++ b/crates/ensemble-core/src/agent/events.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::agent::cancellation::IssueWorkspaceCaptureGuard;
 use crate::agent::protocol::TranscriptBlockKind;
 use crate::interaction::InteractionKind;
 use crate::pipeline::verdict::StepOutput;
@@ -19,9 +20,10 @@ pub struct WorkerIdentity {
 
 /// Orchestrator-only envelope that stamps a runner event with its exact owner.
 #[derive(Debug)]
-pub struct OrchestratorWorkerEvent {
-    pub identity: WorkerIdentity,
-    pub event: WorkerEvent,
+pub(crate) struct OrchestratorWorkerEvent {
+    pub(crate) identity: WorkerIdentity,
+    pub(crate) event: WorkerEvent,
+    pub(crate) workspace_capture: Option<IssueWorkspaceCaptureGuard>,
 }
 
 /// Token usage reported by the ACP agent.

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -17,7 +17,8 @@ use std::sync::Arc;
 
 use crate::config::draft::ConfigDocumentState;
 use crate::config::ensemble::{
-    DiscoveredCapabilities, EnsembleConfig, InteractionPolicyOverrideMode, PermissionMode, StepKind,
+    ArtifactAccess, DiscoveredCapabilities, EnsembleConfig, InteractionPolicyOverrideMode,
+    PermissionMode, StepKind,
 };
 use crate::config::template::render_prompt_with_context;
 use crate::error::AgentError;
@@ -94,6 +95,7 @@ pub struct AgentRunRequest<'a> {
     pub agent_name: &'a str,
     pub step_name: &'a str,
     pub step_kind: StepKind,
+    pub artifact_access: ArtifactAccess,
     pub attempt: Option<u32>,
     /// Effective per-step turn timeout in milliseconds.
     pub timeout_ms: u64,
@@ -735,7 +737,15 @@ impl AgentRunner for AcpAgentRunner {
                 }
                 AcpxRuntime::new().run_step(&request, &prompt).await
             }
-            runtime::RuntimeKind::Direct => self.run_direct_step(request).await,
+            runtime::RuntimeKind::Direct => {
+                if request.artifact_access == ArtifactAccess::Immutable {
+                    tracing::warn!(
+                        step = request.step_name,
+                        "direct ACP cannot enforce immutable Artifact runtime permissions; integrity verification remains authoritative"
+                    );
+                }
+                self.run_direct_step(request).await
+            }
         };
 
         if let Some(ref script) = config.hooks.after_run {
@@ -1038,6 +1048,7 @@ on_failure: Todo
             agent_name: "builder",
             step_name: "build",
             step_kind: StepKind::Agent,
+            artifact_access: ArtifactAccess::Mutable,
             attempt: None,
             interaction_response: None,
             workspace_path: Path::new("."),
@@ -1197,6 +1208,7 @@ on_failure: Todo
                 agent_name: "builder",
                 step_name: "build",
                 step_kind: StepKind::Agent,
+                artifact_access: ArtifactAccess::Mutable,
                 attempt: None,
                 timeout_ms: 100,
                 interaction_response: None,
@@ -1245,6 +1257,7 @@ on_failure: Todo
                 agent_name: "builder",
                 step_name: "build",
                 step_kind: StepKind::Agent,
+                artifact_access: ArtifactAccess::Mutable,
                 attempt: None,
                 timeout_ms: 100,
                 interaction_response: None,
@@ -1309,6 +1322,7 @@ exit 1
                 agent_name: "builder",
                 step_name: "build",
                 step_kind: StepKind::Agent,
+                artifact_access: ArtifactAccess::Mutable,
                 attempt: None,
                 timeout_ms: 100,
                 interaction_response: None,
@@ -1381,6 +1395,7 @@ exit 0
                 agent_name: "builder",
                 step_name: "build",
                 step_kind: StepKind::Agent,
+                artifact_access: ArtifactAccess::Mutable,
                 attempt: None,
                 timeout_ms: 100,
                 interaction_response: None,

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -1023,6 +1023,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }])
         .unwrap();
 

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -1309,6 +1309,8 @@ on_failure: Failed
                         record_count: 5,
                     }],
                     artifact_snapshots: Vec::new(),
+                    artifact_integrity_violations: Vec::new(),
+                    artifact_access_evidence: Vec::new(),
                 }),
             })
             .await
@@ -1367,6 +1369,8 @@ on_failure: Failed
                         record_count: 5,
                     }],
                     artifact_snapshots: Vec::new(),
+                    artifact_integrity_violations: Vec::new(),
+                    artifact_access_evidence: Vec::new(),
                 }),
             })
             .await

--- a/crates/ensemble-core/src/artifact.rs
+++ b/crates/ensemble-core/src/artifact.rs
@@ -1,6 +1,7 @@
 //! Durable, content-free Artifact snapshot identities captured at producer boundaries.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Read;
 use std::path::Path;
 #[cfg(test)]
 use std::path::PathBuf;
@@ -11,6 +12,11 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::config::ensemble::ArtifactSnapshotConfig;
+
+const MAX_REPORTED_CHANGED_PATHS: usize = 100;
+const MISSING_ARTIFACT_PATH_DIGEST: &str = "missing-artifact-path-v1";
+const RAW_PATH_PREFIX: &str = "raw-bytes:";
+const MAX_ARTIFACT_DIRECTORY_DEPTH: usize = 64;
 
 #[cfg(test)]
 struct CaptureAfterHeadHook {
@@ -75,8 +81,98 @@ pub struct ArtifactRepositoryObservation {
     pub repository: String,
     pub head: String,
     pub index_digest: String,
+    /// Per-path content-free index identities, including skip-worktree and assume-unchanged flags.
+    #[serde(default)]
+    pub tracked_index_entries: BTreeMap<String, String>,
     pub tracked_worktree_digest: String,
+    /// Repository-relative tracked paths with staged or unstaged changes.
+    #[serde(default)]
+    pub tracked_paths: Vec<String>,
+    /// Per-path content-free digests of every tracked worktree entry.
+    /// Missing values from older snapshots intentionally fall back to Git's conservative diff.
+    #[serde(default)]
+    pub tracked_path_digests: BTreeMap<String, String>,
     pub untracked_paths: Vec<String>,
+    /// Content-free digest of the non-ignored untracked path bytes and modes.
+    #[serde(default)]
+    pub untracked_digest: String,
+    /// Per-path content-free digests used only to identify the bounded changed-path evidence.
+    /// Missing values from older snapshots intentionally fall back to conservative path union.
+    #[serde(default)]
+    pub untracked_path_digests: BTreeMap<String, String>,
+}
+
+/// Content-free evidence that an immutable Artifact input no longer matches its producer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct ArtifactIntegrityViolation {
+    pub consumer_step: String,
+    pub producer_step: String,
+    pub artifact_identity: String,
+    pub repository: String,
+    pub expected_digest: String,
+    pub observed_digest: String,
+    /// Deterministically ordered repository-relative paths involved in the drift.
+    pub changed_paths: Vec<String>,
+    /// Number of changed paths omitted after the bounded diagnostic prefix.
+    pub omitted_changed_path_count: usize,
+}
+
+/// Runtime permission treatment recorded for an immutable Artifact consumer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactAccessEnforcement {
+    AcpxApproveReads,
+    AcpxDenyAll,
+    DirectAcpUnsupported,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
+pub struct ArtifactAccessEvidence {
+    pub consumer_step: String,
+    pub enforcement: ArtifactAccessEnforcement,
+}
+
+/// Re-observe every repository selected by immutable Artifact inputs.
+///
+/// The comparison intentionally contains no repository contents or local paths. A failed
+/// observation is fail-closed because Ensemble cannot prove the producer state remains intact.
+pub async fn verify_immutable_inputs(
+    consumer_step: &str,
+    snapshots: &[ArtifactSnapshot],
+    repositories: &BTreeMap<String, std::path::PathBuf>,
+) -> Result<Vec<ArtifactIntegrityViolation>, String> {
+    let mut violations = Vec::new();
+    for snapshot in snapshots {
+        for expected in &snapshot.repositories {
+            let worktree = repositories.get(&expected.repository).ok_or_else(|| {
+                format!(
+                    "configured repository '{}' has no prepared worktree",
+                    expected.repository
+                )
+            })?;
+            let observed = observe_repository(&expected.repository, worktree)
+                .await
+                .map_err(|_| "could not observe immutable Artifact input".to_string())?;
+            if &observed != expected {
+                let (changed_paths, omitted_changed_path_count) =
+                    changed_paths(worktree, expected, &observed).await?;
+                violations.push(ArtifactIntegrityViolation {
+                    consumer_step: consumer_step.to_string(),
+                    producer_step: snapshot.producer_step.clone(),
+                    artifact_identity: snapshot.identity.clone(),
+                    repository: expected.repository.clone(),
+                    expected_digest: observation_digest(expected),
+                    observed_digest: observation_digest(&observed),
+                    changed_paths,
+                    omitted_changed_path_count,
+                });
+            }
+        }
+    }
+    violations.sort_by(|left, right| {
+        (&left.producer_step, &left.repository).cmp(&(&right.producer_step, &right.repository))
+    });
+    Ok(violations)
 }
 
 /// Capture every configured repository atomically: no snapshot is returned unless all observations succeed.
@@ -127,28 +223,1108 @@ async fn observe_repository(
     let head = git_stdout(worktree, &["rev-parse", "HEAD"]).await?;
     #[cfg(test)]
     pause_capture_after_head_if_configured(worktree).await;
-    let index = git_stdout(worktree, &["ls-files", "-s"]).await?;
-    let staged = git_stdout(worktree, &["diff", "--cached", "--raw", "--no-ext-diff"]).await?;
-    let unstaged = git_stdout(worktree, &["diff", "--binary", "--no-ext-diff"]).await?;
-    let mut untracked_paths: Vec<String> =
-        git_stdout(worktree, &["ls-files", "--others", "--exclude-standard"])
-            .await?
-            .lines()
-            .filter(|path| !path.is_empty())
-            .map(ToOwned::to_owned)
-            .collect();
-    untracked_paths.sort();
-    untracked_paths.dedup();
+    // `-v` includes the skip-worktree and assume-unchanged index flags; without it, those
+    // flags can make Git's diff view omit changed worktree bytes from an observation.
+    let index = git_stdout_bytes(worktree, &["ls-files", "--stage", "-v", "-z"]).await?;
+    let tracked_index_entries = git_index_entries(&index)?;
+    let gitlink_paths = gitlink_path_bytes(&index)?;
+    let mut tracked_paths = git_nul_paths(
+        worktree,
+        &[
+            "diff",
+            "--cached",
+            "--name-only",
+            "-z",
+            "--no-ext-diff",
+            "--no-renames",
+        ],
+    )
+    .await?;
+    tracked_paths.extend(
+        git_nul_paths(
+            worktree,
+            &["diff", "--name-only", "-z", "--no-ext-diff", "--no-renames"],
+        )
+        .await?,
+    );
+    tracked_paths.sort();
+    tracked_paths.dedup();
+    let tracked_worktree_paths = git_nul_path_bytes(worktree, &["ls-files", "-z"]).await?;
+    let tracked_path_digests =
+        tracked_path_digests(worktree, &tracked_worktree_paths, &gitlink_paths).await?;
+    let untracked_path_bytes = git_nul_path_bytes(
+        worktree,
+        &["ls-files", "--others", "--exclude-standard", "-z"],
+    )
+    .await?;
+    let untracked_paths = untracked_path_bytes
+        .iter()
+        .map(|path| artifact_path_display(path))
+        .collect();
+    let untracked_path_digests = path_digests(worktree, &untracked_path_bytes, "untracked").await?;
+    let untracked_digest = digest_path_digests(&untracked_path_digests);
     Ok(ArtifactRepositoryObservation {
         repository: repository.to_string(),
         head,
-        index_digest: digest_bytes(index.as_bytes()),
-        tracked_worktree_digest: digest_bytes(format!("{staged}\n{unstaged}").as_bytes()),
+        index_digest: digest_bytes(&index),
+        tracked_index_entries,
+        tracked_worktree_digest: digest_path_digests(&tracked_path_digests),
+        tracked_paths,
+        tracked_path_digests,
         untracked_paths,
+        untracked_digest,
+        untracked_path_digests,
     })
 }
 
+async fn tracked_path_digests(
+    worktree: &Path,
+    paths: &[Vec<u8>],
+    gitlink_paths: &BTreeSet<Vec<u8>>,
+) -> Result<BTreeMap<String, String>, String> {
+    let mut digests = BTreeMap::new();
+    for path in paths {
+        let digest = if gitlink_paths.contains(path) {
+            gitlink_path_digest(worktree, path).await?
+        } else {
+            path_digest(worktree, path, "tracked").await?
+        }
+        .unwrap_or_else(|| MISSING_ARTIFACT_PATH_DIGEST.to_string());
+        digests.insert(artifact_path_display(path), digest);
+    }
+    Ok(digests)
+}
+
+async fn path_digests(
+    worktree: &Path,
+    paths: &[Vec<u8>],
+    path_kind: &str,
+) -> Result<BTreeMap<String, String>, String> {
+    let mut digests = BTreeMap::new();
+    for path in paths {
+        let digest = path_digest(worktree, path, path_kind)
+            .await?
+            .unwrap_or_else(|| MISSING_ARTIFACT_PATH_DIGEST.to_string());
+        digests.insert(artifact_path_display(path), digest);
+    }
+    Ok(digests)
+}
+
+fn digest_path_digests(path_digests: &BTreeMap<String, String>) -> String {
+    let mut digest = Sha256::new();
+    for (relative_path, path_digest) in path_digests {
+        digest.update(relative_path.as_bytes());
+        digest.update([0]);
+        digest.update(path_digest.as_bytes());
+    }
+    format!("{:x}", digest.finalize())
+}
+
+#[cfg(unix)]
+async fn gitlink_path_digest(
+    worktree: &Path,
+    relative_path: &[u8],
+) -> Result<Option<String>, String> {
+    let worktree = worktree.to_path_buf();
+    let relative_path = relative_path.to_vec();
+    tokio::task::spawn_blocking(move || {
+        let Some(entry) = open_worktree_path(&worktree, &relative_path, "tracked")? else {
+            return Ok(None);
+        };
+        let OpenedArtifactPath::Directory {
+            len,
+            mode,
+            directory,
+        } = entry
+        else {
+            return Err("could not safely inspect tracked Artifact gitlink".to_string());
+        };
+        let mut digest = Sha256::new();
+        digest.update(len.to_le_bytes());
+        digest.update(mode.to_le_bytes());
+        digest_directory_filtered(&mut digest, directory, "tracked", 0, &[], &[])?;
+        Ok(Some(format!("{:x}", digest.finalize())))
+    })
+    .await
+    .map_err(|error| format!("Artifact gitlink digest task failed: {error}"))?
+}
+
+#[cfg(not(unix))]
+async fn gitlink_path_digest(
+    _worktree: &Path,
+    _relative_path: &[u8],
+) -> Result<Option<String>, String> {
+    Err(
+        "tracked Artifact gitlinks require descriptor-bound Git observation on this platform"
+            .to_string(),
+    )
+}
+
+#[cfg(unix)]
+enum OpenedArtifactPath {
+    Symlink {
+        len: u64,
+        mode: u32,
+        target: Vec<u8>,
+    },
+    Regular {
+        len: u64,
+        mode: u32,
+        file: std::fs::File,
+    },
+    Directory {
+        len: u64,
+        mode: u32,
+        directory: std::os::fd::OwnedFd,
+    },
+    Other {
+        len: u64,
+        mode: u32,
+    },
+}
+
+#[cfg(unix)]
+async fn path_digest(
+    worktree: &Path,
+    relative_path: &[u8],
+    path_kind: &str,
+) -> Result<Option<String>, String> {
+    let worktree = worktree.to_path_buf();
+    let relative_path = relative_path.to_vec();
+    let path_kind = path_kind.to_string();
+    tokio::task::spawn_blocking(move || path_digest_blocking(&worktree, &relative_path, &path_kind))
+        .await
+        .map_err(|error| format!("Artifact path digest task failed: {error}"))?
+}
+
+#[cfg(unix)]
+fn path_digest_blocking(
+    worktree: &Path,
+    relative_path: &[u8],
+    path_kind: &str,
+) -> Result<Option<String>, String> {
+    let ancestor_matchers = if path_kind == "untracked" {
+        ancestor_ignore_matchers(worktree, relative_path, path_kind)?
+    } else {
+        Vec::new()
+    };
+    let Some(entry) = open_worktree_path(worktree, relative_path, path_kind)? else {
+        return Ok(None);
+    };
+    let mut digest = Sha256::new();
+    match entry {
+        OpenedArtifactPath::Symlink { len, mode, target } => {
+            digest.update(len.to_le_bytes());
+            digest.update(mode.to_le_bytes());
+            digest.update(target);
+        }
+        OpenedArtifactPath::Regular { len, mode, file } => {
+            digest.update(len.to_le_bytes());
+            digest.update(mode.to_le_bytes());
+            digest_regular_file(&mut digest, file, path_kind)?;
+        }
+        OpenedArtifactPath::Directory {
+            len,
+            mode,
+            directory,
+        } => {
+            digest.update(len.to_le_bytes());
+            digest.update(mode.to_le_bytes());
+            digest_directory_filtered(
+                &mut digest,
+                directory,
+                path_kind,
+                0,
+                relative_path,
+                &ancestor_matchers,
+            )?;
+        }
+        OpenedArtifactPath::Other { len, mode } => {
+            digest.update(len.to_le_bytes());
+            digest.update(mode.to_le_bytes());
+        }
+    }
+    Ok(Some(format!("{:x}", digest.finalize())))
+}
+
+#[cfg(not(unix))]
+async fn path_digest(
+    worktree: &Path,
+    relative_path: &[u8],
+    path_kind: &str,
+) -> Result<Option<String>, String> {
+    let relative_path = std::str::from_utf8(relative_path)
+        .map_err(|_| "could not inspect non-UTF-8 Artifact path on this platform".to_string())?;
+    let worktree = worktree.to_path_buf();
+    let relative_path = relative_path.to_string();
+    let path_kind = path_kind.to_string();
+    tokio::task::spawn_blocking(move || {
+        path_digest_blocking(&worktree, Path::new(&relative_path), &path_kind)
+    })
+    .await
+    .map_err(|error| format!("Artifact path digest task failed: {error}"))?
+}
+
+#[cfg(not(unix))]
+fn path_digest_blocking(
+    worktree: &Path,
+    relative_path: &Path,
+    path_kind: &str,
+) -> Result<Option<String>, String> {
+    use cap_std::ambient_authority;
+    use cap_std::fs::Dir;
+    use std::path::Component;
+
+    let components = relative_path
+        .components()
+        .map(|component| match component {
+            Component::Normal(component) => Ok(component),
+            _ => Err(format!("invalid {path_kind} Artifact path")),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let (entry, parents) = components
+        .split_last()
+        .ok_or_else(|| format!("invalid {path_kind} Artifact path"))?;
+    let mut directory = Dir::open_ambient_dir(worktree, ambient_authority()).map_err(|error| {
+        format!("could not safely inspect {path_kind} Artifact worktree: {error}")
+    })?;
+    for parent in parents {
+        let file = match open_nofollow(&directory, parent) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(format!(
+                    "could not safely inspect {path_kind} Artifact path: {error}"
+                ));
+            }
+        };
+        if !file
+            .metadata()
+            .map_err(|error| format!("could not inspect {path_kind} Artifact path: {error}"))?
+            .is_dir()
+        {
+            return Err(format!(
+                "could not safely inspect {path_kind} Artifact path"
+            ));
+        }
+        directory = Dir::from_std_file(file.into_std());
+    }
+    let metadata = match directory.symlink_metadata(entry) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "could not inspect {path_kind} Artifact path: {error}"
+            ));
+        }
+    };
+    let mut digest = Sha256::new();
+    digest.update(metadata.len().to_le_bytes());
+    if metadata.file_type().is_symlink() {
+        digest.update(
+            read_link_contents_capability_safe(&directory, entry)
+                .map_err(|error| format!("could not read {path_kind} Artifact symlink: {error}"))?
+                .as_os_str()
+                .as_encoded_bytes(),
+        );
+    } else if metadata.is_file() {
+        digest_regular_file_non_unix(
+            &mut digest,
+            open_nofollow(&directory, entry).map_err(|error| {
+                format!("could not safely inspect {path_kind} Artifact path: {error}")
+            })?,
+            path_kind,
+        )?;
+    } else if metadata.is_dir() {
+        let directory = Dir::from_std_file(
+            open_nofollow(&directory, entry)
+                .map_err(|error| {
+                    format!("could not safely inspect {path_kind} Artifact path: {error}")
+                })?
+                .into_std(),
+        );
+        digest_directory_non_unix(&mut digest, directory, path_kind, 0)?;
+    }
+    Ok(Some(format!("{:x}", digest.finalize())))
+}
+
+#[cfg(not(unix))]
+fn open_nofollow(
+    directory: &cap_std::fs::Dir,
+    path: &std::ffi::OsStr,
+) -> std::io::Result<cap_std::fs::File> {
+    use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+    use cap_std::fs::OpenOptions;
+
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    directory.open_with(path, &options)
+}
+
+#[cfg(any(not(unix), test))]
+fn read_link_contents_capability_safe(
+    directory: &cap_std::fs::Dir,
+    path: &std::ffi::OsStr,
+) -> std::io::Result<std::path::PathBuf> {
+    directory.read_link_contents(path)
+}
+
+#[cfg(not(unix))]
+fn digest_regular_file_non_unix(
+    digest: &mut Sha256,
+    file: cap_std::fs::File,
+    path_kind: &str,
+) -> Result<(), String> {
+    let mut file = file;
+    let mut buffer = [0; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("could not read {path_kind} Artifact path: {error}"))?;
+        if read == 0 {
+            return Ok(());
+        }
+        digest.update(&buffer[..read]);
+    }
+}
+
+#[cfg(not(unix))]
+fn digest_directory_non_unix(
+    digest: &mut Sha256,
+    directory: cap_std::fs::Dir,
+    path_kind: &str,
+    depth: usize,
+) -> Result<(), String> {
+    if depth >= MAX_ARTIFACT_DIRECTORY_DEPTH {
+        return Err(format!(
+            "{path_kind} Artifact directory exceeds the traversal depth bound"
+        ));
+    }
+    match directory.symlink_metadata(".git") {
+        Ok(_) => {
+            return Err(
+                "embedded Git repositories require descriptor-bound Git observation on this platform"
+                    .to_string(),
+            );
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "could not inspect embedded Git repository: {error}"
+            ));
+        }
+    }
+    let mut entries = directory
+        .read_dir(".")
+        .map_err(|error| format!("could not read {path_kind} Artifact directory: {error}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("could not read {path_kind} Artifact directory: {error}"))?;
+    entries.sort_by(|left, right| {
+        left.file_name()
+            .as_encoded_bytes()
+            .cmp(right.file_name().as_encoded_bytes())
+    });
+    for entry in entries {
+        let name = entry.file_name();
+        let metadata = entry.metadata().map_err(|error| {
+            format!("could not inspect {path_kind} Artifact directory entry: {error}")
+        })?;
+        digest.update((name.as_encoded_bytes().len() as u64).to_le_bytes());
+        digest.update(name.as_encoded_bytes());
+        digest.update(metadata.len().to_le_bytes());
+        if entry
+            .file_type()
+            .map_err(|error| {
+                format!("could not inspect {path_kind} Artifact directory entry: {error}")
+            })?
+            .is_symlink()
+        {
+            digest.update([0]);
+            digest.update(
+                read_link_contents_capability_safe(&directory, &name)
+                    .map_err(|error| {
+                        format!("could not read {path_kind} Artifact symlink: {error}")
+                    })?
+                    .as_os_str()
+                    .as_encoded_bytes(),
+            );
+        } else if metadata.is_file() {
+            digest.update([1]);
+            digest_regular_file_non_unix(
+                digest,
+                open_nofollow(&directory, &name).map_err(|error| {
+                    format!("could not safely inspect {path_kind} Artifact path: {error}")
+                })?,
+                path_kind,
+            )?;
+        } else if metadata.is_dir() {
+            digest.update([2]);
+            digest_directory_non_unix(
+                digest,
+                cap_std::fs::Dir::from_std_file(
+                    open_nofollow(&directory, &name)
+                        .map_err(|error| {
+                            format!("could not safely inspect {path_kind} Artifact path: {error}")
+                        })?
+                        .into_std(),
+                ),
+                path_kind,
+                depth + 1,
+            )?;
+        } else {
+            digest.update([3]);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_worktree_path(
+    worktree: &Path,
+    relative_path: &[u8],
+    path_kind: &str,
+) -> Result<Option<OpenedArtifactPath>, String> {
+    use rustix::fs::{open, openat, readlinkat, statat, AtFlags, FileType, Mode, OFlags};
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Component;
+
+    let components = Path::new(OsStr::from_bytes(relative_path))
+        .components()
+        .map(|component| match component {
+            Component::Normal(component) => Ok(component),
+            _ => Err(format!("invalid {path_kind} Artifact path")),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let (entry, parents) = components
+        .split_last()
+        .ok_or_else(|| format!("invalid {path_kind} Artifact path"))?;
+    let mut directory = open(
+        worktree,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map_err(|error| format!("could not safely inspect {path_kind} Artifact worktree: {error}"))?;
+    for parent in parents {
+        directory = match openat(
+            &directory,
+            *parent,
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+            Mode::empty(),
+        ) {
+            Ok(directory) => directory,
+            Err(rustix::io::Errno::NOENT) => return Ok(None),
+            Err(error) => {
+                return Err(format!(
+                    "could not safely inspect {path_kind} Artifact path: {error}"
+                ));
+            }
+        };
+    }
+    let stat = match statat(&directory, *entry, AtFlags::SYMLINK_NOFOLLOW) {
+        Ok(stat) => stat,
+        Err(rustix::io::Errno::NOENT) => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "could not inspect {path_kind} Artifact path: {error}"
+            ));
+        }
+    };
+    let len = stat.st_size as u64;
+    let mode = stat.st_mode as u32;
+    match FileType::from_raw_mode(stat.st_mode) {
+        FileType::Symlink => Ok(Some(OpenedArtifactPath::Symlink {
+            len,
+            mode,
+            target: readlinkat(&directory, *entry, Vec::new())
+                .map_err(|error| format!("could not read {path_kind} Artifact symlink: {error}"))?
+                .as_bytes()
+                .to_vec(),
+        })),
+        FileType::RegularFile => {
+            let file = openat(
+                &directory,
+                *entry,
+                OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+                Mode::empty(),
+            )
+            .map_err(|error| format!("could not safely read {path_kind} Artifact path: {error}"))?;
+            Ok(Some(OpenedArtifactPath::Regular {
+                len,
+                mode,
+                file: file.into(),
+            }))
+        }
+        FileType::Directory => {
+            let directory = openat(
+                &directory,
+                *entry,
+                OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+                Mode::empty(),
+            )
+            .map_err(|error| {
+                format!("could not safely read {path_kind} Artifact directory: {error}")
+            })?;
+            Ok(Some(OpenedArtifactPath::Directory {
+                len,
+                mode,
+                directory,
+            }))
+        }
+        _ => Ok(Some(OpenedArtifactPath::Other { len, mode })),
+    }
+}
+
+#[cfg(unix)]
+fn digest_regular_file(
+    digest: &mut Sha256,
+    file: std::fs::File,
+    path_kind: &str,
+) -> Result<(), String> {
+    let mut file = file;
+    let mut buffer = [0; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("could not read {path_kind} Artifact path: {error}"))?;
+        if read == 0 {
+            return Ok(());
+        }
+        digest.update(&buffer[..read]);
+    }
+}
+
+#[cfg(unix)]
+fn ancestor_ignore_matchers(
+    worktree: &Path,
+    relative_path: &[u8],
+    path_kind: &str,
+) -> Result<Vec<ignore::gitignore::Gitignore>, String> {
+    use rustix::fs::{open, openat, Mode, OFlags};
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Component;
+
+    let components = Path::new(OsStr::from_bytes(relative_path))
+        .components()
+        .map(|component| match component {
+            Component::Normal(component) => Ok(component),
+            _ => Err(format!("invalid {path_kind} Artifact path")),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let (_, parents) = components
+        .split_last()
+        .ok_or_else(|| format!("invalid {path_kind} Artifact path"))?;
+    let mut directory = open(
+        worktree,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map_err(|error| format!("could not safely inspect {path_kind} Artifact worktree: {error}"))?;
+    let mut prefix = Vec::new();
+    let mut matchers = Vec::new();
+    if let Some(matcher) = local_ignore_matcher(&directory, &prefix, path_kind, false)? {
+        matchers.push(matcher);
+    }
+    for parent in parents {
+        directory = openat(
+            &directory,
+            *parent,
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+            Mode::empty(),
+        )
+        .map_err(|error| format!("could not safely inspect {path_kind} Artifact path: {error}"))?;
+        prefix.extend_from_slice(parent.as_bytes());
+        prefix.push(b'/');
+        let embedded_git = embedded_git_metadata(&directory, path_kind)?;
+        if embedded_git.is_some() {
+            prefix.clear();
+            matchers.clear();
+        }
+        if let Some(matcher) = local_ignore_matcher(
+            &directory,
+            &prefix,
+            path_kind,
+            matches!(embedded_git, Some(EmbeddedGitMetadata::Directory)),
+        )? {
+            matchers.push(matcher);
+        }
+    }
+    Ok(matchers)
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy)]
+enum EmbeddedGitMetadata {
+    Directory,
+    GitFile,
+}
+
+#[cfg(unix)]
+fn embedded_git_metadata(
+    directory: &std::os::fd::OwnedFd,
+    path_kind: &str,
+) -> Result<Option<EmbeddedGitMetadata>, String> {
+    use rustix::fs::{openat, statat, AtFlags, FileType, Mode, OFlags};
+
+    let metadata = match statat(directory, ".git", AtFlags::SYMLINK_NOFOLLOW) {
+        Ok(metadata) => metadata,
+        Err(rustix::io::Errno::NOENT) => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "could not inspect {path_kind} embedded Git metadata: {error}"
+            ));
+        }
+    };
+    match FileType::from_raw_mode(metadata.st_mode) {
+        FileType::Directory => {
+            openat(
+                directory,
+                ".git",
+                OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+                Mode::empty(),
+            )
+            .map_err(|error| {
+                format!("could not safely inspect {path_kind} embedded Git metadata: {error}")
+            })?;
+            Ok(Some(EmbeddedGitMetadata::Directory))
+        }
+        FileType::RegularFile if path_kind == "tracked" => {
+            openat(
+                directory,
+                ".git",
+                OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+                Mode::empty(),
+            )
+            .map_err(|error| {
+                format!("could not safely inspect tracked embedded Git metadata: {error}")
+            })?;
+            Ok(Some(EmbeddedGitMetadata::GitFile))
+        }
+        _ => Err(format!(
+            "could not safely inspect {path_kind} embedded Git metadata"
+        )),
+    }
+}
+
+#[cfg(unix)]
+fn optional_ignore_file(
+    directory: &std::os::fd::OwnedFd,
+    name: &[u8],
+    path_kind: &str,
+) -> Result<Option<String>, String> {
+    use rustix::fs::{openat, statat, AtFlags, FileType, Mode, OFlags};
+
+    let metadata = match statat(directory, name, AtFlags::SYMLINK_NOFOLLOW) {
+        Ok(metadata) => metadata,
+        Err(rustix::io::Errno::NOENT) => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "could not inspect {path_kind} Artifact ignore file: {error}"
+            ));
+        }
+    };
+    if FileType::from_raw_mode(metadata.st_mode) != FileType::RegularFile {
+        return Err(format!(
+            "could not safely inspect {path_kind} Artifact ignore file"
+        ));
+    }
+    let file = openat(
+        directory,
+        name,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map_err(|error| format!("could not safely read {path_kind} Artifact ignore file: {error}"))?;
+    let mut contents = String::new();
+    std::fs::File::from(file)
+        .read_to_string(&mut contents)
+        .map_err(|error| format!("could not read {path_kind} Artifact ignore file: {error}"))?;
+    Ok(Some(contents))
+}
+
+#[cfg(unix)]
+fn embedded_git_exclude_file(
+    directory: &std::os::fd::OwnedFd,
+    path_kind: &str,
+) -> Result<Option<String>, String> {
+    use rustix::fs::{openat, Mode, OFlags};
+
+    let git_directory = openat(
+        directory,
+        ".git",
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map_err(|error| {
+        format!("could not safely inspect {path_kind} embedded Git metadata: {error}")
+    })?;
+    let info_directory = match openat(
+        &git_directory,
+        "info",
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+        Mode::empty(),
+    ) {
+        Ok(directory) => directory,
+        Err(rustix::io::Errno::NOENT) => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "could not safely inspect {path_kind} embedded Git exclude metadata: {error}"
+            ));
+        }
+    };
+    optional_ignore_file(&info_directory, b"exclude", path_kind)
+}
+
+#[cfg(unix)]
+fn local_ignore_matcher(
+    directory: &std::os::fd::OwnedFd,
+    prefix: &[u8],
+    path_kind: &str,
+    embedded_git: bool,
+) -> Result<Option<ignore::gitignore::Gitignore>, String> {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let local = optional_ignore_file(directory, b".gitignore", path_kind)?;
+    let repository_excludes = if embedded_git {
+        embedded_git_exclude_file(directory, path_kind)?
+    } else {
+        None
+    };
+    if local.is_none() && repository_excludes.is_none() {
+        return Ok(None);
+    }
+    let root = std::path::PathBuf::from(OsString::from_vec(prefix.to_vec()));
+    let source = root.join(".gitignore");
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(&root);
+    for contents in repository_excludes.into_iter().chain(local) {
+        for line in contents.lines() {
+            builder
+                .add_line(Some(source.clone()), line)
+                .map_err(|error| format!("invalid {path_kind} Artifact ignore rule: {error}"))?;
+        }
+    }
+    builder
+        .build()
+        .map(Some)
+        .map_err(|error| format!("invalid {path_kind} Artifact ignore rules: {error}"))
+}
+
+#[cfg(unix)]
+fn is_ignored(
+    matchers: &[ignore::gitignore::Gitignore],
+    relative_path: &[u8],
+    is_dir: bool,
+) -> bool {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let path = Path::new(OsStr::from_bytes(relative_path));
+    matchers
+        .iter()
+        .rev()
+        .map(|matcher| matcher.matched_path_or_any_parents(path, is_dir))
+        .find(|matched| !matched.is_none())
+        .is_some_and(|matched| matched.is_ignore())
+}
+
+#[cfg(unix)]
+fn digest_directory_filtered(
+    digest: &mut Sha256,
+    directory: std::os::fd::OwnedFd,
+    path_kind: &str,
+    depth: usize,
+    prefix: &[u8],
+    matchers: &[ignore::gitignore::Gitignore],
+) -> Result<(), String> {
+    use rustix::fs::{openat, readlinkat, statat, AtFlags, Dir, FileType, Mode, OFlags};
+
+    if depth >= MAX_ARTIFACT_DIRECTORY_DEPTH {
+        return Err(format!(
+            "{path_kind} Artifact directory exceeds the traversal depth bound"
+        ));
+    }
+    let embedded_git = embedded_git_metadata(&directory, path_kind)?;
+    let prefix = if embedded_git.is_some() {
+        &[][..]
+    } else {
+        prefix
+    };
+    let mut matchers = if embedded_git.is_some() {
+        Vec::new()
+    } else {
+        matchers.to_vec()
+    };
+    if let Some(matcher) = local_ignore_matcher(
+        &directory,
+        prefix,
+        path_kind,
+        matches!(embedded_git, Some(EmbeddedGitMetadata::Directory)),
+    )? {
+        matchers.push(matcher);
+    }
+    let mut names = Vec::new();
+    let mut directory_reader = Dir::read_from(&directory)
+        .map_err(|error| format!("could not read {path_kind} Artifact directory: {error}"))?;
+    while let Some(entry) = directory_reader.read() {
+        let name = entry
+            .map_err(|error| format!("could not read {path_kind} Artifact directory: {error}"))?
+            .file_name()
+            .to_bytes()
+            .to_vec();
+        if name != b"." && name != b".." {
+            names.push(name);
+        }
+    }
+    names.sort();
+    for name in names {
+        if embedded_git.is_some() && name == b".git" {
+            continue;
+        }
+        let mut relative_path = prefix.to_vec();
+        relative_path.extend_from_slice(&name);
+        let stat =
+            statat(&directory, name.as_slice(), AtFlags::SYMLINK_NOFOLLOW).map_err(|error| {
+                format!("could not inspect {path_kind} Artifact directory entry: {error}")
+            })?;
+        let kind = FileType::from_raw_mode(stat.st_mode);
+        if kind.is_dir() {
+            relative_path.push(b'/');
+        }
+        if is_ignored(&matchers, &relative_path, kind.is_dir()) {
+            continue;
+        }
+        digest.update((name.len() as u64).to_le_bytes());
+        digest.update(&name);
+        digest.update(stat.st_size.to_le_bytes());
+        digest.update(stat.st_mode.to_le_bytes());
+        if kind.is_symlink() {
+            digest.update(
+                readlinkat(&directory, name.as_slice(), Vec::new())
+                    .map_err(|error| {
+                        format!("could not read {path_kind} Artifact symlink: {error}")
+                    })?
+                    .as_bytes(),
+            );
+        } else if kind.is_file() {
+            let file = openat(
+                &directory,
+                name.as_slice(),
+                OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+                Mode::empty(),
+            )
+            .map_err(|error| format!("could not safely read {path_kind} Artifact path: {error}"))?;
+            digest_regular_file(digest, file.into(), path_kind)?;
+        } else if kind.is_dir() {
+            let child = openat(
+                &directory,
+                name.as_slice(),
+                OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+                Mode::empty(),
+            )
+            .map_err(|error| {
+                format!("could not safely read {path_kind} Artifact directory: {error}")
+            })?;
+            digest_directory_filtered(
+                digest,
+                child,
+                path_kind,
+                depth + 1,
+                &relative_path,
+                &matchers,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+async fn changed_paths(
+    worktree: &Path,
+    expected: &ArtifactRepositoryObservation,
+    observed: &ArtifactRepositoryObservation,
+) -> Result<(Vec<String>, usize), String> {
+    let mut paths = expected
+        .tracked_paths
+        .iter()
+        .chain(expected.untracked_paths.iter())
+        .chain(observed.tracked_paths.iter())
+        .chain(observed.untracked_paths.iter())
+        .cloned()
+        .collect::<Vec<_>>();
+    remove_digest_covered_paths(
+        &mut paths,
+        &expected.tracked_index_entries,
+        &observed.tracked_index_entries,
+    );
+    remove_digest_covered_paths(
+        &mut paths,
+        &expected.tracked_path_digests,
+        &observed.tracked_path_digests,
+    );
+    remove_digest_covered_paths(
+        &mut paths,
+        &expected.untracked_path_digests,
+        &observed.untracked_path_digests,
+    );
+    paths.extend(changed_digest_paths(
+        &expected.tracked_index_entries,
+        &observed.tracked_index_entries,
+    ));
+    paths.extend(changed_digest_paths(
+        &expected.tracked_path_digests,
+        &observed.tracked_path_digests,
+    ));
+    paths.extend(changed_digest_paths(
+        &expected.untracked_path_digests,
+        &observed.untracked_path_digests,
+    ));
+    if expected.head != observed.head {
+        paths.extend(
+            git_nul_paths(
+                worktree,
+                &[
+                    "diff",
+                    "--name-only",
+                    "-z",
+                    "--no-ext-diff",
+                    "--no-renames",
+                    &expected.head,
+                    &observed.head,
+                ],
+            )
+            .await?,
+        );
+    }
+    paths.sort();
+    paths.dedup();
+    let omitted_changed_path_count = paths.len().saturating_sub(MAX_REPORTED_CHANGED_PATHS);
+    paths.truncate(MAX_REPORTED_CHANGED_PATHS);
+    Ok((paths, omitted_changed_path_count))
+}
+
+fn git_index_entries(output: &[u8]) -> Result<BTreeMap<String, String>, String> {
+    let mut entries = BTreeMap::<String, Vec<String>>::new();
+    for entry in output
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+    {
+        let separator = entry
+            .iter()
+            .position(|byte| *byte == b'\t')
+            .ok_or_else(|| "git reported a malformed Artifact index entry".to_string())?;
+        let (identity, path_with_separator) = entry.split_at(separator);
+        let path = artifact_path_display(&path_with_separator[1..]);
+        let identity = std::str::from_utf8(identity)
+            .map_err(|_| "git reported a malformed Artifact index identity".to_string())?;
+        entries.entry(path).or_default().push(identity.to_string());
+    }
+    Ok(entries
+        .into_iter()
+        .map(|(path, mut identities)| {
+            identities.sort();
+            (
+                path,
+                digest_bytes(&serde_json::to_vec(&identities).expect("index entries serialize")),
+            )
+        })
+        .collect())
+}
+
+fn gitlink_path_bytes(output: &[u8]) -> Result<BTreeSet<Vec<u8>>, String> {
+    let mut paths = BTreeSet::new();
+    for entry in output
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+    {
+        let separator = entry
+            .iter()
+            .position(|byte| *byte == b'\t')
+            .ok_or_else(|| "git reported a malformed Artifact index entry".to_string())?;
+        let (identity, path_with_separator) = entry.split_at(separator);
+        let mut fields = identity.split(|byte| byte.is_ascii_whitespace());
+        let _tag = fields.next();
+        if fields.next() == Some(b"160000".as_slice()) {
+            paths.insert(path_with_separator[1..].to_vec());
+        }
+    }
+    Ok(paths)
+}
+
+fn remove_digest_covered_paths(
+    paths: &mut Vec<String>,
+    expected: &BTreeMap<String, String>,
+    observed: &BTreeMap<String, String>,
+) {
+    if expected.is_empty() || observed.is_empty() {
+        return;
+    }
+    paths.retain(|path| !expected.contains_key(path) && !observed.contains_key(path));
+}
+
+fn changed_digest_paths(
+    expected: &BTreeMap<String, String>,
+    observed: &BTreeMap<String, String>,
+) -> Vec<String> {
+    if expected.is_empty() || observed.is_empty() {
+        return Vec::new();
+    }
+    expected
+        .iter()
+        .filter_map(|(path, digest)| (observed.get(path) != Some(digest)).then_some(path.clone()))
+        .chain(
+            observed
+                .keys()
+                .filter(|path| !expected.contains_key(*path))
+                .cloned(),
+        )
+        .collect()
+}
+
+async fn git_nul_paths(worktree: &Path, args: &[&str]) -> Result<Vec<String>, String> {
+    Ok(git_nul_path_bytes(worktree, args)
+        .await?
+        .iter()
+        .map(|path| artifact_path_display(path))
+        .collect())
+}
+
+async fn git_nul_path_bytes(worktree: &Path, args: &[&str]) -> Result<Vec<Vec<u8>>, String> {
+    let output = git_stdout_bytes(worktree, args).await?;
+    let mut paths = output
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+fn artifact_path_display(path: &[u8]) -> String {
+    match std::str::from_utf8(path) {
+        Ok(path) if !path.starts_with(RAW_PATH_PREFIX) => path.to_string(),
+        _ => {
+            let mut encoded = String::with_capacity(RAW_PATH_PREFIX.len() + path.len() * 2);
+            encoded.push_str(RAW_PATH_PREFIX);
+            for byte in path {
+                use std::fmt::Write;
+                write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+            }
+            encoded
+        }
+    }
+}
+
 pub(crate) async fn git_stdout(worktree: &Path, args: &[&str]) -> Result<String, String> {
+    Ok(
+        String::from_utf8_lossy(&git_stdout_bytes(worktree, args).await?)
+            .trim()
+            .to_string(),
+    )
+}
+
+async fn git_stdout_bytes(worktree: &Path, args: &[&str]) -> Result<Vec<u8>, String> {
     let output = tokio::process::Command::new("git")
         .args(args)
         .current_dir(worktree)
@@ -162,13 +1338,18 @@ pub(crate) async fn git_stdout(worktree: &Path, args: &[&str]) -> Result<String,
             String::from_utf8_lossy(&output.stderr).trim()
         ));
     }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    Ok(output.stdout)
 }
 
 fn digest_bytes(bytes: &[u8]) -> String {
     let mut digest = Sha256::new();
     digest.update(bytes);
     format!("{:x}", digest.finalize())
+}
+
+fn observation_digest(observation: &ArtifactRepositoryObservation) -> String {
+    // Serialization here is an internal, deterministic digest input rather than exposed data.
+    digest_bytes(&serde_json::to_vec(observation).expect("artifact observation serializes"))
 }
 
 #[cfg(test)]
@@ -215,6 +1396,22 @@ mod tests {
 
         assert_eq!(first, second);
         assert_eq!(first.repositories[0].untracked_paths, vec!["visible.txt"]);
+
+        tokio::fs::write(dir.path().join("ignored.out"), "changed ignored content")
+            .await
+            .unwrap();
+        let after_ignored_change = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({"ok": true}),
+            &selection,
+            &repositories,
+        )
+        .await
+        .unwrap();
+        assert_eq!(first, after_ignored_change);
     }
 
     #[tokio::test]
@@ -262,6 +1459,1111 @@ mod tests {
         );
     }
 
+    #[cfg(not(unix))]
+    #[tokio::test]
+    async fn directory_path_digest_changes_when_a_nested_file_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("embedded/nested");
+        tokio::fs::create_dir_all(&nested).await.unwrap();
+        tokio::fs::write(nested.join("child.txt"), "before")
+            .await
+            .unwrap();
+
+        let before = path_digest(dir.path(), b"embedded", "untracked")
+            .await
+            .unwrap();
+        tokio::fs::write(nested.join("child.txt"), "after")
+            .await
+            .unwrap();
+        let after = path_digest(dir.path(), b"embedded", "untracked")
+            .await
+            .unwrap();
+
+        assert_ne!(before, after);
+    }
+
+    #[cfg(not(unix))]
+    #[tokio::test]
+    async fn missing_parent_path_digest_is_observed_as_missing() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert_eq!(
+            path_digest(dir.path(), b"removed/nested.txt", "tracked")
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn capture_records_a_missing_tracked_entry_without_failing() {
+        let dir = initialized_repository().await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        tokio::fs::create_dir_all(dir.path().join("tracked-parent"))
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join("tracked-parent/child.txt"), "tracked")
+            .await
+            .unwrap();
+        run_git(dir.path(), &["add", "tracked-parent/child.txt"]).await;
+        run_git(dir.path(), &["commit", "-m", "tracked child"]).await;
+        tokio::fs::remove_dir_all(dir.path().join("tracked-parent"))
+            .await
+            .unwrap();
+
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .expect("a producer snapshot must record a missing tracked entry");
+
+        assert!(snapshot.repositories[0]
+            .tracked_path_digests
+            .contains_key("tracked-parent/child.txt"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn immutable_verification_retains_non_utf8_git_path_bytes() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let dir = initialized_repository().await;
+        let path = std::ffi::OsString::from_vec(b"raw-\xff.txt".to_vec());
+        tokio::fs::write(dir.path().join(&path), "before")
+            .await
+            .unwrap();
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            snapshot.repositories[0].untracked_paths,
+            vec!["raw-bytes:7261772dff2e747874"]
+        );
+
+        tokio::fs::write(dir.path().join(&path), "after")
+            .await
+            .unwrap();
+        let violations = verify_immutable_inputs("review", &[snapshot], &repositories)
+            .await
+            .unwrap();
+        assert_eq!(
+            violations[0].changed_paths,
+            vec!["raw-bytes:7261772dff2e747874"]
+        );
+    }
+
+    #[tokio::test]
+    async fn immutable_verification_detects_rewrite_inside_an_untracked_embedded_repository() {
+        let dir = initialized_repository().await;
+        tokio::fs::write(dir.path().join(".gitignore"), "ordinary/outer-cache/\n")
+            .await
+            .unwrap();
+        run_git(dir.path(), &["add", ".gitignore"]).await;
+        run_git(dir.path(), &["commit", "-m", "outer ignore"]).await;
+        let embedded = dir.path().join("ordinary/embedded");
+        tokio::fs::create_dir_all(&embedded).await.unwrap();
+        run_git(&embedded, &["init", "--initial-branch=main"]).await;
+        run_git(&embedded, &["config", "user.email", "test@example.com"]).await;
+        run_git(&embedded, &["config", "user.name", "Test User"]).await;
+        tokio::fs::write(embedded.join("child.txt"), "before")
+            .await
+            .unwrap();
+        tokio::fs::write(embedded.join(".gitignore"), "cache/\n")
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(embedded.join("cache"))
+            .await
+            .unwrap();
+        tokio::fs::write(embedded.join("cache/output.bin"), "before")
+            .await
+            .unwrap();
+        tokio::fs::write(embedded.join(".git/info/exclude"), "info-cache/\n")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(embedded.join("info-cache"))
+            .await
+            .unwrap();
+        tokio::fs::write(embedded.join("info-cache/output.bin"), "before")
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(embedded.join("sub/cache"))
+            .await
+            .unwrap();
+        tokio::fs::write(embedded.join("sub/.gitignore"), "/cache/\n")
+            .await
+            .unwrap();
+        tokio::fs::write(embedded.join("sub/cache/output.bin"), "before")
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(dir.path().join("ordinary/outer-cache"))
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join("ordinary/outer-cache/output.bin"), "before")
+            .await
+            .unwrap();
+        run_git(
+            &embedded,
+            &["add", "child.txt", ".gitignore", "sub/.gitignore"],
+        )
+        .await;
+        run_git(&embedded, &["commit", "-m", "embedded"]).await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::write(embedded.join("cache/output.bin"), "after")
+            .await
+            .unwrap();
+        tokio::fs::write(embedded.join("info-cache/output.bin"), "after")
+            .await
+            .unwrap();
+        tokio::fs::write(embedded.join("sub/cache/output.bin"), "after")
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join("ordinary/outer-cache/output.bin"), "after")
+            .await
+            .unwrap();
+        assert!(
+            verify_immutable_inputs("review", std::slice::from_ref(&snapshot), &repositories)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        tokio::fs::write(embedded.join("child.txt"), "after")
+            .await
+            .unwrap();
+        assert_eq!(
+            verify_immutable_inputs("review", &[snapshot], &repositories)
+                .await
+                .unwrap()[0]
+                .changed_paths,
+            vec!["ordinary/embedded/"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capture_refuses_external_metadata_for_an_untracked_embedded_repository() {
+        use std::os::unix::fs::symlink;
+
+        let dir = initialized_repository().await;
+        let embedded = dir.path().join("ordinary/embedded");
+        tokio::fs::create_dir_all(&embedded).await.unwrap();
+        let external = initialized_repository().await;
+        symlink(external.path().join(".git"), embedded.join(".git")).unwrap();
+        tokio::fs::write(embedded.join("child.txt"), "content")
+            .await
+            .unwrap();
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+
+        let error = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.contains("could not safely inspect untracked embedded Git metadata"));
+    }
+
+    #[tokio::test]
+    async fn capture_supports_an_untracked_directory_with_more_than_ten_thousand_entries() {
+        let dir = initialized_repository().await;
+        let embedded = dir.path().join("embedded");
+        tokio::fs::create_dir_all(&embedded).await.unwrap();
+        run_git(&embedded, &["init", "--initial-branch=main"]).await;
+        for index in 0..10_001 {
+            tokio::fs::write(embedded.join(format!("entry-{index:05}")), "content")
+                .await
+                .unwrap();
+        }
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .expect("ordinary embedded repositories are not limited to ten thousand entries");
+
+        assert_eq!(snapshot.repositories[0].untracked_paths, vec!["embedded/"]);
+        tokio::fs::write(embedded.join("entry-10000"), "changed")
+            .await
+            .unwrap();
+        assert_eq!(
+            verify_immutable_inputs("review", &[snapshot], &repositories)
+                .await
+                .unwrap()[0]
+                .changed_paths,
+            vec!["embedded/"]
+        );
+    }
+
+    #[tokio::test]
+    async fn immutable_verification_detects_rewrite_inside_a_tracked_gitlink_ignored_by_git() {
+        let dir = initialized_repository().await;
+        let embedded = dir.path().join("submodule");
+        tokio::fs::create_dir_all(&embedded).await.unwrap();
+        run_git(&embedded, &["init", "--initial-branch=main"]).await;
+        run_git(&embedded, &["config", "user.email", "test@example.com"]).await;
+        run_git(&embedded, &["config", "user.name", "Test User"]).await;
+        tokio::fs::write(embedded.join("child.txt"), "before")
+            .await
+            .unwrap();
+        tokio::fs::write(embedded.join(".gitignore"), "cache/\n")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(embedded.join("cache")).await.unwrap();
+        tokio::fs::write(embedded.join("cache/output.bin"), "before")
+            .await
+            .unwrap();
+        run_git(&embedded, &["add", "child.txt", ".gitignore"]).await;
+        run_git(&embedded, &["commit", "-m", "embedded"]).await;
+        tokio::fs::write(dir.path().join(".gitignore"), "*")
+            .await
+            .unwrap();
+        run_git(dir.path(), &["add", "-f", "submodule"]).await;
+        run_git(dir.path(), &["commit", "-m", "gitlink"]).await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::write(embedded.join("cache/output.bin"), "after")
+            .await
+            .unwrap();
+        assert!(
+            verify_immutable_inputs("review", std::slice::from_ref(&snapshot), &repositories)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        tokio::fs::write(embedded.join("child.txt"), "after")
+            .await
+            .unwrap();
+        assert_eq!(
+            verify_immutable_inputs("review", &[snapshot], &repositories)
+                .await
+                .unwrap()[0]
+                .changed_paths,
+            vec!["submodule"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capture_supports_a_standard_gitfile_for_a_tracked_gitlink() {
+        let parent = initialized_repository().await;
+        let child = initialized_repository().await;
+        tokio::fs::write(child.path().join(".gitignore"), "cache/\n")
+            .await
+            .unwrap();
+        tokio::fs::write(child.path().join("child.txt"), "before")
+            .await
+            .unwrap();
+        run_git(child.path(), &["add", ".gitignore", "child.txt"]).await;
+        run_git(child.path(), &["commit", "-m", "child files"]).await;
+        let child_path = child.path().to_string_lossy().to_string();
+        run_git(
+            parent.path(),
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                &child_path,
+                "submodule",
+            ],
+        )
+        .await;
+        run_git(parent.path(), &["commit", "-am", "add submodule"]).await;
+        assert!(tokio::fs::metadata(parent.path().join("submodule/.git"))
+            .await
+            .unwrap()
+            .is_file());
+        tokio::fs::create_dir(parent.path().join("submodule/cache"))
+            .await
+            .unwrap();
+        tokio::fs::write(parent.path().join("submodule/cache/output.bin"), "before")
+            .await
+            .unwrap();
+        tokio::fs::write(
+            parent.path().join(".git/modules/submodule/info/exclude"),
+            "metadata-cache/\n",
+        )
+        .await
+        .unwrap();
+        tokio::fs::create_dir(parent.path().join("submodule/metadata-cache"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            parent.path().join("submodule/metadata-cache/output.bin"),
+            "before",
+        )
+        .await
+        .unwrap();
+        let repositories = BTreeMap::from([("repo".to_string(), parent.path().to_path_buf())]);
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::write(parent.path().join("submodule/cache/output.bin"), "after")
+            .await
+            .unwrap();
+        assert!(
+            verify_immutable_inputs("review", std::slice::from_ref(&snapshot), &repositories)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        tokio::fs::write(
+            parent.path().join("submodule/metadata-cache/output.bin"),
+            "after",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            verify_immutable_inputs("review", std::slice::from_ref(&snapshot), &repositories)
+                .await
+                .unwrap()[0]
+                .changed_paths,
+            vec!["submodule"]
+        );
+        tokio::fs::write(
+            parent.path().join("submodule/metadata-cache/output.bin"),
+            "before",
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(parent.path().join("submodule/child.txt"), "after")
+            .await
+            .unwrap();
+        assert_eq!(
+            verify_immutable_inputs("review", &[snapshot], &repositories)
+                .await
+                .unwrap()[0]
+                .changed_paths,
+            vec!["submodule"]
+        );
+    }
+
+    #[tokio::test]
+    async fn capture_records_an_uninitialized_gitlink_as_missing() {
+        let dir = initialized_repository().await;
+        let embedded = dir.path().join("submodule");
+        tokio::fs::create_dir_all(&embedded).await.unwrap();
+        run_git(&embedded, &["init", "--initial-branch=main"]).await;
+        run_git(&embedded, &["config", "user.email", "test@example.com"]).await;
+        run_git(&embedded, &["config", "user.name", "Test User"]).await;
+        tokio::fs::write(embedded.join("child.txt"), "content")
+            .await
+            .unwrap();
+        run_git(&embedded, &["add", "child.txt"]).await;
+        run_git(&embedded, &["commit", "-m", "embedded"]).await;
+        run_git(dir.path(), &["add", "submodule"]).await;
+        run_git(dir.path(), &["commit", "-m", "gitlink"]).await;
+        tokio::fs::remove_dir_all(&embedded).await.unwrap();
+
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            snapshot.repositories[0].tracked_path_digests["submodule"],
+            MISSING_ARTIFACT_PATH_DIGEST
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capture_refuses_a_gitlink_replaced_by_an_external_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = initialized_repository().await;
+        let embedded = dir.path().join("submodule");
+        tokio::fs::create_dir_all(&embedded).await.unwrap();
+        run_git(&embedded, &["init", "--initial-branch=main"]).await;
+        run_git(&embedded, &["config", "user.email", "test@example.com"]).await;
+        run_git(&embedded, &["config", "user.name", "Test User"]).await;
+        tokio::fs::write(embedded.join("child.txt"), "content")
+            .await
+            .unwrap();
+        run_git(&embedded, &["add", "child.txt"]).await;
+        run_git(&embedded, &["commit", "-m", "embedded"]).await;
+        run_git(dir.path(), &["add", "submodule"]).await;
+        run_git(dir.path(), &["commit", "-m", "gitlink"]).await;
+        let external = initialized_repository().await;
+        tokio::fs::remove_dir_all(&embedded).await.unwrap();
+        symlink(external.path(), &embedded).unwrap();
+
+        let error = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.contains("could not safely inspect tracked Artifact gitlink"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capture_never_follows_an_untracked_directory_symlink_cycle() {
+        use std::os::unix::fs::symlink;
+
+        let dir = initialized_repository().await;
+        symlink(".", dir.path().join("cycle")).unwrap();
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+        assert_eq!(snapshot.repositories[0].untracked_paths, vec!["cycle"]);
+    }
+
+    #[tokio::test]
+    async fn immutable_verification_detects_a_deleted_tracked_entry() {
+        let dir = initialized_repository().await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+        tokio::fs::remove_file(dir.path().join("tracked.txt"))
+            .await
+            .unwrap();
+
+        let violations = verify_immutable_inputs("review", &[snapshot], &repositories)
+            .await
+            .unwrap();
+
+        assert_eq!(violations[0].changed_paths, vec!["tracked.txt"]);
+    }
+
+    #[tokio::test]
+    async fn immutable_verification_detects_a_restored_tracked_entry() {
+        let dir = initialized_repository().await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        tokio::fs::remove_file(dir.path().join("tracked.txt"))
+            .await
+            .unwrap();
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(dir.path().join("tracked.txt"), "restored\n")
+            .await
+            .unwrap();
+
+        let violations = verify_immutable_inputs("review", &[snapshot], &repositories)
+            .await
+            .unwrap();
+
+        assert_eq!(violations[0].changed_paths, vec!["tracked.txt"]);
+    }
+
+    #[tokio::test]
+    async fn capture_changes_identity_when_a_tracked_skip_worktree_flag_changes() {
+        let dir = initialized_repository().await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let selection = ArtifactSnapshotConfig {
+            repositories: vec!["repo".to_string()],
+        };
+        let first = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &selection,
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        run_git(
+            dir.path(),
+            &["update-index", "--skip-worktree", "tracked.txt"],
+        )
+        .await;
+        let flag_only_violations =
+            verify_immutable_inputs("review", std::slice::from_ref(&first), &repositories)
+                .await
+                .unwrap();
+        assert_eq!(flag_only_violations[0].changed_paths, vec!["tracked.txt"]);
+        let second = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &selection,
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        assert_ne!(first.identity, second.identity);
+        assert_ne!(
+            first.repositories[0].index_digest,
+            second.repositories[0].index_digest
+        );
+    }
+
+    #[test]
+    fn tracked_index_entries_keep_every_unmerged_stage_for_one_path() {
+        let entries = git_index_entries(
+            b"M 100644 base 1\tconflicted.txt\0M 100644 ours 2\tconflicted.txt\0M 100644 theirs 3\tconflicted.txt\0",
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_ne!(
+            entries["conflicted.txt"],
+            digest_bytes(&serde_json::to_vec(&["M 100644 theirs 3"]).unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn immutable_verification_detects_tracked_rewrites_hidden_by_index_flags() {
+        for flag in ["--skip-worktree", "--assume-unchanged"] {
+            let dir = initialized_repository().await;
+            let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+            let snapshot = capture(
+                "run-1",
+                1,
+                "build",
+                1,
+                &serde_json::json!({}),
+                &ArtifactSnapshotConfig {
+                    repositories: vec!["repo".to_string()],
+                },
+                &repositories,
+            )
+            .await
+            .unwrap();
+
+            run_git(dir.path(), &["update-index", flag, "tracked.txt"]).await;
+            tokio::fs::write(dir.path().join("tracked.txt"), "consumer rewrite\n")
+                .await
+                .unwrap();
+
+            let violations = verify_immutable_inputs("review", &[snapshot], &repositories)
+                .await
+                .unwrap();
+            assert_eq!(violations.len(), 1, "{flag}");
+            assert_eq!(violations[0].changed_paths, vec!["tracked.txt"], "{flag}");
+            assert!(
+                !serde_json::to_string(&violations)
+                    .unwrap()
+                    .contains("consumer rewrite"),
+                "{flag}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn immutable_verification_detects_rewrite_when_skip_worktree_precedes_capture() {
+        let dir = initialized_repository().await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        run_git(
+            dir.path(),
+            &["update-index", "--skip-worktree", "tracked.txt"],
+        )
+        .await;
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::write(dir.path().join("tracked.txt"), "hidden rewrite\n")
+            .await
+            .unwrap();
+
+        let violations = verify_immutable_inputs("review", &[snapshot], &repositories)
+            .await
+            .unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].changed_paths, vec!["tracked.txt"]);
+    }
+
+    #[tokio::test]
+    async fn capture_changes_identity_when_untracked_path_bytes_change() {
+        let dir = initialized_repository().await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let selection = ArtifactSnapshotConfig {
+            repositories: vec!["repo".to_string()],
+        };
+        tokio::fs::write(
+            dir.path().join("visible.txt"),
+            "untracked-secret-before-rewrite",
+        )
+        .await
+        .unwrap();
+        let first = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &selection,
+            &repositories,
+        )
+        .await
+        .unwrap();
+        assert!(!serde_json::to_string(&first)
+            .unwrap()
+            .contains("untracked-secret-before-rewrite"));
+        tokio::fs::write(
+            dir.path().join("visible.txt"),
+            "untracked-secret-after-rewrite",
+        )
+        .await
+        .unwrap();
+        let second = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &selection,
+            &repositories,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            first.repositories[0].untracked_paths,
+            second.repositories[0].untracked_paths
+        );
+        assert_ne!(
+            first.repositories[0].untracked_digest,
+            second.repositories[0].untracked_digest
+        );
+        assert_ne!(first.identity, second.identity);
+        let violations =
+            verify_immutable_inputs("review", std::slice::from_ref(&first), &repositories)
+                .await
+                .unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].changed_paths, vec!["visible.txt"]);
+    }
+
+    #[tokio::test]
+    async fn untracked_paths_use_raw_nul_records_without_git_quoting() {
+        let dir = initialized_repository().await;
+        let path = "café\ncontrol.txt";
+        tokio::fs::write(dir.path().join(path), "before")
+            .await
+            .unwrap();
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let selection = ArtifactSnapshotConfig {
+            repositories: vec!["repo".to_string()],
+        };
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &selection,
+            &repositories,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            snapshot.repositories[0].untracked_paths,
+            vec![path.to_string()]
+        );
+
+        tokio::fs::write(dir.path().join(path), "after")
+            .await
+            .unwrap();
+        let violations = verify_immutable_inputs("review", &[snapshot], &repositories)
+            .await
+            .unwrap();
+        assert_eq!(violations[0].changed_paths, vec![path.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn tracked_paths_use_raw_nul_records_without_git_quoting() {
+        let dir = initialized_repository().await;
+        let path = "tracked-café\ncontrol.txt";
+        tokio::fs::write(dir.path().join(path), "before")
+            .await
+            .unwrap();
+        run_git(dir.path(), &["add", path]).await;
+        run_git(dir.path(), &["commit", "-m", "special tracked path"]).await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let selection = ArtifactSnapshotConfig {
+            repositories: vec!["repo".to_string()],
+        };
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &selection,
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::write(dir.path().join(path), "after")
+            .await
+            .unwrap();
+        let violations = verify_immutable_inputs("review", &[snapshot], &repositories)
+            .await
+            .unwrap();
+        assert_eq!(violations[0].changed_paths, vec![path.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn untracked_regular_file_digest_handles_large_same_length_rewrite() {
+        let dir = initialized_repository().await;
+        let path = dir.path().join("large.bin");
+        tokio::fs::write(&path, vec![b'a'; 2 * 1024 * 1024])
+            .await
+            .unwrap();
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let selection = ArtifactSnapshotConfig {
+            repositories: vec!["repo".to_string()],
+        };
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &selection,
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::write(&path, vec![b'b'; 2 * 1024 * 1024])
+            .await
+            .unwrap();
+        let violations = verify_immutable_inputs("review", &[snapshot], &repositories)
+            .await
+            .unwrap();
+        assert_eq!(violations[0].changed_paths, vec!["large.bin"]);
+    }
+
+    #[tokio::test]
+    async fn untracked_changed_path_evidence_omits_unchanged_paths() {
+        let dir = initialized_repository().await;
+        for number in 0..=MAX_REPORTED_CHANGED_PATHS {
+            tokio::fs::write(
+                dir.path().join(format!("untracked-{number:03}.txt")),
+                "before",
+            )
+            .await
+            .unwrap();
+        }
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let selection = ArtifactSnapshotConfig {
+            repositories: vec!["repo".to_string()],
+        };
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            &selection,
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::write(dir.path().join("untracked-057.txt"), "after")
+            .await
+            .unwrap();
+        let violations = verify_immutable_inputs("review", &[snapshot], &repositories)
+            .await
+            .unwrap();
+        assert_eq!(violations[0].changed_paths, vec!["untracked-057.txt"]);
+        assert_eq!(violations[0].omitted_changed_path_count, 0);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capture_hashes_an_untracked_symlink_target_without_reading_its_destination() {
+        use std::os::unix::fs::symlink;
+
+        let dir = initialized_repository().await;
+        let destination = TempDir::new().unwrap();
+        tokio::fs::write(
+            destination.path().join("secret.txt"),
+            "outside-worktree-secret",
+        )
+        .await
+        .unwrap();
+        symlink(
+            destination.path().join("secret.txt"),
+            dir.path().join("linked.txt"),
+        )
+        .unwrap();
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        assert!(!serde_json::to_string(&snapshot)
+            .unwrap()
+            .contains("outside-worktree-secret"));
+        tokio::fs::write(
+            destination.path().join("secret.txt"),
+            "rewritten-outside-secret",
+        )
+        .await
+        .unwrap();
+        assert!(
+            verify_immutable_inputs("review", std::slice::from_ref(&snapshot), &repositories)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capability_safe_link_read_retains_an_absolute_target() {
+        use cap_std::ambient_authority;
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("absolute-target");
+        symlink(&target, dir.path().join("link")).unwrap();
+        let capability =
+            cap_std::fs::Dir::open_ambient_dir(dir.path(), ambient_authority()).unwrap();
+
+        assert_eq!(
+            read_link_contents_capability_safe(&capability, std::ffi::OsStr::new("link")).unwrap(),
+            target
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capture_refuses_a_tracked_path_beneath_an_intermediate_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = initialized_repository().await;
+        let nested = dir.path().join("nested");
+        tokio::fs::create_dir(&nested).await.unwrap();
+        tokio::fs::write(nested.join("tracked.txt"), "inside")
+            .await
+            .unwrap();
+        run_git(dir.path(), &["add", "nested/tracked.txt"]).await;
+        run_git(dir.path(), &["commit", "-m", "nested tracked path"]).await;
+
+        let outside = TempDir::new().unwrap();
+        tokio::fs::write(outside.path().join("tracked.txt"), "outside-secret")
+            .await
+            .unwrap();
+        tokio::fs::remove_dir_all(&nested).await.unwrap();
+        symlink(outside.path(), &nested).unwrap();
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+
+        let error = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.contains("tracked Artifact path"), "{error}");
+        assert!(!error.contains("outside-secret"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capture_refuses_a_missing_tracked_path_beneath_an_intermediate_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = initialized_repository().await;
+        let nested = dir.path().join("nested");
+        tokio::fs::create_dir(&nested).await.unwrap();
+        tokio::fs::write(nested.join("tracked.txt"), "inside")
+            .await
+            .unwrap();
+        run_git(dir.path(), &["add", "nested/tracked.txt"]).await;
+        run_git(dir.path(), &["commit", "-m", "nested tracked path"]).await;
+        tokio::fs::remove_dir_all(&nested).await.unwrap();
+        let outside = TempDir::new().unwrap();
+        symlink(outside.path(), &nested).unwrap();
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+
+        let error = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.contains("tracked Artifact path"), "{error}");
+    }
+
+    #[test]
+    fn observation_without_the_untracked_digest_remains_readable_for_fail_closed_recovery() {
+        let observation: ArtifactRepositoryObservation =
+            serde_json::from_value(serde_json::json!({
+                "repository": "repo",
+                "head": "head",
+                "index_digest": "index",
+                "tracked_worktree_digest": "worktree",
+                "untracked_paths": ["visible.txt"]
+            }))
+            .unwrap();
+
+        assert_eq!(observation.untracked_digest, "");
+    }
+
     #[tokio::test]
     async fn capture_does_not_publish_partial_snapshot_when_any_repository_fails() {
         let dir = initialized_repository().await;
@@ -286,6 +2588,85 @@ mod tests {
         .unwrap_err();
 
         assert!(error.contains("git rev-parse HEAD"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn immutable_verification_reports_content_free_changed_observation() {
+        let dir = initialized_repository().await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::write(dir.path().join("tracked.txt"), "changed\n")
+            .await
+            .unwrap();
+        let violations =
+            verify_immutable_inputs("review", std::slice::from_ref(&snapshot), &repositories)
+                .await
+                .unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].consumer_step, "review");
+        assert_eq!(violations[0].producer_step, "build");
+        assert_eq!(violations[0].artifact_identity, snapshot.identity);
+        assert_ne!(violations[0].expected_digest, violations[0].observed_digest);
+        assert_eq!(violations[0].changed_paths, vec!["tracked.txt"]);
+        assert_eq!(violations[0].omitted_changed_path_count, 0);
+    }
+
+    #[tokio::test]
+    async fn immutable_verification_bounds_sorted_changed_path_evidence() {
+        let dir = initialized_repository().await;
+        let repositories = BTreeMap::from([("repo".to_string(), dir.path().to_path_buf())]);
+        let snapshot = capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::json!({}),
+            &ArtifactSnapshotConfig {
+                repositories: vec!["repo".to_string()],
+            },
+            &repositories,
+        )
+        .await
+        .unwrap();
+
+        for number in (0..=MAX_REPORTED_CHANGED_PATHS).rev() {
+            tokio::fs::write(
+                dir.path().join(format!("changed-{number:03}.txt")),
+                "changed",
+            )
+            .await
+            .unwrap();
+        }
+        let violations =
+            verify_immutable_inputs("review", std::slice::from_ref(&snapshot), &repositories)
+                .await
+                .unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            violations[0].changed_paths.len(),
+            MAX_REPORTED_CHANGED_PATHS
+        );
+        assert_eq!(violations[0].changed_paths[0], "changed-000.txt");
+        assert_eq!(
+            violations[0].changed_paths.last().unwrap(),
+            "changed-099.txt"
+        );
+        assert_eq!(violations[0].omitted_changed_path_count, 1);
     }
 
     async fn initialized_repository() -> TempDir {

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -650,6 +650,27 @@ pub struct StepConfig {
     /// Optional selection of repository state captured after this step's output validates.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_snapshot: Option<ArtifactSnapshotConfig>,
+    /// Direct producer steps whose Artifact snapshots this step consumes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_inputs: Vec<String>,
+    /// Whether this step may mutate its Artifact inputs.
+    #[serde(default, skip_serializing_if = "ArtifactAccess::is_default")]
+    pub artifact_access: ArtifactAccess,
+}
+
+/// Access requested by a consumer of one or more Artifact snapshots.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactAccess {
+    #[default]
+    Mutable,
+    Immutable,
+}
+
+impl ArtifactAccess {
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Mutable)
+    }
 }
 
 /// One config-relative Draft 2020-12 JSON Schema used to validate a step output.
@@ -2164,25 +2185,68 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
             crate::pipeline::dag::build_dag(steps)?
         };
         for step in &dag.steps {
-            let Some(source) = &steps
+            let configured = steps
                 .iter()
                 .find(|configured| configured.name == step.name)
-                .and_then(|configured| configured.affected_paths.as_ref())
-            else {
-                continue;
-            };
-            if !step
-                .depends
-                .iter()
-                .any(|dependency| dependency == &source.step)
+                .expect("resolved DAG steps originate from configuration");
+            if let Some(source) = &configured.affected_paths {
+                if !step
+                    .depends
+                    .iter()
+                    .any(|dependency| dependency == &source.step)
+                {
+                    return Err(PipelineError::InvalidStepConfig {
+                        step: step.name.clone(),
+                        reason: format!(
+                            "affected_paths step '{}' must be a direct dependency",
+                            source.step
+                        ),
+                    });
+                }
+            }
+            if configured.artifact_access == ArtifactAccess::Immutable
+                && configured.artifact_inputs.is_empty()
             {
                 return Err(PipelineError::InvalidStepConfig {
                     step: step.name.clone(),
-                    reason: format!(
-                        "affected_paths step '{}' must be a direct dependency",
-                        source.step
-                    ),
+                    reason: "immutable artifact_access requires at least one artifact_inputs entry"
+                        .to_string(),
                 });
+            }
+            let mut artifact_inputs = std::collections::HashSet::new();
+            let mut selected_repositories = std::collections::HashMap::new();
+            for producer in &configured.artifact_inputs {
+                let producer_config = steps.iter().find(|candidate| candidate.name == *producer);
+                if producer.trim().is_empty()
+                    || !artifact_inputs.insert(producer)
+                    || !step.depends.iter().any(|dependency| dependency == producer)
+                    || producer_config.is_none_or(|candidate| candidate.artifact_snapshot.is_none())
+                {
+                    return Err(PipelineError::InvalidStepConfig {
+                        step: step.name.clone(),
+                        reason: format!(
+                            "artifact_inputs must name unique direct dependencies that declare artifact_snapshot ('{producer}')"
+                        ),
+                    });
+                }
+                if configured.artifact_access == ArtifactAccess::Immutable {
+                    for repository in &producer_config
+                        .expect("validated artifact producer is configured")
+                        .artifact_snapshot
+                        .as_ref()
+                        .expect("validated artifact producer declares a snapshot")
+                        .repositories
+                    {
+                        if let Some(previous) = selected_repositories.insert(repository, producer) {
+                            return Err(PipelineError::InvalidStepConfig {
+                                step: step.name.clone(),
+                                reason: format!(
+                                    "immutable artifact_inputs must select disjoint artifact_snapshot repositories ('{previous}' and '{producer}' overlap '{repository}')"
+                                ),
+                            });
+                        }
+                    }
+                }
             }
         }
     }
@@ -2320,6 +2384,133 @@ on_failure: Failed
         assert!(error
             .to_string()
             .contains("artifact_snapshot must select at least one repository"));
+    }
+
+    #[test]
+    fn artifact_inputs_reject_invalid_immutable_consumer_references() {
+        let config = minimal_yaml().replace(
+            "    agent: build\n",
+            "    agent: build\n    artifact_access: immutable\n",
+        );
+
+        let error = validate_config(&parse_config(&config).unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("artifact_inputs"));
+    }
+
+    #[test]
+    fn artifact_inputs_accept_direct_snapshot_producer() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+repos:
+  - path: /tmp/repo
+    branch: main
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: Build
+steps:
+  - name: build
+    agent: build
+    artifact_snapshot:
+      repositories: [repo]
+  - name: review
+    agent: build
+    depends: [build]
+    artifact_inputs: [build]
+    artifact_access: immutable
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn immutable_artifact_inputs_reject_overlapping_producer_repositories() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+repos:
+  - path: /tmp/repo
+    branch: main
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: Build
+steps:
+  - name: build-a
+    agent: build
+    artifact_snapshot:
+      repositories: [repo]
+  - name: build-b
+    agent: build
+    artifact_snapshot:
+      repositories: [repo]
+  - name: review
+    agent: build
+    depends: [build-a, build-b]
+    artifact_inputs: [build-a, build-b]
+    artifact_access: immutable
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        let error = validate_config(&config).unwrap_err();
+
+        assert!(error.to_string().contains("disjoint"));
+        assert!(error.to_string().contains("repo"));
+    }
+
+    #[test]
+    fn immutable_artifact_inputs_accept_disjoint_producer_repositories() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+repos:
+  - path: /tmp/repo-a
+    branch: main
+  - path: /tmp/repo-b
+    branch: main
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: Build
+steps:
+  - name: build-a
+    agent: build
+    artifact_snapshot:
+      repositories: [repo-a]
+  - name: build-b
+    agent: build
+    artifact_snapshot:
+      repositories: [repo-b]
+  - name: review
+    agent: build
+    depends: [build-a, build-b]
+    artifact_inputs: [build-a, build-b]
+    artifact_access: immutable
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        assert!(validate_config(&config).is_ok());
     }
 
     #[test]

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -861,6 +861,8 @@ fn build_setup_dag(steps: &[SetupStep]) -> Result<crate::pipeline::dag::StepDag,
                 affected_paths: None,
                 output_schema: None,
                 artifact_snapshot: None,
+                artifact_inputs: Vec::new(),
+                artifact_access: Default::default(),
 })
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/ensemble-core/src/history/artifacts.rs
+++ b/crates/ensemble-core/src/history/artifacts.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-use crate::artifact::ArtifactSnapshot;
+use crate::artifact::{ArtifactAccessEvidence, ArtifactIntegrityViolation, ArtifactSnapshot};
 use crate::workspace::finalize::FinalizeMode;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
@@ -12,6 +12,10 @@ pub struct RunArtifacts {
     pub transcripts: Vec<StepTranscriptArtifact>,
     #[serde(default)]
     pub artifact_snapshots: Vec<ArtifactSnapshot>,
+    #[serde(default)]
+    pub artifact_integrity_violations: Vec<ArtifactIntegrityViolation>,
+    #[serde(default)]
+    pub artifact_access_evidence: Vec<ArtifactAccessEvidence>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]

--- a/crates/ensemble-core/src/history/writer.rs
+++ b/crates/ensemble-core/src/history/writer.rs
@@ -268,6 +268,8 @@ mod tests {
                 record_count: 3,
             }],
             artifact_snapshots: Vec::new(),
+            artifact_integrity_violations: Vec::new(),
+            artifact_access_evidence: Vec::new(),
         });
 
         writer.append(&record).await.unwrap();

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -470,6 +470,8 @@ mod tests {
                 record_count: 2,
             }],
             artifact_snapshots: Vec::new(),
+            artifact_integrity_violations: Vec::new(),
+            artifact_access_evidence: Vec::new(),
         });
 
         store.append_history_record("run-1", &record).await.unwrap();

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -1057,6 +1057,8 @@ mod tests {
                     affected_paths: None,
                     output_schema: None,
                     artifact_snapshot: None,
+                    artifact_inputs: Vec::new(),
+                    artifact_access: Default::default(),
                 },
                 StepConfig {
                     name: "review".to_string(),
@@ -1072,6 +1074,8 @@ mod tests {
                     affected_paths: None,
                     output_schema: None,
                     artifact_snapshot: None,
+                    artifact_inputs: Vec::new(),
+                    artifact_access: Default::default(),
                 },
             ],
             on_success: "finalize".to_string(),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 use tokio::sync::RwLock;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
@@ -29,16 +29,18 @@ use crate::acceptance::{
     evaluate_file_requirement, evaluate_handoff_requirement, AcceptanceCommandRunner,
     AcceptanceEvidence, AcceptanceStatus, ResolvedAcceptancePlan, ShellAcceptanceCommandRunner,
 };
-#[cfg(test)]
-use crate::agent::cancellation::StateWorkerCapacity;
 use crate::agent::cancellation::{
-    await_worker_drain, await_worker_quiescence, has_available_lane_worker_capacity,
-    has_available_state_worker_capacity, is_reconciliation_owned, live_worker_count,
-    mark_all_for_drain, mark_issue_for_drain, mark_worker_launched, new_cancellation_registry,
-    pending_reconciliation_issue_ids, remove_completed_worker, remove_drained_workers,
-    rollback_worker_reservation, sibling_worker_completion_handles, try_reserve_scheduler_worker,
-    CancellationRegistry, WorkerCapacity, WorkerDrainHandle, WorkerReservationError,
+    acquire_issue_workspace_capture, await_worker_drain, await_worker_quiescence,
+    has_available_lane_worker_capacity, has_available_state_worker_capacity,
+    is_reconciliation_owned, live_worker_count, mark_all_for_drain, mark_issue_for_drain,
+    mark_worker_launched, new_cancellation_registry, pending_reconciliation_issue_ids,
+    remove_completed_worker, remove_drained_workers, rollback_worker_reservation,
+    sibling_worker_completion_handles, try_reserve_scheduler_worker_with_workspace_exclusivity,
+    worker_uses_exclusive_issue_workspace, CancellationRegistry, WorkerCapacity, WorkerDrainHandle,
+    WorkerReservationError,
 };
+#[cfg(test)]
+use crate::agent::cancellation::{issue_workspace_capture_is_active, StateWorkerCapacity};
 use crate::agent::events::{
     AgentEvent, InteractionRequestDraft, OrchestratorWorkerEvent, StepApprovalRequestDraft,
     WorkerEvent, WorkerFailureKind, WorkerIdentity, WorkerResult,
@@ -53,7 +55,9 @@ use crate::attention::{
     AttentionEvidence, AttentionIdentity, AttentionPresentation, AttentionReporter,
     AttentionUpsert,
 };
-use crate::config::ensemble::{repository_key, EnsembleConfig, OnFailure, StepKind};
+use crate::config::ensemble::{
+    repository_key, AgentConfig, ArtifactAccess, EnsembleConfig, OnFailure, StepKind,
+};
 use crate::error::{AgentError, EnsembleError};
 use crate::history::artifacts::{finalize_mode_name, RunArtifacts};
 use crate::history::model::{HistoryRecord, TokenTotals};
@@ -88,7 +92,7 @@ use crate::pipeline::engine::{
     DispatchRequest, PipelineAction, PipelineRun, PipelineRunSnapshot, SelectedWorkflowSnapshot,
     StepOutputTemplateContext, StepState,
 };
-use crate::pipeline::verdict::StepResult;
+use crate::pipeline::verdict::{StepOutput, StepResult};
 use crate::timeline::persistence::TimelinePersistence;
 use crate::tracker::model::{Issue, RetryEntry, RunningEntry};
 use crate::tracker::{IssueTracker, OwnershipClaim, OwnershipLease};
@@ -119,6 +123,107 @@ use state::{
     RepoFinalizeState, WaitingOnHumanEntry,
 };
 
+fn immutable_artifact_verification_failure(error: impl std::fmt::Display) -> StepOutput {
+    StepOutput {
+        result: StepResult::Failed {
+            summary: format!("immutable Artifact input could not be verified: {error}"),
+        },
+        summary: Some("immutable Artifact input could not be verified".to_string()),
+        output: None,
+    }
+}
+
+fn artifact_snapshot_capture_failure(error: impl std::fmt::Display) -> StepOutput {
+    StepOutput {
+        result: StepResult::Failed {
+            summary: format!("artifact snapshot capture failed: {error}"),
+        },
+        summary: Some("artifact snapshot capture failed".to_string()),
+        output: None,
+    }
+}
+
+fn worker_failure_output(error: String) -> StepOutput {
+    StepOutput {
+        result: StepResult::Failed {
+            summary: error.clone(),
+        },
+        summary: Some(error),
+        output: None,
+    }
+}
+
+struct SuccessfulWorkerExitAction {
+    action: PipelineAction,
+    config_snapshot: Option<Arc<EnsembleConfig>>,
+    step_transition: Option<PipelineTransitionInput>,
+    integrity_failed: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StepDispatchFailureKind {
+    Ordinary,
+    ImmutableIntegrity,
+}
+
+#[derive(Debug)]
+struct StepDispatchError {
+    kind: StepDispatchFailureKind,
+    error: EnsembleError,
+}
+
+impl StepDispatchError {
+    fn ordinary(error: impl Into<EnsembleError>) -> Self {
+        Self {
+            kind: StepDispatchFailureKind::Ordinary,
+            error: error.into(),
+        }
+    }
+
+    fn immutable_integrity(error: impl Into<EnsembleError>) -> Self {
+        Self {
+            kind: StepDispatchFailureKind::ImmutableIntegrity,
+            error: error.into(),
+        }
+    }
+}
+
+impl From<EnsembleError> for StepDispatchError {
+    fn from(error: EnsembleError) -> Self {
+        Self::ordinary(error)
+    }
+}
+
+impl From<AgentError> for StepDispatchError {
+    fn from(error: AgentError) -> Self {
+        Self::ordinary(error)
+    }
+}
+
+impl std::fmt::Display for StepDispatchError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(formatter)
+    }
+}
+
+fn immutable_artifact_access_enforcement(
+    agent: Option<&AgentConfig>,
+) -> artifact::ArtifactAccessEnforcement {
+    match agent {
+        Some(agent)
+            if crate::agent::runtime::RuntimeKind::for_agent(agent)
+                == crate::agent::runtime::RuntimeKind::Acpx =>
+        {
+            if agent.permission_mode.as_deref() == Some("deny_all") {
+                artifact::ArtifactAccessEnforcement::AcpxDenyAll
+            } else {
+                artifact::ArtifactAccessEnforcement::AcpxApproveReads
+            }
+        }
+        _ => artifact::ArtifactAccessEnforcement::DirectAcpUnsupported,
+    }
+}
+
 struct StepDispatchContext<'a> {
     step_name: &'a str,
     agent_name: &'a str,
@@ -145,6 +250,32 @@ struct PendingWorkerReservation {
     identity: WorkerIdentity,
     completion: Option<watch::Sender<bool>>,
 }
+
+/// A worker task exists behind `start_gate`, but cannot call an agent runtime
+/// until `expected` is durably visible. `StepLaunched` is launch authority,
+/// not proof that the child processed instructions.
+struct PendingImmutableLaunch {
+    issue: Issue,
+    expected: PipelineTransitionInput,
+    identity: WorkerIdentity,
+    reservation: PendingWorkerReservation,
+    start_gate: oneshot::Sender<()>,
+    local_event_rx: mpsc::Receiver<WorkerEvent>,
+    previous_step_state: StepState,
+    running_session_id: String,
+    evidence: artifact::ArtifactAccessEvidence,
+    previous_evidence: Option<artifact::ArtifactAccessEvidence>,
+    retired_interaction: Option<(InteractionRequest, InteractionRequest)>,
+}
+
+struct ArtifactWorkerExitOutcome {
+    output: StepOutput,
+    captured_snapshot: Option<artifact::ArtifactSnapshot>,
+    deferred_sibling_exits: Vec<OrchestratorWorkerEvent>,
+    integrity_failed: bool,
+}
+
+type ImmutablePostcheckOutcome = (StepOutput, Vec<OrchestratorWorkerEvent>, bool);
 
 impl PendingWorkerReservation {
     fn new(
@@ -486,6 +617,8 @@ pub struct Orchestrator {
     pipeline_journal_restored: AtomicBool,
     pending_run_started_transitions:
         Box<std::sync::Mutex<HashMap<String, PendingRunStartedTransition>>>,
+    /// Immutable workers waiting for exact `StepLaunched` reconciliation.
+    pending_immutable_launches: std::sync::Mutex<HashMap<WorkerIdentity, PendingImmutableLaunch>>,
     pending_acceptance_transitions: std::sync::Mutex<HashMap<String, PendingAcceptanceTransition>>,
     /// Remote claims held only until their first synchronous `RunStarted` journal append.
     pending_ownership_leases: std::sync::Mutex<HashMap<String, OwnershipLease>>,
@@ -821,6 +954,7 @@ impl Orchestrator {
             pipeline_journal: PipelineRunJournal::new(config_dir.to_path_buf()),
             pipeline_journal_restored: AtomicBool::new(false),
             pending_run_started_transitions: Box::new(std::sync::Mutex::new(HashMap::new())),
+            pending_immutable_launches: std::sync::Mutex::new(HashMap::new()),
             pending_acceptance_transitions: std::sync::Mutex::new(HashMap::new()),
             pending_ownership_leases: std::sync::Mutex::new(HashMap::new()),
             event_bus: parts.event_bus,
@@ -1151,6 +1285,7 @@ impl Orchestrator {
         }
 
         Box::pin(self.reconcile_pending_run_started_transitions()).await;
+        self.reconcile_pending_immutable_launches().await;
         self.reconcile_pending_acceptance_transitions().await;
         self.restore_pipeline_runs_from_journal().await;
         self.reconcile_parked_recovery_attention().await;
@@ -2355,6 +2490,147 @@ impl Orchestrator {
         }
     }
 
+    async fn reconcile_pending_immutable_launches(&self) {
+        let identities = self
+            .pending_immutable_launches
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for identity in identities {
+            let Some(pending) = self
+                .pending_immutable_launches
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .remove(&identity)
+            else {
+                continue;
+            };
+            let transaction = self
+                .pipeline_journal
+                .begin_issue_transition(&pending.issue.id)
+                .await;
+            match transaction.latest_record_matches(&pending.expected).await {
+                Ok(true) => self.release_immutable_launch(pending).await,
+                Ok(false) => {
+                    self.rollback_unconfirmed_immutable_launch(pending, &transaction)
+                        .await;
+                }
+                Err(error) => {
+                    warn!(
+                        issue_id = %pending.issue.id,
+                        step = %pending.identity.step_name,
+                        error = %error,
+                        "immutable worker launch remains ambiguous; retaining its closed gate"
+                    );
+                    self.pending_immutable_launches
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .insert(identity, pending);
+                }
+            }
+        }
+    }
+
+    async fn release_immutable_launch(&self, pending: PendingImmutableLaunch) {
+        let PendingImmutableLaunch {
+            identity,
+            reservation,
+            start_gate,
+            local_event_rx,
+            ..
+        } = pending;
+        match reservation.mark_launched() {
+            Ok(completion_tx) => {
+                tokio::spawn(bridge_worker_events(
+                    local_event_rx,
+                    self.worker_tx.clone(),
+                    self.cancellation_registry.clone(),
+                    identity,
+                    completion_tx,
+                ));
+                let _ = start_gate.send(());
+            }
+            Err(error) => {
+                warn!(error = %error, "durably committed immutable worker could not be released");
+            }
+        }
+    }
+
+    async fn rollback_unconfirmed_immutable_launch(
+        &self,
+        pending: PendingImmutableLaunch,
+        transaction: &crate::orchestrator::pipeline_journal::PipelineIssueJournalTransaction<'_>,
+    ) {
+        let PendingImmutableLaunch {
+            issue,
+            identity,
+            previous_step_state,
+            running_session_id,
+            evidence,
+            previous_evidence,
+            retired_interaction,
+            ..
+        } = pending;
+        let rollback_transition = {
+            let mut state = self.state.write().await;
+            let Some(run) = state.get_pipeline_run_mut(&issue.id) else {
+                return;
+            };
+            if run.step_states.get(&identity.step_name)
+                != Some(&StepState::Running {
+                    session_id: running_session_id,
+                })
+            {
+                return;
+            }
+            run.step_states
+                .insert(identity.step_name.clone(), previous_step_state.clone());
+            run.clear_active_scheduler_reservation(&identity.step_name);
+            run.clear_immutable_consumer_launch_commitment(&identity.step_name);
+            run.restore_artifact_access_evidence(&evidence, previous_evidence);
+            let kind = match previous_step_state {
+                StepState::BlockedOnHuman { .. } => {
+                    Some(PipelineTransitionKind::StepBlockedOnHuman)
+                }
+                StepState::AwaitingApproval { .. } => {
+                    Some(PipelineTransitionKind::StepAwaitingApproval)
+                }
+                _ => None,
+            };
+            kind.and_then(|kind| {
+                Self::transition_input_for_run(
+                    &state,
+                    &issue.id,
+                    &issue.identifier,
+                    kind,
+                    Some(identity.step_name.clone()),
+                    Some("immutable worker launch was not durably committed".to_string()),
+                    None,
+                )
+            })
+        };
+        let restores_interaction = retired_interaction.is_some();
+        if let Some((previous, retired)) = retired_interaction {
+            if let Err(error) = self
+                .interaction_store
+                .restore_waiting_state_after_failed_transition(&retired, &previous)
+                .await
+            {
+                warn!(issue_id = %issue.id, interaction_id = %previous.id, error = %error, "failed to restore interaction after unconfirmed immutable launch");
+            }
+        }
+        if restores_interaction {
+            self.state.write().await.remove_running(&issue.id);
+        }
+        if let Some(transition) = rollback_transition {
+            if let Err(error) = transaction.append(transition).await {
+                warn!(issue_id = %issue.id, step = %identity.step_name, error = %error, "failed to persist unconfirmed immutable launch rollback");
+            }
+        }
+    }
+
     async fn dispatch_ready_active_pipelines(&self, permit: &DispatchPermit) {
         let mut active_issue_ids = {
             let state = self.state.read().await;
@@ -2457,6 +2733,7 @@ impl Orchestrator {
             let workspace_path = match self.prepare_step_workspace(&issue, &config_snapshot).await {
                 Ok(path) => path,
                 Err(error) => {
+                    let error = StepDispatchError::ordinary(error);
                     self.handle_step_dispatch_error(
                         &issue,
                         &request.step_name,
@@ -2532,7 +2809,10 @@ impl Orchestrator {
         let Some(record) = record else {
             return Ok(None);
         };
-        if record.kind != PipelineTransitionKind::StepRunning {
+        if !matches!(
+            record.kind,
+            PipelineTransitionKind::StepRunning | PipelineTransitionKind::StepLaunched
+        ) {
             return Ok(None);
         }
         let Some(interaction_id) = interaction_id_from_resume_reason(record.reason.as_deref())
@@ -2598,7 +2878,7 @@ impl Orchestrator {
         issue: &Issue,
         step_name: &str,
         config_snapshot: &Arc<EnsembleConfig>,
-        error: &EnsembleError,
+        error: &StepDispatchError,
     ) {
         warn!(
             issue_id = %issue.id,
@@ -2606,6 +2886,108 @@ impl Orchestrator {
             error = %error,
             "failed to persist step dispatch"
         );
+        let immutable_integrity_failure = error.kind == StepDispatchFailureKind::ImmutableIntegrity;
+        if immutable_integrity_failure {
+            let mut sibling_handles = mark_issue_for_drain(&self.cancellation_registry, &issue.id);
+            if !self
+                .await_worker_drain_with_event_pump(
+                    &mut sibling_handles,
+                    WORKER_DRAIN_TIMEOUT,
+                    DrainEventMode::ApplyExceptIssue(&issue.id),
+                )
+                .await
+            {
+                warn!(issue_id = %issue.id, step = step_name, "immutable Artifact halt could not drain siblings");
+                return;
+            }
+            remove_drained_workers(&self.cancellation_registry, &sibling_handles);
+            let journal_transaction = self
+                .pipeline_journal
+                .begin_issue_transition(&issue.id)
+                .await;
+            let mut state = self.state.write().await;
+            let Some(entry) = state.get_running(&issue.id) else {
+                return;
+            };
+            let Some(run) = state.get_pipeline_run(&issue.id) else {
+                return;
+            };
+            let mut halted_run = run.clone();
+            halted_run.step_failed(step_name, error.to_string());
+            let transition = PipelineTransitionInput {
+                kind: PipelineTransitionKind::PipelineHalted,
+                issue_id: issue.id.clone(),
+                identifier: entry.identifier.clone(),
+                run_id: entry.run_id.clone(),
+                cycle: halted_run.cycle,
+                step: Some(step_name.to_string()),
+                reason: Some(error.to_string()),
+                retry: None,
+                snapshot: Some(halted_run.to_snapshot()),
+                terminal_transition: None,
+                delivery: None,
+            };
+            let transition_is_durable = match journal_transaction.append(transition.clone()).await {
+                Ok(_) => true,
+                Err(append_error) => {
+                    match journal_transaction.latest_record_matches(&transition).await {
+                        Ok(true) => true,
+                        Ok(false) => {
+                            warn!(
+                                issue_id = %issue.id,
+                                step = step_name,
+                                error = %append_error,
+                                "immutable Artifact halt was not durably committed; retaining running owner"
+                            );
+                            false
+                        }
+                        Err(reconciliation_error) => {
+                            warn!(
+                                issue_id = %issue.id,
+                                step = step_name,
+                                append_error = %append_error,
+                                reconciliation_error = %reconciliation_error,
+                                "immutable Artifact halt remains ambiguous; retaining running owner"
+                            );
+                            false
+                        }
+                    }
+                }
+            };
+            if !transition_is_durable {
+                return;
+            }
+            let Some(run) = state.get_pipeline_run_mut(&issue.id) else {
+                return;
+            };
+            run.step_failed(step_name, error.to_string());
+            let agent_name = run
+                .step(step_name)
+                .map(|step| step.agent.clone())
+                .unwrap_or_default();
+            let entry = state
+                .remove_running(&issue.id)
+                .expect("validated immutable halt owner is still running");
+            state.add_runtime_seconds(&entry);
+            state.add_waiting_on_human(WaitingOnHumanEntry {
+                issue_id: issue.id.clone(),
+                identifier: entry.identifier.clone(),
+                interaction_request_id: format!("halted:{}:{step_name}", issue.id),
+                step_name: step_name.to_string(),
+                kind: InteractionKind::Handoff,
+                prompt: error.to_string(),
+                agent_name,
+                retry_attempt: entry.retry_attempt,
+                started_at: Some(entry.started_at),
+                agent_input_tokens: entry.agent_input_tokens,
+                agent_output_tokens: entry.agent_output_tokens,
+                agent_total_tokens: entry.agent_total_tokens,
+                requested_at: Utc::now(),
+                run_id: entry.run_id.clone(),
+                issue: Some(entry.issue),
+            });
+            return;
+        }
         let terminal = {
             let mut state = self.state.write().await;
             let Some(run) = state.get_pipeline_run_mut(&issue.id) else {
@@ -3108,14 +3490,33 @@ impl Orchestrator {
     }
 
     /// Dispatch a single pipeline step after its workspace is ready.
-    async fn dispatch_step(
+    // Keep the #480 immutable preflight disposition out of callers that already retain event or
+    // terminal-lifecycle state on a Tokio worker stack.
+    fn dispatch_step<'a>(
+        &'a self,
+        issue: &'a Issue,
+        config_snapshot: Arc<EnsembleConfig>,
+        dispatch: StepDispatchContext<'a>,
+        permit: &'a DispatchPermit,
+    ) -> Pin<Box<dyn Future<Output = Result<StepDispatchOutcome, StepDispatchError>> + Send + 'a>>
+    {
+        Box::pin(self.dispatch_step_inner(issue, config_snapshot, dispatch, permit))
+    }
+
+    async fn dispatch_step_inner(
         &self,
         issue: &Issue,
         config_snapshot: Arc<EnsembleConfig>,
         dispatch: StepDispatchContext<'_>,
         _permit: &DispatchPermit,
-    ) -> Result<StepDispatchOutcome, EnsembleError> {
-        let (worker_identity, issue_snapshot) = {
+    ) -> Result<StepDispatchOutcome, StepDispatchError> {
+        let (
+            worker_identity,
+            issue_snapshot,
+            immutable_inputs,
+            immutable_input_count,
+            artifact_access,
+        ) = {
             let state = self.state.read().await;
             let running_entry =
                 state
@@ -3144,6 +3545,34 @@ impl Orchestrator {
                         dispatch.step_name
                     ),
                 })?;
+            let (immutable_inputs, immutable_input_count): (
+                Vec<artifact::ArtifactSnapshot>,
+                usize,
+            ) = state
+                .get_pipeline_run(&issue.id)
+                .filter(|run| {
+                    run.artifact_inputs_for(dispatch.step_name)
+                        .is_some_and(|(_, access)| access == ArtifactAccess::Immutable)
+                })
+                .map(|run| {
+                    let producers = run
+                        .artifact_inputs_for(dispatch.step_name)
+                        .expect("immutable Artifact access has resolved inputs")
+                        .0;
+                    (
+                        producers
+                            .iter()
+                            .filter_map(|producer| run.artifact_snapshots.get(producer).cloned())
+                            .collect(),
+                        producers.len(),
+                    )
+                })
+                .unwrap_or_default();
+            let artifact_access = state
+                .get_pipeline_run(&issue.id)
+                .and_then(|run| run.artifact_inputs_for(dispatch.step_name))
+                .map(|(_, access)| access)
+                .unwrap_or_default();
             (
                 WorkerIdentity {
                     issue_id: issue.id.clone(),
@@ -3153,9 +3582,22 @@ impl Orchestrator {
                     started_at: running_entry.started_at,
                 },
                 running_entry.issue.clone(),
+                immutable_inputs,
+                immutable_input_count,
+                artifact_access,
             )
         };
         let issue = &issue_snapshot;
+        if immutable_inputs.len() != immutable_input_count {
+            return Err(StepDispatchError::immutable_integrity(
+                AgentError::PromptError {
+                    reason: format!(
+                        "immutable Artifact input is unavailable before step '{}'",
+                        dispatch.step_name
+                    ),
+                },
+            ));
+        }
         let cancel_token = tokio_util::sync::CancellationToken::new();
         let (completion_tx, completion_rx) = watch::channel(false);
         let selected_lane = {
@@ -3226,7 +3668,7 @@ impl Orchestrator {
             .iter()
             .map(|(name, config)| (name.clone(), config.capacity))
             .collect();
-        match try_reserve_scheduler_worker(
+        match try_reserve_scheduler_worker_with_workspace_exclusivity(
             &self.cancellation_registry,
             worker_identity.clone(),
             cancel_token.clone(),
@@ -3236,6 +3678,7 @@ impl Orchestrator {
             worker_capacity,
             &resource_capacities,
             scheduler_reservation.clone(),
+            artifact_access == ArtifactAccess::Immutable,
         ) {
             Ok(()) => {}
             Err(
@@ -3243,7 +3686,8 @@ impl Orchestrator {
                 | WorkerReservationError::IssueCapacityExhausted
                 | WorkerReservationError::CapacityBucketExhausted
                 | WorkerReservationError::ResourceExhausted
-                | WorkerReservationError::PathConflict,
+                | WorkerReservationError::PathConflict
+                | WorkerReservationError::IssueWorkspaceExclusive,
             ) => {
                 debug!(
                     issue_id = %issue.id,
@@ -3267,6 +3711,51 @@ impl Orchestrator {
             worker_identity.clone(),
             completion_tx,
         );
+        if !immutable_inputs.is_empty() {
+            let repositories = self
+                .workspace_mgr
+                .owned_worktree_paths(&issue.id)
+                .map(|paths| paths.into_iter().collect::<BTreeMap<_, _>>())
+                .map_err(|error| StepDispatchError::immutable_integrity(AgentError::PromptError {
+                    reason: format!(
+                        "immutable Artifact input could not be verified: prepared worktree unavailable: {error}"
+                    ),
+                }))?;
+            let violations = artifact::verify_immutable_inputs(
+                dispatch.step_name,
+                &immutable_inputs,
+                &repositories,
+            )
+            .await
+            .map_err(|reason| {
+                StepDispatchError::immutable_integrity(AgentError::PromptError {
+                    reason: format!("immutable Artifact input could not be verified: {reason}"),
+                })
+            })?;
+            if !violations.is_empty() {
+                if let Some(run) = self.state.write().await.get_pipeline_run_mut(&issue.id) {
+                    run.record_artifact_integrity_violations(violations.clone());
+                }
+                return Err(StepDispatchError::immutable_integrity(
+                    AgentError::PromptError {
+                        reason: format!(
+                            "immutable Artifact input changed before step '{}': {}",
+                            dispatch.step_name,
+                            violations
+                                .iter()
+                                .map(|violation| format!(
+                                    "{}:{} ({})",
+                                    violation.producer_step,
+                                    violation.repository,
+                                    violation.artifact_identity
+                                ))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ),
+                    },
+                ));
+            }
+        }
         info!(
             event = STEP_STARTED,
             issue_id = %issue.id,
@@ -3322,6 +3811,14 @@ impl Orchestrator {
             .pipeline_journal
             .begin_issue_transition(&issue.id)
             .await;
+        let artifact_access_evidence = (artifact_access == ArtifactAccess::Immutable).then(|| {
+            artifact::ArtifactAccessEvidence {
+                consumer_step: dispatch.step_name.to_string(),
+                enforcement: immutable_artifact_access_enforcement(
+                    config_snapshot.agents.get(dispatch.agent_name),
+                ),
+            }
+        });
 
         // Mark step as running in pipeline
         let (
@@ -3331,6 +3828,7 @@ impl Orchestrator {
             step_running_transition,
             previous_step_state,
             running_session_id,
+            previous_artifact_access_evidence,
         ) = {
             let mut state = self.state.write().await;
             let step_owner_is_current = state
@@ -3368,6 +3866,9 @@ impl Orchestrator {
                             dispatch.step_name
                         ),
                     })?;
+            let previous_artifact_access_evidence = artifact_access_evidence
+                .as_ref()
+                .and_then(|evidence| run.record_artifact_access_evidence(evidence.clone()));
             let previous_step_state = run.step_states.get(dispatch.step_name).cloned();
             let running_session_id = format!(
                 "{}-{}-{}",
@@ -3393,6 +3894,7 @@ impl Orchestrator {
                 transition,
                 previous_step_state,
                 running_session_id,
+                previous_artifact_access_evidence,
             )
         };
 
@@ -3420,6 +3922,12 @@ impl Orchestrator {
                                 run.step_states
                                     .insert(dispatch.step_name.to_string(), previous_step_state);
                                 run.clear_active_scheduler_reservation(dispatch.step_name);
+                                if let Some(evidence) = artifact_access_evidence.as_ref() {
+                                    run.restore_artifact_access_evidence(
+                                        evidence,
+                                        previous_artifact_access_evidence.clone(),
+                                    );
+                                }
                             }
                         }
                         return Err(AgentError::PromptError {
@@ -3450,72 +3958,87 @@ impl Orchestrator {
             }
         }
 
-        if let Some(interaction_id) = dispatch.interaction_to_retire {
-            if let Err(interaction_error) = self
+        let retired_interaction = if let Some(interaction_id) = dispatch.interaction_to_retire {
+            match self
                 .interaction_store
                 .retire_waiting_state(interaction_id)
                 .await
             {
-                let derived_rollback_transition = {
-                    let mut state = self.state.write().await;
-                    let run = state.get_pipeline_run_mut(&issue.id);
-                    if let Some(run) = run {
-                        if run.step_states.get(dispatch.step_name)
-                            == Some(&StepState::Running {
-                                session_id: running_session_id.clone(),
-                            })
-                        {
-                            if let Some(previous_step_state) = previous_step_state.clone() {
-                                run.step_states
-                                    .insert(dispatch.step_name.to_string(), previous_step_state);
-                                run.clear_active_scheduler_reservation(dispatch.step_name);
+                Ok(retired) => Some(retired),
+                Err(interaction_error) => {
+                    let derived_rollback_transition = {
+                        let mut state = self.state.write().await;
+                        let run = state.get_pipeline_run_mut(&issue.id);
+                        if let Some(run) = run {
+                            if run.step_states.get(dispatch.step_name)
+                                == Some(&StepState::Running {
+                                    session_id: running_session_id.clone(),
+                                })
+                            {
+                                if let Some(previous_step_state) = previous_step_state.clone() {
+                                    run.step_states.insert(
+                                        dispatch.step_name.to_string(),
+                                        previous_step_state,
+                                    );
+                                    run.clear_active_scheduler_reservation(dispatch.step_name);
+                                    if let Some(evidence) = artifact_access_evidence.as_ref() {
+                                        run.restore_artifact_access_evidence(
+                                            evidence,
+                                            previous_artifact_access_evidence.clone(),
+                                        );
+                                    }
+                                }
                             }
                         }
-                    }
-                    let rollback_kind = match previous_step_state {
-                        Some(StepState::BlockedOnHuman { .. }) => {
-                            Some(PipelineTransitionKind::StepBlockedOnHuman)
-                        }
-                        Some(StepState::AwaitingApproval { .. }) => {
-                            Some(PipelineTransitionKind::StepAwaitingApproval)
-                        }
-                        _ => None,
+                        let rollback_kind = match previous_step_state {
+                            Some(StepState::BlockedOnHuman { .. }) => {
+                                Some(PipelineTransitionKind::StepBlockedOnHuman)
+                            }
+                            Some(StepState::AwaitingApproval { .. }) => {
+                                Some(PipelineTransitionKind::StepAwaitingApproval)
+                            }
+                            _ => None,
+                        };
+                        rollback_kind.and_then(|kind| {
+                            Self::transition_input_for_run(
+                                &state,
+                                &issue.id,
+                                &issue.identifier,
+                                kind,
+                                Some(dispatch.step_name.to_string()),
+                                Some(format!(
+                                    "interaction '{}' retirement failed: {interaction_error}",
+                                    interaction_id
+                                )),
+                                None,
+                            )
+                        })
                     };
-                    rollback_kind.and_then(|kind| {
-                        Self::transition_input_for_run(
-                            &state,
-                            &issue.id,
-                            &issue.identifier,
-                            kind,
-                            Some(dispatch.step_name.to_string()),
-                            Some(format!(
-                                "interaction '{}' retirement failed: {interaction_error}",
-                                interaction_id
-                            )),
-                            None,
-                        )
-                    })
-                };
-                let rollback_transition = dispatch
-                    .interaction_retirement_rollback
-                    .clone()
-                    .or(derived_rollback_transition);
-                if let Some(rollback_transition) = rollback_transition {
-                    if let Err(rollback_error) =
-                        journal_transaction.append(rollback_transition).await
-                    {
-                        warn!(
-                            issue_id = %issue.id,
-                            step = dispatch.step_name,
-                            interaction_id,
-                            error = %rollback_error,
-                            "failed to persist blocked owner after interaction retirement failure"
-                        );
+                    let rollback_transition = dispatch
+                        .interaction_retirement_rollback
+                        .clone()
+                        .or(derived_rollback_transition);
+                    if let Some(rollback_transition) = rollback_transition {
+                        if let Err(rollback_error) =
+                            journal_transaction.append(rollback_transition).await
+                        {
+                            warn!(
+                                issue_id = %issue.id,
+                                step = dispatch.step_name,
+                                interaction_id,
+                                error = %rollback_error,
+                                "failed to persist blocked owner after interaction retirement failure"
+                            );
+                        }
                     }
+                    return Err(StepDispatchError::ordinary(EnsembleError::from(
+                        interaction_error,
+                    )));
                 }
-                return Err(interaction_error.into());
             }
-        }
+        } else {
+            None
+        };
 
         self.publish_pipeline_event(
             run_id,
@@ -3531,7 +4054,8 @@ impl Orchestrator {
         )
         .await;
 
-        // Spawn worker task
+        // Spawn worker task. Immutable consumers wait behind a gate until a
+        // `StepLaunched` snapshot commits their authority to run.
         let issue_clone = issue.clone();
         let step_name_owned = dispatch.step_name.to_string();
         let agent_name_owned = dispatch.agent_name.to_string();
@@ -3542,10 +4066,120 @@ impl Orchestrator {
         let attempt = dispatch.attempt;
         let timeout_ms = dispatch.timeout_ms;
         let step_outputs = dispatch.step_outputs.clone();
-        let (local_event_tx, local_event_rx) = mpsc::channel(100);
+        if artifact_access == ArtifactAccess::Immutable {
+            let (start_gate, wait_for_launch) = oneshot::channel();
+            let local_event_rx = spawn_agent_worker(
+                runner,
+                config_snapshot,
+                issue_clone,
+                agent_name_owned,
+                step_name_owned,
+                dispatch.step_kind,
+                artifact_access,
+                attempt,
+                timeout_ms,
+                interaction_response,
+                workspace_path,
+                cancel_token,
+                step_outputs,
+                Some(wait_for_launch),
+            );
+
+            let launch_transition = {
+                let mut state = self.state.write().await;
+                let Some(run) = state.get_pipeline_run_mut(&issue.id) else {
+                    return Err(AgentError::PromptError {
+                        reason: format!(
+                            "cannot confirm immutable step '{}' launch without a pipeline run",
+                            dispatch.step_name
+                        ),
+                    }
+                    .into());
+                };
+                run.mark_immutable_consumer_launch_committed(dispatch.step_name);
+                Self::transition_input_for_run(
+                    &state,
+                    &issue.id,
+                    &issue.identifier,
+                    PipelineTransitionKind::StepLaunched,
+                    Some(dispatch.step_name.to_string()),
+                    dispatch.interaction_resume_id.map(|interaction_id| {
+                        format!("{INTERACTION_RESUME_REASON_PREFIX}{interaction_id}")
+                    }),
+                    None,
+                )
+            }
+            .expect("running immutable step has a transition snapshot");
+            let pending = PendingImmutableLaunch {
+                issue: issue.clone(),
+                expected: launch_transition.clone(),
+                identity: worker_identity.clone(),
+                reservation,
+                start_gate,
+                local_event_rx,
+                previous_step_state: previous_step_state
+                    .clone()
+                    .expect("immutable launch has a prior step state"),
+                running_session_id: running_session_id.clone(),
+                evidence: artifact_access_evidence
+                    .expect("immutable launch records access evidence"),
+                previous_evidence: previous_artifact_access_evidence,
+                retired_interaction,
+            };
+            match journal_transaction.append(launch_transition.clone()).await {
+                Ok(_) => self.release_immutable_launch(pending).await,
+                Err(error) => match journal_transaction
+                    .latest_record_matches(&launch_transition)
+                    .await
+                {
+                    Ok(true) => self.release_immutable_launch(pending).await,
+                    Ok(false) => {
+                        self.rollback_unconfirmed_immutable_launch(pending, &journal_transaction)
+                            .await;
+                        return Err(AgentError::PromptError {
+                            reason: format!(
+                                "failed to persist immutable step '{}' launch: {error}",
+                                dispatch.step_name
+                            ),
+                        }
+                        .into());
+                    }
+                    Err(reconciliation_error) => {
+                        warn!(
+                            issue_id = %issue.id,
+                            step = dispatch.step_name,
+                            append_error = %error,
+                            reconciliation_error = %reconciliation_error,
+                            "immutable worker launch remains ambiguous; retaining its closed gate"
+                        );
+                        self.pending_immutable_launches
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .insert(worker_identity, pending);
+                    }
+                },
+            }
+            return Ok(StepDispatchOutcome::Spawned);
+        }
         let bridge_registry = self.cancellation_registry.clone();
         let bridge_identity = worker_identity.clone();
         let completion_tx = reservation.mark_launched()?;
+        let local_event_rx = spawn_agent_worker(
+            runner,
+            config_snapshot,
+            issue_clone,
+            agent_name_owned,
+            step_name_owned,
+            dispatch.step_kind,
+            artifact_access,
+            attempt,
+            timeout_ms,
+            interaction_response,
+            workspace_path,
+            cancel_token,
+            step_outputs,
+            None,
+        );
         tokio::spawn(bridge_worker_events(
             local_event_rx,
             orchestrator_event_tx,
@@ -3553,43 +4187,17 @@ impl Orchestrator {
             bridge_identity,
             completion_tx,
         ));
-        tokio::spawn(async move {
-            let worker_result = catch_worker_panic(
-                runner.run(AgentRunRequest {
-                    config: Arc::clone(&config_snapshot),
-                    issue: &issue_clone,
-                    agent_name: &agent_name_owned,
-                    step_name: &step_name_owned,
-                    step_kind: dispatch.step_kind,
-                    attempt,
-                    timeout_ms,
-                    interaction_response: interaction_response.clone(),
-                    workspace_path: &workspace_path,
-                    event_tx: local_event_tx.clone(),
-                    cancel_token,
-                    step_outputs,
-                }),
-                &issue_clone.id,
-                &step_name_owned,
-            )
-            .await;
-
-            let _ = local_event_tx
-                .send(WorkerEvent::WorkerExited {
-                    issue_id: issue_clone.id.clone(),
-                    step_name: step_name_owned,
-                    result: worker_result,
-                    timestamp: Utc::now(),
-                })
-                .await;
-        });
-
         Ok(StepDispatchOutcome::Spawned)
     }
 
     /// Handle a worker event from the channel.
     async fn handle_worker_event(&self, owned_event: OrchestratorWorkerEvent) {
-        let worker_exit_permit = if matches!(&owned_event.event, WorkerEvent::WorkerExited { .. }) {
+        let OrchestratorWorkerEvent {
+            identity,
+            event,
+            workspace_capture,
+        } = owned_event;
+        let worker_exit_permit = if matches!(&event, WorkerEvent::WorkerExited { .. }) {
             let Some(permit) = self.quiescing.begin_dispatch() else {
                 return;
             };
@@ -3597,8 +4205,7 @@ impl Orchestrator {
         } else {
             None
         };
-        let identity = owned_event.identity;
-        let event_matches_identity = match &owned_event.event {
+        let event_matches_identity = match &event {
             WorkerEvent::AgentUpdate {
                 issue_id,
                 step_name,
@@ -3618,7 +4225,7 @@ impl Orchestrator {
         }
 
         let reconciliation_owned = is_reconciliation_owned(&self.cancellation_registry, &identity);
-        match owned_event.event {
+        match event {
             WorkerEvent::AgentUpdate {
                 issue_id,
                 step_name,
@@ -3631,52 +4238,75 @@ impl Orchestrator {
                 self.handle_agent_update(&issue_id, &step_name, agent_event, timestamp)
                     .await;
             }
-            WorkerEvent::WorkerExited {
-                issue_id,
-                step_name,
-                result,
-                ..
-            } => {
-                if !reconciliation_owned {
-                    if worker_result_halts_pipeline(&result) {
-                        let mut sibling_handles =
-                            mark_issue_for_drain(&self.cancellation_registry, &issue_id);
-                        if !self
-                            .await_worker_drain_with_event_pump(
-                                &mut sibling_handles,
-                                WORKER_DRAIN_TIMEOUT,
-                                DrainEventMode::ApplyExceptIssue(&issue_id),
-                            )
-                            .await
-                        {
-                            warn!(
-                                issue_id = %issue_id,
-                                step = %step_name,
-                                siblings = sibling_handles.len(),
-                                "parallel sibling drain timed out before failure disposition"
-                            );
-                            return;
-                        }
-                        remove_drained_workers(&self.cancellation_registry, &sibling_handles);
-                        if !self.worker_identity_is_current(&identity).await {
-                            return;
-                        }
-                    }
-                    self.handle_worker_exit_with_permit(
-                        &issue_id,
-                        &step_name,
-                        result,
-                        worker_exit_permit
-                            .as_ref()
-                            .expect("worker exit has a dispatch permit"),
-                    )
-                    .await;
-                }
+            WorkerEvent::WorkerExited { result, .. } => {
+                self.handle_worker_exit_event(
+                    result,
+                    identity,
+                    reconciliation_owned,
+                    workspace_capture.is_some(),
+                    worker_exit_permit
+                        .as_ref()
+                        .expect("worker exit has a dispatch permit"),
+                )
+                .await;
             }
         }
+        drop(workspace_capture);
         if let Some(permit) = worker_exit_permit.as_ref() {
             self.dispatch_ready_active_pipelines(permit).await;
         }
+    }
+
+    // Do not retain the worker event, sibling-drain state, and the terminal lifecycle state
+    // machine in one Tokio poll frame. This is the worker-exit boundary; downstream lifecycle
+    // boundaries remain unchanged.
+    fn handle_worker_exit_event<'a>(
+        &'a self,
+        result: WorkerResult,
+        identity: WorkerIdentity,
+        reconciliation_owned: bool,
+        workspace_capture_held: bool,
+        permit: &'a DispatchPermit,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            let issue_id = identity.issue_id.clone();
+            let step_name = identity.step_name.clone();
+            if reconciliation_owned {
+                return;
+            }
+            if worker_result_halts_pipeline(&result) {
+                let mut sibling_handles =
+                    mark_issue_for_drain(&self.cancellation_registry, &issue_id);
+                if !self
+                    .await_worker_drain_with_event_pump(
+                        &mut sibling_handles,
+                        WORKER_DRAIN_TIMEOUT,
+                        DrainEventMode::ApplyExceptIssue(&issue_id),
+                    )
+                    .await
+                {
+                    warn!(
+                        issue_id = %issue_id,
+                        step = %step_name,
+                        siblings = sibling_handles.len(),
+                        "parallel sibling drain timed out before failure disposition"
+                    );
+                    return;
+                }
+                remove_drained_workers(&self.cancellation_registry, &sibling_handles);
+                if !self.worker_identity_is_current(&identity).await {
+                    return;
+                }
+            }
+            self.handle_worker_exit_with_permit(
+                &issue_id,
+                &step_name,
+                result,
+                workspace_capture_held,
+                permit,
+            )
+            .await;
+        })
     }
 
     #[cfg(test)]
@@ -4274,13 +4904,321 @@ impl Orchestrator {
         }
     }
 
+    // The immutable post-check awaits workspace drains and Git observations. Keep it out of the
+    // worker-exit future so the expanded Artifact evidence cannot inflate the normal acceptance
+    // and terminal-transition poll stack.
+    fn verify_immutable_inputs_after_worker_exit<'a>(
+        &'a self,
+        issue_id: &'a str,
+        step_name: &'a str,
+        output: crate::pipeline::verdict::StepOutput,
+        workspace_capture_held: bool,
+    ) -> Pin<Box<dyn Future<Output = ImmutablePostcheckOutcome> + Send + 'a>> {
+        Box::pin(self.verify_immutable_inputs_after_worker_exit_inner(
+            issue_id,
+            step_name,
+            output,
+            workspace_capture_held,
+        ))
+    }
+
+    async fn verify_immutable_inputs_after_worker_exit_inner(
+        &self,
+        issue_id: &str,
+        step_name: &str,
+        mut output: crate::pipeline::verdict::StepOutput,
+        workspace_capture_held: bool,
+    ) -> (
+        crate::pipeline::verdict::StepOutput,
+        Vec<OrchestratorWorkerEvent>,
+        bool,
+    ) {
+        let immutable_inputs: Vec<artifact::ArtifactSnapshot> = {
+            let state = self.state.read().await;
+            state
+                .get_pipeline_run(issue_id)
+                .filter(|run| {
+                    run.artifact_inputs_for(step_name)
+                        .is_some_and(|(_, access)| access == ArtifactAccess::Immutable)
+                })
+                .map(|run| {
+                    run.artifact_inputs_for(step_name)
+                        .expect("immutable Artifact access has resolved inputs")
+                        .0
+                        .iter()
+                        .filter_map(|producer| run.artifact_snapshots.get(producer).cloned())
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        if immutable_inputs.is_empty() {
+            return (output, Vec::new(), false);
+        }
+
+        let _capture_guard = if workspace_capture_held {
+            None
+        } else {
+            Some(acquire_issue_workspace_capture(&self.cancellation_registry, issue_id).await)
+        };
+        let mut sibling_writers =
+            sibling_worker_completion_handles(&self.cancellation_registry, issue_id, step_name);
+        let deferred_exits = match self
+            .await_sibling_workspace_writers(issue_id, &mut sibling_writers)
+            .await
+        {
+            Ok(exits) => exits,
+            Err(error) => {
+                output = immutable_artifact_verification_failure(error);
+                return (output, Vec::new(), true);
+            }
+        };
+        let repositories = match self.workspace_mgr.owned_worktree_paths(issue_id) {
+            Ok(paths) => paths.into_iter().collect(),
+            Err(error) => {
+                output = immutable_artifact_verification_failure(error);
+                return (output, deferred_exits, true);
+            }
+        };
+        let mut integrity_failed = false;
+        match artifact::verify_immutable_inputs(step_name, &immutable_inputs, &repositories).await {
+            Ok(violations) if violations.is_empty() => {}
+            Ok(violations) => {
+                integrity_failed = true;
+                if let Some(run) = self.state.write().await.get_pipeline_run_mut(issue_id) {
+                    run.record_artifact_integrity_violations(violations.clone());
+                }
+                output = crate::pipeline::verdict::StepOutput {
+                    result: StepResult::Failed {
+                        summary: format!(
+                            "immutable Artifact input changed after step execution: {}",
+                            violations
+                                .iter()
+                                .map(|violation| format!(
+                                    "{}:{} ({})",
+                                    violation.producer_step,
+                                    violation.repository,
+                                    violation.artifact_identity
+                                ))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ),
+                    },
+                    summary: Some("immutable Artifact input changed".to_string()),
+                    output: None,
+                };
+            }
+            Err(error) => {
+                integrity_failed = true;
+                output = immutable_artifact_verification_failure(error);
+            }
+        }
+        (output, deferred_exits, integrity_failed)
+    }
+
+    // Producer capture and consumer verification both carry ArtifactSnapshot state. Type-erase
+    // this #480 addition so it cannot enlarge the acceptance and terminal failure poll chain.
+    fn process_artifacts_after_worker_exit<'a>(
+        &'a self,
+        issue_id: &'a str,
+        step_name: &'a str,
+        output: StepOutput,
+        capture_artifact: bool,
+        workspace_capture_held: bool,
+    ) -> Pin<Box<dyn Future<Output = Box<ArtifactWorkerExitOutcome>> + Send + 'a>> {
+        Box::pin(self.process_artifacts_after_worker_exit_inner(
+            issue_id,
+            step_name,
+            output,
+            capture_artifact,
+            workspace_capture_held,
+        ))
+    }
+
+    async fn process_artifacts_after_worker_exit_inner(
+        &self,
+        issue_id: &str,
+        step_name: &str,
+        mut output: StepOutput,
+        capture_artifact: bool,
+        workspace_capture_held: bool,
+    ) -> Box<ArtifactWorkerExitOutcome> {
+        let capture_request = if !capture_artifact
+            || matches!(output.result, StepResult::Failed { .. })
+        {
+            None
+        } else {
+            let state = self.state.read().await;
+            state.get_pipeline_run(issue_id).and_then(|run| {
+                run.artifact_snapshot_selection_for(step_name)
+                    .cloned()
+                    .map(|selection| {
+                        let running = state.running.get(issue_id);
+                        let run_id = running
+                            .and_then(|entry| entry.run_id.clone())
+                            .or_else(|| state.issue_run_ids.get(issue_id).cloned())
+                            .unwrap_or_else(|| issue_id.to_string());
+                        let attempt = running.and_then(|entry| entry.retry_attempt).unwrap_or(1);
+                        (run_id, run.cycle, attempt, selection)
+                    })
+            })
+        };
+        let mut captured_snapshot = None;
+        let mut deferred_sibling_exits = Vec::new();
+        if let Some((run_id, cycle, attempt, selection)) = capture_request {
+            let capture_guard = if workspace_capture_held {
+                None
+            } else {
+                Some(acquire_issue_workspace_capture(&self.cancellation_registry, issue_id).await)
+            };
+            let mut sibling_writers =
+                sibling_worker_completion_handles(&self.cancellation_registry, issue_id, step_name);
+            let capture_result = self
+                .await_sibling_workspace_writers(issue_id, &mut sibling_writers)
+                .await
+                .and_then(|deferred_exits| {
+                    deferred_sibling_exits = deferred_exits;
+                    self.workspace_mgr
+                        .owned_worktree_paths(issue_id)
+                        .map(|paths| paths.into_iter().collect::<BTreeMap<_, _>>())
+                        .map_err(|error| error.to_string())
+                });
+            match capture_result {
+                Ok(repositories) => match artifact::capture(
+                    &run_id,
+                    cycle,
+                    step_name,
+                    attempt,
+                    output.output.as_ref().unwrap_or(&serde_json::Value::Null),
+                    &selection,
+                    &repositories,
+                )
+                .await
+                {
+                    Ok(snapshot) => captured_snapshot = Some(snapshot),
+                    Err(error) => {
+                        output = artifact_snapshot_capture_failure(error);
+                    }
+                },
+                Err(error) => output = artifact_snapshot_capture_failure(error),
+            }
+            drop(capture_guard);
+        }
+        let (output, postcheck_exits, integrity_failed) = self
+            .verify_immutable_inputs_after_worker_exit(
+                issue_id,
+                step_name,
+                output,
+                workspace_capture_held,
+            )
+            .await;
+        deferred_sibling_exits.extend(postcheck_exits);
+        if integrity_failed {
+            captured_snapshot = None;
+        }
+        Box::new(ArtifactWorkerExitOutcome {
+            output,
+            captured_snapshot,
+            deferred_sibling_exits,
+            integrity_failed,
+        })
+    }
+
+    // Complete the #480 Artifact observation before re-entering the existing success/acceptance
+    // state machine. Keeping this boxed prevents the observation vectors from inflating that
+    // Tokio worker future.
+    fn process_successful_worker_exit<'a>(
+        &'a self,
+        issue_id: &'a str,
+        step_name: &'a str,
+        issue_identifier: Option<&'a str>,
+        output: StepOutput,
+        has_approval_request: bool,
+        workspace_capture_held: bool,
+    ) -> Pin<Box<dyn Future<Output = Option<SuccessfulWorkerExitAction>> + Send + 'a>> {
+        Box::pin(self.process_successful_worker_exit_inner(
+            issue_id,
+            step_name,
+            issue_identifier,
+            output,
+            has_approval_request,
+            workspace_capture_held,
+        ))
+    }
+
+    async fn process_successful_worker_exit_inner(
+        &self,
+        issue_id: &str,
+        step_name: &str,
+        issue_identifier: Option<&str>,
+        output: StepOutput,
+        has_approval_request: bool,
+        workspace_capture_held: bool,
+    ) -> Option<SuccessfulWorkerExitAction> {
+        let mut artifact_outcome = self
+            .process_artifacts_after_worker_exit(
+                issue_id,
+                step_name,
+                output,
+                true,
+                workspace_capture_held,
+            )
+            .await;
+        while let Some(event) = artifact_outcome.deferred_sibling_exits.pop() {
+            if self.worker_tx.send(event).await.is_err() {
+                warn!(issue_id = %issue_id, "failed to restore deferred sibling worker exit");
+            }
+        }
+        let captured_snapshot = artifact_outcome.captured_snapshot.take();
+        let integrity_failed = artifact_outcome.integrity_failed;
+        let output = artifact_outcome.output;
+        let verdict_value = match &output.result {
+            StepResult::Succeeded => "succeeded",
+            StepResult::Failed { .. } => "failed",
+            StepResult::Concern { .. } => "concern",
+        };
+        info!(
+            issue_id = %issue_id,
+            step = step_name,
+            verdict_value,
+            "received validated step result"
+        );
+        let mut state = self.state.write().await;
+        let run = match state.get_pipeline_run_mut(issue_id) {
+            Some(run) => run,
+            None => {
+                warn!(issue_id = %issue_id, "no pipeline run found for worker exit");
+                return None;
+            }
+        };
+        if let Some(snapshot) = captured_snapshot {
+            run.record_artifact_snapshot(step_name, snapshot);
+        }
+        let action = run.step_completed(step_name, output, has_approval_request);
+        let config_snapshot = state.get_pipeline_config(issue_id).cloned();
+        let step_transition = Self::transition_input_for_run(
+            &state,
+            issue_id,
+            issue_identifier.unwrap_or(issue_id),
+            Self::transition_kind_for_action(&action),
+            Some(step_name.to_string()),
+            Some(verdict_value.to_string()),
+            None,
+        );
+        Some(SuccessfulWorkerExitAction {
+            action,
+            config_snapshot,
+            step_transition,
+            integrity_failed,
+        })
+    }
+
     /// Handle a worker exit. Integrates with PipelineRun to drive step DAG.
     #[cfg(test)]
     async fn handle_worker_exit(&self, issue_id: &str, step_name: &str, result: WorkerResult) {
         let Some(permit) = self.quiescing.begin_dispatch() else {
             return;
         };
-        self.handle_worker_exit_with_permit(issue_id, step_name, result, &permit)
+        self.handle_worker_exit_with_permit(issue_id, step_name, result, false, &permit)
             .await;
     }
 
@@ -4291,12 +5229,14 @@ impl Orchestrator {
         issue_id: &'a str,
         step_name: &'a str,
         result: WorkerResult,
+        workspace_capture_held: bool,
         worker_exit_permit: &'a DispatchPermit,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         Box::pin(self.handle_worker_exit_with_permit_inner(
             issue_id,
             step_name,
             result,
+            workspace_capture_held,
             worker_exit_permit,
         ))
     }
@@ -4306,6 +5246,7 @@ impl Orchestrator {
         issue_id: &str,
         step_name: &str,
         result: WorkerResult,
+        workspace_capture_held: bool,
         worker_exit_permit: &DispatchPermit,
     ) {
         // Get the issue snapshot for potential re-dispatch
@@ -4325,131 +5266,27 @@ impl Orchestrator {
                     "worker exited successfully"
                 );
 
-                let capture_request = if matches!(output.result, StepResult::Failed { .. }) {
-                    None
-                } else {
-                    let state = self.state.read().await;
-                    state.get_pipeline_run(issue_id).and_then(|run| {
-                        run.artifact_snapshot_selection_for(step_name)
-                            .cloned()
-                            .map(|selection| {
-                                let running = state.running.get(issue_id);
-                                let run_id = running
-                                    .and_then(|entry| entry.run_id.clone())
-                                    .or_else(|| state.issue_run_ids.get(issue_id).cloned())
-                                    .unwrap_or_else(|| issue_id.to_string());
-                                let attempt =
-                                    running.and_then(|entry| entry.retry_attempt).unwrap_or(1);
-                                (run_id, run.cycle, attempt, selection)
-                            })
-                    })
-                };
-                let mut captured_snapshot = None;
-                let mut resolved_output = output;
-                let mut deferred_sibling_exits = Vec::new();
-                if let Some((run_id, cycle, attempt, selection)) = capture_request {
-                    let mut sibling_writers = sibling_worker_completion_handles(
-                        &self.cancellation_registry,
+                let successful_action = self
+                    .process_successful_worker_exit(
                         issue_id,
                         step_name,
-                    );
-                    let capture_result = self
-                        .await_sibling_workspace_writers(issue_id, &mut sibling_writers)
-                        .await
-                        .and_then(|deferred_exits| {
-                            deferred_sibling_exits = deferred_exits;
-                            self.workspace_mgr
-                                .owned_worktree_paths(issue_id)
-                                .map(|paths| paths.into_iter().collect::<BTreeMap<_, _>>())
-                                .map_err(|error| error.to_string())
-                        });
-                    match capture_result {
-                        Ok(repositories) => match artifact::capture(
-                            &run_id,
-                            cycle,
-                            step_name,
-                            attempt,
-                            resolved_output
-                                .output
-                                .as_ref()
-                                .unwrap_or(&serde_json::Value::Null),
-                            &selection,
-                            &repositories,
-                        )
-                        .await
-                        {
-                            Ok(snapshot) => captured_snapshot = Some(snapshot),
-                            Err(error) => {
-                                resolved_output = crate::pipeline::verdict::StepOutput {
-                                    result: StepResult::Failed {
-                                        summary: format!(
-                                            "artifact snapshot capture failed: {error}"
-                                        ),
-                                    },
-                                    summary: Some("artifact snapshot capture failed".to_string()),
-                                    output: None,
-                                };
-                            }
-                        },
-                        Err(error) => {
-                            resolved_output = crate::pipeline::verdict::StepOutput {
-                                result: StepResult::Failed {
-                                    summary: format!("artifact snapshot capture failed: {error}"),
-                                },
-                                summary: Some("artifact snapshot capture failed".to_string()),
-                                output: None,
-                            };
-                        }
-                    }
-                }
-
-                for event in deferred_sibling_exits {
-                    if self.worker_tx.send(event).await.is_err() {
-                        warn!(issue_id = %issue_id, "failed to restore deferred sibling worker exit");
-                    }
-                }
-
-                let mut state = self.state.write().await;
-
-                let verdict_value = match &resolved_output.result {
-                    StepResult::Succeeded => "succeeded",
-                    StepResult::Failed { .. } => "failed",
-                    StepResult::Concern { .. } => "concern",
-                };
-                info!(
-                    issue_id = %issue_id,
-                    step = step_name,
-                    verdict_value,
-                    "received validated step result"
-                );
-
-                // Drive the pipeline
-                let pipeline_action = if let Some(run) = state.get_pipeline_run_mut(issue_id) {
-                    if let Some(snapshot) = captured_snapshot {
-                        run.record_artifact_snapshot(step_name, snapshot);
-                    }
-                    Some((
-                        run.step_completed(step_name, resolved_output, approval_request.is_some()),
-                        state.get_pipeline_config(issue_id).cloned(),
-                    ))
-                } else {
-                    warn!(issue_id = %issue_id, "no pipeline run found for worker exit");
-                    None
-                };
-
-                if let Some((action, config_snapshot)) = pipeline_action {
-                    let step_transition = Self::transition_input_for_run(
-                        &state,
-                        issue_id,
                         issue_snapshot
                             .as_ref()
-                            .map(|issue| issue.identifier.as_str())
-                            .unwrap_or(issue_id),
-                        Self::transition_kind_for_action(&action),
-                        Some(step_name.to_string()),
-                        Some(verdict_value.to_string()),
-                        None,
-                    );
+                            .map(|issue| issue.identifier.as_str()),
+                        output,
+                        approval_request.is_some(),
+                        workspace_capture_held,
+                    )
+                    .await;
+
+                if let Some(SuccessfulWorkerExitAction {
+                    action,
+                    config_snapshot,
+                    step_transition,
+                    integrity_failed,
+                }) = successful_action
+                {
+                    let mut state = self.state.write().await;
                     match action {
                         PipelineAction::Dispatch(requests) => {
                             // Collect output contexts while state lock is still held
@@ -4706,11 +5543,15 @@ impl Orchestrator {
                                 .and_then(|run| run.step(&step))
                                 .cloned();
                             let step_config = config_snapshot.steps.iter().find(|s| s.name == step);
-                            let on_failure = runtime_step
-                                .as_ref()
-                                .map(|s| s.on_failure)
-                                .or_else(|| step_config.map(|s| s.on_failure))
-                                .unwrap_or_default();
+                            let on_failure = if integrity_failed {
+                                OnFailure::Halt
+                            } else {
+                                runtime_step
+                                    .as_ref()
+                                    .map(|s| s.on_failure)
+                                    .or_else(|| step_config.map(|s| s.on_failure))
+                                    .unwrap_or_default()
+                            };
                             match on_failure {
                                 OnFailure::RetryStep => {
                                     if let Some(run) = state.get_pipeline_run_mut(issue_id) {
@@ -5131,6 +5972,42 @@ impl Orchestrator {
                 }
             }
             WorkerResult::BlockedOnHuman { request } => {
+                // Keep the all-exit Artifact outcome boxed before entering interaction handling.
+                let artifact_outcome = self
+                    .process_artifacts_after_worker_exit(
+                        issue_id,
+                        step_name,
+                        StepOutput {
+                            result: StepResult::Succeeded,
+                            summary: None,
+                            output: None,
+                        },
+                        false,
+                        workspace_capture_held,
+                    )
+                    .await;
+                let ArtifactWorkerExitOutcome {
+                    output,
+                    deferred_sibling_exits,
+                    integrity_failed,
+                    ..
+                } = *artifact_outcome;
+                for event in deferred_sibling_exits {
+                    if self.worker_tx.send(event).await.is_err() {
+                        warn!(issue_id = %issue_id, "failed to restore deferred sibling worker exit");
+                    }
+                }
+                if integrity_failed {
+                    let reason = match output.result {
+                        StepResult::Failed { summary } => summary,
+                        StepResult::Succeeded | StepResult::Concern { .. } => {
+                            "immutable Artifact input could not be verified".to_string()
+                        }
+                    };
+                    self.handle_pipeline_step_failure(issue_id, step_name, reason, true)
+                        .await;
+                    return;
+                }
                 if let Err(error) = self
                     .handle_blocked_on_human(issue_id, step_name, &request, issue_snapshot.as_ref())
                     .await
@@ -5167,6 +6044,32 @@ impl Orchestrator {
                 }
             }
             WorkerResult::Failed { error, kind } => {
+                // Keep the #480 Artifact result off this already large failure/retry future.
+                let mut artifact_outcome = self
+                    .process_artifacts_after_worker_exit(
+                        issue_id,
+                        step_name,
+                        worker_failure_output(error.clone()),
+                        false,
+                        workspace_capture_held,
+                    )
+                    .await;
+                while let Some(event) = artifact_outcome.deferred_sibling_exits.pop() {
+                    if self.worker_tx.send(event).await.is_err() {
+                        warn!(issue_id = %issue_id, "failed to restore deferred sibling worker exit");
+                    }
+                }
+                if artifact_outcome.integrity_failed {
+                    let reason = match &artifact_outcome.output.result {
+                        StepResult::Failed { summary } => summary.clone(),
+                        StepResult::Succeeded | StepResult::Concern { .. } => {
+                            "immutable Artifact input could not be verified".to_string()
+                        }
+                    };
+                    self.handle_pipeline_step_failure(issue_id, step_name, reason, true)
+                        .await;
+                    return;
+                }
                 if kind == WorkerFailureKind::Timeout {
                     warn!(
                         issue_id = %issue_id,
@@ -5174,7 +6077,7 @@ impl Orchestrator {
                         error = %error,
                         "worker exited with timeout"
                     );
-                    self.handle_pipeline_step_failure(issue_id, step_name, error)
+                    self.handle_pipeline_step_failure(issue_id, step_name, error, false)
                         .await;
                     return;
                 }
@@ -5492,7 +6395,13 @@ impl Orchestrator {
         }
     }
 
-    async fn handle_pipeline_step_failure(&self, issue_id: &str, step: &str, reason: String) {
+    async fn handle_pipeline_step_failure(
+        &self,
+        issue_id: &str,
+        step: &str,
+        reason: String,
+        force_integrity_halt: bool,
+    ) {
         let mut state = self.state.write().await;
         let Some(config_snapshot) = state.get_pipeline_config(issue_id).cloned() else {
             warn!(
@@ -5535,11 +6444,15 @@ impl Orchestrator {
             .and_then(|run| run.step(step))
             .cloned();
         let step_config = config_snapshot.steps.iter().find(|s| s.name == step);
-        let on_failure = runtime_step
-            .as_ref()
-            .map(|s| s.on_failure)
-            .or_else(|| step_config.map(|s| s.on_failure))
-            .unwrap_or_default();
+        let on_failure = if force_integrity_halt {
+            OnFailure::Halt
+        } else {
+            runtime_step
+                .as_ref()
+                .map(|s| s.on_failure)
+                .or_else(|| step_config.map(|s| s.on_failure))
+                .unwrap_or_default()
+        };
 
         match on_failure {
             OnFailure::RetryStep => {
@@ -6632,8 +7545,10 @@ impl Orchestrator {
         }
         let repair_matches_durable_predecessor = match interaction.resume_strategy {
             InteractionResumeStrategy::RerunStep => {
-                latest_record.kind == PipelineTransitionKind::StepRunning
-                    && latest_record.cycle == interaction.pipeline_cycle
+                matches!(
+                    latest_record.kind,
+                    PipelineTransitionKind::StepRunning | PipelineTransitionKind::StepLaunched
+                ) && latest_record.cycle == interaction.pipeline_cycle
                     && latest_record.step.as_deref() == Some(interaction.step_name.as_str())
                     && interaction_id_from_resume_reason(latest_record.reason.as_deref()).is_none()
             }
@@ -6907,11 +7822,21 @@ impl Orchestrator {
                 let step_dispatch_was_reserved = live_records
                     .get(&interaction.issue_id)
                     .is_some_and(|record| {
-                        record.kind == PipelineTransitionKind::StepRunning
-                            && interaction.status == InteractionStatus::Resolved
+                        matches!(
+                            record.kind,
+                            PipelineTransitionKind::StepRunning
+                                | PipelineTransitionKind::StepLaunched
+                        ) && interaction.status == InteractionStatus::Resolved
                             && interaction_id_from_resume_reason(record.reason.as_deref())
                                 == Some(interaction.id.as_str())
-                    });
+                    })
+                    && self
+                        .state
+                        .read()
+                        .await
+                        .get_pipeline_run(&interaction.issue_id)
+                        .and_then(|run| run.step_states.get(&interaction.step_name))
+                        .is_some_and(|step_state| matches!(step_state, StepState::Running { .. }));
                 if step_dispatch_was_reserved {
                     match self
                         .interaction_store
@@ -8575,6 +9500,9 @@ impl Orchestrator {
             .any(|step_state| matches!(step_state, StepState::Running { .. }))
     }
 
+    // Keep #480 Artifact evidence projection and the resulting HistoryRecord out of lifecycle
+    // futures that carry terminal-transition state on Tokio worker stacks.
+    #[inline(never)]
     pub(super) fn build_history_record(
         &self,
         input: RunningHistoryRecordInput<'_>,
@@ -8628,13 +9556,22 @@ impl Orchestrator {
         running_entry: &RunningEntry,
         workspace_path: &str,
     ) -> Option<RunArtifacts> {
-        if run.artifact_snapshots.is_empty() {
+        if run.artifact_snapshots.is_empty()
+            && run.artifact_integrity_violations.is_empty()
+            && run.artifact_access_evidence.is_empty()
+        {
             return artifacts;
         }
         let mut snapshots = run.artifact_snapshots.values().cloned().collect::<Vec<_>>();
         snapshots.sort_by(|left, right| left.producer_step.cmp(&right.producer_step));
+        let violations = run.artifact_integrity_violations.clone();
+        let access_evidence = run.artifact_access_evidence.clone();
         match artifacts.as_mut() {
-            Some(artifacts) => artifacts.artifact_snapshots = snapshots,
+            Some(artifacts) => {
+                artifacts.artifact_snapshots = snapshots;
+                artifacts.artifact_integrity_violations = violations;
+                artifacts.artifact_access_evidence = access_evidence;
+            }
             None => {
                 artifacts = Some(RunArtifacts {
                     run_id: running_entry
@@ -8645,6 +9582,8 @@ impl Orchestrator {
                     repos: Vec::new(),
                     transcripts: Vec::new(),
                     artifact_snapshots: snapshots,
+                    artifact_integrity_violations: violations,
+                    artifact_access_evidence: access_evidence,
                 });
             }
         }
@@ -9121,6 +10060,16 @@ impl Orchestrator {
                 {
                     Ok(outcome) => outcome,
                     Err(error) => {
+                        if error.kind == StepDispatchFailureKind::ImmutableIntegrity {
+                            self.handle_step_dispatch_error(
+                                issue,
+                                &pipeline_step.name,
+                                &pipeline_config,
+                                &error,
+                            )
+                            .await;
+                            return Err(error.error);
+                        }
                         let dispatch_retains_owner = {
                             let state = self.state.read().await;
                             matches!(
@@ -9138,7 +10087,7 @@ impl Orchestrator {
                                 previous_running.as_ref(),
                             );
                         }
-                        return Err(error);
+                        return Err(error.error);
                     }
                 };
                 if dispatch_outcome == StepDispatchOutcome::Deferred {
@@ -9313,6 +10262,16 @@ impl Orchestrator {
                             {
                                 Ok(outcome) => outcome,
                                 Err(error) => {
+                                    if error.kind == StepDispatchFailureKind::ImmutableIntegrity {
+                                        self.handle_step_dispatch_error(
+                                            issue,
+                                            &req.step_name,
+                                            &pipeline_config,
+                                            &error,
+                                        )
+                                        .await;
+                                        return Err(error.error);
+                                    }
                                     let failed_dispatch_retains_owner = {
                                         let state = self.state.read().await;
                                         matches!(
@@ -9337,7 +10296,7 @@ impl Orchestrator {
                                         state.remove_waiting_on_human(&issue.id);
                                         state.clear_resume_request(&issue.id);
                                     }
-                                    return Err(error);
+                                    return Err(error.error);
                                 }
                             };
                             if dispatch_outcome == StepDispatchOutcome::Deferred {
@@ -9761,6 +10720,16 @@ impl Orchestrator {
     }
 
     async fn cancel_active_runs(&self) -> bool {
+        // A launch whose journal visibility is still ambiguous has a closed
+        // runtime gate and no event bridge. Dropping its pending reservation
+        // signals completion and releases its capacity before shutdown waits.
+        let pending_launches = std::mem::take(
+            &mut *self
+                .pending_immutable_launches
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        );
+        drop(pending_launches);
         let mut handles = mark_all_for_drain(&self.cancellation_registry);
         let cancelled = handles.len();
         if cancelled > 0 {
@@ -9885,10 +10854,18 @@ async fn bridge_worker_events(
     completion_tx: watch::Sender<bool>,
 ) {
     while let Some(event) = local_event_rx.recv().await {
+        let workspace_capture = if matches!(&event, WorkerEvent::WorkerExited { .. })
+            && worker_uses_exclusive_issue_workspace(&cancellation_registry, &identity)
+        {
+            Some(acquire_issue_workspace_capture(&cancellation_registry, &identity.issue_id).await)
+        } else {
+            None
+        };
         if orchestrator_event_tx
             .send(OrchestratorWorkerEvent {
                 identity: identity.clone(),
                 event,
+                workspace_capture,
             })
             .await
             .is_err()
@@ -9898,6 +10875,70 @@ async fn bridge_worker_events(
     }
     let _ = completion_tx.send(true);
     remove_completed_worker(&cancellation_registry, &identity);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_agent_worker(
+    runner: Arc<dyn AgentRunner>,
+    config: Arc<EnsembleConfig>,
+    issue: Issue,
+    agent_name: String,
+    step_name: String,
+    step_kind: StepKind,
+    artifact_access: ArtifactAccess,
+    attempt: Option<u32>,
+    timeout_ms: u64,
+    interaction_response: Option<InteractionResponseEnvelope>,
+    workspace_path: std::path::PathBuf,
+    cancel_token: tokio_util::sync::CancellationToken,
+    step_outputs: StepOutputTemplateContext,
+    start_gate: Option<oneshot::Receiver<()>>,
+) -> mpsc::Receiver<WorkerEvent> {
+    let (local_event_tx, local_event_rx) = mpsc::channel(100);
+    tokio::spawn(async move {
+        if let Some(start_gate) = start_gate {
+            tokio::select! {
+                result = start_gate => {
+                    if result.is_err() {
+                        return;
+                    }
+                }
+                () = cancel_token.cancelled() => return,
+            }
+        }
+        if cancel_token.is_cancelled() {
+            return;
+        }
+        let worker_result = catch_worker_panic(
+            runner.run(AgentRunRequest {
+                config,
+                issue: &issue,
+                agent_name: &agent_name,
+                step_name: &step_name,
+                step_kind,
+                artifact_access,
+                attempt,
+                timeout_ms,
+                interaction_response,
+                workspace_path: &workspace_path,
+                event_tx: local_event_tx.clone(),
+                cancel_token,
+                step_outputs,
+            }),
+            &issue.id,
+            &step_name,
+        )
+        .await;
+        let _ = local_event_tx
+            .send(WorkerEvent::WorkerExited {
+                issue_id: issue.id,
+                step_name,
+                result: worker_result,
+                timestamp: Utc::now(),
+            })
+            .await;
+    });
+    local_event_rx
 }
 
 async fn catch_worker_panic<F>(fut: F, issue_id: &str, step_name: &str) -> WorkerResult
@@ -10899,6 +11940,45 @@ mod tests {
                 approval_request: None,
             })
         }
+    }
+
+    #[tokio::test]
+    async fn gated_immutable_worker_exits_when_cancelled_before_launch() {
+        let observed_commands = Arc::new(RwLock::new(Vec::new()));
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: Some(Arc::clone(&observed_commands)),
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let config = Arc::new(make_config());
+        let issue = test_issue("gated-cancel", "Todo");
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let (_gate_sender, start_gate) = oneshot::channel();
+        let mut events = spawn_agent_worker(
+            runner,
+            Arc::clone(&config),
+            issue,
+            "builder".to_string(),
+            "build".to_string(),
+            StepKind::Agent,
+            ArtifactAccess::Immutable,
+            None,
+            config.agent.turn_timeout_ms,
+            None,
+            std::path::PathBuf::new(),
+            cancel_token.clone(),
+            StepOutputTemplateContext::default(),
+            Some(start_gate),
+        );
+
+        cancel_token.cancel();
+
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_millis(100), events.recv()).await,
+            Ok(None)
+        ));
+        assert!(observed_commands.read().await.is_empty());
     }
 
     fn succeeded_step_output() -> crate::pipeline::verdict::StepOutput {
@@ -12945,6 +14025,8 @@ mod tests {
                 }],
                 transcripts: Vec::new(),
                 artifact_snapshots: Vec::new(),
+                artifact_integrity_violations: Vec::new(),
+                artifact_access_evidence: Vec::new(),
             });
         let snapshot = {
             let config = orchestrator.config.read().await;
@@ -13123,6 +14205,8 @@ mod tests {
             }],
             transcripts: Vec::new(),
             artifact_snapshots: Vec::new(),
+            artifact_integrity_violations: Vec::new(),
+            artifact_access_evidence: Vec::new(),
         });
         let snapshot = {
             let config = orchestrator.config.read().await;
@@ -13877,6 +14961,30 @@ agent:
   stall_timeout_ms: 300000
 "#;
         parse_config(yaml).unwrap()
+    }
+
+    #[test]
+    fn immutable_artifact_access_evidence_uses_the_resolved_runtime_kind() {
+        let mut config = make_config();
+        let agent = config.agents.get_mut("builder").unwrap();
+        agent.acpx_agent = Some("configured-through-acpx".to_string());
+        agent.runtime = Some("direct".to_string());
+        assert_eq!(
+            immutable_artifact_access_enforcement(Some(agent)),
+            artifact::ArtifactAccessEnforcement::DirectAcpUnsupported
+        );
+
+        agent.runtime = Some("acpx".to_string());
+        assert_eq!(
+            immutable_artifact_access_enforcement(Some(agent)),
+            artifact::ArtifactAccessEnforcement::AcpxApproveReads
+        );
+
+        agent.permission_mode = Some("deny_all".to_string());
+        assert_eq!(
+            immutable_artifact_access_enforcement(Some(agent)),
+            artifact::ArtifactAccessEnforcement::AcpxDenyAll
+        );
     }
 
     async fn install_retry_pipeline_config(orchestrator: &Orchestrator, issue_id: &str) {
@@ -15157,6 +16265,16 @@ agent:
         let dag = build_dag(&cfg.steps).unwrap();
         let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
         run.step_failed("build", "manual halt".to_string());
+        run.record_artifact_integrity_violations([artifact::ArtifactIntegrityViolation {
+            consumer_step: "build".to_string(),
+            producer_step: "producer".to_string(),
+            artifact_identity: "artifact-1".to_string(),
+            repository: "repo".to_string(),
+            expected_digest: "expected".to_string(),
+            observed_digest: "observed".to_string(),
+            changed_paths: vec!["src/lib.rs".to_string()],
+            omitted_changed_path_count: 0,
+        }]);
         setup
             .pipeline_journal
             .append(PipelineTransitionInput {
@@ -15297,6 +16415,16 @@ agent:
         let dag = build_dag(&cfg.steps).unwrap();
         let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
         run.step_failed("build", "manual halt".to_string());
+        run.record_artifact_integrity_violations([artifact::ArtifactIntegrityViolation {
+            consumer_step: "build".to_string(),
+            producer_step: "producer".to_string(),
+            artifact_identity: "artifact-1".to_string(),
+            repository: "repo".to_string(),
+            expected_digest: "expected".to_string(),
+            observed_digest: "observed".to_string(),
+            changed_paths: vec!["src/lib.rs".to_string()],
+            omitted_changed_path_count: 0,
+        }]);
         orchestrator
             .pipeline_journal
             .append(PipelineTransitionInput {
@@ -15319,6 +16447,13 @@ agent:
 
         let lock = state.read().await;
         assert!(lock.get_pipeline_run(&issue.id).is_some());
+        assert_eq!(
+            lock.get_pipeline_run(&issue.id)
+                .unwrap()
+                .artifact_integrity_violations
+                .len(),
+            1
+        );
         assert!(lock.is_claimed(&issue.id));
         assert!(lock.is_waiting_on_human(&issue.id));
     }
@@ -15635,9 +16770,10 @@ agent:
     }
 
     #[tokio::test]
-    async fn restart_reconciles_reserved_step_before_hydrating_stale_interaction() {
+    async fn restart_discards_unlaunched_immutable_evidence_before_hydrating_interaction() {
         let temp = tempfile::tempdir().unwrap();
-        let cfg = make_config();
+        let mut cfg = make_config();
+        cfg.steps[0].artifact_access = ArtifactAccess::Immutable;
         let issue = test_issue("1", "Todo");
         let responses = Arc::new(RwLock::new(Vec::new()));
         let runner: Arc<dyn AgentRunner> = Arc::new(InteractionCaptureRunner {
@@ -15648,6 +16784,10 @@ agent:
         let dag = build_dag(&cfg.steps).unwrap();
         let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
         run.start();
+        run.record_artifact_access_evidence(artifact::ArtifactAccessEvidence {
+            consumer_step: "build".to_string(),
+            enforcement: artifact::ArtifactAccessEnforcement::DirectAcpUnsupported,
+        });
         run.mark_running("build", "reserved-session".to_string());
         orchestrator
             .pipeline_journal
@@ -15711,20 +16851,25 @@ agent:
         orchestrator.restore_pipeline_runs_from_journal().await;
         orchestrator.hydrate_waiting_on_human_from_store().await;
 
-        let state = state.read().await;
-        assert!(state.is_claimed(&issue.id));
-        assert!(!state.is_waiting_on_human(&issue.id));
+        let restored_state = state.read().await;
+        assert!(restored_state.is_claimed(&issue.id));
+        assert!(restored_state.is_waiting_on_human(&issue.id));
         assert_eq!(
-            state
+            restored_state
                 .get_pipeline_run(&issue.id)
                 .unwrap()
                 .step_states
                 .get("build"),
             Some(&StepState::Pending)
         );
-        drop(state);
+        assert!(restored_state
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .artifact_access_evidence
+            .is_empty());
+        drop(restored_state);
         assert!(
-            !orchestrator
+            orchestrator
                 .interaction_store
                 .get("interaction-1")
                 .await
@@ -15743,6 +16888,18 @@ agent:
                 .map(|response| serde_json::to_value(response).unwrap()["interaction_id"].clone()),
             Some(serde_json::json!("interaction-1"))
         );
+        assert_eq!(
+            state
+                .read()
+                .await
+                .get_pipeline_run(&issue.id)
+                .unwrap()
+                .artifact_access_evidence,
+            vec![artifact::ArtifactAccessEvidence {
+                consumer_step: "build".to_string(),
+                enforcement: artifact::ArtifactAccessEnforcement::DirectAcpUnsupported,
+            }]
+        );
         drop(captured);
         let latest = orchestrator
             .pipeline_journal
@@ -15750,10 +16907,14 @@ agent:
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(
-            interaction_id_from_resume_reason(latest.reason.as_deref()),
-            Some("interaction-1")
-        );
+        assert_eq!(latest.kind, PipelineTransitionKind::StepLaunched);
+        assert!(latest
+            .snapshot
+            .unwrap()
+            .artifact_integrity_evidence
+            .artifact_access_evidence
+            .iter()
+            .any(|evidence| evidence.consumer_step == "build"));
         drop(orchestrator);
 
         let runner: Arc<dyn AgentRunner> = Arc::new(InteractionCaptureRunner {
@@ -15767,6 +16928,8 @@ agent:
         tokio::time::sleep(Duration::from_millis(10)).await;
         let captured = responses.read().await;
         assert_eq!(captured.len(), 2);
+        // A committed `StepLaunched` marker retains the input identity, so a
+        // crash before gate delivery replays the resolved response exactly.
         assert_eq!(
             captured[1]
                 .as_ref()
@@ -17030,6 +18193,8 @@ agent:
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }])
         .unwrap();
         let stale_run = PipelineRun::new(issue.id.clone(), 1, stale_dag);
@@ -17752,6 +18917,118 @@ agent:
     }
 
     #[tokio::test]
+    async fn immutable_halt_returns_without_reentrant_state_locking() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let issue = test_issue("immutable-halt", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            }),
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        install_retry_pipeline_config(&orchestrator, &issue.id).await;
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, Some(1));
+            state
+                .get_pipeline_run_mut(&issue.id)
+                .unwrap()
+                .record_artifact_integrity_violations([artifact::ArtifactIntegrityViolation {
+                    consumer_step: "build".to_string(),
+                    producer_step: "producer".to_string(),
+                    artifact_identity: "artifact-1".to_string(),
+                    repository: "repo".to_string(),
+                    expected_digest: "expected".to_string(),
+                    observed_digest: "observed".to_string(),
+                    changed_paths: vec!["src/lib.rs".to_string()],
+                    omitted_changed_path_count: 0,
+                }]);
+        }
+        let error = StepDispatchError::immutable_integrity(AgentError::PromptError {
+            reason: "immutable Artifact input changed before step 'build': build:repo (artifact-1)"
+                .to_string(),
+        });
+        let config_snapshot = Arc::new(config.read().await.clone());
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            orchestrator.handle_step_dispatch_error(&issue, "build", &config_snapshot, &error),
+        )
+        .await
+        .expect("immutable halt does not reenter the state lock during its journal checkpoint");
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.is_running(&issue.id));
+        assert!(!state.retry_attempts.contains_key(&issue.id));
+        let waiting = state.waiting_on_human.get(&issue.id).unwrap();
+        assert!(waiting.interaction_request_id.starts_with("halted:"));
+        drop(state);
+        let latest = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue(&issue.id)
+            .await
+            .unwrap()
+            .expect("halt transition is journaled for restart recovery");
+        assert_eq!(latest.kind, PipelineTransitionKind::PipelineHalted);
+    }
+
+    #[tokio::test]
+    async fn ordinary_dispatch_error_phrase_does_not_force_immutable_artifact_halt() {
+        let config = Arc::new(RwLock::new(make_retry_step_config()));
+        let issue = test_issue("ordinary-dispatch-phrase", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            }),
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        install_retry_pipeline_config(&orchestrator, &issue.id).await;
+        orchestrator
+            .state
+            .write()
+            .await
+            .add_running(&issue, Some(1));
+        let error = StepDispatchError::ordinary(AgentError::PromptError {
+            reason: "ordinary setup error quoted immutable Artifact input".to_string(),
+        });
+        let config_snapshot = Arc::new(config.read().await.clone());
+
+        orchestrator
+            .handle_step_dispatch_error(&issue, "build", &config_snapshot, &error)
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.retry_attempts.contains_key(&issue.id));
+        assert!(!state.waiting_on_human.contains_key(&issue.id));
+    }
+
+    #[tokio::test]
     async fn dispatch_passes_effective_step_timeout_to_agent_runner() {
         let observed_timeouts = Arc::new(RwLock::new(Vec::new()));
         let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
@@ -17892,6 +19169,8 @@ agent:
                     }],
                     transcripts: vec![],
                     artifact_snapshots: Vec::new(),
+                    artifact_integrity_violations: Vec::new(),
+                    artifact_access_evidence: Vec::new(),
                 },
             );
         }
@@ -18165,6 +19444,58 @@ agent:
             run.step_states.get("test"),
             Some(StepState::Pending)
         ));
+    }
+
+    #[tokio::test]
+    async fn ordinary_failure_text_does_not_force_an_immutable_artifact_halt() {
+        let config = Arc::new(RwLock::new(make_retry_step_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            }),
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let issue = test_issue("ordinary-failure-phrase", "Todo");
+        let cfg = config.read().await;
+        let mut run = PipelineRun::new(issue.id.clone(), 1, build_dag(&cfg.steps).unwrap());
+        run.start();
+        run.mark_running("build", "session-1".to_string());
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, None);
+            state.insert_pipeline_run(&issue.id, run, Arc::new(cfg.clone()));
+        }
+        drop(cfg);
+
+        orchestrator
+            .handle_worker_exit(
+                &issue.id,
+                "build",
+                WorkerResult::Success {
+                    output: failed_step_output(
+                        "agent quoted immutable Artifact input but did not observe it",
+                    ),
+                    approval_request: None,
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.retry_attempts.contains_key(&issue.id));
+        assert!(!state.waiting_on_human.contains_key(&issue.id));
     }
 
     #[tokio::test]
@@ -19591,6 +20922,8 @@ agent:
                     }],
                     transcripts: vec![],
                     artifact_snapshots: Vec::new(),
+                    artifact_integrity_violations: Vec::new(),
+                    artifact_access_evidence: Vec::new(),
                 },
             );
         }
@@ -19669,6 +21002,11 @@ agent:
         assert!(!state.is_running("1"));
         assert!(state.is_claimed("1"));
         assert!(state.is_waiting_on_human("1"));
+        assert!(state
+            .get_pipeline_run("1")
+            .unwrap()
+            .artifact_integrity_violations
+            .is_empty());
         assert!(state.agent_totals.seconds_running >= 0.0);
     }
 
@@ -20816,6 +22154,8 @@ agent:
                 repos: vec![],
                 transcripts: vec![],
                 artifact_snapshots: Vec::new(),
+                artifact_integrity_violations: Vec::new(),
+                artifact_access_evidence: Vec::new(),
             },
         );
 
@@ -21907,7 +23247,9 @@ agent:
     async fn restored_interaction_does_not_dispatch_when_running_journal_write_fails() {
         use std::os::unix::fs::PermissionsExt;
 
-        let config = Arc::new(RwLock::new(make_config()));
+        let mut immutable_config = make_config();
+        immutable_config.steps[0].artifact_access = ArtifactAccess::Immutable;
+        let config = Arc::new(RwLock::new(immutable_config));
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
             issues: Arc::new(RwLock::new(vec![])),
         });
@@ -21936,6 +23278,10 @@ agent:
             let dag = build_dag(&cfg.steps).unwrap();
             let mut run = PipelineRun::new(issue.id.clone(), 1, dag);
             run.start();
+            run.record_artifact_access_evidence(artifact::ArtifactAccessEvidence {
+                consumer_step: "build".to_string(),
+                enforcement: artifact::ArtifactAccessEnforcement::AcpxDenyAll,
+            });
             run.step_blocked_on_human("build", "interaction-1".to_string());
             let snapshot = run.to_snapshot();
             let mut state = orchestrator.state.write().await;
@@ -22041,6 +23387,15 @@ agent:
             state.get_pipeline_run(&issue.id).unwrap().to_snapshot(),
             snapshot
         );
+        assert_eq!(
+            state
+                .get_pipeline_run(&issue.id)
+                .unwrap()
+                .artifact_access_evidence,
+            snapshot
+                .artifact_integrity_evidence
+                .artifact_access_evidence
+        );
         drop(state);
         assert!(
             orchestrator
@@ -22092,11 +23447,118 @@ agent:
             PipelineTransitionKind::StepBlockedOnHuman
         );
 
-        orchestrator.pipeline_journal.transaction_append_late_error = true;
+        // A confirmed-absent `StepLaunched` append restores the interaction
+        // and never releases the worker gate.
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 2));
+        let absent_error = orchestrator
+            .resume_blocked_issue(&issue)
+            .await
+            .expect_err("an absent launch commitment must prevent worker launch");
+        assert!(absent_error.to_string().contains("immutable step"));
+        assert!(observed_commands.read().await.is_empty());
+        assert!(
+            orchestrator
+                .interaction_store
+                .get("interaction-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .awaiting_resume
+        );
+        orchestrator.hydrate_waiting_on_human_from_store().await;
+        // An unreadable outcome retains its closed gate until exact visibility
+        // is retried; confirmed absence then performs the same rollback.
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = Some((Arc::new(AtomicUsize::new(0)), 2));
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = true;
         orchestrator
             .resume_blocked_issue(&issue)
             .await
-            .expect("an exact visible running record makes a late append error successful");
+            .expect("ambiguous immutable launch is retained for reconciliation");
+        assert!(observed_commands.read().await.is_empty());
+        assert!(tokio::time::timeout(
+            Duration::from_millis(100),
+            orchestrator.cancel_active_runs()
+        )
+        .await
+        .expect("shutdown must drain an ambiguous gated launch"));
+        assert!(orchestrator
+            .pending_immutable_launches
+            .lock()
+            .unwrap()
+            .is_empty());
+        let retired_interaction = orchestrator
+            .interaction_store
+            .get("interaction-1")
+            .await
+            .unwrap()
+            .unwrap();
+        let mut restored_interaction = retired_interaction.clone();
+        restored_interaction.status = InteractionStatus::Resolved;
+        restored_interaction.awaiting_resume = true;
+        orchestrator
+            .interaction_store
+            .restore_waiting_state_after_failed_transition(
+                &retired_interaction,
+                &restored_interaction,
+            )
+            .await
+            .unwrap();
+        // Restore the blocked owner for the remaining absence/visibility cases.
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, None);
+            state.add_waiting_on_human(WaitingOnHumanEntry {
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                interaction_request_id: "interaction-1".to_string(),
+                step_name: "build".to_string(),
+                kind: InteractionKind::Question,
+                prompt: "Need input".to_string(),
+                agent_name: "builder".to_string(),
+                retry_attempt: None,
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: Utc::now(),
+                run_id: Some("run-1".to_string()),
+                issue: Some(issue.clone()),
+            });
+            let run = state.get_pipeline_run_mut(&issue.id).unwrap();
+            run.step_blocked_on_human("build", "interaction-1".to_string());
+        }
+        orchestrator
+            .pipeline_journal
+            .transaction_latest_record_match_error = false;
+        orchestrator
+            .pipeline_journal
+            .transaction_append_error_on_call = None;
+        orchestrator.reconcile_pending_immutable_launches().await;
+        assert!(observed_commands.read().await.is_empty());
+        assert!(
+            orchestrator
+                .interaction_store
+                .get("interaction-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .awaiting_resume
+        );
+        orchestrator.state.write().await.remove_running(&issue.id);
+        orchestrator.hydrate_waiting_on_human_from_store().await;
+        orchestrator
+            .pipeline_journal
+            .transaction_append_late_error_kind = Some(PipelineTransitionKind::StepLaunched);
+        orchestrator
+            .resume_blocked_issue(&issue)
+            .await
+            .expect("an exact visible launch record releases the worker gate once");
         tokio::task::yield_now().await;
 
         assert_eq!(observed_commands.read().await.len(), 1);
@@ -22104,6 +23566,16 @@ agent:
         assert!(state.is_running(&issue.id));
         assert!(!state.is_waiting_on_human(&issue.id));
         assert!(!state.is_resume_requested(&issue.id));
+        assert_eq!(
+            state
+                .get_pipeline_run(&issue.id)
+                .unwrap()
+                .artifact_access_evidence,
+            vec![artifact::ArtifactAccessEvidence {
+                consumer_step: "build".to_string(),
+                enforcement: artifact::ArtifactAccessEnforcement::DirectAcpUnsupported,
+            }]
+        );
         drop(state);
         assert!(
             !orchestrator
@@ -22114,6 +23586,9 @@ agent:
                 .unwrap()
                 .awaiting_resume
         );
+        orchestrator
+            .pipeline_journal
+            .transaction_append_late_error_kind = None;
     }
 
     #[tokio::test]
@@ -22220,7 +23695,13 @@ agent:
         )
         .unwrap();
         assert_eq!(metadata["branch_name"], "ensemble/issue-1");
-        assert!(!observed_commands.read().await.is_empty());
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while observed_commands.read().await.is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("journaled dispatch should launch its agent");
     }
 
     fn selected_test_config() -> EnsembleConfig {
@@ -24427,6 +25908,10 @@ agent:
                 },
             );
         }
+        run.record_artifact_access_evidence(artifact::ArtifactAccessEvidence {
+            consumer_step: "a-review".to_string(),
+            enforcement: artifact::ArtifactAccessEnforcement::DirectAcpUnsupported,
+        });
         let mut state = orchestrator.state.write().await;
         state.add_running(&test_issue("1", "Todo"), None);
         let entry = state.running.get("1").unwrap().clone();
@@ -24441,15 +25926,21 @@ agent:
             artifacts: None,
         });
 
+        let artifacts = record.artifacts.unwrap();
         assert_eq!(
-            record
-                .artifacts
-                .unwrap()
+            artifacts
                 .artifact_snapshots
                 .iter()
                 .map(|snapshot| snapshot.producer_step.as_str())
                 .collect::<Vec<_>>(),
             vec!["a-review", "z-build"]
+        );
+        assert_eq!(
+            artifacts.artifact_access_evidence,
+            vec![artifact::ArtifactAccessEvidence {
+                consumer_step: "a-review".to_string(),
+                enforcement: artifact::ArtifactAccessEnforcement::DirectAcpUnsupported,
+            }]
         );
     }
 
@@ -24573,6 +26064,7 @@ agent:
             .worker_tx
             .send(OrchestratorWorkerEvent {
                 identity: sibling_identity.clone(),
+                workspace_capture: None,
                 event: WorkerEvent::WorkerExited {
                     issue_id: issue.id.clone(),
                     step_name: sibling_identity.step_name.clone(),
@@ -24615,6 +26107,34 @@ agent:
         assert!(output.status.success());
         sibling_complete.send(true).unwrap();
         capture_reached_rx.await.unwrap();
+        assert!(remove_completed_worker(
+            &orchestrator.cancellation_registry,
+            &sibling_identity
+        ));
+        let writer_identity = WorkerIdentity {
+            issue_id: issue.id.clone(),
+            run_id: run_id.clone(),
+            cycle: 1,
+            step_name: "new-writer".to_string(),
+            started_at: Utc::now(),
+        };
+        let (_, writer_completion) = watch::channel(false);
+        assert_eq!(
+            try_reserve_scheduler_worker_with_workspace_exclusivity(
+                &orchestrator.cancellation_registry,
+                writer_identity,
+                tokio_util::sync::CancellationToken::new(),
+                writer_completion,
+                config.concurrency.max_concurrent_agents,
+                config.concurrency.max_step_parallelism,
+                WorkerCapacity::new(&issue.state, &config.agent.max_concurrent_agents_by_state,),
+                &BTreeMap::new(),
+                SchedulerReservation::default(),
+                false,
+            ),
+            Err(WorkerReservationError::IssueWorkspaceExclusive),
+            "a freed sibling slot must not admit a new same-issue writer during producer capture"
+        );
         capture_resume.add_permits(1);
         producer.await.unwrap();
 
@@ -24643,6 +26163,800 @@ agent:
         assert_ne!(captured.identity, before.identity);
         assert_eq!(captured.identity, expected.identity);
 
+        drop(repo_temp);
+    }
+
+    #[tokio::test]
+    async fn immutable_postcheck_excludes_new_same_issue_writers_until_verification_finishes() {
+        let (repo_temp, mut repo) = create_finalize_repo().await;
+        repo.finalize = Default::default();
+        let repo_key = repository_key(&repo, 0);
+        let mut config = make_config();
+        config.repos = vec![repo.clone()];
+        config.steps[0].artifact_snapshot = Some(crate::config::ensemble::ArtifactSnapshotConfig {
+            repositories: vec![repo_key.clone()],
+        });
+        let mut review = config.steps[0].clone();
+        review.name = "review".to_string();
+        review.depends = Some(vec!["build".to_string()]);
+        review.artifact_snapshot = None;
+        review.artifact_inputs = vec!["build".to_string()];
+        review.artifact_access = ArtifactAccess::Immutable;
+        config.steps.push(review);
+        let issue = test_issue("immutable-postcheck-capture", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), Some(config.repos.clone())).unwrap();
+        let worktree = workspace_mgr
+            .prepare_workspace(&issue.id, &issue.identifier)
+            .await
+            .unwrap()
+            .worktrees
+            .remove(&repo_key)
+            .unwrap()
+            .path;
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Arc::new(Orchestrator::new(
+            Arc::new(RwLock::new(config.clone())),
+            tracker,
+            Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            }),
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        ));
+        let mut run = PipelineRun::new(issue.id.clone(), 1, build_dag(&config.steps).unwrap());
+        run.start();
+        let snapshot = artifact::capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            config.steps[0].artifact_snapshot.as_ref().unwrap(),
+            &BTreeMap::from([(repo_key, worktree)]),
+        )
+        .await
+        .unwrap();
+        run.record_artifact_snapshot("build", snapshot);
+        run.step_states
+            .insert("build".to_string(), StepState::Passed);
+        {
+            let mut state = orchestrator.state.write().await;
+            state.insert_pipeline_run(&issue.id, run, Arc::new(config.clone()));
+        }
+        let sibling_identity = WorkerIdentity {
+            issue_id: issue.id.clone(),
+            run_id: "run-1".to_string(),
+            cycle: 1,
+            step_name: "sibling-writer".to_string(),
+            started_at: Utc::now(),
+        };
+        let (sibling_done, sibling_completion) = watch::channel(false);
+        crate::agent::cancellation::register_worker(
+            &orchestrator.cancellation_registry,
+            sibling_identity.clone(),
+            tokio_util::sync::CancellationToken::new(),
+            sibling_completion,
+        );
+
+        let postcheck = {
+            let orchestrator = Arc::clone(&orchestrator);
+            let issue_id = issue.id.clone();
+            tokio::spawn(async move {
+                orchestrator
+                    .verify_immutable_inputs_after_worker_exit(
+                        &issue_id,
+                        "review",
+                        succeeded_step_output(),
+                        false,
+                    )
+                    .await
+            })
+        };
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !issue_workspace_capture_is_active(&orchestrator.cancellation_registry, &issue.id)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("immutable postcheck reserves the workspace before draining siblings");
+
+        let (_, writer_completion) = watch::channel(false);
+        assert_eq!(
+            try_reserve_scheduler_worker_with_workspace_exclusivity(
+                &orchestrator.cancellation_registry,
+                WorkerIdentity {
+                    issue_id: issue.id.clone(),
+                    run_id: "run-1".to_string(),
+                    cycle: 1,
+                    step_name: "new-writer".to_string(),
+                    started_at: Utc::now(),
+                },
+                tokio_util::sync::CancellationToken::new(),
+                writer_completion,
+                config.concurrency.max_concurrent_agents,
+                config.concurrency.max_step_parallelism,
+                WorkerCapacity::new(&issue.state, &config.agent.max_concurrent_agents_by_state),
+                &BTreeMap::new(),
+                SchedulerReservation::default(),
+                false,
+            ),
+            Err(WorkerReservationError::IssueWorkspaceExclusive),
+            "the postcheck must keep a stable workspace after its sibling set is collected"
+        );
+
+        sibling_done.send(true).unwrap();
+        let (_output, deferred_exits, integrity_failed) = postcheck.await.unwrap();
+        assert!(!integrity_failed);
+        assert!(deferred_exits.is_empty());
+        assert!(remove_completed_worker(
+            &orchestrator.cancellation_registry,
+            &sibling_identity
+        ));
+        drop(repo_temp);
+    }
+
+    #[tokio::test]
+    async fn immutable_consumer_blocked_on_human_postcheck_halts_and_discards_dual_role_snapshot() {
+        let (repo_temp, mut repo) = create_finalize_repo().await;
+        repo.finalize = Default::default();
+        let repo_key = repository_key(&repo, 0);
+        let mut config = make_config();
+        config.repos = vec![repo.clone()];
+        config.steps[0].artifact_snapshot = Some(crate::config::ensemble::ArtifactSnapshotConfig {
+            repositories: vec![repo_key.clone()],
+        });
+        let mut review = config.steps[0].clone();
+        review.name = "review".to_string();
+        review.depends = Some(vec!["build".to_string()]);
+        review.artifact_snapshot = config.steps[0].artifact_snapshot.clone();
+        review.artifact_inputs = vec!["build".to_string()];
+        review.artifact_access = ArtifactAccess::Immutable;
+        review.on_failure = OnFailure::RetryIssue;
+        config.steps.push(review);
+        let issue = test_issue("immutable-postcheck", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), Some(config.repos.clone())).unwrap();
+        let worktree = workspace_mgr
+            .prepare_workspace(&issue.id, &issue.identifier)
+            .await
+            .unwrap()
+            .worktrees
+            .remove(&repo_key)
+            .unwrap()
+            .path;
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::new(RwLock::new(config.clone())),
+            tracker,
+            Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            }),
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let mut run = PipelineRun::new(issue.id.clone(), 1, build_dag(&config.steps).unwrap());
+        run.start();
+        let snapshot = artifact::capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            config.steps[0].artifact_snapshot.as_ref().unwrap(),
+            &BTreeMap::from([(repo_key, worktree.clone())]),
+        )
+        .await
+        .unwrap();
+        run.record_artifact_snapshot("build", snapshot);
+        run.step_states
+            .insert("build".to_string(), StepState::Passed);
+        run.mark_running("review", "review-session".to_string());
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, Some(1));
+            state.insert_pipeline_run(&issue.id, run, Arc::new(config));
+        }
+        let transferred_capture =
+            acquire_issue_workspace_capture(&orchestrator.cancellation_registry, &issue.id).await;
+        let clean_dual_role = tokio::time::timeout(
+            Duration::from_secs(1),
+            orchestrator.process_artifacts_after_worker_exit(
+                &issue.id,
+                "review",
+                succeeded_step_output(),
+                true,
+                true,
+            ),
+        )
+        .await
+        .expect("an immutable producer reuses its transferred exit capture");
+        assert!(clean_dual_role.captured_snapshot.is_some());
+        assert!(!clean_dual_role.integrity_failed);
+        drop(transferred_capture);
+        tokio::fs::write(worktree.join("README.md"), "post-run mutation\n")
+            .await
+            .unwrap();
+
+        orchestrator
+            .handle_worker_exit(
+                &issue.id,
+                "review",
+                WorkerResult::BlockedOnHuman {
+                    request: InteractionRequestDraft {
+                        schema_version: 1,
+                        kind: InteractionKind::BrainstormPrompt,
+                        blocking: true,
+                        title: "Need review input".to_string(),
+                        body: "Choose an option".to_string(),
+                        options: vec!["continue".to_string()],
+                        artifacts: Vec::new(),
+                    },
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        let halted_interaction_id = state
+            .waiting_on_human
+            .get(&issue.id)
+            .expect("integrity failure becomes a durable halt")
+            .interaction_request_id
+            .clone();
+        assert!(!state.retry_attempts.contains_key(&issue.id));
+        assert_eq!(
+            state
+                .get_pipeline_run(&issue.id)
+                .unwrap()
+                .artifact_integrity_violations
+                .len(),
+            1
+        );
+        assert!(!state
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .artifact_snapshots
+            .contains_key("review"));
+        drop(state);
+        assert!(orchestrator
+            .interaction_store
+            .get(&halted_interaction_id)
+            .await
+            .unwrap()
+            .is_none());
+        let latest = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue(&issue.id)
+            .await
+            .unwrap()
+            .expect("postcheck halt is journaled for restart");
+        assert_eq!(latest.kind, PipelineTransitionKind::PipelineHalted);
+        drop(repo_temp);
+    }
+
+    #[tokio::test]
+    async fn immutable_consumer_blocked_on_human_postcheck_preserves_clean_interaction() {
+        let (repo_temp, mut repo) = create_finalize_repo().await;
+        repo.finalize = Default::default();
+        let repo_key = repository_key(&repo, 0);
+        let mut config = make_config();
+        config.repos = vec![repo.clone()];
+        config.steps[0].artifact_snapshot = Some(crate::config::ensemble::ArtifactSnapshotConfig {
+            repositories: vec![repo_key.clone()],
+        });
+        let mut review = config.steps[0].clone();
+        review.name = "review".to_string();
+        review.depends = Some(vec!["build".to_string()]);
+        review.artifact_inputs = vec!["build".to_string()];
+        review.artifact_access = ArtifactAccess::Immutable;
+        config.steps.push(review);
+        let issue = test_issue("immutable-clean-block", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), Some(config.repos.clone())).unwrap();
+        let worktree = workspace_mgr
+            .prepare_workspace(&issue.id, &issue.identifier)
+            .await
+            .unwrap()
+            .worktrees
+            .remove(&repo_key)
+            .unwrap()
+            .path;
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::new(RwLock::new(config.clone())),
+            tracker,
+            Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            }),
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let mut run = PipelineRun::new(issue.id.clone(), 1, build_dag(&config.steps).unwrap());
+        run.start();
+        let snapshot = artifact::capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            config.steps[0].artifact_snapshot.as_ref().unwrap(),
+            &BTreeMap::from([(repo_key, worktree)]),
+        )
+        .await
+        .unwrap();
+        run.record_artifact_snapshot("build", snapshot);
+        run.step_states
+            .insert("build".to_string(), StepState::Passed);
+        run.mark_running("review", "review-session".to_string());
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, Some(1));
+            state.insert_pipeline_run(&issue.id, run, Arc::new(config));
+        }
+
+        orchestrator
+            .handle_worker_exit(
+                &issue.id,
+                "review",
+                WorkerResult::BlockedOnHuman {
+                    request: InteractionRequestDraft {
+                        schema_version: 1,
+                        kind: InteractionKind::BrainstormPrompt,
+                        blocking: true,
+                        title: "Need review input".to_string(),
+                        body: "Choose an option".to_string(),
+                        options: vec!["continue".to_string()],
+                        artifacts: Vec::new(),
+                    },
+                },
+            )
+            .await;
+
+        let state = orchestrator.state.read().await;
+        assert!(!state.retry_attempts.contains_key(&issue.id));
+        let interaction_id = state
+            .waiting_on_human
+            .get(&issue.id)
+            .expect("clean immutable consumer preserves its interaction")
+            .interaction_request_id
+            .clone();
+        assert!(!interaction_id.starts_with("halted:"));
+        assert!(state
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .artifact_integrity_violations
+            .is_empty());
+        drop(state);
+        let interaction = orchestrator
+            .interaction_store
+            .get(&interaction_id)
+            .await
+            .unwrap()
+            .expect("clean blocked request is persisted");
+        assert_eq!(interaction.title, "Need review input");
+        drop(repo_temp);
+    }
+
+    #[tokio::test]
+    async fn immutable_consumer_unobservable_preflight_halts_before_agent_starts() {
+        let (repo_temp, mut repo) = create_finalize_repo().await;
+        repo.finalize = Default::default();
+        let repo_key = repository_key(&repo, 0);
+        let mut config = make_config();
+        config.repos = vec![repo.clone()];
+        config.steps[0].artifact_snapshot = Some(crate::config::ensemble::ArtifactSnapshotConfig {
+            repositories: vec![repo_key.clone()],
+        });
+        let mut review = config.steps[0].clone();
+        review.name = "review".to_string();
+        review.depends = Some(vec!["build".to_string()]);
+        review.artifact_snapshot = None;
+        review.artifact_inputs = vec!["build".to_string()];
+        review.artifact_access = ArtifactAccess::Immutable;
+        config.steps.push(review);
+        let issue = test_issue("immutable-preflight", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), Some(config.repos.clone())).unwrap();
+        let worktree = workspace_mgr
+            .prepare_workspace(&issue.id, &issue.identifier)
+            .await
+            .unwrap()
+            .worktrees
+            .remove(&repo_key)
+            .unwrap()
+            .path;
+        let (started_tx, mut started_rx) = tokio::sync::oneshot::channel();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::new(RwLock::new(config.clone())),
+            tracker,
+            Arc::new(BlockingDrainRunner {
+                started: std::sync::Mutex::new(Some(started_tx)),
+                cancellation_observed: std::sync::Mutex::new(None),
+                release: Arc::new(tokio::sync::Semaphore::new(0)),
+            }),
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let mut run = PipelineRun::new(issue.id.clone(), 1, build_dag(&config.steps).unwrap());
+        run.start();
+        let snapshot = artifact::capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            config.steps[0].artifact_snapshot.as_ref().unwrap(),
+            &BTreeMap::from([(repo_key, worktree.clone())]),
+        )
+        .await
+        .unwrap();
+        run.record_artifact_snapshot("build", snapshot);
+        run.step_states
+            .insert("build".to_string(), StepState::Passed);
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, Some(1));
+            state.insert_pipeline_run(&issue.id, run, Arc::new(config.clone()));
+        }
+        tokio::fs::remove_dir_all(&worktree).await.unwrap();
+        let permit = orchestrator.quiescing.begin_dispatch().unwrap();
+        let error = orchestrator
+            .dispatch_step(
+                &issue,
+                Arc::new(config.clone()),
+                StepDispatchContext {
+                    step_name: "review",
+                    agent_name: "builder",
+                    step_kind: StepKind::Agent,
+                    tracker_state: None,
+                    attempt: None,
+                    timeout_ms: config.agent.turn_timeout_ms,
+                    interaction_response: None,
+                    interaction_resume_id: None,
+                    interaction_to_retire: None,
+                    interaction_retirement_rollback: None,
+                    workspace_path: worktree.clone(),
+                    step_outputs: StepOutputTemplateContext::default(),
+                },
+                &permit,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind, StepDispatchFailureKind::ImmutableIntegrity);
+        orchestrator
+            .handle_step_dispatch_error(&issue, "review", &Arc::new(config), &error)
+            .await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut started_rx)
+                .await
+                .is_err()
+        );
+        let state = orchestrator.state.read().await;
+        assert!(state.waiting_on_human.contains_key(&issue.id));
+        assert!(!state.retry_attempts.contains_key(&issue.id));
+        assert!(!worktree.exists());
+        drop(repo_temp);
+    }
+
+    #[tokio::test]
+    async fn resumed_immutable_consumer_unobservable_preflight_halts_without_retry() {
+        let (repo_temp, mut repo) = create_finalize_repo().await;
+        repo.finalize = Default::default();
+        let repo_key = repository_key(&repo, 0);
+        let mut config = make_config();
+        config.repos = vec![repo.clone()];
+        config.steps[0].artifact_snapshot = Some(crate::config::ensemble::ArtifactSnapshotConfig {
+            repositories: vec![repo_key.clone()],
+        });
+        let mut review = config.steps[0].clone();
+        review.name = "review".to_string();
+        review.depends = Some(vec!["build".to_string()]);
+        review.artifact_snapshot = None;
+        review.artifact_inputs = vec!["build".to_string()];
+        review.artifact_access = ArtifactAccess::Immutable;
+        review.on_failure = OnFailure::RetryIssue;
+        config.steps.push(review);
+        let issue = test_issue("immutable-resume-preflight", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), Some(config.repos.clone())).unwrap();
+        let worktree = workspace_mgr
+            .prepare_workspace(&issue.id, &issue.identifier)
+            .await
+            .unwrap()
+            .worktrees
+            .remove(&repo_key)
+            .unwrap()
+            .path;
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::new(RwLock::new(config.clone())),
+            tracker,
+            Arc::new(MockRunner {
+                delay_ms: 0,
+                observed_commands: None,
+                observed_timeouts: None,
+                cancellation_probe: None,
+            }),
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let interaction_id = "immutable-resume-interaction".to_string();
+        let mut run = PipelineRun::new(issue.id.clone(), 1, build_dag(&config.steps).unwrap());
+        run.start();
+        let snapshot = artifact::capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            config.steps[0].artifact_snapshot.as_ref().unwrap(),
+            &BTreeMap::from([(repo_key, worktree.clone())]),
+        )
+        .await
+        .unwrap();
+        run.record_artifact_snapshot("build", snapshot);
+        run.step_states
+            .insert("build".to_string(), StepState::Passed);
+        run.step_blocked_on_human("review", interaction_id.clone());
+        {
+            let mut state = orchestrator.state.write().await;
+            state.insert_pipeline_run(&issue.id, run, Arc::new(config));
+            state.add_claimed(&issue.id);
+            state.add_waiting_on_human(WaitingOnHumanEntry {
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                interaction_request_id: interaction_id.clone(),
+                step_name: "review".to_string(),
+                kind: InteractionKind::BrainstormPrompt,
+                prompt: "Need input".to_string(),
+                agent_name: "builder".to_string(),
+                retry_attempt: Some(1),
+                started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: Utc::now(),
+                run_id: Some("run-1".to_string()),
+                issue: Some(issue.clone()),
+            });
+        }
+        orchestrator
+            .interaction_store
+            .create(InteractionRequest {
+                id: interaction_id,
+                schema_version: 1,
+                issue_id: issue.id.clone(),
+                issue_identifier: issue.identifier.clone(),
+                pipeline_cycle: 1,
+                completed_steps: vec!["build".to_string()],
+                step_name: "review".to_string(),
+                agent_name: "builder".to_string(),
+                step_depends: vec!["build".to_string()],
+                step_tracker_state: None,
+                kind: InteractionKind::BrainstormPrompt,
+                status: InteractionStatus::Resolved,
+                blocking: true,
+                awaiting_resume: true,
+                resume_strategy: InteractionResumeStrategy::RerunStep,
+                title: "Need input".to_string(),
+                body: "Continue".to_string(),
+                options: vec![],
+                artifacts: vec![],
+                response: Some(InteractionResponse::Question {
+                    response_schema_version: 1,
+                    text: "continue".to_string(),
+                    selected_option: None,
+                }),
+                waiting_started_at: None,
+                agent_input_tokens: 0,
+                agent_output_tokens: 0,
+                agent_total_tokens: 0,
+                requested_at: Utc::now(),
+                resolved_at: Some(Utc::now()),
+                thread_root_comment_id: None,
+                thread_root_comment_url: None,
+                last_processed_comment_id: None,
+                accepted_command: None,
+                ignored_commands: vec![],
+            })
+            .await
+            .unwrap();
+        tokio::fs::remove_dir_all(&worktree).await.unwrap();
+
+        let error = orchestrator.resume_blocked_issue(&issue).await.unwrap_err();
+
+        assert!(error.to_string().contains("immutable Artifact input"));
+        let state = orchestrator.state.read().await;
+        assert!(!state.retry_attempts.contains_key(&issue.id));
+        assert!(state
+            .waiting_on_human
+            .get(&issue.id)
+            .is_some_and(|waiting| waiting.interaction_request_id.starts_with("halted:")));
+        drop(repo_temp);
+    }
+
+    #[tokio::test]
+    async fn immutable_consumer_defers_for_a_same_issue_writer_then_launches_without_a_false_violation(
+    ) {
+        let (repo_temp, mut repo) = create_finalize_repo().await;
+        repo.finalize = Default::default();
+        let repo_key = repository_key(&repo, 0);
+        let mut config = make_config();
+        config.repos = vec![repo.clone()];
+        config.steps[0].artifact_snapshot = Some(crate::config::ensemble::ArtifactSnapshotConfig {
+            repositories: vec![repo_key.clone()],
+        });
+        let mut review = config.steps[0].clone();
+        review.name = "review".to_string();
+        review.depends = Some(vec!["build".to_string()]);
+        review.artifact_snapshot = None;
+        review.artifact_inputs = vec!["build".to_string()];
+        review.artifact_access = ArtifactAccess::Immutable;
+        config.steps.push(review);
+        let issue = test_issue("immutable-deferred", "Todo");
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(dir.path(), Some(config.repos.clone())).unwrap();
+        let worktree = workspace_mgr
+            .prepare_workspace(&issue.id, &issue.identifier)
+            .await
+            .unwrap()
+            .worktrees
+            .remove(&repo_key)
+            .unwrap()
+            .path;
+        let (started_tx, mut started_rx) = tokio::sync::oneshot::channel();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::new(RwLock::new(config.clone())),
+            tracker,
+            Arc::new(BlockingDrainRunner {
+                started: std::sync::Mutex::new(Some(started_tx)),
+                cancellation_observed: std::sync::Mutex::new(None),
+                release: Arc::new(tokio::sync::Semaphore::new(0)),
+            }),
+            workspace_mgr,
+            dir.path(),
+            shutdown_rx,
+        );
+        let mut run = PipelineRun::new(issue.id.clone(), 1, build_dag(&config.steps).unwrap());
+        run.start();
+        let snapshot = artifact::capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            config.steps[0].artifact_snapshot.as_ref().unwrap(),
+            &BTreeMap::from([(repo_key, worktree.clone())]),
+        )
+        .await
+        .unwrap();
+        let original_readme = tokio::fs::read(&worktree.join("README.md")).await.unwrap();
+        run.record_artifact_snapshot("build", snapshot);
+        run.step_states
+            .insert("build".to_string(), StepState::Passed);
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, Some(1));
+            state.insert_pipeline_run(&issue.id, run, Arc::new(config.clone()));
+        }
+        let sibling_identity = WorkerIdentity {
+            issue_id: issue.id.clone(),
+            run_id: "run-1".to_string(),
+            cycle: 1,
+            step_name: "sibling-writer".to_string(),
+            started_at: Utc::now(),
+        };
+        let sibling_token = tokio_util::sync::CancellationToken::new();
+        let (sibling_done, sibling_completion) = watch::channel(false);
+        crate::agent::cancellation::register_worker(
+            &orchestrator.cancellation_registry,
+            sibling_identity.clone(),
+            sibling_token.clone(),
+            sibling_completion,
+        );
+        tokio::fs::write(worktree.join("README.md"), "sibling writer mutation\n")
+            .await
+            .unwrap();
+        let permit = orchestrator.quiescing.begin_dispatch().unwrap();
+        let dispatch = || StepDispatchContext {
+            step_name: "review",
+            agent_name: "builder",
+            step_kind: StepKind::Agent,
+            tracker_state: None,
+            attempt: None,
+            timeout_ms: config.agent.turn_timeout_ms,
+            interaction_response: None,
+            interaction_resume_id: None,
+            interaction_to_retire: None,
+            interaction_retirement_rollback: None,
+            workspace_path: worktree.clone(),
+            step_outputs: StepOutputTemplateContext::default(),
+        };
+
+        assert_eq!(
+            orchestrator
+                .dispatch_step(&issue, Arc::new(config.clone()), dispatch(), &permit)
+                .await
+                .unwrap(),
+            StepDispatchOutcome::Deferred
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut started_rx)
+                .await
+                .is_err()
+        );
+        assert!(!sibling_token.is_cancelled());
+        assert!(orchestrator
+            .state
+            .read()
+            .await
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .artifact_integrity_violations
+            .is_empty());
+
+        tokio::fs::write(worktree.join("README.md"), original_readme)
+            .await
+            .unwrap();
+        sibling_done.send(true).unwrap();
+        assert!(remove_completed_worker(
+            &orchestrator.cancellation_registry,
+            &sibling_identity
+        ));
+        assert_eq!(
+            orchestrator
+                .dispatch_step(&issue, Arc::new(config.clone()), dispatch(), &permit)
+                .await
+                .unwrap(),
+            StepDispatchOutcome::Spawned
+        );
+        tokio::time::timeout(Duration::from_secs(1), &mut started_rx)
+            .await
+            .expect("immutable consumer launches after same-issue writer quiesces")
+            .unwrap();
+        assert!(orchestrator
+            .state
+            .read()
+            .await
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .artifact_integrity_violations
+            .is_empty());
         drop(repo_temp);
     }
 
@@ -24692,6 +27006,8 @@ agent:
                 record_count: 3,
             }],
             artifact_snapshots: Vec::new(),
+            artifact_integrity_violations: Vec::new(),
+            artifact_access_evidence: Vec::new(),
         };
         let mut state = orchestrator.state.write().await;
         state.add_running(&test_issue("1", "Todo"), None);
@@ -26142,6 +28458,7 @@ agent:
         orchestrator
             .handle_worker_event(OrchestratorWorkerEvent {
                 identity: stale_identity.clone(),
+                workspace_capture: None,
                 event: WorkerEvent::AgentUpdate {
                     issue_id: "1".to_string(),
                     step_name: "build".to_string(),
@@ -26157,6 +28474,7 @@ agent:
         orchestrator
             .handle_worker_event(OrchestratorWorkerEvent {
                 identity: stale_identity.clone(),
+                workspace_capture: None,
                 event: WorkerEvent::AgentUpdate {
                     issue_id: "1".to_string(),
                     step_name: "build".to_string(),
@@ -26175,6 +28493,7 @@ agent:
         orchestrator
             .handle_worker_event(OrchestratorWorkerEvent {
                 identity: stale_identity.clone(),
+                workspace_capture: None,
                 event: WorkerEvent::WorkerExited {
                     issue_id: "1".to_string(),
                     step_name: "build".to_string(),
@@ -26190,6 +28509,7 @@ agent:
         orchestrator
             .handle_worker_event(OrchestratorWorkerEvent {
                 identity: stale_identity,
+                workspace_capture: None,
                 event: WorkerEvent::WorkerExited {
                     issue_id: "1".to_string(),
                     step_name: "build".to_string(),
@@ -26245,6 +28565,7 @@ agent:
         orchestrator
             .handle_worker_event(OrchestratorWorkerEvent {
                 identity,
+                workspace_capture: None,
                 event: WorkerEvent::AgentUpdate {
                     issue_id: "1".to_string(),
                     step_name: "build".to_string(),
@@ -26316,6 +28637,117 @@ agent:
         assert!(crate::agent::cancellation::contains_worker(
             &registry, &identity
         ));
+    }
+
+    #[tokio::test]
+    async fn immutable_exit_transfers_workspace_exclusivity_before_event_visibility() {
+        let registry = crate::agent::cancellation::new_cancellation_registry();
+        let identity = WorkerIdentity {
+            issue_id: "issue-1".to_string(),
+            run_id: "run-1".to_string(),
+            cycle: 1,
+            step_name: "review".to_string(),
+            started_at: Utc::now(),
+        };
+        let (completion_tx, completion_rx) = watch::channel(false);
+        try_reserve_scheduler_worker_with_workspace_exclusivity(
+            &registry,
+            identity.clone(),
+            tokio_util::sync::CancellationToken::new(),
+            completion_rx,
+            4,
+            4,
+            WorkerCapacity::lane("default", None),
+            &BTreeMap::new(),
+            SchedulerReservation::default(),
+            true,
+        )
+        .unwrap();
+        let (local_tx, local_rx) = mpsc::channel(1);
+        let (orchestrator_tx, mut orchestrator_rx) = mpsc::channel(1);
+        let bridge = tokio::spawn(bridge_worker_events(
+            local_rx,
+            orchestrator_tx,
+            registry.clone(),
+            identity.clone(),
+            completion_tx,
+        ));
+        local_tx
+            .send(WorkerEvent::WorkerExited {
+                issue_id: identity.issue_id.clone(),
+                step_name: identity.step_name.clone(),
+                result: WorkerResult::Success {
+                    output: succeeded_step_output(),
+                    approval_request: None,
+                },
+                timestamp: Utc::now(),
+            })
+            .await
+            .unwrap();
+        drop(local_tx);
+        let mut exit = orchestrator_rx.recv().await.unwrap();
+        bridge.await.unwrap();
+        assert!(exit.workspace_capture.is_some());
+        assert!(!crate::agent::cancellation::contains_worker(
+            &registry, &identity
+        ));
+
+        let same_issue = WorkerIdentity {
+            step_name: "writer".to_string(),
+            started_at: Utc::now(),
+            ..identity.clone()
+        };
+        let (_, same_completion) = watch::channel(false);
+        assert_eq!(
+            try_reserve_scheduler_worker_with_workspace_exclusivity(
+                &registry,
+                same_issue.clone(),
+                tokio_util::sync::CancellationToken::new(),
+                same_completion,
+                4,
+                4,
+                WorkerCapacity::lane("default", None),
+                &BTreeMap::new(),
+                SchedulerReservation::default(),
+                false,
+            ),
+            Err(WorkerReservationError::IssueWorkspaceExclusive)
+        );
+        let other_issue = WorkerIdentity {
+            issue_id: "issue-2".to_string(),
+            started_at: Utc::now(),
+            ..same_issue.clone()
+        };
+        let (_, other_completion) = watch::channel(false);
+        assert!(try_reserve_scheduler_worker_with_workspace_exclusivity(
+            &registry,
+            other_issue,
+            tokio_util::sync::CancellationToken::new(),
+            other_completion,
+            4,
+            4,
+            WorkerCapacity::lane("default", None),
+            &BTreeMap::new(),
+            SchedulerReservation::default(),
+            false,
+        )
+        .is_ok());
+
+        drop(exit.workspace_capture.take());
+        let (_, restored_completion) = watch::channel(false);
+        assert!(try_reserve_scheduler_worker_with_workspace_exclusivity(
+            &registry,
+            same_issue,
+            tokio_util::sync::CancellationToken::new(),
+            restored_completion,
+            4,
+            4,
+            WorkerCapacity::lane("default", None),
+            &BTreeMap::new(),
+            SchedulerReservation::default(),
+            false,
+        )
+        .is_ok());
     }
 
     #[tokio::test]
@@ -26505,6 +28937,7 @@ agent:
             .worker_tx
             .send(OrchestratorWorkerEvent {
                 identity,
+                workspace_capture: None,
                 event: WorkerEvent::AgentUpdate {
                     issue_id: "2".to_string(),
                     step_name: "build".to_string(),
@@ -26617,6 +29050,7 @@ agent:
         orchestrator
             .handle_worker_event(OrchestratorWorkerEvent {
                 identity: identity.clone(),
+                workspace_capture: None,
                 event: WorkerEvent::WorkerExited {
                     issue_id: "1".to_string(),
                     step_name: "build".to_string(),
@@ -28259,6 +30693,7 @@ agent:
         orchestrator
             .handle_worker_event(OrchestratorWorkerEvent {
                 identity: stale,
+                workspace_capture: None,
                 event: WorkerEvent::WorkerExited {
                     issue_id: "1".to_string(),
                     step_name: "build".to_string(),

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -68,9 +68,13 @@ impl PipelineIssueJournalTransaction<'_> {
                 )));
             }
         }
+        #[cfg(test)]
+        let kind = input.kind;
         let record = self.journal.append_unlocked(input).await?;
         #[cfg(test)]
-        if self.journal.transaction_append_late_error {
+        if self.journal.transaction_append_late_error
+            || self.journal.transaction_append_late_error_kind == Some(kind)
+        {
             return Err(std::io::Error::other(
                 "injected error after a valid record became visible",
             ));
@@ -103,6 +107,8 @@ impl PipelineIssueJournalTransaction<'_> {
 pub enum PipelineTransitionKind {
     RunStarted,
     StepRunning,
+    /// A worker launch was durably committed; this authorizes gate delivery.
+    StepLaunched,
     StepCompleted,
     StepFailed,
     StepBlockedOnHuman,
@@ -215,6 +221,8 @@ pub struct PipelineRunJournal {
     #[cfg(test)]
     pub(super) transaction_append_late_error: bool,
     #[cfg(test)]
+    pub(super) transaction_append_late_error_kind: Option<PipelineTransitionKind>,
+    #[cfg(test)]
     pub(super) transaction_latest_record_match_error: bool,
     #[cfg(test)]
     pub(super) transaction_append_error_on_call: Option<(Arc<AtomicUsize>, usize)>,
@@ -230,6 +238,8 @@ impl PipelineRunJournal {
             transaction_append_test_barriers: None,
             #[cfg(test)]
             transaction_append_late_error: false,
+            #[cfg(test)]
+            transaction_append_late_error_kind: None,
             #[cfg(test)]
             transaction_latest_record_match_error: false,
             #[cfg(test)]
@@ -641,6 +651,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }
     }
 

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -862,6 +862,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }])
         .unwrap();
         state.pipeline_runs.insert(

--- a/crates/ensemble-core/src/pipeline/dag.rs
+++ b/crates/ensemble-core/src/pipeline/dag.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use serde::{Deserialize, Serialize};
 
 use crate::config::ensemble::{
-    AffectedPathSource, ArtifactSnapshotConfig, OnFailure, ResolvedOutputSchema,
+    AffectedPathSource, ArtifactAccess, ArtifactSnapshotConfig, OnFailure, ResolvedOutputSchema,
     StepApprovalConfig, StepConfig, StepKind,
 };
 use crate::error::PipelineError;
@@ -28,6 +28,10 @@ pub struct DagStep {
     pub output_schema: Option<ResolvedOutputSchema>,
     #[serde(default)]
     pub artifact_snapshot: Option<ArtifactSnapshotConfig>,
+    #[serde(default)]
+    pub artifact_inputs: Vec<String>,
+    #[serde(default)]
+    pub artifact_access: ArtifactAccess,
     pub depends: Vec<String>,
 }
 
@@ -147,6 +151,8 @@ pub fn build_dag(steps: &[StepConfig]) -> Result<StepDag, PipelineError> {
                 })
                 .transpose()?,
             artifact_snapshot: step.artifact_snapshot.clone(),
+            artifact_inputs: step.artifact_inputs.clone(),
+            artifact_access: step.artifact_access,
             depends: deps,
         });
     }
@@ -244,6 +250,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }
     }
 
@@ -262,6 +270,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }
     }
 
@@ -421,6 +431,8 @@ mod tests {
                 affected_paths: None,
                 output_schema: None,
                 artifact_snapshot: None,
+                artifact_inputs: Vec::new(),
+                artifact_access: Default::default(),
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -436,6 +448,8 @@ mod tests {
                 affected_paths: None,
                 output_schema: None,
                 artifact_snapshot: None,
+                artifact_inputs: Vec::new(),
+                artifact_access: Default::default(),
             },
         ];
 
@@ -465,6 +479,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }];
 
         let dag = build_dag(&steps).unwrap();
@@ -491,6 +507,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }];
 
         let dag = build_dag(&steps).unwrap();
@@ -523,6 +541,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }];
 
         let dag = build_dag(&steps).unwrap();

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -3,9 +3,10 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::acceptance::AcceptanceAttempt;
-use crate::artifact::ArtifactSnapshot;
+use crate::artifact::{ArtifactAccessEvidence, ArtifactIntegrityViolation, ArtifactSnapshot};
 use crate::config::ensemble::{
-    AffectedPathSource, ArtifactSnapshotConfig, OnFailure, ResolvedOutputSchema, StepKind,
+    AffectedPathSource, ArtifactAccess, ArtifactSnapshotConfig, OnFailure, ResolvedOutputSchema,
+    StepKind,
 };
 use crate::orchestrator::resources::SchedulerReservation;
 use crate::pipeline::dag::{DagStep, StepDag};
@@ -131,6 +132,12 @@ pub struct PipelineRun {
     pub step_outputs: HashMap<String, StepOutput>,
     /// Captured producer identities, keyed by producer step.
     pub artifact_snapshots: HashMap<String, ArtifactSnapshot>,
+    /// Content-free immutable Artifact evidence retained for restart recovery.
+    pub artifact_integrity_violations: Vec<ArtifactIntegrityViolation>,
+    pub artifact_access_evidence: Vec<ArtifactAccessEvidence>,
+    /// Immutable consumers whose launch was durably committed. This authorizes
+    /// launch; it does not claim that the child processed any instructions.
+    launched_immutable_consumers: HashSet<String>,
     /// Durable acceptance evidence retained across whole-issue cycles.
     pub acceptance_attempts: Vec<AcceptanceAttempt>,
     /// Acceptance descriptors frozen from the configuration that created this run.
@@ -164,6 +171,11 @@ pub struct PipelineRunSnapshot {
     pub step_outputs: HashMap<String, StepOutput>,
     #[serde(default)]
     pub artifact_snapshots: HashMap<String, ArtifactSnapshot>,
+    #[serde(flatten)]
+    pub artifact_integrity_evidence: Box<ArtifactIntegrityEvidence>,
+    /// Consumers whose launches were durably committed before a crash.
+    #[serde(default)]
+    pub launched_immutable_consumers: HashSet<String>,
     #[serde(default)]
     pub acceptance_attempts: Vec<AcceptanceAttempt>,
     #[serde(default)]
@@ -178,6 +190,16 @@ pub struct PipelineRunSnapshot {
     pub selected_workflow: Option<SelectedWorkflowSnapshot>,
     #[serde(default)]
     pub active_scheduler_reservations: HashMap<String, SchedulerReservation>,
+}
+
+/// Heap-backed durable evidence so empty immutable Artifact support does not enlarge every
+/// journal snapshot carried through ordinary acceptance and terminal lifecycle futures.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactIntegrityEvidence {
+    #[serde(default)]
+    pub artifact_integrity_violations: Vec<ArtifactIntegrityViolation>,
+    #[serde(default)]
+    pub artifact_access_evidence: Vec<ArtifactAccessEvidence>,
 }
 
 impl PipelineRun {
@@ -195,6 +217,9 @@ impl PipelineRun {
             step_states,
             step_outputs: HashMap::new(),
             artifact_snapshots: HashMap::new(),
+            artifact_integrity_violations: Vec::new(),
+            artifact_access_evidence: Vec::new(),
+            launched_immutable_consumers: HashSet::new(),
             acceptance_attempts: Vec::new(),
             resolved_acceptance_plan: None,
             dag,
@@ -213,6 +238,11 @@ impl PipelineRun {
             step_states: self.step_states.clone(),
             step_outputs: self.step_outputs.clone(),
             artifact_snapshots: self.artifact_snapshots.clone(),
+            artifact_integrity_evidence: Box::new(ArtifactIntegrityEvidence {
+                artifact_integrity_violations: self.artifact_integrity_violations.clone(),
+                artifact_access_evidence: self.artifact_access_evidence.clone(),
+            }),
+            launched_immutable_consumers: self.launched_immutable_consumers.clone(),
             acceptance_attempts: self.acceptance_attempts.clone(),
             resolved_acceptance_plan: self.resolved_acceptance_plan.clone(),
             dag_steps: self.dag.steps.clone(),
@@ -262,9 +292,71 @@ impl PipelineRun {
             .and_then(|step| step.artifact_snapshot.as_ref())
     }
 
+    pub(crate) fn artifact_inputs_for(
+        &self,
+        step_name: &str,
+    ) -> Option<(&[String], ArtifactAccess)> {
+        self.dag
+            .steps
+            .iter()
+            .find(|step| step.name == step_name)
+            .map(|step| (step.artifact_inputs.as_slice(), step.artifact_access))
+    }
+
     pub(crate) fn record_artifact_snapshot(&mut self, step_name: &str, snapshot: ArtifactSnapshot) {
         self.artifact_snapshots
             .insert(step_name.to_string(), snapshot);
+    }
+
+    pub(crate) fn record_artifact_integrity_violations(
+        &mut self,
+        violations: impl IntoIterator<Item = ArtifactIntegrityViolation>,
+    ) {
+        self.artifact_integrity_violations.extend(violations);
+    }
+
+    pub(crate) fn record_artifact_access_evidence(
+        &mut self,
+        evidence: ArtifactAccessEvidence,
+    ) -> Option<ArtifactAccessEvidence> {
+        if let Some(existing) = self
+            .artifact_access_evidence
+            .iter_mut()
+            .find(|existing| existing.consumer_step == evidence.consumer_step)
+        {
+            return Some(std::mem::replace(existing, evidence));
+        }
+        self.artifact_access_evidence.push(evidence);
+        None
+    }
+
+    pub(crate) fn restore_artifact_access_evidence(
+        &mut self,
+        evidence: &ArtifactAccessEvidence,
+        previous: Option<ArtifactAccessEvidence>,
+    ) {
+        if let Some(index) = self
+            .artifact_access_evidence
+            .iter()
+            .position(|current| current == evidence)
+        {
+            if let Some(previous) = previous {
+                self.artifact_access_evidence[index] = previous;
+            } else {
+                self.artifact_access_evidence.remove(index);
+            }
+        }
+    }
+
+    /// Marks an immutable consumer launch as durably committed. The marker is
+    /// authority to release the worker gate, not evidence that the child ran.
+    pub(crate) fn mark_immutable_consumer_launch_committed(&mut self, step_name: &str) {
+        self.launched_immutable_consumers
+            .insert(step_name.to_string());
+    }
+
+    pub(crate) fn clear_immutable_consumer_launch_commitment(&mut self, step_name: &str) {
+        self.launched_immutable_consumers.remove(step_name);
     }
 
     pub fn from_snapshot(
@@ -277,6 +369,13 @@ impl PipelineRun {
             step_states: snapshot.step_states,
             step_outputs: snapshot.step_outputs,
             artifact_snapshots: snapshot.artifact_snapshots,
+            artifact_integrity_violations: snapshot
+                .artifact_integrity_evidence
+                .artifact_integrity_violations,
+            artifact_access_evidence: snapshot
+                .artifact_integrity_evidence
+                .artifact_access_evidence,
+            launched_immutable_consumers: snapshot.launched_immutable_consumers,
             acceptance_attempts: snapshot.acceptance_attempts,
             resolved_acceptance_plan: snapshot.resolved_acceptance_plan,
             dag: StepDag {
@@ -320,14 +419,26 @@ impl PipelineRun {
     }
 
     pub fn normalize_stale_running_steps(&mut self) {
-        let mut normalized = false;
-        for state in self.step_states.values_mut() {
-            if matches!(state, StepState::Running { .. }) {
-                *state = StepState::Pending;
-                normalized = true;
-            }
+        let stale_steps = self
+            .step_states
+            .iter()
+            .filter_map(|(step_name, state)| {
+                matches!(state, StepState::Running { .. }).then_some(step_name.clone())
+            })
+            .collect::<std::collections::HashSet<_>>();
+        let provisional_steps = stale_steps
+            .iter()
+            .filter(|step_name| !self.launched_immutable_consumers.contains(*step_name))
+            .collect::<std::collections::HashSet<_>>();
+        for step_name in &stale_steps {
+            self.step_states
+                .insert(step_name.clone(), StepState::Pending);
         }
-        if normalized {
+        if !stale_steps.is_empty() {
+            self.artifact_access_evidence
+                .retain(|evidence| !provisional_steps.contains(&evidence.consumer_step));
+            self.launched_immutable_consumers
+                .retain(|step_name| !stale_steps.contains(step_name));
             self.active_scheduler_reservations.clear();
         }
     }
@@ -363,6 +474,7 @@ impl PipelineRun {
         approval_requested: bool,
     ) -> PipelineAction {
         self.clear_active_scheduler_reservation(step_name);
+        self.clear_immutable_consumer_launch_commitment(step_name);
         let result = output.result.clone();
         self.step_outputs.insert(step_name.to_string(), output);
         match result {
@@ -498,6 +610,7 @@ impl PipelineRun {
         step_name: &str,
         interaction_request_id: String,
     ) -> PipelineAction {
+        self.clear_immutable_consumer_launch_commitment(step_name);
         self.step_states.insert(
             step_name.to_string(),
             StepState::BlockedOnHuman {
@@ -515,6 +628,7 @@ impl PipelineRun {
     /// Marks the step as [`StepState::Errored`] and returns
     /// [`PipelineAction::Failed`].
     pub fn step_failed(&mut self, step_name: &str, error: String) -> PipelineAction {
+        self.clear_immutable_consumer_launch_commitment(step_name);
         self.step_states.insert(
             step_name.to_string(),
             StepState::Errored {
@@ -547,6 +661,7 @@ impl PipelineRun {
             self.step_states.insert(step.clone(), StepState::Pending);
             self.step_outputs.remove(step);
             self.artifact_snapshots.remove(step);
+            self.clear_immutable_consumer_launch_commitment(step);
         }
         reset_steps
     }
@@ -603,6 +718,8 @@ impl PipelineRun {
                         affected_paths: None,
                         output_schema: None,
                         artifact_snapshot: None,
+                        artifact_inputs: Vec::new(),
+                        artifact_access: Default::default(),
                         depends: original_deps,
                     },
                 );
@@ -902,7 +1019,9 @@ fn template_entry(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::artifact::{ArtifactRepositoryObservation, ArtifactSnapshot};
+    use crate::artifact::{
+        ArtifactAccessEnforcement, ArtifactRepositoryObservation, ArtifactSnapshot,
+    };
     use crate::config::ensemble::{
         ArtifactSnapshotConfig, OnFailure, OutputSchemaConfig, StepApprovalConfig,
         StepApprovalMode, StepConfig, StepKind,
@@ -931,6 +1050,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }
     }
 
@@ -949,6 +1070,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }
     }
 
@@ -1020,8 +1143,13 @@ mod tests {
                     repository: "app".to_string(),
                     head: "abc123".to_string(),
                     index_digest: "index-1".to_string(),
+                    tracked_index_entries: std::collections::BTreeMap::new(),
                     tracked_worktree_digest: "worktree-1".to_string(),
+                    tracked_paths: Vec::new(),
+                    tracked_path_digests: std::collections::BTreeMap::new(),
                     untracked_paths: vec!["report.json".to_string()],
+                    untracked_digest: "untracked-1".to_string(),
+                    untracked_path_digests: std::collections::BTreeMap::new(),
                 }],
             },
         );
@@ -1116,6 +1244,68 @@ mod tests {
 
         assert!(restored.active_scheduler_reservations.is_empty());
         assert_eq!(restored.step_states["build"], StepState::Pending);
+    }
+
+    #[test]
+    fn stale_running_snapshot_discards_only_the_stale_consumer_evidence() {
+        let mut run = make_run(&[
+            make_step("build", "builder", &[]),
+            make_step("review", "reviewer", &["build"]),
+        ]);
+        run.record_artifact_access_evidence(ArtifactAccessEvidence {
+            consumer_step: "build".to_string(),
+            enforcement: ArtifactAccessEnforcement::DirectAcpUnsupported,
+        });
+        run.record_artifact_access_evidence(ArtifactAccessEvidence {
+            consumer_step: "review".to_string(),
+            enforcement: ArtifactAccessEnforcement::AcpxApproveReads,
+        });
+        run.mark_running("review", "session-review".to_string());
+
+        run.normalize_stale_running_steps();
+
+        assert_eq!(
+            run.artifact_access_evidence,
+            vec![ArtifactAccessEvidence {
+                consumer_step: "build".to_string(),
+                enforcement: ArtifactAccessEnforcement::DirectAcpUnsupported,
+            }]
+        );
+        run.record_artifact_access_evidence(ArtifactAccessEvidence {
+            consumer_step: "review".to_string(),
+            enforcement: ArtifactAccessEnforcement::AcpxDenyAll,
+        });
+        assert_eq!(
+            run.artifact_access_evidence,
+            vec![
+                ArtifactAccessEvidence {
+                    consumer_step: "build".to_string(),
+                    enforcement: ArtifactAccessEnforcement::DirectAcpUnsupported,
+                },
+                ArtifactAccessEvidence {
+                    consumer_step: "review".to_string(),
+                    enforcement: ArtifactAccessEnforcement::AcpxDenyAll,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn stale_running_snapshot_retains_durably_committed_consumer_evidence() {
+        let mut run = make_run(&[make_step("review", "reviewer", &[])]);
+        run.record_artifact_access_evidence(ArtifactAccessEvidence {
+            consumer_step: "review".to_string(),
+            enforcement: ArtifactAccessEnforcement::AcpxApproveReads,
+        });
+        run.mark_running("review", "session-review".to_string());
+        run.mark_immutable_consumer_launch_committed("review");
+
+        let mut restored = PipelineRun::from_snapshot(run.to_snapshot()).unwrap();
+        restored.normalize_stale_running_steps();
+
+        assert_eq!(restored.step_states["review"], StepState::Pending);
+        assert_eq!(restored.artifact_access_evidence.len(), 1);
+        assert!(restored.launched_immutable_consumers.is_empty());
     }
 
     #[test]
@@ -1275,6 +1465,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }];
         let run = make_run(&steps);
 
@@ -1310,6 +1502,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }
     }
 
@@ -1342,6 +1536,8 @@ mod tests {
             affected_paths: None,
             output_schema: None,
             artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: Default::default(),
         }
     }
 
@@ -2090,6 +2286,8 @@ mod tests {
                 affected_paths: None,
                 output_schema: None,
                 artifact_snapshot: None,
+                artifact_inputs: Vec::new(),
+                artifact_access: Default::default(),
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -2105,6 +2303,8 @@ mod tests {
                 affected_paths: None,
                 output_schema: None,
                 artifact_snapshot: None,
+                artifact_inputs: Vec::new(),
+                artifact_access: Default::default(),
             },
         ];
         let mut run = make_run(&steps);
@@ -2258,6 +2458,60 @@ mod tests {
         run.retry_from_step("build");
 
         assert!(run.artifact_snapshots.is_empty());
+        run.record_artifact_integrity_violations([ArtifactIntegrityViolation {
+            consumer_step: "review".to_string(),
+            producer_step: "build".to_string(),
+            artifact_identity: "artifact-1".to_string(),
+            repository: "repo".to_string(),
+            expected_digest: "expected".to_string(),
+            observed_digest: "observed".to_string(),
+            changed_paths: vec!["src/lib.rs".to_string()],
+            omitted_changed_path_count: 0,
+        }]);
+        run.retry_from_step("build");
+        assert_eq!(run.artifact_integrity_violations.len(), 1);
+    }
+
+    #[test]
+    fn immutable_artifact_violations_survive_snapshot_restore() {
+        let mut run = make_run(&[make_step("review", "reviewer", &[])]);
+        run.record_artifact_integrity_violations([ArtifactIntegrityViolation {
+            consumer_step: "review".to_string(),
+            producer_step: "build".to_string(),
+            artifact_identity: "artifact-1".to_string(),
+            repository: "repo".to_string(),
+            expected_digest: "expected".to_string(),
+            observed_digest: "observed".to_string(),
+            changed_paths: vec!["src/lib.rs".to_string()],
+            omitted_changed_path_count: 0,
+        }]);
+
+        let restored = PipelineRun::from_snapshot(run.to_snapshot()).unwrap();
+
+        assert_eq!(restored.artifact_integrity_violations.len(), 1);
+        assert_eq!(
+            restored.artifact_integrity_violations[0].artifact_identity,
+            "artifact-1"
+        );
+    }
+
+    #[test]
+    fn immutable_artifact_access_enforcement_survives_snapshot_restore() {
+        let mut run = make_run(&[make_step("review", "reviewer", &[])]);
+        run.record_artifact_access_evidence(ArtifactAccessEvidence {
+            consumer_step: "review".to_string(),
+            enforcement: crate::artifact::ArtifactAccessEnforcement::DirectAcpUnsupported,
+        });
+
+        let restored = PipelineRun::from_snapshot(run.to_snapshot()).unwrap();
+
+        assert_eq!(
+            restored.artifact_access_evidence,
+            vec![ArtifactAccessEvidence {
+                consumer_step: "review".to_string(),
+                enforcement: crate::artifact::ArtifactAccessEnforcement::DirectAcpUnsupported,
+            }]
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/tests/step_output_templates.rs
+++ b/crates/ensemble-core/tests/step_output_templates.rs
@@ -43,6 +43,8 @@ fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
         affected_paths: None,
         output_schema: None,
         artifact_snapshot: None,
+        artifact_inputs: Vec::new(),
+        artifact_access: Default::default(),
     }
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -362,6 +362,21 @@ Pipeline run recovery:
   live snapshot. Each declared result validates its output through the existing one-repair
   extraction lifecycle; after validation, a producer captures content-free Git observations before
   becoming passed. Recovery restores the identity and never recaptures completed producer state.
+- A consumer may declare unique direct producer dependencies in `artifact_inputs`. Immutable
+  consumers must select disjoint producer repository sets, because one workspace cannot
+  simultaneously represent sequential producer states. With
+  `artifact_access: immutable`, Ensemble re-observes the selected repositories before the
+  consumer begins and holds an exclusive per-issue workspace reservation until it completes;
+  other same-issue writers defer while it runs, while unrelated issues remain concurrent. A
+  mismatch drains siblings and halts the issue instead of taking a normal
+  failure retry. Its durable content-free evidence reports a deterministic bounded prefix of
+  repository-relative changed paths and an omitted-path count. ACPX uses read approval unless
+  configured `deny_all`; direct ACP does not expose an equivalent launch-time permission
+  classification, so this is not sandboxing.
+- Immutable access evidence is provisional in `step_running`. Ensemble appends
+  `step_launched` before opening the runtime gate; it is durable authorization to launch, not
+  proof that the child executed instructions. Recovery drops provisional stale evidence and
+  retains evidence from a durably committed launch.
 - Pre-final results must be a declaration-order prefix of commands, required files, then required
   handoff sections. Ensemble resumes at the first missing check; only a check interrupted before its
   result became durable may run again. All pre-final checks run, and any non-passing result takes the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -651,6 +651,8 @@ Pipeline step definitions. Each step invokes one agent.
 | `affected_paths` | object | — | Output path source with `step` (direct dependency) and JSON `pointer`; normalized repository-relative paths are leased while the worker is live |
 | `output_schema` | object | — | Config-relative JSON Schema declaration, with `path` naming a Draft 2020-12 schema file; every result variant must provide a matching `output` |
 | `artifact_snapshot` | object | — | Producer declaration with a non-empty `repositories` list of configured repository keys to observe after output validation |
+| `artifact_inputs` | list of strings | `[]` | Direct producer dependencies whose completed Artifact snapshots this step consumes |
+| `artifact_access` | string | `mutable` | `immutable` verifies every declared input immediately before the step starts and halts on drift; `mutable` permits normal workspace mutation |
 
 See [Pipeline Guide](pipelines.md) for details on DAG construction and execution.
 
@@ -658,6 +660,11 @@ See [Pipeline Guide](pipelines.md) for details on DAG construction and execution
 Schema Draft 2020-12 (an omitted `$schema` uses that dialect). `artifact_snapshot.repositories`
 must contain unique configured repository keys. A step may declare either or both; an empty
 snapshot declaration is rejected during configuration activation.
+`artifact_inputs` entries must be unique direct dependencies that declare `artifact_snapshot`.
+For immutable consumers, their producer snapshots must select disjoint repository keys.
+`artifact_access: immutable` requires at least one input. ACPX consumers use read approval unless
+the configured agent explicitly uses `deny_all`; direct ACP has no equivalent launch-time
+permission classification, so snapshot verification remains the enforcement boundary.
 
 Approval behavior:
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -84,8 +84,24 @@ After validation and before a producer becomes passed, Ensemble waits for concur
 siblings of that issue to finish, then records a content-free Artifact snapshot identity for each
 selected repository. It covers the run, cycle, producer, attempt,
 validated-output digest, repository HEAD/index/tracked state, and non-ignored untracked relative
-paths. Source contents, absolute paths, ignored files, workspace copies, consumer mutation rules,
-assessment gates, and automatic cleanup are deliberately out of scope. The identity is journaled,
+paths with content-free per-path digests. A direct dependent may list those producer names in
+`artifact_inputs`. Immutable consumers must select disjoint repositories across those producer
+snapshots. With
+`artifact_access: immutable`, Ensemble compares the producer observations immediately before the
+consumer starts; a mismatch drains sibling workers and leaves the issue halted for manual
+intervention rather than retrying automatically. A `step_launched` journal commitment opens the
+runtime gate; it authorizes launch, rather than proving the child executed instructions. ACPX
+receives read approval for such a consumer
+unless its configured mode is `deny_all`; direct ACP cannot offer an equivalent runtime guarantee.
+The durable violation records a sorted, bounded list of repository-relative changed paths plus an
+omitted-path count, never contents or absolute paths. Source contents, absolute paths, ignored
+files, workspace copies, assessment gates, and automatic cleanup are deliberately out of scope.
+Tracked Gitlinks and untracked embedded Git repositories use their nested repository's ignore
+rules when the host can bind Git observation to an already opened directory; hosts without that
+descriptor-bound facility fail closed rather than observe a mutable external path. Self-contained
+Git metadata contributes `info/exclude`. Standard tracked Gitfiles are never followed: worktree
+`.gitignore` rules apply, while metadata-local excludes outside the opened worktree are deliberately
+not observed and therefore remain part of the captured identity. The identity is journaled,
 appears beside direct dependency output and completed history, and is restored rather than
 recaptured after restart.
 


### PR DESCRIPTION
Closes #480

## Summary
- Add validated direct-producer ArtifactSnapshot bindings with mutable or immutable access frozen into active runs.
- Verify selected repository observations before launch and after the complete agent attempt; drift halts without retry, drains siblings, blocks downstream work, and preserves the workspace.
- Persist content-free violation and runtime-enforcement evidence through journal restart and history, including bounded repository-relative changed paths.
- Apply truthful ACPX read-only defense in depth while recording direct ACP as unsupported; no sandbox claim.
- Document configuration, retry/restart, diagnostics, and trusted-critic boundaries.

## Validation
- Serial workspace tests: core 1361 passed
- Product E2E: 45 passed, 1 ignored
- Web UI feature check
- Workspace Clippy with warnings denied
- cargo fmt and diff checks