### PR TITLE
Expose durable evaluation evidence

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -333,6 +333,328 @@ async fn immutable_artifact_postattempt_mutation_halts() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn configured_evaluation_evidence_reaches_live_api_and_completed_history() {
+    let fixture = TestFixture::new_with_evaluation().expect("fixture setup");
+    let port = reserve_local_port().expect("reserve local port");
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let child = command.spawn().expect("spawn ensemble web");
+    let _guard = ChildGuard::new(child);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+
+    let detail = wait_for_completed_evaluation(&client, &base_url)
+        .await
+        .unwrap();
+    let gate = &detail["artifacts"]["gate_evidence"]["gate"];
+    assert_eq!(gate["outcome"], "passed");
+    assert_eq!(
+        gate["assessments"]["review_a"]["findings"][0]["id"],
+        "finding-1"
+    );
+    assert_eq!(
+        gate["adjudication"]["dispositions"][0]["disposition"],
+        "upheld"
+    );
+    assert_eq!(
+        detail["artifacts"]["artifact_snapshots"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let history = wait_for_evaluation_history_record(&client, &base_url, &fixture.workspace_root)
+        .await
+        .unwrap();
+    assert_eq!(
+        history["artifacts"]["gate_evidence"],
+        detail["artifacts"]["gate_evidence"]
+    );
+    assert_eq!(
+        history["artifacts"]["artifact_snapshots"],
+        detail["artifacts"]["artifact_snapshots"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unresolved_gate_approval_retains_its_deterministic_outcome_and_human_decision() {
+    let fixture = TestFixture::new_with_evaluation().unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_E2E_UNRESOLVED_GATE", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let guard = ChildGuard::new(command.spawn().unwrap());
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    let waiting = wait_for_unresolved_evaluation(&client, &base_url)
+        .await
+        .unwrap();
+    let prompts_before_restart = fs::read_to_string(&fixture.acpx_log_path).unwrap();
+    drop(guard);
+    let mut restarted = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    restarted
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_E2E_UNRESOLVED_GATE", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let _restarted_guard = ChildGuard::new(restarted.spawn().unwrap());
+    wait_for_server(&client, &base_url).await.unwrap();
+    let prompts_after_restart = fs::read_to_string(&fixture.acpx_log_path).unwrap();
+    assert_eq!(
+        prompts_after_restart, prompts_before_restart,
+        "restart must not replay completed steps"
+    );
+    let interaction_id = waiting["current_interaction"]["interaction_request_id"]
+        .as_str()
+        .unwrap();
+    let response = client
+        .post(format!(
+            "{base_url}/api/v1/interactions/{interaction_id}/respond"
+        ))
+        .json(&serde_json::json!({
+            "kind": "approval", "response_schema_version": 1, "approved": true,
+            "reason": "accepted residual risk"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let resume = client
+        .post(format!("{base_url}/api/v1/issues/{ISSUE_ID}/resume"))
+        .send()
+        .await
+        .unwrap();
+    assert!(resume.status().is_success());
+    let completed = wait_for_completed_evaluation(&client, &base_url)
+        .await
+        .unwrap();
+    let gate = &completed["artifacts"]["gate_evidence"]["gate"];
+    assert_eq!(gate["outcome"], "awaiting_human");
+    assert_eq!(gate["human_resolution"]["decision"], "approved");
+    assert_eq!(gate["human_resolution"]["reason"], "accepted residual risk");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unresolved_gate_rejection_retains_its_deterministic_outcome_and_human_decision() {
+    let fixture = TestFixture::new_with_evaluation().unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_E2E_UNRESOLVED_GATE", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let _guard = ChildGuard::new(command.spawn().unwrap());
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    let waiting = wait_for_unresolved_evaluation(&client, &base_url)
+        .await
+        .unwrap();
+    let interaction_id = waiting["current_interaction"]["interaction_request_id"]
+        .as_str()
+        .unwrap();
+    let response = client
+        .post(format!(
+            "{base_url}/api/v1/interactions/{interaction_id}/respond"
+        ))
+        .json(&serde_json::json!({
+            "kind": "approval", "response_schema_version": 1, "approved": false,
+            "reason": "blocking risk remains"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let resume = client
+        .post(format!("{base_url}/api/v1/issues/{ISSUE_ID}/resume"))
+        .send()
+        .await
+        .unwrap();
+    assert!(resume.status().is_success());
+    let failed = wait_for_completed_evaluation_with_status(&client, &base_url, "completed_failed")
+        .await
+        .unwrap();
+    let gate = &failed["artifacts"]["gate_evidence"]["gate"];
+    assert_eq!(gate["outcome"], "awaiting_human");
+    assert_eq!(gate["human_resolution"]["decision"], "rejected");
+    assert_eq!(gate["human_resolution"]["reason"], "blocking risk remains");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dismissed_and_non_blocking_upheld_findings_pass_the_gate() {
+    for (disposition, severity) in [("dismissed", "blocking"), ("upheld", "non_blocking")] {
+        let detail = run_evaluation_variant(disposition, severity, "completed_succeeded").await;
+        assert_eq!(
+            detail["artifacts"]["gate_evidence"]["gate"]["outcome"],
+            "passed"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn upheld_blocking_finding_fails_the_gate() {
+    let detail = run_evaluation_variant("upheld", "blocking", "completed_failed").await;
+    assert_eq!(
+        detail["artifacts"]["gate_evidence"]["gate"]["outcome"],
+        "failed"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concern_result_can_be_approved_through_the_public_interaction() {
+    let fixture = TestFixture::new_with_concern_approval().unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_E2E_CONCERN_PUBLISH", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let _guard = ChildGuard::new(command.spawn().unwrap());
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    let waiting = wait_for_interaction_step(&client, &base_url, "publish")
+        .await
+        .unwrap();
+    let id = waiting["current_interaction"]["interaction_request_id"]
+        .as_str()
+        .unwrap();
+    assert!(client.post(format!("{base_url}/api/v1/interactions/{id}/respond"))
+        .json(&serde_json::json!({"kind":"approval","response_schema_version":1,"approved":true,"reason":"approved concern"}))
+        .send().await.unwrap().status().is_success());
+    assert!(client
+        .post(format!("{base_url}/api/v1/issues/{ISSUE_ID}/resume"))
+        .send()
+        .await
+        .unwrap()
+        .status()
+        .is_success());
+    let completed = wait_for_completed_evaluation(&client, &base_url)
+        .await
+        .unwrap();
+    assert_eq!(
+        completed["workflow_steps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|step| step["name"] == "publish")
+            .unwrap()["state"],
+        "passed"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hidden_extraction_repair_succeeds_once_and_exhaustion_fails() {
+    let repaired = run_repair_variant("1", "completed_succeeded").await;
+    assert_eq!(repaired["status"], "completed_succeeded");
+    let exhausted = run_repair_variant("exhaust", "completed_failed").await;
+    assert_eq!(exhausted["status"], "completed_failed");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn producer_approval_pause_exposes_prelaunch_immutable_drift() {
+    let fixture = TestFixture::new_with_producer_approval().unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let _guard = ChildGuard::new(command.spawn().unwrap());
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    let waiting = wait_for_interaction_step(&client, &base_url, "produce")
+        .await
+        .unwrap();
+    let workspace = PathBuf::from(waiting["workspace"]["path"].as_str().unwrap());
+    let source = fs::read_dir(workspace.join("source"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    fs::write(source.join("README.md"), "drift before evaluator launch\n").unwrap();
+    let id = waiting["current_interaction"]["interaction_request_id"]
+        .as_str()
+        .unwrap();
+    assert!(client.post(format!("{base_url}/api/v1/interactions/{id}/respond")).json(&serde_json::json!({"kind":"approval","response_schema_version":1,"approved":true,"reason":null})).send().await.unwrap().status().is_success());
+    assert!(client
+        .post(format!("{base_url}/api/v1/issues/{ISSUE_ID}/resume"))
+        .send()
+        .await
+        .unwrap()
+        .status()
+        .is_success());
+    let halted = wait_for_interaction_step(&client, &base_url, "review_a")
+        .await
+        .unwrap();
+    assert_eq!(halted["current_interaction"]["step_name"], "review_a");
+    assert!(!fs::read_to_string(&fixture.acpx_log_path)
+        .unwrap()
+        .contains("Evaluation reviewer"));
+}
+
 struct TestFixture {
     config_dir: TempDir,
     todo_path: PathBuf,
@@ -412,6 +734,59 @@ impl TestFixture {
             acpx_log_path,
             mock_bin_dir,
         })
+    }
+
+    fn new_with_evaluation() -> io::Result<Self> {
+        let config_dir = TempDir::new()?;
+        let root = config_dir.path();
+        let todo_path = root.join("TODO.md");
+        let workspace_root = root.join("workspaces");
+        let repo_path = root.join("source");
+        let mock_bin_dir = root.join("bin");
+        let acpx_log_path = root.join("mock-acpx.log");
+        fs::create_dir_all(&workspace_root)?;
+        fs::create_dir_all(&mock_bin_dir)?;
+        init_git_repo(&repo_path)?;
+        fs::write(&todo_path, todo_fixture())?;
+        fs::write(
+            root.join("config.yaml"),
+            evaluation_config_yaml(&todo_path, &workspace_root, &repo_path),
+        )?;
+        fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(mock_bin_dir.join("acpx"), fs::Permissions::from_mode(0o755))?;
+        }
+        Ok(Self {
+            config_dir,
+            todo_path,
+            workspace_root,
+            acpx_log_path,
+            mock_bin_dir,
+        })
+    }
+
+    fn new_with_concern_approval() -> io::Result<Self> {
+        let fixture = Self::new_with_evaluation()?;
+        let config_path = fixture.config_dir.path().join("config.yaml");
+        let config = fs::read_to_string(&config_path)?.replace(
+            "  - name: publish\n    agent: publisher\n    depends: [gate]",
+            "  - name: publish\n    agent: publisher\n    depends: [gate]\n    approval:\n      mode: always",
+        );
+        fs::write(config_path, config)?;
+        Ok(fixture)
+    }
+
+    fn new_with_producer_approval() -> io::Result<Self> {
+        let fixture = Self::new_with_evaluation()?;
+        let config_path = fixture.config_dir.path().join("config.yaml");
+        let config = fs::read_to_string(&config_path)?.replace(
+            "  - name: produce\n    agent: producer\n    artifact_snapshot: { repositories: [source] }",
+            "  - name: produce\n    agent: producer\n    artifact_snapshot: { repositories: [source] }\n    approval:\n      mode: always",
+        );
+        fs::write(config_path, config)?;
+        Ok(fixture)
     }
 
     fn path_with_mock_bin(&self) -> OsString {
@@ -565,6 +940,64 @@ agent:
     )
 }
 
+fn evaluation_config_yaml(todo_path: &Path, workspace_root: &Path, repo_path: &Path) -> String {
+    format!(
+        r#"
+tracker:
+  kind: todo_file
+  path: {}
+  active_states: [Todo, In Progress]
+  terminal_states: [Done]
+workspace:
+  root: {}
+repos:
+  - path: {}
+    branch: main
+agents:
+  producer: {{ acpx_agent: builder, prompt: "Evaluation producer" }}
+  publisher: {{ acpx_agent: builder, prompt: "Evaluation publish" }}
+  reviewer: {{ acpx_agent: builder, prompt: "Evaluation reviewer" }}
+  synthesizer: {{ acpx_agent: builder, prompt: "Evaluation synthesis" }}
+steps:
+  - name: produce
+    agent: producer
+    artifact_snapshot: {{ repositories: [source] }}
+  - name: review_a
+    agent: reviewer
+    depends: [produce]
+    artifact_inputs: [produce]
+    artifact_access: immutable
+  - name: review_b
+    agent: reviewer
+    depends: [produce]
+    artifact_inputs: [produce]
+    artifact_access: immutable
+  - name: adjudicate
+    kind: synthesis
+    agent: synthesizer
+    depends: [review_a, review_b]
+  - name: gate
+    kind: gate
+    depends: [adjudicate]
+    gate:
+      assessment_steps: [review_a, review_b]
+      adjudication_step: adjudicate
+  - name: publish
+    agent: publisher
+    depends: [gate]
+on_success: Done
+on_failure: Failed
+max_cycles: 1
+polling: {{ interval_ms: 100 }}
+concurrency: {{ max_concurrent_agents: 2, max_step_parallelism: 2 }}
+agent: {{ read_timeout_ms: 5000, turn_timeout_ms: 10000, max_retry_backoff_ms: 100 }}
+"#,
+        yaml_quote(&todo_path.display().to_string()),
+        yaml_quote(&workspace_root.display().to_string()),
+        yaml_quote(&repo_path.display().to_string()),
+    )
+}
+
 fn init_git_repo(repo_path: &Path) -> io::Result<()> {
     fs::create_dir_all(repo_path)?;
     let run = |args: &[&str]| -> io::Result<()> {
@@ -632,9 +1065,7 @@ async fn wait_for_halted_immutable_issue(
         let response = client.get(&url).send().await.map_err(|e| e.to_string())?;
         if response.status().is_success() {
             let detail = response.json::<Value>().await.map_err(|e| e.to_string())?;
-            if detail["status"] == "waiting_on_human"
-                && detail["current_interaction"]["step_name"] == "review"
-            {
+            if detail["status"] == "waiting_on_human" {
                 return Ok(detail);
             }
             if Instant::now() >= deadline {
@@ -724,11 +1155,28 @@ if [[ " $* " == *" prompt "* ]]; then
   printf ' prompt-input=%s\n' "$prompt" >> "$log"
   mkdir -p "$cwd/.ensemble"
   cat > "$cwd/.ensemble/mock-prompt.txt"
-  if [[ "${ENSEMBLE_E2E_MISSING_HANDOFF:-}" == "1" ]]; then
-    printf '%s\n' '{"result":"succeeded","summary":"mock agent completed","output":{}}' > "$cwd/.ensemble/verdict-implement.json"
-  else
-    printf '%s\n' '{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}}' > "$cwd/.ensemble/verdict-implement.json"
+  verdict='{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}}'
+  if [[ "${ENSEMBLE_E2E_INVALID_EXTRACTION:-}" == "1" && "$prompt" == Extract* && "$prompt" == *"Evaluation publish"* ]]; then
+    verdict='{"invalid":"extraction"}'
+  elif [[ "${ENSEMBLE_E2E_INVALID_EXTRACTION:-}" == "1" && "$prompt" == "The previous Ensemble step result was invalid."* ]]; then
+    verdict='{"result":"succeeded","summary":"repaired","output":{"artifact":"repaired"}}'
+  elif [[ "${ENSEMBLE_E2E_INVALID_EXTRACTION:-}" == "exhaust" && "$prompt" == *"Extract the Ensemble step result"* && "$prompt" == *"Evaluation publish"* ]]; then
+    verdict='{"invalid":"extraction"}'
+  elif [[ "${ENSEMBLE_E2E_INVALID_EXTRACTION:-}" == "exhaust" && "$prompt" == "The previous Ensemble step result was invalid."* ]]; then
+    verdict='{"invalid":"repair"}'
+  elif [[ "${ENSEMBLE_E2E_CONCERN_PUBLISH:-}" == "1" && "$prompt" == *"Evaluation publish"* ]]; then
+    verdict='{"result":"concern","summary":"operator should approve","output":{"artifact":"mock"}}'
+  elif [[ "$prompt" == *"Evaluation reviewer"* ]]; then
+    severity="${ENSEMBLE_E2E_FINDING_SEVERITY:-non_blocking}"
+    verdict="{\"result\":\"succeeded\",\"summary\":\"assessment\",\"output\":{\"assessment\":{\"findings\":[{\"id\":\"finding-1\",\"severity\":\"$severity\",\"summary\":\"Minor concern\",\"evidence\":{\"path\":\"README.md\"}}]}}}"
+  elif [[ "$prompt" == *"Evaluation synthesis"* ]]; then
+    disposition="${ENSEMBLE_E2E_DISPOSITION:-upheld}"
+    if [[ "${ENSEMBLE_E2E_UNRESOLVED_GATE:-}" == "1" ]]; then disposition="unresolved"; fi
+    verdict="{\"result\":\"succeeded\",\"summary\":\"adjudication\",\"output\":{\"adjudication\":{\"dispositions\":[{\"source_step\":\"review_a\",\"finding_id\":\"finding-1\",\"disposition\":\"$disposition\",\"rationale\":\"retained\",\"evidence\":{\"path\":\"README.md\"}},{\"source_step\":\"review_b\",\"finding_id\":\"finding-1\",\"disposition\":\"$disposition\",\"rationale\":\"retained\",\"evidence\":{\"path\":\"README.md\"}}]}}}"
+  elif [[ "${ENSEMBLE_E2E_MISSING_HANDOFF:-}" == "1" ]]; then
+    verdict='{"result":"succeeded","summary":"mock agent completed","output":{}}'
   fi
+  printf '%s\n' "$verdict" > "$cwd/.ensemble/verdict-implement.json"
   if [[ "${ENSEMBLE_E2E_SKIP_REQUIRED_FILE:-}" != "1" ]]; then
     repo_worktree="$(find "$cwd/source" -mindepth 1 -maxdepth 1 -type d -print -quit)"
     printf 'artifact\n' > "$repo_worktree/acceptance.txt"
@@ -739,11 +1187,7 @@ if [[ " $* " == *" prompt "* ]]; then
 
   printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"mock agent completed"}}}}'
   printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-1","status":"completed","content":{"type":"tool_call","name":"read_file","arguments":{"path":"Cargo.toml"}}}}}'
-  if [[ "${ENSEMBLE_E2E_MISSING_HANDOFF:-}" == "1" ]]; then
-    printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"turn_complete","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7},"verdict":{"result":"succeeded","summary":"mock agent completed","output":{}},"stopReason":"end_turn"}}}'
-  else
-    printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"turn_complete","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7},"verdict":{"result":"succeeded","summary":"mock agent completed","output":{"artifact":"mock"}},"stopReason":"end_turn"}}}'
-  fi
+  printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock-session","update":{"sessionUpdate":"turn_complete","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7},"verdict":%s,"stopReason":"end_turn"}}}\n' "$verdict"
   exit 0
 fi
 
@@ -810,6 +1254,167 @@ async fn wait_for_completed_issue(
     }
 }
 
+async fn wait_for_completed_evaluation(
+    client: &reqwest::Client,
+    base_url: &str,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let url = format!("{base_url}/api/v1/{ISSUE_ID}");
+    loop {
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|error| error.to_string())?;
+        if response.status().is_success() {
+            let detail = response
+                .json::<Value>()
+                .await
+                .map_err(|error| error.to_string())?;
+            if detail["status"] == "completed_succeeded"
+                && detail["artifacts"]["gate_evidence"]["gate"].is_object()
+            {
+                return Ok(detail);
+            }
+            if Instant::now() >= deadline {
+                return Err(format!("evaluation evidence did not complete: {detail:#?}"));
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_completed_evaluation_with_status(
+    client: &reqwest::Client,
+    base_url: &str,
+    status: &str,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        let detail = client
+            .get(format!("{base_url}/api/v1/{ISSUE_ID}"))
+            .send()
+            .await
+            .map_err(|error| error.to_string())?
+            .json::<Value>()
+            .await
+            .map_err(|error| error.to_string())?;
+        if detail["status"] == status && detail["artifacts"]["gate_evidence"]["gate"].is_object() {
+            return Ok(detail);
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("evaluation did not reach {status}: {detail:#?}"));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn run_evaluation_variant(disposition: &str, severity: &str, status: &str) -> Value {
+    let fixture = TestFixture::new_with_evaluation().unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_E2E_DISPOSITION", disposition)
+        .env("ENSEMBLE_E2E_FINDING_SEVERITY", severity)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let _guard = ChildGuard::new(command.spawn().unwrap());
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    wait_for_completed_evaluation_with_status(&client, &base_url, status)
+        .await
+        .unwrap()
+}
+
+async fn run_repair_variant(mode: &str, status: &str) -> Value {
+    let fixture = TestFixture::new_with_evaluation().unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .env("ENSEMBLE_E2E_INVALID_EXTRACTION", mode)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let _guard = ChildGuard::new(command.spawn().unwrap());
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    wait_for_completed_evaluation_with_status(&client, &base_url, status)
+        .await
+        .unwrap()
+}
+
+async fn wait_for_unresolved_evaluation(
+    client: &reqwest::Client,
+    base_url: &str,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        let detail = client
+            .get(format!("{base_url}/api/v1/{ISSUE_ID}"))
+            .send()
+            .await
+            .map_err(|error| error.to_string())?
+            .json::<Value>()
+            .await
+            .map_err(|error| error.to_string())?;
+        if detail["status"] == "waiting_on_human"
+            && detail["current_interaction"]["step_name"] == "gate"
+        {
+            return Ok(detail);
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("unresolved gate did not wait: {detail:#?}"));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_interaction_step(
+    client: &reqwest::Client,
+    base_url: &str,
+    step_name: &str,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        let detail = client
+            .get(format!("{base_url}/api/v1/{ISSUE_ID}"))
+            .send()
+            .await
+            .map_err(|error| error.to_string())?
+            .json::<Value>()
+            .await
+            .map_err(|error| error.to_string())?;
+        if detail["status"] == "waiting_on_human"
+            && detail["current_interaction"]["step_name"] == step_name
+        {
+            return Ok(detail);
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("{step_name} did not await approval: {detail:#?}"));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
 async fn wait_for_history_record(
     client: &reqwest::Client,
     base_url: &str,
@@ -833,6 +1438,41 @@ async fn wait_for_history_record(
             });
             return Err(format!(
                 "history record not found before timeout: {json:#?}\npersisted history:\n{persisted_history}"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_evaluation_history_record(
+    client: &reqwest::Client,
+    base_url: &str,
+    workspace_root: &Path,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let url = format!("{base_url}/api/v1/history?outcome=succeeded");
+    loop {
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|error| error.to_string())?;
+        let json = response
+            .json::<Value>()
+            .await
+            .map_err(|error| error.to_string())?;
+        if let Some(record) = json["records"].as_array().and_then(|records| {
+            records
+                .iter()
+                .find(|record| record["issue_identifier"] == ISSUE_ID)
+        }) {
+            return Ok(record.clone());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "evaluation history record not found: {json:#?}\npersisted history:\n{}",
+                fs::read_to_string(workspace_root.join("ensemble_history.jsonl"))
+                    .unwrap_or_default()
             ));
         }
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -141,6 +141,24 @@ pub async fn get_issue_detail(
     }
 
     if let Some(mut detail) = live_detail {
+        if detail.status.starts_with("completed_") {
+            match latest_history_record(&state.history_path, &identifier).await {
+                Ok(Some(record)) => {
+                    if record.artifacts.is_some() {
+                        detail.artifacts = record.artifacts;
+                    }
+                    detail.acceptance_attempts = record.acceptance_attempts;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    let error = ApiError::new(
+                        "history_read_error",
+                        &format!("failed to read history: {error}"),
+                    );
+                    return (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response();
+                }
+            }
+        }
         if let Err(response) = enrich_issue_attention(&state, exposure, &mut detail).await {
             return response;
         }
@@ -636,7 +654,7 @@ mod tests {
     use crate::config::ensemble::ConcurrencyConfig;
     use crate::history::model::{HistoryRecord, TokenTotals};
     use crate::history::writer::HistoryWriter;
-    use crate::orchestrator::state::OrchestratorState;
+    use crate::orchestrator::state::{CompletedEntry, OrchestratorState};
     use crate::tracker::model::{Issue, RetryEntry, RunningEntry};
     use chrono::{TimeZone, Utc};
     use tempfile::NamedTempFile;
@@ -1334,6 +1352,106 @@ on_failure: Failed
 
         assert_eq!(detail["artifacts"]["run_id"].as_str(), Some("run-77"));
         assert_eq!(detail["workflow_steps"][0]["can_navigate"], true);
+    }
+
+    #[tokio::test]
+    async fn completed_detail_uses_terminal_history_artifacts_when_state_artifacts_lack_gate_evidence(
+    ) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let history_path = tmp.path().join("ensemble_history.jsonl");
+        let mut history_artifacts = crate::history::artifacts::RunArtifacts {
+            run_id: "run-history".into(),
+            workspace_path: tmp.path().join("repo-77").display().to_string(),
+            repos: Vec::new(),
+            transcripts: Vec::new(),
+            artifact_snapshots: Vec::new(),
+            artifact_integrity_violations: Vec::new(),
+            artifact_access_evidence: Vec::new(),
+            gate_evidence: Default::default(),
+        };
+        history_artifacts.gate_evidence.insert(
+            "gate".into(),
+            crate::pipeline::assessment::GateEvidence {
+                assessments: Default::default(),
+                adjudication: crate::pipeline::assessment::Adjudication {
+                    dispositions: Vec::new(),
+                },
+                outcome: crate::pipeline::assessment::GateOutcome::Failed,
+                human_resolution: None,
+            },
+        );
+        HistoryWriter::new(history_path.clone())
+            .append(&HistoryRecord {
+                issue_identifier: "repo#77".into(),
+                issue_id: "NODE_77".into(),
+                outcome: "failed".into(),
+                steps_traversed: vec!["gate".into()],
+                attempts: 1,
+                tokens: TokenTotals {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    total_tokens: 0,
+                },
+                duration_seconds: 1,
+                started_at: Utc::now(),
+                completed_at: Utc::now(),
+                last_error: None,
+                verdict: Some("failed".into()),
+                workspace_path: tmp.path().join("repo-77").display().to_string(),
+                acceptance_attempts: vec![],
+                artifacts: Some(history_artifacts),
+            })
+            .await
+            .unwrap();
+
+        let mut app_state = build_empty_state();
+        app_state.history_path = history_path;
+        app_state.workspace_root = tmp.path().display().to_string();
+        let mut completed_issue = test_issue();
+        completed_issue.id = "NODE_77".into();
+        completed_issue.identifier = "repo#77".into();
+        let stale_artifacts = crate::history::artifacts::RunArtifacts {
+            run_id: "run-stale".into(),
+            workspace_path: tmp.path().join("repo-77").display().to_string(),
+            repos: Vec::new(),
+            transcripts: Vec::new(),
+            artifact_snapshots: Vec::new(),
+            artifact_integrity_violations: Vec::new(),
+            artifact_access_evidence: Vec::new(),
+            gate_evidence: Default::default(),
+        };
+        {
+            let mut state = app_state.orchestrator_state.write().await;
+            state.completed.insert(
+                "NODE_77".into(),
+                CompletedEntry {
+                    issue_id: "NODE_77".into(),
+                    identifier: "repo#77".into(),
+                    run_id: Some("run-stale".into()),
+                    issue: completed_issue,
+                    status: "completed_failed".into(),
+                    workflow_steps: Vec::new(),
+                    completed_at: Utc::now(),
+                    outcome_summary: None,
+                },
+            );
+            state.artifacts.insert("NODE_77".into(), stale_artifacts);
+        }
+
+        let response = get_issue_detail(
+            State(app_state),
+            trusted_local(),
+            Path("repo#77".to_string()),
+        )
+        .await
+        .into_response();
+        let detail = response_json(response).await;
+
+        assert_eq!(detail["artifacts"]["run_id"], "run-history");
+        assert_eq!(
+            detail["artifacts"]["gate_evidence"]["gate"]["outcome"],
+            "failed"
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/history/artifacts.rs
+++ b/crates/ensemble-core/src/history/artifacts.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use crate::artifact::{ArtifactAccessEvidence, ArtifactIntegrityViolation, ArtifactSnapshot};
+use crate::pipeline::engine::PipelineRun;
 use crate::workspace::finalize::FinalizeMode;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
@@ -19,6 +20,53 @@ pub struct RunArtifacts {
     pub artifact_access_evidence: Vec<ArtifactAccessEvidence>,
     #[serde(default)]
     pub gate_evidence: BTreeMap<String, crate::pipeline::assessment::GateEvidence>,
+}
+
+/// Merge durable pipeline evidence into the public artifact envelope used by
+/// both live snapshots and completed history.
+pub fn with_pipeline_evidence(
+    mut artifacts: Option<RunArtifacts>,
+    run: &PipelineRun,
+    run_id: Option<&str>,
+    issue_id: &str,
+    workspace_path: &str,
+) -> Option<RunArtifacts> {
+    if run.artifact_snapshots.is_empty()
+        && run.artifact_integrity_violations.is_empty()
+        && run.artifact_access_evidence.is_empty()
+        && run.gate_evidence.is_empty()
+    {
+        return artifacts;
+    }
+
+    let mut snapshots = run.artifact_snapshots.values().cloned().collect::<Vec<_>>();
+    snapshots.sort_by(|left, right| left.producer_step.cmp(&right.producer_step));
+    let gate_evidence = run
+        .gate_evidence
+        .iter()
+        .map(|(step, evidence)| (step.clone(), evidence.clone()))
+        .collect();
+    match artifacts.as_mut() {
+        Some(artifacts) => {
+            artifacts.artifact_snapshots = snapshots;
+            artifacts.artifact_integrity_violations = run.artifact_integrity_violations.clone();
+            artifacts.artifact_access_evidence = run.artifact_access_evidence.clone();
+            artifacts.gate_evidence = gate_evidence;
+        }
+        None => {
+            artifacts = Some(RunArtifacts {
+                run_id: run_id.unwrap_or(issue_id).to_string(),
+                workspace_path: workspace_path.to_string(),
+                repos: Vec::new(),
+                transcripts: Vec::new(),
+                artifact_snapshots: snapshots,
+                artifact_integrity_violations: run.artifact_integrity_violations.clone(),
+                artifact_access_evidence: run.artifact_access_evidence.clone(),
+                gate_evidence,
+            });
+        }
+    }
+    artifacts
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -472,7 +472,20 @@ mod tests {
             artifact_snapshots: Vec::new(),
             artifact_integrity_violations: Vec::new(),
             artifact_access_evidence: Vec::new(),
-            gate_evidence: Default::default(),
+            gate_evidence: std::collections::BTreeMap::from([(
+                "gate".into(),
+                crate::pipeline::assessment::GateEvidence {
+                    assessments: Default::default(),
+                    adjudication: crate::pipeline::assessment::Adjudication {
+                        dispositions: Vec::new(),
+                    },
+                    outcome: crate::pipeline::assessment::GateOutcome::AwaitingHuman,
+                    human_resolution: Some(crate::pipeline::assessment::GateHumanResolution {
+                        decision: crate::pipeline::assessment::GateHumanDecision::Rejected,
+                        reason: Some("risk remains".into()),
+                    }),
+                },
+            )]),
         });
 
         store.append_history_record("run-1", &record).await.unwrap();
@@ -484,6 +497,15 @@ mod tests {
             Some("https://github.com/acme/repo/pull/12")
         );
         assert_eq!(artifacts.transcripts[0].step_name, "build");
+        assert_eq!(
+            artifacts.gate_evidence["gate"]
+                .human_resolution
+                .as_ref()
+                .unwrap()
+                .reason
+                .as_deref(),
+            Some("risk remains")
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -645,8 +645,22 @@ pub async fn build_issue_snapshot(
         }
     };
 
-    let artifacts = state.artifacts.get(&issue_id).cloned();
     let pipeline_run = state.pipeline_runs.get(&issue_id);
+    let active_run_id = running_entry
+        .and_then(|entry| entry.run_id.as_deref())
+        .or_else(|| waiting_entry.and_then(|entry| entry.run_id.as_deref()));
+    let artifacts = pipeline_run.map_or_else(
+        || state.artifacts.get(&issue_id).cloned(),
+        |run| {
+            crate::history::artifacts::with_pipeline_evidence(
+                state.artifacts.get(&issue_id).cloned(),
+                run,
+                active_run_id,
+                &issue_id,
+                &workspace_path,
+            )
+        },
+    );
     let config = state.pipeline_configs.get(&issue_id);
 
     // Try to get workflow_steps from running config first, then from completed entry
@@ -1298,6 +1312,46 @@ mod tests {
         let running = detail.running.unwrap();
         assert_eq!(running.turn_count, 7);
         assert_eq!(running.session_id, Some("session-abc".to_string()));
+    }
+
+    #[tokio::test]
+    async fn live_issue_snapshot_projects_gate_evidence_before_terminal_history() {
+        let mut state = build_test_state();
+        attach_pipeline_state(&mut state, "NODE_123");
+        state
+            .pipeline_runs
+            .get_mut("NODE_123")
+            .unwrap()
+            .gate_evidence
+            .insert(
+                "gate".to_string(),
+                crate::pipeline::assessment::GateEvidence {
+                    assessments: Default::default(),
+                    adjudication: crate::pipeline::assessment::Adjudication {
+                        dispositions: Vec::new(),
+                    },
+                    outcome: crate::pipeline::assessment::GateOutcome::AwaitingHuman,
+                    human_resolution: Some(crate::pipeline::assessment::GateHumanResolution {
+                        decision: crate::pipeline::assessment::GateHumanDecision::Approved,
+                        reason: Some("accepted residual risk".to_string()),
+                    }),
+                },
+            );
+
+        let detail = build_issue_snapshot(&state, "my-repo#42", "/tmp/workspaces", None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            detail.artifacts.as_ref().unwrap().gate_evidence["gate"]
+                .human_resolution
+                .as_ref()
+                .unwrap()
+                .reason
+                .as_deref(),
+            Some("accepted residual risk")
+        );
+        assert_eq!(detail.artifacts.as_ref().unwrap().run_id, "run-1");
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -10117,49 +10117,19 @@ impl Orchestrator {
     // Keep snapshot projection out of the terminal worker-exit future's stack frame.
     #[inline(never)]
     fn history_artifacts_with_snapshots(
-        mut artifacts: Option<RunArtifacts>,
+        artifacts: Option<RunArtifacts>,
         run: &PipelineRun,
         run_id: Option<&str>,
         issue_id: &str,
         workspace_path: &str,
     ) -> Option<RunArtifacts> {
-        if run.artifact_snapshots.is_empty()
-            && run.artifact_integrity_violations.is_empty()
-            && run.artifact_access_evidence.is_empty()
-            && run.gate_evidence.is_empty()
-        {
-            return artifacts;
-        }
-        let mut snapshots = run.artifact_snapshots.values().cloned().collect::<Vec<_>>();
-        snapshots.sort_by(|left, right| left.producer_step.cmp(&right.producer_step));
-        let violations = run.artifact_integrity_violations.clone();
-        let access_evidence = run.artifact_access_evidence.clone();
-        let gate_evidence = run
-            .gate_evidence
-            .iter()
-            .map(|(step, evidence)| (step.clone(), evidence.clone()))
-            .collect();
-        match artifacts.as_mut() {
-            Some(artifacts) => {
-                artifacts.artifact_snapshots = snapshots;
-                artifacts.artifact_integrity_violations = violations;
-                artifacts.artifact_access_evidence = access_evidence;
-                artifacts.gate_evidence = gate_evidence;
-            }
-            None => {
-                artifacts = Some(RunArtifacts {
-                    run_id: run_id.unwrap_or(issue_id).to_string(),
-                    workspace_path: workspace_path.to_string(),
-                    repos: Vec::new(),
-                    transcripts: Vec::new(),
-                    artifact_snapshots: snapshots,
-                    artifact_integrity_violations: violations,
-                    artifact_access_evidence: access_evidence,
-                    gate_evidence,
-                });
-            }
-        }
-        artifacts
+        crate::history::artifacts::with_pipeline_evidence(
+            artifacts,
+            run,
+            run_id,
+            issue_id,
+            workspace_path,
+        )
     }
 
     pub(super) fn build_owned_history_record(
@@ -10713,17 +10683,12 @@ impl Orchestrator {
                             approved, reason, ..
                         } => {
                             if approved {
-                                run.approve_gate(&pipeline_step.name)
+                                run.approve_gate(&pipeline_step.name, reason)
                             } else {
-                                run.reject_gate(
-                                    &pipeline_step.name,
-                                    reason.unwrap_or_else(|| {
-                                        format!(
-                                            "approval rejected for step '{}'",
-                                            pipeline_step.name
-                                        )
-                                    }),
-                                )
+                                let failure_reason = reason.clone().unwrap_or_else(|| {
+                                    format!("approval rejected for step '{}'", pipeline_step.name)
+                                });
+                                run.reject_gate(&pipeline_step.name, failure_reason, reason)
                             }
                         }
                         _ => {
@@ -27442,6 +27407,7 @@ agent:
                     dispositions: Vec::new(),
                 },
                 outcome: crate::pipeline::assessment::GateOutcome::AwaitingHuman,
+                human_resolution: None,
             },
         );
         let requested_at = Utc::now();
@@ -28196,6 +28162,116 @@ agent:
         assert!(state.waiting_on_human.contains_key(&issue.id));
         assert!(!state.retry_attempts.contains_key(&issue.id));
         assert!(!worktree.exists());
+        drop(repo_temp);
+    }
+
+    #[tokio::test]
+    async fn restart_revalidates_stale_immutable_evaluator_inputs_without_rerunning_the_producer() {
+        let (repo_temp, mut repo) = create_finalize_repo().await;
+        repo.finalize = Default::default();
+        let repo_key = repository_key(&repo, 0);
+        let mut config = make_config();
+        config.repos = vec![repo.clone()];
+        config.steps[0].artifact_snapshot = Some(crate::config::ensemble::ArtifactSnapshotConfig {
+            repositories: vec![repo_key.clone()],
+        });
+        let mut review = config.steps[0].clone();
+        review.name = "review".to_string();
+        review.depends = Some(vec!["build".to_string()]);
+        review.artifact_snapshot = None;
+        review.artifact_inputs = vec!["build".to_string()];
+        review.artifact_access = ArtifactAccess::Immutable;
+        config.steps.push(review);
+        let issue = test_issue("immutable-restart-preflight", "Todo");
+        let temp = tempfile::tempdir().unwrap();
+        let (setup, _) = make_restart_test_orchestrator(&temp, &config, &issue);
+        let worktree = setup
+            .workspace_mgr
+            .prepare_workspace(&issue.id, &issue.identifier)
+            .await
+            .unwrap()
+            .worktrees
+            .remove(&repo_key)
+            .unwrap()
+            .path;
+        let mut run = PipelineRun::new(issue.id.clone(), 1, build_dag(&config.steps).unwrap());
+        run.start();
+        let snapshot = artifact::capture(
+            "run-1",
+            1,
+            "build",
+            1,
+            &serde_json::Value::Null,
+            config.steps[0].artifact_snapshot.as_ref().unwrap(),
+            &BTreeMap::from([(repo_key, worktree.clone())]),
+        )
+        .await
+        .unwrap();
+        run.record_artifact_snapshot("build", snapshot);
+        run.step_states
+            .insert("build".to_string(), StepState::Passed);
+        run.mark_running("review", "crashed-review-session".to_string());
+        setup
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepRunning,
+                issue_id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                run_id: Some("run-1".to_string()),
+                cycle: 1,
+                step: Some("review".to_string()),
+                reason: None,
+                retry: None,
+                snapshot: Some(run.to_snapshot()),
+                terminal_transition: None,
+                delivery: None,
+            })
+            .await
+            .unwrap();
+        drop(setup);
+
+        tokio::fs::write(
+            worktree.join("README.md"),
+            "mutated after evaluator crash\n",
+        )
+        .await
+        .unwrap();
+        let observed_commands = Arc::new(RwLock::new(Vec::new()));
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: Some(Arc::clone(&observed_commands)),
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let (restart, state) =
+            make_restart_test_orchestrator_with_runner(&temp, &config, &issue, runner);
+
+        restart.restore_pipeline_runs_from_journal().await;
+        assert_eq!(
+            state
+                .read()
+                .await
+                .get_pipeline_run(&issue.id)
+                .unwrap()
+                .step_states
+                .get("review"),
+            Some(&StepState::Pending),
+            "a stale evaluator must be re-dispatched through ordinary preflight"
+        );
+
+        restart.dispatch_issue(&issue, None).await;
+
+        assert!(
+            observed_commands.read().await.is_empty(),
+            "the mutated artifact must stop the stale evaluator before any producer or evaluator launch"
+        );
+        let state = state.read().await;
+        let run = state.get_pipeline_run(&issue.id).unwrap();
+        assert_eq!(run.step_states.get("build"), Some(&StepState::Passed));
+        assert!(state.waiting_on_human.contains_key(&issue.id));
+        assert_eq!(run.artifact_integrity_violations.len(), 1);
+        assert_eq!(run.artifact_integrity_violations[0].consumer_step, "review");
+        assert_eq!(run.artifact_integrity_violations[0].producer_step, "build");
         drop(repo_temp);
     }
 

--- a/crates/ensemble-core/src/pipeline/assessment.rs
+++ b/crates/ensemble-core/src/pipeline/assessment.rs
@@ -58,6 +58,10 @@ pub struct GateEvidence {
     pub assessments: BTreeMap<String, Assessment>,
     pub adjudication: Adjudication,
     pub outcome: GateOutcome,
+    /// The authoritative human response for an initially unresolved gate.
+    /// Its absence means the deterministic gate outcome has not been resolved.
+    #[serde(default)]
+    pub human_resolution: Option<GateHumanResolution>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
@@ -66,6 +70,21 @@ pub enum GateOutcome {
     Passed,
     Failed,
     AwaitingHuman,
+}
+
+/// The durable disposition selected by an operator for an unresolved gate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct GateHumanResolution {
+    pub decision: GateHumanDecision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GateHumanDecision {
+    Approved,
+    Rejected,
 }
 
 #[derive(Debug, Deserialize)]
@@ -169,6 +188,7 @@ pub fn evaluate_gate(
         assessments,
         adjudication,
         outcome,
+        human_resolution: None,
     })
 }
 

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -9,7 +9,9 @@ use crate::config::ensemble::{
     StepKind,
 };
 use crate::orchestrator::resources::SchedulerReservation;
-use crate::pipeline::assessment::{evaluate_gate, GateEvidence, GateOutcome};
+use crate::pipeline::assessment::{
+    evaluate_gate, GateEvidence, GateHumanDecision, GateHumanResolution, GateOutcome,
+};
 use crate::pipeline::dag::{DagStep, StepDag};
 use crate::pipeline::verdict::{StepOutput, StepResult};
 use crate::tracker::OwnershipLease;
@@ -563,13 +565,15 @@ impl PipelineRun {
 
     /// Mark an approval gate as approved, transitioning the step to `Passed`
     /// without re-running it and dispatching any downstream steps.
-    pub fn approve_gate(&mut self, step_name: &str) -> PipelineAction {
+    pub fn approve_gate(&mut self, step_name: &str, reason: Option<String>) -> PipelineAction {
         if !matches!(
             self.step_states.get(step_name),
             Some(StepState::AwaitingApproval { .. })
         ) {
             return PipelineAction::Waiting;
         }
+
+        self.record_gate_human_resolution(step_name, GateHumanDecision::Approved, reason);
 
         self.step_states
             .insert(step_name.to_string(), StepState::Passed);
@@ -581,13 +585,24 @@ impl PipelineRun {
     }
 
     /// Mark an approval gate as failed, halting the pipeline.
-    pub fn reject_gate(&mut self, step_name: &str, reason: String) -> PipelineAction {
+    pub fn reject_gate(
+        &mut self,
+        step_name: &str,
+        reason: String,
+        resolution_reason: Option<String>,
+    ) -> PipelineAction {
         if !matches!(
             self.step_states.get(step_name),
             Some(StepState::AwaitingApproval { .. })
         ) {
             return PipelineAction::Waiting;
         }
+
+        self.record_gate_human_resolution(
+            step_name,
+            GateHumanDecision::Rejected,
+            resolution_reason,
+        );
 
         self.step_states.insert(
             step_name.to_string(),
@@ -598,6 +613,20 @@ impl PipelineRun {
         PipelineAction::Failed {
             step: step_name.to_string(),
             reason,
+        }
+    }
+
+    fn record_gate_human_resolution(
+        &mut self,
+        step_name: &str,
+        decision: GateHumanDecision,
+        reason: Option<String>,
+    ) {
+        let Some(evidence) = self.gate_evidence.get_mut(step_name) else {
+            return;
+        };
+        if evidence.human_resolution.is_none() {
+            evidence.human_resolution = Some(GateHumanResolution { decision, reason });
         }
     }
 
@@ -1910,7 +1939,7 @@ mod tests {
             }
         );
 
-        let action = run.approve_gate("implement");
+        let action = run.approve_gate("implement", None);
         assert!(
             matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "review"),
             "expected downstream review dispatch after approval, got {action:?}"
@@ -2003,7 +2032,7 @@ mod tests {
             }
         );
 
-        let action = run.approve_gate("implement");
+        let action = run.approve_gate("implement", None);
         assert!(
             matches!(&action, PipelineAction::Dispatch(reqs) if reqs.len() == 1 && reqs[0].step_name == "review"),
             "expected review dispatch after gate approval, got {action:?}"
@@ -2169,7 +2198,7 @@ mod tests {
         let action = run.bind_approval_interaction("review", "approval-789".to_string());
         assert_eq!(action, PipelineAction::Waiting);
 
-        let action = run.reject_gate("review", "needs more work".to_string());
+        let action = run.reject_gate("review", "needs more work".to_string(), None);
         assert_eq!(
             action,
             PipelineAction::Failed {
@@ -2534,7 +2563,22 @@ mod tests {
             unresolved.step_states["gate"],
             StepState::AwaitingApproval { .. }
         ));
-        assert_eq!(unresolved.approve_gate("gate"), PipelineAction::Succeeded);
+        assert_eq!(
+            unresolved.approve_gate(
+                "gate",
+                Some("operator accepted the residual risk".to_string())
+            ),
+            PipelineAction::Succeeded
+        );
+        let evidence = unresolved.gate_evidence.get("gate").unwrap();
+        assert_eq!(evidence.outcome, GateOutcome::AwaitingHuman);
+        assert_eq!(
+            evidence.human_resolution,
+            Some(crate::pipeline::assessment::GateHumanResolution {
+                decision: crate::pipeline::assessment::GateHumanDecision::Approved,
+                reason: Some("operator accepted the residual risk".to_string()),
+            })
+        );
 
         let mut blocking = make_run(&steps);
         blocking.start();

--- a/crates/ensemble-core/tests/openapi_spec.rs
+++ b/crates/ensemble-core/tests/openapi_spec.rs
@@ -237,6 +237,14 @@ fn openapi_keeps_review_gate_evidence_on_issue_detail() {
         "#/components/schemas/ArtifactSnapshot"
     );
     assert_eq!(
+        schemas["RunArtifacts"]["properties"]["gate_evidence"]["additionalProperties"]["$ref"],
+        "#/components/schemas/GateEvidence"
+    );
+    assert_eq!(
+        schemas["GateEvidence"]["properties"]["human_resolution"]["oneOf"][1]["$ref"],
+        "#/components/schemas/GateHumanResolution"
+    );
+    assert_eq!(
         schemas["RepoFinalizeSnapshot"]["properties"]["observation"]["oneOf"][1]["$ref"],
         "#/components/schemas/DeliveryObservation"
     );

--- a/crates/ensemble-ui/src-ui/src/components/ArtifactsPanel.test.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ArtifactsPanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import type { RunArtifacts } from "@/generated/models";
+import type { GateEvidence, RunArtifacts } from "@/generated/models";
 import ArtifactsPanel from "./ArtifactsPanel";
 
 const artifacts = {
@@ -28,6 +28,45 @@ const artifacts = {
       ],
     },
   ],
+} satisfies RunArtifacts;
+
+const evaluatedArtifacts = {
+  ...artifacts,
+  artifact_access_evidence: [
+    { consumer_step: "review-a", enforcement: "direct_acp_unsupported" },
+  ],
+  artifact_integrity_violations: [
+    {
+      consumer_step: "review-b",
+      producer_step: "produce",
+      artifact_identity: "snapshot-identity",
+      repository: "source",
+      expected_digest: "expected",
+      observed_digest: "observed",
+      changed_paths: ["README.md"],
+      omitted_changed_path_count: 0,
+    },
+  ],
+  gate_evidence: {
+    gate: {
+      assessments: {
+        "review-a": {
+          findings: [{ id: "a-1", severity: "non_blocking", summary: "Minor concern", evidence: { path: "README.md" } }],
+        },
+        "review-b": {
+          findings: [{ id: "b-1", severity: "blocking", summary: "Major concern", evidence: { path: "src/lib.rs" } }],
+        },
+      },
+      adjudication: {
+        dispositions: [
+          { source_step: "review-a", finding_id: "a-1", disposition: "dismissed", rationale: "not reproducible", evidence: { check: "none" } },
+          { source_step: "review-b", finding_id: "b-1", disposition: "unresolved", rationale: "needs approval", evidence: { check: "manual" } },
+        ],
+      },
+      outcome: "awaiting_human",
+      human_resolution: { decision: "approved", reason: "accepted residual risk" },
+    },
+  },
 } satisfies RunArtifacts;
 
 describe("ArtifactsPanel", () => {
@@ -92,5 +131,79 @@ describe("ArtifactsPanel", () => {
 
     expect(screen.queryByRole("link", { name: "Producer step: review" })).not.toBeInTheDocument();
     expect(screen.getByText(/Step details are unavailable/)).toBeInTheDocument();
+  });
+
+  it("groups assessment findings by source with dispositions and content-free integrity evidence", () => {
+    render(
+      <MemoryRouter>
+        <ArtifactsPanel
+          identifier="ensemble#303"
+          workspacePath="/tmp/workspace"
+          artifacts={evaluatedArtifacts}
+          workflowSteps={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Evaluation evidence")).toBeInTheDocument();
+    expect(screen.getByText("Assessment source: review-a")).toBeInTheDocument();
+    expect(screen.getByText("Assessment source: review-b")).toBeInTheDocument();
+    expect(screen.getByText(/a-1: Minor concern/)).toBeInTheDocument();
+    expect(screen.getByText(/Severity: non_blocking; Disposition: dismissed/)).toBeInTheDocument();
+    expect(screen.getByText(/b-1: Major concern/)).toBeInTheDocument();
+    expect(screen.getByText(/Severity: blocking; Disposition: unresolved/)).toBeInTheDocument();
+    expect(screen.getByText(/Outcome:/)).toHaveTextContent("awaiting_human");
+    expect(screen.getByText(/Human decision:/)).toHaveTextContent("approved");
+    expect(screen.getByText(/immutable access enforcement is unsupported/i)).toBeInTheDocument();
+    expect(screen.getByText(/README\.md/)).toBeInTheDocument();
+    expect(screen.queryByText("not reproducible")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["passed", { assessments: {}, adjudication: { dispositions: [] }, outcome: "passed" }, "passed", null],
+    ["failed", { assessments: {}, adjudication: { dispositions: [] }, outcome: "failed" }, "failed", null],
+    ["unresolved", { assessments: {}, adjudication: { dispositions: [] }, outcome: "awaiting_human" }, "awaiting_human", "unresolved"],
+    [
+      "human-resolved",
+      {
+        assessments: {},
+        adjudication: { dispositions: [] },
+        outcome: "awaiting_human",
+        human_resolution: { decision: "approved", reason: "accepted residual risk" },
+      },
+      "awaiting_human",
+      "approved",
+    ],
+  ] satisfies [string, GateEvidence, string, string | null][])(
+    "renders %s gate evidence",
+    (_state, gate, outcome, humanDecision) => {
+      render(
+        <MemoryRouter>
+          <ArtifactsPanel
+            identifier="ensemble#303"
+            workspacePath="/tmp/workspace"
+            artifacts={{ ...artifacts, gate_evidence: { gate } }}
+            workflowSteps={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByLabelText("gate gate evidence")).toHaveTextContent(`Outcome: ${outcome}`);
+      if (humanDecision) {
+        expect(screen.getByLabelText("gate gate evidence")).toHaveTextContent(`Human decision: ${humanDecision}`);
+      } else {
+        expect(screen.getByLabelText("gate gate evidence")).not.toHaveTextContent("Human decision:");
+      }
+    },
+  );
+
+  it("does not imply evaluation evidence for legacy artifacts", () => {
+    render(
+      <MemoryRouter>
+        <ArtifactsPanel identifier="ensemble#303" workspacePath="/tmp/workspace" artifacts={artifacts} workflowSteps={[]} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("Evaluation evidence")).not.toBeInTheDocument();
   });
 });

--- a/crates/ensemble-ui/src-ui/src/components/ArtifactsPanel.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/ArtifactsPanel.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { RunArtifacts, WorkflowStepInfo } from "@/generated/models";
+import { EvaluationEvidence } from "./EvaluationEvidence";
 
 interface ArtifactsPanelProps {
   identifier: string;
@@ -133,6 +134,8 @@ export default function ArtifactsPanel({
           </div>
         </div>
       ) : null}
+
+      {artifacts ? <EvaluationEvidence artifacts={artifacts} /> : null}
 
       {transcripts.length > 0 ? (
         <div className="rounded-lg border bg-muted/20 p-3">

--- a/crates/ensemble-ui/src-ui/src/components/EvaluationEvidence.tsx
+++ b/crates/ensemble-ui/src-ui/src/components/EvaluationEvidence.tsx
@@ -1,0 +1,84 @@
+import type { RunArtifacts } from "@/generated/models";
+
+function enforcementDescription(enforcement: string): string {
+  switch (enforcement) {
+    case "acpx_approve_reads":
+      return "Immutable access enforced: ACPX approves reads.";
+    case "acpx_deny_all":
+      return "Immutable access enforced: ACPX denies all.";
+    case "direct_acp_unsupported":
+      return "Limitation: immutable access enforcement is unsupported for this runtime.";
+    default:
+      return `Immutable access enforcement: ${enforcement}.`;
+  }
+}
+
+interface EvaluationEvidenceProps {
+  artifacts: RunArtifacts;
+}
+
+export function EvaluationEvidence({ artifacts }: EvaluationEvidenceProps) {
+  const gates = Object.entries(artifacts.gate_evidence ?? {});
+  const accessEvidence = artifacts.artifact_access_evidence ?? [];
+  const violations = artifacts.artifact_integrity_violations ?? [];
+  if (gates.length === 0 && accessEvidence.length === 0 && violations.length === 0) return null;
+
+  return (
+    <section className="rounded-lg border bg-muted/20 p-3" aria-labelledby="evaluation-evidence-heading">
+      <h3 id="evaluation-evidence-heading" className="font-medium">Evaluation evidence</h3>
+      <div className="mt-2 space-y-3 text-xs">
+        {gates.map(([gateStep, gate]) => (
+          <section key={gateStep} className="rounded border bg-background p-2" aria-label={`${gateStep} gate evidence`}>
+            <div className="font-medium">Gate: {gateStep}</div>
+            <div className="mt-1 text-muted-foreground">Outcome: <span className="text-foreground">{gate.outcome}</span></div>
+            {gate.human_resolution ? (
+              <div className="text-muted-foreground">
+                Human decision: <span className="text-foreground">{gate.human_resolution.decision}</span>
+                {gate.human_resolution.reason ? <span> — {gate.human_resolution.reason}</span> : null}
+              </div>
+            ) : gate.outcome === "awaiting_human" ? (
+              <div className="text-muted-foreground">Human decision: unresolved</div>
+            ) : null}
+            {Object.entries(gate.assessments).map(([sourceStep, assessment]) => (
+              <section key={sourceStep} className="mt-2 rounded bg-muted/30 p-2" aria-label={`${sourceStep} assessment`}>
+                <div className="font-medium">Assessment source: {sourceStep}</div>
+                {assessment.findings.map((finding) => {
+                  const disposition = gate.adjudication.dispositions.find(
+                    (candidate) => candidate.source_step === sourceStep && candidate.finding_id === finding.id,
+                  );
+                  return (
+                    <div key={finding.id} className="mt-1 text-muted-foreground">
+                      <span className="text-foreground">{finding.id}: {finding.summary}</span>
+                      {" — "}Severity: {finding.severity}; Disposition: {disposition?.disposition ?? "missing"}
+                    </div>
+                  );
+                })}
+              </section>
+            ))}
+          </section>
+        ))}
+        {accessEvidence.length > 0 ? (
+          <section aria-label="Immutable access enforcement">
+            <div className="font-medium">Immutable access enforcement</div>
+            {accessEvidence.map((evidence) => (
+              <div key={evidence.consumer_step} className="text-muted-foreground">
+                {evidence.consumer_step}: {enforcementDescription(evidence.enforcement)}
+              </div>
+            ))}
+          </section>
+        ) : null}
+        {violations.length > 0 ? (
+          <section aria-label="Artifact integrity violations">
+            <div className="font-medium text-destructive">Artifact integrity violations</div>
+            {violations.map((violation) => (
+              <div key={`${violation.consumer_step}:${violation.producer_step}:${violation.repository}`} className="text-muted-foreground">
+                {violation.consumer_step} rejected {violation.producer_step} ({violation.repository}): {violation.changed_paths.join(", ")}
+                {violation.omitted_changed_path_count > 0 ? ` and ${violation.omitted_changed_path_count} more path(s)` : ""}
+              </div>
+            ))}
+          </section>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -347,6 +347,13 @@ orchestrator updates the issue tracker state to `approval.state` (if set) and wa
 `Rejected` transition does not write a separate rejection state — it is treated as a failure in the
 `on_failure` sense.
 
+**Evaluation evidence:** Live issue detail and completed history expose the same content-free
+artifact evidence envelope: immutable snapshot identities, access-enforcement records, bounded
+integrity violations, assessments and their exact adjudication dispositions, and gate outcomes.
+An initially `awaiting_human` gate retains that deterministic outcome after an operator approves
+or rejects it, alongside the optional human reason. Older records that omit evaluation fields
+remain readable and expose no inferred evaluation evidence.
+
 Pipeline run recovery:
 
 - Ensemble appends pipeline transition records to


### PR DESCRIPTION
## Summary

- persist and project deterministic gate evidence and human resolutions across live detail and completed history
- render evaluation findings, dispositions, integrity violations, and immutable-access limitations in Mission Control
- prove passing, failing, repair, human-decision, drift, and restart behavior through the real host product seam

## Validation

- product E2E: 53 passed, 1 intentionally ignored live-dogfood case
- frontend: OpenAPI/Orval codegen, TypeScript, 342 Vitest tests, Vite build
- web-ui check, workspace clippy with warnings denied, cargo fmt, targeted API/history/restart tests
- full workspace parallel run retained known artifact fixture flakes (all 30 artifact tests pass serially) and the pre-existing shutdown cancellation RecvError

Closes #482