### PR TITLE
Authorize tracker event handoffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/ensemble-cli/Cargo.toml
+++ b/crates/ensemble-cli/Cargo.toml
@@ -32,3 +32,4 @@ opener = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+wiremock = { workspace = true }

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -8,15 +8,60 @@ use std::io::{self, Read, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
 const ISSUE_ID: &str = "E2E-1";
 const ISSUE_TITLE: &str = "Exercise product workflow";
 // Exercise acceptance-failure lifecycle boundaries below Tokio's 2 MiB worker default so future
 // growth cannot silently reintroduce platform-dependent stack overflows.
 const ACCEPTANCE_FAILURE_WORKER_STACK_BYTES: usize = 15 * 128 * 1024;
+
+struct GithubTimelineResponder {
+    visible: Arc<AtomicBool>,
+}
+
+impl Respond for GithubTimelineResponder {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let nodes = self.visible.load(Ordering::SeqCst).then(|| {
+            serde_json::json!({
+                "id": "E_status_ready",
+                // Deliberately after the test Artifact capture. The adapter must still
+                // reject it until the fixture exposes it as tracker history.
+                "createdAt": "2099-01-01T00:00:00Z",
+                "previousStatus": "Todo",
+                "status": "In Progress",
+                "project": { "id": "P_configured" },
+                "actor": { "id": "U_operator", "login": "operator" }
+            })
+        });
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "node": { "timelineItems": {
+                "pageInfo": { "hasNextPage": false, "endCursor": null },
+                "nodes": nodes.into_iter().collect::<Vec<_>>()
+            }}}
+        }))
+    }
+}
+
+struct GithubMutationResponder {
+    calls: Arc<AtomicUsize>,
+}
+
+impl Respond for GithubMutationResponder {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "updateProjectV2ItemFieldValue": {
+                "projectV2Item": { "id": "PVT_item" }
+            }}
+        }))
+    }
+}
 
 struct ChildGuard {
     child: Child,
@@ -655,12 +700,127 @@ async fn producer_approval_pause_exposes_prelaunch_immutable_drift() {
         .contains("Evaluation reviewer"));
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_wait_for_event_survives_restart_without_replaying_the_artifact_producer() {
+    let fixture = GithubAuthorizationFixture::new(false).await.unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let first = spawn_web(&fixture.fixture, port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    wait_for_acpx_text(&fixture.fixture.acpx_log_path, "GitHub producer").await;
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    let prompts_before_restart = fs::read_to_string(&fixture.fixture.acpx_log_path).unwrap();
+    assert!(
+        !prompts_before_restart.contains("GitHub protected"),
+        "protected step ran before external tracker evidence: {prompts_before_restart}"
+    );
+    assert_eq!(fixture.mutations.load(Ordering::SeqCst), 0);
+
+    drop(first);
+    let restarted = spawn_web(&fixture.fixture, port);
+    wait_for_server(&client, &base_url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    assert_eq!(
+        fs::read_to_string(&fixture.fixture.acpx_log_path).unwrap(),
+        prompts_before_restart,
+        "restart must retain the completed Artifact producer and pending handoff"
+    );
+    assert_eq!(fixture.mutations.load(Ordering::SeqCst), 0);
+
+    fixture.event_visible.store(true, Ordering::SeqCst);
+    let completed = wait_for_history_step(&client, &base_url, "protected").await;
+    assert_eq!(completed["outcome"], "succeeded");
+    wait_for_acpx_text(&fixture.fixture.acpx_log_path, "GitHub protected").await;
+    let records = read_pipeline_journal_records(fixture.fixture.config_dir.path()).unwrap();
+    assert_journal_evidence_precedes_step(&records, "protected");
+    drop(restarted);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_automatic_transition_waits_for_revalidated_event_before_dispatch() {
+    let fixture = GithubAuthorizationFixture::new(true).await.unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let guard = spawn_web(&fixture.fixture, port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    wait_for_acpx_text(&fixture.fixture.acpx_log_path, "GitHub producer").await;
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    let before = fs::read_to_string(&fixture.fixture.acpx_log_path).unwrap();
+    assert!(
+        !before.contains("GitHub protected"),
+        "protected step ran before tracker evidence: {before}"
+    );
+    assert_eq!(
+        fixture.mutations.load(Ordering::SeqCst),
+        0,
+        "automatic transition must not write its configured tracker state early"
+    );
+
+    fixture.event_visible.store(true, Ordering::SeqCst);
+    let completed = wait_for_history_step(&client, &base_url, "protected").await;
+    assert_eq!(completed["outcome"], "succeeded");
+    wait_for_acpx_text(&fixture.fixture.acpx_log_path, "GitHub protected").await;
+    assert!(
+        fixture.mutations.load(Ordering::SeqCst) >= 1,
+        "automatic transition should reuse the protected step's tracker state"
+    );
+    let records = read_pipeline_journal_records(fixture.fixture.config_dir.path()).unwrap();
+    assert_journal_evidence_precedes_step(&records, "protected");
+    drop(guard);
+
+    let drift = GithubAuthorizationFixture::new(true).await.unwrap();
+    let drift_port = reserve_local_port().unwrap();
+    let drift_base_url = format!("http://127.0.0.1:{drift_port}");
+    let drift_guard = spawn_web(&drift.fixture, drift_port);
+    wait_for_server(&client, &drift_base_url).await.unwrap();
+    wait_for_acpx_text(&drift.fixture.acpx_log_path, "GitHub producer").await;
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    let readme = find_workspace_file(&drift.fixture.workspace_root, "README.md").unwrap();
+    fs::write(readme, "drift after authorization Artifact capture\n").unwrap();
+    drift.event_visible.store(true, Ordering::SeqCst);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(
+        !fs::read_to_string(&drift.fixture.acpx_log_path)
+            .unwrap()
+            .contains("GitHub protected"),
+        "Artifact drift must stop dispatch even when the event matches"
+    );
+    assert_eq!(drift.mutations.load(Ordering::SeqCst), 0);
+    drop(drift_guard);
+}
+
 struct TestFixture {
     config_dir: TempDir,
     todo_path: PathBuf,
     workspace_root: PathBuf,
     acpx_log_path: PathBuf,
     mock_bin_dir: PathBuf,
+}
+
+struct GithubAuthorizationFixture {
+    fixture: TestFixture,
+    _server: MockServer,
+    event_visible: Arc<AtomicBool>,
+    mutations: Arc<AtomicUsize>,
+}
+
+impl GithubAuthorizationFixture {
+    async fn new(automatic_transition: bool) -> io::Result<Self> {
+        let server = MockServer::start().await;
+        let event_visible = Arc::new(AtomicBool::new(false));
+        let mutations = Arc::new(AtomicUsize::new(0));
+        mount_github_authorization_api(&server, event_visible.clone(), mutations.clone()).await;
+        let fixture =
+            TestFixture::new_with_github_authorization(&server.uri(), automatic_transition)?;
+        Ok(Self {
+            fixture,
+            _server: server,
+            event_visible,
+            mutations,
+        })
+    }
 }
 
 impl TestFixture {
@@ -751,6 +911,44 @@ impl TestFixture {
         fs::write(
             root.join("config.yaml"),
             evaluation_config_yaml(&todo_path, &workspace_root, &repo_path),
+        )?;
+        fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(mock_bin_dir.join("acpx"), fs::Permissions::from_mode(0o755))?;
+        }
+        Ok(Self {
+            config_dir,
+            todo_path,
+            workspace_root,
+            acpx_log_path,
+            mock_bin_dir,
+        })
+    }
+
+    fn new_with_github_authorization(
+        endpoint: &str,
+        automatic_transition: bool,
+    ) -> io::Result<Self> {
+        let config_dir = TempDir::new()?;
+        let root = config_dir.path();
+        let todo_path = root.join("unused-TODO.md");
+        let workspace_root = root.join("workspaces");
+        let repo_path = root.join("source");
+        let mock_bin_dir = root.join("bin");
+        let acpx_log_path = root.join("mock-acpx.log");
+        fs::create_dir_all(&workspace_root)?;
+        fs::create_dir_all(&mock_bin_dir)?;
+        init_git_repo(&repo_path)?;
+        fs::write(
+            root.join("config.yaml"),
+            github_authorization_config_yaml(
+                endpoint,
+                &workspace_root,
+                &repo_path,
+                automatic_transition,
+            ),
         )?;
         fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
         #[cfg(unix)]
@@ -998,6 +1196,152 @@ agent: {{ read_timeout_ms: 5000, turn_timeout_ms: 10000, max_retry_backoff_ms: 1
     )
 }
 
+fn github_authorization_config_yaml(
+    endpoint: &str,
+    workspace_root: &Path,
+    repo_path: &Path,
+    automatic_transition: bool,
+) -> String {
+    let handoff = if automatic_transition {
+        "automatic_transition"
+    } else {
+        "wait_for_event"
+    };
+    let tracker_state = automatic_transition.then_some("    tracker_state: In Progress\n");
+    format!(
+        r#"
+tracker:
+  kind: github
+  endpoint: {}
+  api_key: fixture-token
+  repository: acme/repo
+  project_number: 1
+  github:
+    status_field: Status
+  active_states: [Todo]
+  terminal_states: [Done]
+workspace:
+  root: {}
+repos:
+  - path: {}
+    branch: main
+agents:
+  producer: {{ acpx_agent: builder, prompt: "GitHub producer" }}
+  protected: {{ acpx_agent: builder, prompt: "GitHub protected" }}
+steps:
+  - name: produce
+    agent: producer
+    artifact_snapshot: {{ repositories: [source] }}
+  - name: protected
+    agent: protected
+    depends: [produce]
+{}    authorization:
+      artifact_step: produce
+      event:
+        field: F_status
+        value: In Progress
+        actors: [U_operator]
+      after_artifact: true
+      handoff: {}
+on_success: Done
+on_failure: Done
+max_cycles: 1
+polling: {{ interval_ms: 100 }}
+concurrency: {{ max_concurrent_agents: 1, max_step_parallelism: 1 }}
+agent: {{ read_timeout_ms: 5000, turn_timeout_ms: 10000, max_retry_backoff_ms: 100 }}
+"#,
+        yaml_quote(endpoint),
+        yaml_quote(&workspace_root.display().to_string()),
+        yaml_quote(&repo_path.display().to_string()),
+        tracker_state.unwrap_or_default(),
+        handoff,
+    )
+}
+
+async fn mount_github_authorization_api(
+    server: &MockServer,
+    event_visible: Arc<AtomicBool>,
+    mutations: Arc<AtomicUsize>,
+) {
+    let discovery = serde_json::json!({ "data": { "repository": { "projectV2": {
+        "id": "P_configured",
+        "fields": { "pageInfo": { "hasNextPage": false, "endCursor": null }, "nodes": [{
+            "id": "F_status", "name": "Status", "options": [
+                { "id": "O_todo", "name": "Todo" },
+                { "id": "O_progress", "name": "In Progress" },
+                { "id": "O_done", "name": "Done" }
+            ]
+        }] }
+    }}}});
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("projectNumber"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(discovery))
+        .mount(server)
+        .await;
+
+    let project_items = serde_json::json!({ "data": { "node": { "items": {
+        "pageInfo": { "hasNextPage": false, "endCursor": null },
+        "edges": [{ "cursor": "item-1", "node": {
+            "fieldValues": { "nodes": [{
+                "name": "Todo", "optionId": "O_todo",
+                "field": { "id": "F_status", "name": "Status" }
+            }]},
+            "content": {
+                "id": ISSUE_ID, "number": 1, "title": ISSUE_TITLE, "body": "",
+                "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+                "url": "https://github.example/acme/repo/issues/1",
+                "labels": { "nodes": [] }, "assignees": { "totalCount": 0, "nodes": [] }
+            }
+        }}]
+    }}}});
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("orderBy: {field: POSITION"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_items))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("timelineItems(first:"))
+        .respond_with(GithubTimelineResponder {
+            visible: event_visible,
+        })
+        .mount(server)
+        .await;
+
+    let project_item = serde_json::json!({ "data": { "node": { "projectItems": {
+        "nodes": [{ "id": "PVT_item", "project": { "id": "P_configured" } }]
+    }}}});
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("projectItems(first: 100)"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_item))
+        .mount(server)
+        .await;
+
+    let states = serde_json::json!({ "data": { "nodes": [{
+        "id": ISSUE_ID, "number": 1, "title": ISSUE_TITLE, "state": "OPEN",
+        "url": "https://github.example/acme/repo/issues/1",
+        "labels": { "nodes": [{ "name": "Todo" }] },
+        "assignees": { "totalCount": 0, "nodes": [] }
+    }]}});
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("nodes(ids:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(states))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("updateProjectV2ItemFieldValue"))
+        .respond_with(GithubMutationResponder { calls: mutations })
+        .mount(server)
+        .await;
+}
+
 fn init_git_repo(repo_path: &Path) -> io::Result<()> {
     fs::create_dir_all(repo_path)?;
     let run = |args: &[&str]| -> io::Result<()> {
@@ -1194,6 +1538,95 @@ fi
 echo "unexpected mock acpx invocation: $*" >&2
 exit 2
 "#
+}
+
+fn spawn_web(fixture: &TestFixture, port: u16) -> ChildGuard {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    command
+        .arg("web")
+        .arg("--config-dir")
+        .arg(fixture.config_dir.path())
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("PATH", fixture.path_with_mock_bin())
+        .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    ChildGuard::new(command.spawn().expect("spawn ensemble web"))
+}
+
+async fn wait_for_acpx_text(path: &Path, text: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if fs::read_to_string(path).unwrap_or_default().contains(text) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for '{text}' in {}",
+            path.display()
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn find_workspace_file(root: &Path, name: &str) -> io::Result<PathBuf> {
+    fn visit(directory: &Path, name: &str) -> io::Result<Option<PathBuf>> {
+        for entry in fs::read_dir(directory)? {
+            let path = entry?.path();
+            if path.file_name() == Some(OsStr::new(".git")) {
+                continue;
+            }
+            if path.file_name() == Some(OsStr::new(name)) {
+                return Ok(Some(path));
+            }
+            if path.is_dir() {
+                if let Some(found) = visit(&path, name)? {
+                    return Ok(Some(found));
+                }
+            }
+        }
+        Ok(None)
+    }
+    visit(root, name)?.ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, name))
+}
+
+fn read_pipeline_journal_records(config_dir: &Path) -> Result<Vec<Value>, String> {
+    let journal_dir = config_dir.join("state").join("pipeline-runs");
+    let entries = fs::read_dir(journal_dir).map_err(|error| error.to_string())?;
+    let mut records = Vec::new();
+    for entry in entries {
+        let contents = fs::read_to_string(entry.map_err(|error| error.to_string())?.path())
+            .map_err(|error| error.to_string())?;
+        records.extend(
+            contents
+                .lines()
+                .map(serde_json::from_str)
+                .collect::<Result<Vec<Value>, _>>()
+                .map_err(|error| error.to_string())?,
+        );
+    }
+    records.sort_by_key(|record| record["seq"].as_u64());
+    Ok(records)
+}
+
+fn assert_journal_evidence_precedes_step(records: &[Value], step: &str) {
+    let evidence = records
+        .iter()
+        .find(|record| {
+            record["kind"] == "authorization_evidence_selected" && record["step"] == step
+        })
+        .expect("authorization evidence should be durable");
+    let running = records
+        .iter()
+        .find(|record| record["kind"] == "step_running" && record["step"] == step)
+        .expect("protected step should be durably running");
+    assert!(
+        evidence["seq"].as_u64() < running["seq"].as_u64(),
+        "authorization evidence must be journaled before dispatch: {records:#?}"
+    );
 }
 
 async fn wait_for_server(client: &reqwest::Client, base_url: &str) -> Result<(), String> {
@@ -1440,6 +1873,28 @@ async fn wait_for_history_record(
                 "history record not found before timeout: {json:#?}\npersisted history:\n{persisted_history}"
             ));
         }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_history_step(client: &reqwest::Client, base_url: &str, step: &str) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let url = format!("{base_url}/api/v1/history?outcome=succeeded&step={step}");
+    loop {
+        if let Ok(response) = client.get(&url).send().await {
+            if let Ok(json) = response.json::<Value>().await {
+                if let Some(record) = json["records"]
+                    .as_array()
+                    .and_then(|records| records.first())
+                {
+                    return record.clone();
+                }
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for completed {step} history"
+        );
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -310,9 +310,13 @@ pub(crate) async fn prepare_orchestrator_runtime(
         return Ok(None);
     };
 
+    let authorization_event_fields = config.authorization_event_fields();
     let tracker: Arc<dyn IssueTracker> = Arc::from(create_tracker_for_runtime(&config)?);
     let config = Arc::new(RwLock::new(config));
     tracker.validate_configuration().await?;
+    for field in authorization_event_fields {
+        tracker.validate_event_evidence(&field).await?;
+    }
     // `AcpAgentRunner` is the shared runtime dispatcher: `acpx_agent` steps run through the
     // acpx CLI/session runtime, while explicit direct configs keep the ACP stdio path.
     let agent_runner: Arc<dyn AgentRunner> = Arc::new(AcpAgentRunner::new_with_document_state(

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -1034,6 +1034,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }])
         .unwrap();
 

--- a/crates/ensemble-core/src/artifact.rs
+++ b/crates/ensemble-core/src/artifact.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 #[cfg(test)]
 use std::sync::{Mutex, OnceLock};
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -72,6 +73,10 @@ pub struct ArtifactSnapshot {
     pub producer_step: String,
     pub attempt: u32,
     pub output_digest: String,
+    /// Instant at which the immutable producer evidence was captured. Older
+    /// snapshots intentionally deserialize without this proof.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub captured_at: Option<DateTime<Utc>>,
     pub repositories: Vec<ArtifactRepositoryObservation>,
 }
 
@@ -212,6 +217,7 @@ pub async fn capture(
         producer_step: producer_step.to_string(),
         attempt,
         output_digest,
+        captured_at: Some(Utc::now()),
         repositories: observations,
     })
 }
@@ -1394,7 +1400,11 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(first, second);
+        assert!(first.captured_at.is_some());
+        assert!(second.captured_at.is_some());
+        assert_eq!(first.identity, second.identity);
+        assert_eq!(first.output_digest, second.output_digest);
+        assert_eq!(first.repositories, second.repositories);
         assert_eq!(first.repositories[0].untracked_paths, vec!["visible.txt"]);
 
         tokio::fs::write(dir.path().join("ignored.out"), "changed ignored content")
@@ -1411,7 +1421,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(first, after_ignored_change);
+        assert!(after_ignored_change.captured_at.is_some());
+        assert_eq!(first.identity, after_ignored_change.identity);
+        assert_eq!(first.output_digest, after_ignored_change.output_digest);
+        assert_eq!(first.repositories, after_ignored_change.repositories);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -668,6 +668,38 @@ pub struct StepConfig {
     /// sources and their ordinary-synthesis adjudicator.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gate: Option<GateConfig>,
+    /// Optional tracker-event authorization required before this step can run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization: Option<StepAuthorizationConfig>,
+}
+
+/// Immutable upstream Artifact and tracker-event evidence required before one
+/// protected step may begin. Field and value are opaque adapter data.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct StepAuthorizationConfig {
+    pub artifact_step: String,
+    pub event: TrackerEventPredicateConfig,
+    #[serde(default)]
+    pub after_artifact: bool,
+    pub handoff: AuthorizationHandoffMode,
+}
+
+/// Opaque matching predicate over one normalized tracker event.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TrackerEventPredicateConfig {
+    pub field: String,
+    pub value: String,
+    pub actors: Vec<String>,
+}
+
+/// The explicit source of an authorization event.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorizationHandoffMode {
+    WaitForEvent,
+    AutomaticTransition,
 }
 
 /// Static evidence sources consumed by a deterministic gate.
@@ -1089,6 +1121,25 @@ pub(crate) fn read_dotenv(path: &Path) -> HashMap<String, String> {
 impl EnsembleConfig {
     pub fn uses_workflow_selection(&self) -> bool {
         !self.workflow_selection.is_empty()
+    }
+
+    /// Every opaque event field whose adapter evidence must be proven before
+    /// this configuration generation is allowed to activate.
+    pub fn authorization_event_fields(&self) -> Vec<String> {
+        let mut fields = self
+            .steps
+            .iter()
+            .chain(
+                self.pipelines
+                    .values()
+                    .flat_map(|pipeline| pipeline.steps.iter()),
+            )
+            .filter_map(|step| step.authorization.as_ref())
+            .map(|authorization| authorization.event.field.clone())
+            .collect::<Vec<_>>();
+        fields.sort();
+        fields.dedup();
+        fields
     }
 
     /// Resolve a durable selected-workflow identity into the whole immutable
@@ -2270,6 +2321,81 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
             }
         }
         validate_gate_configs(steps, &dag)?;
+        validate_authorization_configs(steps, &dag)?;
+    }
+    Ok(())
+}
+
+fn validate_authorization_configs(
+    steps: &[StepConfig],
+    dag: &crate::pipeline::dag::StepDag,
+) -> Result<(), PipelineError> {
+    for step in steps {
+        let Some(authorization) = step.authorization.as_ref() else {
+            continue;
+        };
+        let invalid = |reason: &str| PipelineError::InvalidStepConfig {
+            step: step.name.clone(),
+            reason: reason.to_string(),
+        };
+        if step.kind == StepKind::Gate {
+            return Err(invalid(
+                "authorization is valid only for dispatched agent or synthesis steps, not gates",
+            ));
+        }
+        if authorization.artifact_step.trim().is_empty()
+            || !dag
+                .steps
+                .iter()
+                .find(|candidate| candidate.name == step.name)
+                .is_some_and(|resolved| resolved.depends.contains(&authorization.artifact_step))
+            || steps
+                .iter()
+                .find(|candidate| candidate.name == authorization.artifact_step)
+                .is_none_or(|producer| producer.artifact_snapshot.is_none())
+        {
+            return Err(invalid(
+                "authorization artifact_step must name a direct dependency that declares artifact_snapshot",
+            ));
+        }
+        let predicate = &authorization.event;
+        if predicate.field.trim().is_empty() || predicate.value.trim().is_empty() {
+            return Err(invalid(
+                "authorization event field and value must be non-blank",
+            ));
+        }
+        let mut actors = std::collections::HashSet::new();
+        if predicate.actors.is_empty()
+            || predicate
+                .actors
+                .iter()
+                .any(|actor| actor.trim().is_empty() || !actors.insert(actor))
+        {
+            return Err(invalid(
+                "authorization event actors must be non-blank and unique",
+            ));
+        }
+        if matches!(
+            authorization.handoff,
+            AuthorizationHandoffMode::AutomaticTransition
+        ) && step
+            .tracker_state
+            .as_deref()
+            .is_none_or(|state| state.trim().is_empty())
+        {
+            return Err(invalid(
+                "automatic_transition authorization requires the protected step's tracker_state",
+            ));
+        }
+        if matches!(
+            authorization.handoff,
+            AuthorizationHandoffMode::WaitForEvent
+        ) && step.tracker_state.is_some()
+        {
+            return Err(invalid(
+                "wait_for_event authorization forbids the protected step's tracker_state",
+            ));
+        }
     }
     Ok(())
 }
@@ -5287,5 +5413,99 @@ on_failure: Failed
             PipelineError::InvalidSynthesisStep { step, reason }
                 if step == "synthesize" && reason.contains("explicit non-empty depends")
         ));
+    }
+
+    #[test]
+    fn authorization_requires_direct_artifact_and_explicit_handoff_contract() {
+        let mut config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+repos:
+  - path: /tmp/repo
+    branch: main
+agents:
+  worker:
+    acpx_agent: claude
+    prompt: "Work."
+steps:
+  - name: produce
+    agent: worker
+    artifact_snapshot:
+      repositories: [repo]
+  - name: protected
+    agent: worker
+    depends: [produce]
+    authorization:
+      artifact_step: produce
+      event:
+        field: opaque-field
+        value: opaque-value
+        actors: [actor-1]
+      after_artifact: true
+      handoff: wait_for_event
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        validate_config(&config).unwrap();
+        assert_eq!(config.authorization_event_fields(), ["opaque-field"]);
+        config.steps[1].tracker_state = Some("In Progress".to_string());
+        assert!(validate_config(&config)
+            .unwrap_err()
+            .to_string()
+            .contains("wait_for_event authorization forbids"));
+
+        config.steps[1].tracker_state = None;
+        config.steps[1].kind = StepKind::Gate;
+        let dag = crate::pipeline::dag::build_dag(&config.steps).unwrap();
+        assert!(validate_authorization_configs(&config.steps, &dag)
+            .unwrap_err()
+            .to_string()
+            .contains(
+                "authorization is valid only for dispatched agent or synthesis steps, not gates"
+            ));
+    }
+
+    #[test]
+    fn automatic_authorization_requires_a_tracker_transition() {
+        let config = parse_config(
+            r#"
+tracker:
+  kind: todo_file
+repos:
+  - path: /tmp/repo
+    branch: main
+agents:
+  worker:
+    acpx_agent: claude
+    prompt: "Work."
+steps:
+  - name: produce
+    agent: worker
+    artifact_snapshot:
+      repositories: [repo]
+  - name: protected
+    agent: worker
+    depends: [produce]
+    authorization:
+      artifact_step: produce
+      event:
+        field: opaque-field
+        value: opaque-value
+        actors: [actor-1]
+      handoff: automatic_transition
+on_success: Done
+on_failure: Failed
+"#,
+        )
+        .unwrap();
+
+        assert!(validate_config(&config)
+            .unwrap_err()
+            .to_string()
+            .contains("automatic_transition authorization requires"));
     }
 }

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -909,6 +909,7 @@ fn build_setup_dag(steps: &[SetupStep]) -> Result<crate::pipeline::dag::StepDag,
                 artifact_inputs: step.artifact_inputs.clone(),
                 artifact_access: step.artifact_access,
                 gate: step.gate.clone(),
+                authorization: None,
             })
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -1074,6 +1074,7 @@ mod tests {
                     artifact_inputs: Vec::new(),
                     artifact_access: Default::default(),
                     gate: None,
+                    authorization: None,
                 },
                 StepConfig {
                     name: "review".to_string(),
@@ -1092,6 +1093,7 @@ mod tests {
                     artifact_inputs: Vec::new(),
                     artifact_access: Default::default(),
                     gate: None,
+                    authorization: None,
                 },
             ],
             on_success: "finalize".to_string(),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -56,7 +56,8 @@ use crate::attention::{
     AttentionUpsert,
 };
 use crate::config::ensemble::{
-    repository_key, AgentConfig, ArtifactAccess, EnsembleConfig, OnFailure, StepKind,
+    repository_key, AgentConfig, ArtifactAccess, AuthorizationHandoffMode, EnsembleConfig,
+    OnFailure, StepKind,
 };
 use crate::error::{AgentError, EnsembleError};
 use crate::history::artifacts::{finalize_mode_name, RunArtifacts};
@@ -74,8 +75,7 @@ use crate::interaction::{
 use crate::observability::events::{EventBus, PipelineEvent};
 use crate::observability::events_contract::{
     elapsed_ms, ISSUE_DISPATCH_COMPLETED, ISSUE_DISPATCH_STARTED, ORCH_TICK_FINISHED,
-    ORCH_TICK_STARTED, STEP_STARTED, TRACKER_TRANSITION_FAILED, TRACKER_TRANSITION_REQUESTED,
-    TRACKER_TRANSITION_SUCCEEDED,
+    ORCH_TICK_STARTED, STEP_STARTED,
 };
 #[cfg(test)]
 use crate::orchestrator::delivery::{
@@ -90,8 +90,8 @@ use crate::orchestrator::resources::{resolve_output_paths, SchedulerReservation}
 use crate::pipeline::assessment::{DispositionKind, GateEvidence};
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{
-    DispatchRequest, PipelineAction, PipelineRun, PipelineRunSnapshot, SelectedWorkflowSnapshot,
-    StepOutputTemplateContext, StepState,
+    AutomaticTransitionState, DispatchRequest, PipelineAction, PipelineRun, PipelineRunSnapshot,
+    SelectedWorkflowSnapshot, StepOutputTemplateContext, StepState,
 };
 use crate::pipeline::verdict::{StepOutput, StepResult};
 use crate::timeline::persistence::TimelinePersistence;
@@ -3550,6 +3550,12 @@ impl Orchestrator {
         dispatch: StepDispatchContext<'_>,
         _permit: &DispatchPermit,
     ) -> Result<StepDispatchOutcome, StepDispatchError> {
+        if !self
+            .select_current_authorization_evidence(issue, dispatch.step_name)
+            .await?
+        {
+            return Ok(StepDispatchOutcome::Deferred);
+        }
         let (
             worker_identity,
             issue_snapshot,
@@ -3805,44 +3811,15 @@ impl Orchestrator {
             "dispatching pipeline step"
         );
 
-        // Set tracker state if specified by the step
-        if let Some(state_name) = dispatch.tracker_state {
-            if self.tracker.supports_writes() {
-                info!(
-                    event = TRACKER_TRANSITION_REQUESTED,
-                    issue_id = %issue.id,
-                    step = dispatch.step_name,
-                    tracker_state_to = state_name,
-                    "requesting tracker state transition"
-                );
-                match self.tracker.set_issue_state(&issue.id, state_name).await {
-                    Ok(()) => {
-                        let mut transitioned_issue = issue.clone();
-                        transitioned_issue.state = state_name.to_string();
-                        self.state
-                            .write()
-                            .await
-                            .update_issue_snapshot(&issue.id, transitioned_issue);
-                        info!(
-                            event = TRACKER_TRANSITION_SUCCEEDED,
-                            issue_id = %issue.id,
-                            step = dispatch.step_name,
-                            tracker_state_to = state_name,
-                            "tracker state transition succeeded"
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                            event = TRACKER_TRANSITION_FAILED,
-                            issue_id = %issue.id,
-                            step = dispatch.step_name,
-                            tracker_state_to = state_name,
-                            error = %e,
-                            "failed to set tracker state for step dispatch"
-                        );
-                    }
-                }
-            }
+        if !self
+            .apply_tracker_handoff_before_dispatch(
+                issue,
+                dispatch.step_name,
+                dispatch.tracker_state,
+            )
+            .await?
+        {
+            return Ok(StepDispatchOutcome::Deferred);
         }
 
         // Reserve this issue's journal ordering before publishing the speculative
@@ -4228,6 +4205,298 @@ impl Orchestrator {
             completion_tx,
         ));
         Ok(StepDispatchOutcome::Spawned)
+    }
+
+    async fn apply_tracker_handoff_before_dispatch(
+        &self,
+        issue: &Issue,
+        step_name: &str,
+        tracker_state: Option<&str>,
+    ) -> Result<bool, StepDispatchError> {
+        let handoff = self
+            .state
+            .read()
+            .await
+            .get_pipeline_run(&issue.id)
+            .and_then(|run| run.authorization_handoff(step_name));
+        match handoff {
+            Some(AuthorizationHandoffMode::WaitForEvent) => Ok(true),
+            Some(AuthorizationHandoffMode::AutomaticTransition) => {
+                let Some(target_state) = tracker_state else {
+                    return Ok(false);
+                };
+                let pending = {
+                    let mut state = self.state.write().await;
+                    let Some(run) = state.get_pipeline_run_mut(&issue.id) else {
+                        return Ok(false);
+                    };
+                    match run.automatic_transition_state(step_name) {
+                        Some(AutomaticTransitionState::Applied {
+                            target_state: applied,
+                        }) if applied == target_state => return Ok(true),
+                        Some(AutomaticTransitionState::Pending {
+                            target_state: pending_target,
+                            expected_state,
+                        }) if pending_target == target_state => {
+                            Some((expected_state.clone(), false, None))
+                        }
+                        _ => {
+                            let previous = run.automatic_transition_state(step_name).cloned();
+                            run.set_automatic_transition_pending(
+                                step_name,
+                                target_state.to_string(),
+                                issue.state.clone(),
+                            );
+                            Some((issue.state.clone(), true, previous))
+                        }
+                    }
+                };
+                let Some((expected_state, newly_pending, previous_pending)) = pending else {
+                    return Ok(false);
+                };
+                if newly_pending {
+                    let transition = {
+                        let state = self.state.read().await;
+                        Self::transition_input_for_run(
+                            &state,
+                            &issue.id,
+                            &issue.identifier,
+                            PipelineTransitionKind::AutomaticTransitionPending,
+                            Some(step_name.to_string()),
+                            None,
+                            None,
+                        )
+                    };
+                    if let Some(transition) = transition {
+                        let transaction = self
+                            .pipeline_journal
+                            .begin_issue_transition(&issue.id)
+                            .await;
+                        let pending_is_durable = match transaction.append(transition.clone()).await
+                        {
+                            Ok(_) => true,
+                            Err(_) => transaction
+                                .latest_record_matches(&transition)
+                                .await
+                                .unwrap_or(false),
+                        };
+                        drop(transaction);
+                        if !pending_is_durable {
+                            if let Some(run) =
+                                self.state.write().await.get_pipeline_run_mut(&issue.id)
+                            {
+                                run.restore_automatic_transition_state(step_name, previous_pending);
+                            }
+                            return Ok(false);
+                        }
+                    } else {
+                        return Ok(false);
+                    }
+                }
+                let current = match self
+                    .tracker
+                    .fetch_issue_states_by_ids(std::slice::from_ref(&issue.id))
+                    .await
+                {
+                    Ok(states) => states
+                        .into_iter()
+                        .find(|candidate| candidate.id == issue.id),
+                    Err(_) => return Ok(false),
+                };
+                let Some(current) = current else {
+                    return Ok(false);
+                };
+                if current.state != target_state {
+                    if current.state != expected_state || !self.tracker.supports_writes() {
+                        return Ok(false);
+                    }
+                    if self
+                        .tracker
+                        .set_issue_state(&issue.id, target_state)
+                        .await
+                        .is_err()
+                    {
+                        return Ok(false);
+                    }
+                }
+                let original_current = current.clone();
+                let transition = {
+                    let mut state = self.state.write().await;
+                    let Some(run) = state.get_pipeline_run_mut(&issue.id) else {
+                        return Ok(false);
+                    };
+                    run.set_automatic_transition_applied(step_name, target_state.to_string());
+                    let mut transitioned = current;
+                    transitioned.state = target_state.to_string();
+                    state.update_issue_snapshot(&issue.id, transitioned);
+                    Self::transition_input_for_run(
+                        &state,
+                        &issue.id,
+                        &issue.identifier,
+                        PipelineTransitionKind::AutomaticTransitionApplied,
+                        Some(step_name.to_string()),
+                        None,
+                        None,
+                    )
+                };
+                let Some(transition) = transition else {
+                    return Ok(false);
+                };
+                if self.pipeline_journal.append(transition).await.is_err() {
+                    // The remote write may already have succeeded, but only a
+                    // durable `AutomaticTransitionApplied` record opens the
+                    // protected dispatch gate. Keep the in-memory owner at
+                    // its durable Pending checkpoint so a crash or later tick
+                    // revalidates the remote state without repeating the write.
+                    let mut state = self.state.write().await;
+                    if let Some(run) = state.get_pipeline_run_mut(&issue.id) {
+                        run.set_automatic_transition_pending(
+                            step_name,
+                            target_state.to_string(),
+                            expected_state,
+                        );
+                    }
+                    state.update_issue_snapshot(&issue.id, original_current);
+                    return Ok(false);
+                }
+                Ok(true)
+            }
+            None => {
+                if let Some(state_name) = tracker_state {
+                    if self.tracker.supports_writes()
+                        && self
+                            .tracker
+                            .set_issue_state(&issue.id, state_name)
+                            .await
+                            .is_ok()
+                    {
+                        let mut transitioned = issue.clone();
+                        transitioned.state = state_name.to_string();
+                        self.state
+                            .write()
+                            .await
+                            .update_issue_snapshot(&issue.id, transitioned);
+                    }
+                }
+                Ok(true)
+            }
+        }
+    }
+
+    /// Re-read adapter evidence immediately before reservation. An unavailable
+    /// or changed proof deliberately leaves the step pending without consuming
+    /// agent capacity; the next poll can retry the read.
+    async fn select_current_authorization_evidence(
+        &self,
+        issue: &Issue,
+        step_name: &str,
+    ) -> Result<bool, StepDispatchError> {
+        let authorization_artifact = {
+            let state = self.state.read().await;
+            state.get_pipeline_run(&issue.id).and_then(|run| {
+                run.authorization_for(step_name).and_then(|authorization| {
+                    run.artifact_snapshots
+                        .get(&authorization.artifact_step)
+                        .cloned()
+                })
+            })
+        };
+        let Some(authorization_artifact) = authorization_artifact else {
+            let configured = self
+                .state
+                .read()
+                .await
+                .get_pipeline_run(&issue.id)
+                .is_some_and(|run| run.authorization_for(step_name).is_some());
+            if configured {
+                return Ok(false);
+            }
+            return Ok(true);
+        };
+        let events = match self.tracker.fetch_tracker_events(&issue.id).await {
+            Ok(events) => events,
+            Err(error) => {
+                warn!(issue_id = %issue.id, step = step_name, error = %error, "authorization evidence is unavailable; retaining pending step");
+                return Ok(false);
+            }
+        };
+        let repositories = self
+            .workspace_mgr
+            .owned_worktree_paths(&issue.id)
+            .map(|paths| paths.into_iter().collect::<BTreeMap<_, _>>())
+            .map_err(|error| StepDispatchError::immutable_integrity(AgentError::PromptError {
+                reason: format!(
+                    "authorization Artifact could not be verified: prepared worktree unavailable: {error}"
+                ),
+            }))?;
+        let violations = artifact::verify_immutable_inputs(
+            step_name,
+            std::slice::from_ref(&authorization_artifact),
+            &repositories,
+        )
+        .await
+        .map_err(|reason| {
+            StepDispatchError::immutable_integrity(AgentError::PromptError {
+                reason: format!("authorization Artifact could not be verified: {reason}"),
+            })
+        })?;
+        if !violations.is_empty() {
+            if let Some(run) = self.state.write().await.get_pipeline_run_mut(&issue.id) {
+                run.record_artifact_integrity_violations(violations.clone());
+            }
+            return Err(StepDispatchError::immutable_integrity(
+                AgentError::PromptError {
+                    reason: format!(
+                        "authorization Artifact changed before step '{}': {}",
+                        step_name,
+                        violations
+                            .iter()
+                            .map(|violation| format!(
+                                "{}:{} ({})",
+                                violation.producer_step,
+                                violation.repository,
+                                violation.artifact_identity
+                            ))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                },
+            ));
+        }
+        let transition = {
+            let mut state = self.state.write().await;
+            let Some(run) = state.get_pipeline_run_mut(&issue.id) else {
+                return Ok(false);
+            };
+            let Some(evidence) = run.select_authorization_evidence(step_name, &events) else {
+                run.clear_authorization_evidence(step_name);
+                return Ok(false);
+            };
+            if run.authorization_evidence_is_current(step_name, &events) {
+                return Ok(true);
+            }
+            run.record_authorization_evidence(step_name, evidence);
+            Self::transition_input_for_run(
+                &state,
+                &issue.id,
+                &issue.identifier,
+                PipelineTransitionKind::AuthorizationEvidenceSelected,
+                Some(step_name.to_string()),
+                None,
+                None,
+            )
+        };
+        let Some(transition) = transition else {
+            return Ok(false);
+        };
+        if let Err(error) = self.pipeline_journal.append(transition).await {
+            warn!(issue_id = %issue.id, step = step_name, error = %error, "failed to persist authorization evidence; retaining pending step");
+            if let Some(run) = self.state.write().await.get_pipeline_run_mut(&issue.id) {
+                run.clear_authorization_evidence(step_name);
+            }
+            return Ok(false);
+        }
+        Ok(true)
     }
 
     /// Handle a worker event from the channel.
@@ -5164,8 +5433,8 @@ impl Orchestrator {
     }
 
     // Complete the #480 Artifact observation before re-entering the existing success/acceptance
-    // state machine. Keeping this boxed prevents the observation vectors from inflating that
-    // Tokio worker future.
+    // state machine. The #512 durable transition snapshot is returned behind its own box, so it
+    // cannot inflate the caller's acceptance and terminal-lifecycle worker frame.
     fn process_successful_worker_exit<'a>(
         &'a self,
         issue_id: &'a str,
@@ -5174,7 +5443,7 @@ impl Orchestrator {
         output: StepOutput,
         has_approval_request: bool,
         workspace_capture_held: bool,
-    ) -> Pin<Box<dyn Future<Output = Option<SuccessfulWorkerExitAction>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Option<Box<SuccessfulWorkerExitAction>>> + Send + 'a>> {
         Box::pin(self.process_successful_worker_exit_inner(
             issue_id,
             step_name,
@@ -5193,7 +5462,7 @@ impl Orchestrator {
         output: StepOutput,
         has_approval_request: bool,
         workspace_capture_held: bool,
-    ) -> Option<SuccessfulWorkerExitAction> {
+    ) -> Option<Box<SuccessfulWorkerExitAction>> {
         let mut artifact_outcome = self
             .process_artifacts_after_worker_exit(
                 issue_id,
@@ -5248,12 +5517,12 @@ impl Orchestrator {
             Some(verdict_value.to_string()),
             None,
         );
-        Some(SuccessfulWorkerExitAction {
+        Some(Box::new(SuccessfulWorkerExitAction {
             action,
             config_snapshot,
             step_transition,
             integrity_failed,
-        })
+        }))
     }
 
     /// Handle a worker exit. Integrates with PipelineRun to drive step DAG.
@@ -5323,13 +5592,13 @@ impl Orchestrator {
                     )
                     .await;
 
-                if let Some(SuccessfulWorkerExitAction {
-                    action,
-                    config_snapshot,
-                    step_transition,
-                    integrity_failed,
-                }) = successful_action
-                {
+                if let Some(successful_action) = successful_action {
+                    let SuccessfulWorkerExitAction {
+                        action,
+                        config_snapshot,
+                        step_transition,
+                        integrity_failed,
+                    } = *successful_action;
                     let mut state = self.state.write().await;
                     match action {
                         PipelineAction::Dispatch(requests) => {
@@ -11918,8 +12187,9 @@ mod tests {
     };
     use crate::artifact::ArtifactSnapshot;
     use crate::config::ensemble::{
-        parse_config, ConcurrencyConfig, PipelineConfig, SchedulerConfig, SchedulerLaneConfig,
-        StepConfig, WorkflowOrderKey, WorkflowSelectionRuleConfig,
+        parse_config, AuthorizationHandoffMode, ConcurrencyConfig, PipelineConfig, SchedulerConfig,
+        SchedulerLaneConfig, StepAuthorizationConfig, StepConfig, TrackerEventPredicateConfig,
+        WorkflowOrderKey, WorkflowSelectionRuleConfig,
     };
     use crate::error::AgentError;
     use crate::interaction::{
@@ -12676,6 +12946,13 @@ mod tests {
         state_writes: Arc<RwLock<Vec<(String, String)>>>,
     }
 
+    /// Stateful test adapter for recovery boundaries: a successful write is
+    /// immediately visible to the next runtime instance.
+    struct RestartableWriteTracker {
+        issues: Arc<RwLock<Vec<Issue>>>,
+        state_writes: Arc<RwLock<Vec<(String, String)>>>,
+    }
+
     #[async_trait]
     impl IssueTracker for RecordingTracker {
         async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
@@ -12717,6 +12994,60 @@ mod tests {
                 .write()
                 .await
                 .push((id.to_string(), state.to_string()));
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl IssueTracker for RestartableWriteTracker {
+        async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+            Ok(self.issues.read().await.clone())
+        }
+
+        async fn fetch_issues_by_states(
+            &self,
+            states: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            let issues = self.issues.read().await;
+            let states_lower: Vec<String> =
+                states.iter().map(|state| state.to_lowercase()).collect();
+            Ok(issues
+                .iter()
+                .filter(|issue| states_lower.contains(&issue.state.to_lowercase()))
+                .cloned()
+                .collect())
+        }
+
+        async fn fetch_issue_states_by_ids(
+            &self,
+            ids: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            let issues = self.issues.read().await;
+            Ok(issues
+                .iter()
+                .filter(|issue| ids.contains(&issue.id))
+                .cloned()
+                .collect())
+        }
+
+        fn supports_writes(&self) -> bool {
+            true
+        }
+
+        async fn set_issue_state(&self, id: &str, state: &str) -> Result<(), TrackerError> {
+            self.state_writes
+                .write()
+                .await
+                .push((id.to_string(), state.to_string()));
+            if let Some(issue) = self
+                .issues
+                .write()
+                .await
+                .iter_mut()
+                .find(|issue| issue.id == id)
+            {
+                issue.state = state.to_string();
+            }
             Ok(())
         }
     }
@@ -15652,6 +15983,197 @@ agent:
   stall_timeout_ms: 300000
 "#;
         parse_config(yaml).unwrap()
+    }
+
+    #[tokio::test]
+    async fn automatic_handoff_restart_after_remote_write_requires_durable_applied_record() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let mut config = make_config();
+        config.steps[0].artifact_snapshot = Some(crate::config::ensemble::ArtifactSnapshotConfig {
+            repositories: Vec::new(),
+        });
+        let mut protected = config.steps[0].clone();
+        protected.name = "protected".to_string();
+        protected.depends = Some(vec!["build".to_string()]);
+        protected.tracker_state = Some("In Progress".to_string());
+        protected.artifact_snapshot = None;
+        protected.authorization = Some(StepAuthorizationConfig {
+            artifact_step: "build".to_string(),
+            event: TrackerEventPredicateConfig {
+                field: "project.status".to_string(),
+                value: "Ready".to_string(),
+                actors: vec!["operator".to_string()],
+            },
+            after_artifact: false,
+            handoff: AuthorizationHandoffMode::AutomaticTransition,
+        });
+        config.steps.push(protected);
+
+        let config = Arc::new(RwLock::new(config));
+        let issue = test_issue("restart-after-write", "Todo");
+        let tracker_issues = Arc::new(RwLock::new(vec![issue.clone()]));
+        let state_writes = Arc::new(RwLock::new(Vec::new()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(RestartableWriteTracker {
+            issues: Arc::clone(&tracker_issues),
+            state_writes: Arc::clone(&state_writes),
+        });
+
+        let first_state = Arc::new(RwLock::new(OrchestratorState::new(
+            config.read().await.polling.interval_ms,
+            &config.read().await.concurrency,
+        )));
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut first = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&first_state),
+                config: Arc::clone(&config),
+                tracker: Arc::clone(&tracker),
+                agent_runner: Arc::new(CountingRunner {
+                    runs: Arc::new(AtomicUsize::new(0)),
+                }),
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
+                workspace_mgr: WorkspaceManager::new(&config_dir.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root: config_dir.path().join("workspaces"),
+            },
+            config_dir.path(),
+            shutdown_rx,
+        );
+        {
+            let config_snapshot = config.read().await.clone();
+            let run = PipelineRun::new(
+                issue.id.clone(),
+                1,
+                build_dag(&config_snapshot.steps).unwrap(),
+            );
+            let mut state = first_state.write().await;
+            state.insert_pipeline_run(&issue.id, run, Arc::new(config_snapshot));
+            state.add_claimed(&issue.id);
+        }
+
+        // A failed first pending append must not leave an in-memory checkpoint
+        // that a later dispatch can mistake for durable intent.
+        first.pipeline_journal.transaction_append_error_on_call =
+            Some((Arc::new(AtomicUsize::new(0)), 1));
+        assert!(!first
+            .apply_tracker_handoff_before_dispatch(&issue, "protected", Some("In Progress"),)
+            .await
+            .unwrap());
+        assert!(state_writes.read().await.is_empty());
+        assert!(first
+            .state
+            .read()
+            .await
+            .get_pipeline_run(&issue.id)
+            .and_then(|run| run.automatic_transition_state("protected"))
+            .is_none());
+
+        // The pending checkpoint is durable first. Then the remote write
+        // succeeds, but an injected pre-append error models a crash before
+        // `AutomaticTransitionApplied` reaches the journal.
+        first.pipeline_journal.transaction_append_error_on_call =
+            Some((Arc::new(AtomicUsize::new(0)), 2));
+        assert!(!first
+            .apply_tracker_handoff_before_dispatch(&issue, "protected", Some("In Progress"),)
+            .await
+            .unwrap());
+        assert_eq!(
+            state_writes.read().await.as_slice(),
+            [(issue.id.clone(), "In Progress".to_string())]
+        );
+        assert!(matches!(
+            first
+                .state
+                .read()
+                .await
+                .get_pipeline_run(&issue.id)
+                .and_then(|run| run.automatic_transition_state("protected")),
+            Some(AutomaticTransitionState::Pending { .. })
+        ));
+        assert_eq!(
+            first
+                .pipeline_journal
+                .read_records_for_issue(&issue.id)
+                .await
+                .unwrap()
+                .last()
+                .unwrap()
+                .kind,
+            PipelineTransitionKind::AutomaticTransitionPending
+        );
+        drop(first);
+
+        let restarted_state = Arc::new(RwLock::new(OrchestratorState::new(
+            config.read().await.polling.interval_ms,
+            &config.read().await.concurrency,
+        )));
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let restarted = Orchestrator::new_with_state(
+            OrchestratorRuntimeParts {
+                state: Arc::clone(&restarted_state),
+                config: Arc::clone(&config),
+                tracker,
+                agent_runner: Arc::new(CountingRunner {
+                    runs: Arc::new(AtomicUsize::new(0)),
+                }),
+                acceptance_runner: Arc::new(ShellAcceptanceCommandRunner),
+                workspace_mgr: WorkspaceManager::new(&config_dir.path().join("workspaces"), None)
+                    .unwrap(),
+                refresh_requested: Arc::new(tokio::sync::Notify::new()),
+                cancellation_registry: new_cancellation_registry(),
+                event_bus: EventBus::new(),
+                transcript_event_bus: TranscriptEventBus::new(),
+                workspace_root: config_dir.path().join("workspaces"),
+            },
+            config_dir.path(),
+            shutdown_rx,
+        );
+        restarted.restore_pipeline_runs_from_journal().await;
+
+        assert!(matches!(
+            restarted_state
+                .read()
+                .await
+                .get_pipeline_run(&issue.id)
+                .and_then(|run| run.automatic_transition_state("protected")),
+            Some(AutomaticTransitionState::Pending { .. })
+        ));
+        assert!(
+            restarted
+                .apply_tracker_handoff_before_dispatch(&issue, "protected", Some("In Progress"),)
+                .await
+                .unwrap(),
+            "the protected dispatch gate opens only after its Applied record is durable"
+        );
+        assert_eq!(
+            state_writes.read().await.len(),
+            1,
+            "restart must not repeat the remote write"
+        );
+        assert!(matches!(
+            restarted
+                .state
+                .read()
+                .await
+                .get_pipeline_run(&issue.id)
+                .and_then(|run| run.automatic_transition_state("protected")),
+            Some(AutomaticTransitionState::Applied { .. })
+        ));
+        assert_eq!(
+            restarted
+                .pipeline_journal
+                .read_records_for_issue(&issue.id)
+                .await
+                .unwrap()
+                .last()
+                .unwrap()
+                .kind,
+            PipelineTransitionKind::AutomaticTransitionApplied
+        );
     }
 
     #[test]
@@ -19093,6 +19615,7 @@ agent:
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }])
         .unwrap();
         let stale_run = PipelineRun::new(issue.id.clone(), 1, stale_dag);
@@ -27334,6 +27857,7 @@ agent:
                     producer_step: producer_step.to_string(),
                     attempt: 1,
                     output_digest: format!("output-{producer_step}"),
+                    captured_at: None,
                     repositories: Vec::new(),
                 },
             );

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
@@ -26,6 +28,9 @@ fn requires_durable_sync(kind: PipelineTransitionKind, created: bool) -> bool {
             PipelineTransitionKind::DeliveryOwned
                 | PipelineTransitionKind::PendingTerminalTransition
                 | PipelineTransitionKind::TerminalTransitionApplied
+                | PipelineTransitionKind::AuthorizationEvidenceSelected
+                | PipelineTransitionKind::AutomaticTransitionPending
+                | PipelineTransitionKind::AutomaticTransitionApplied
         )
 }
 
@@ -107,6 +112,10 @@ impl PipelineIssueJournalTransaction<'_> {
 pub enum PipelineTransitionKind {
     RunStarted,
     StepRunning,
+    /// Immutable event and Artifact evidence selected before protected dispatch.
+    AuthorizationEvidenceSelected,
+    AutomaticTransitionPending,
+    AutomaticTransitionApplied,
     /// A worker launch was durably committed; this authorizes gate delivery.
     StepLaunched,
     StepCompleted,
@@ -277,7 +286,17 @@ impl PipelineRunJournal {
         }
     }
 
-    async fn append_unlocked(
+    // Serialization and durable I/O retain a complete transition snapshot. Keep that large
+    // future separate from transaction callers such as dispatch and acceptance recovery.
+    fn append_unlocked<'a>(
+        &'a self,
+        input: PipelineTransitionInput,
+    ) -> Pin<Box<dyn Future<Output = Result<PipelineTransitionRecord, std::io::Error>> + Send + 'a>>
+    {
+        Box::pin(self.append_unlocked_inner(input))
+    }
+
+    async fn append_unlocked_inner(
         &self,
         input: PipelineTransitionInput,
     ) -> Result<PipelineTransitionRecord, std::io::Error> {
@@ -629,6 +648,17 @@ mod tests {
     }
 
     #[test]
+    fn authorization_handoff_records_require_durable_sync() {
+        for kind in [
+            PipelineTransitionKind::AuthorizationEvidenceSelected,
+            PipelineTransitionKind::AutomaticTransitionPending,
+            PipelineTransitionKind::AutomaticTransitionApplied,
+        ] {
+            assert!(requires_durable_sync(kind, false));
+        }
+    }
+
+    #[test]
     fn newly_created_journal_requires_durable_sync() {
         assert!(requires_durable_sync(
             PipelineTransitionKind::RunStarted,
@@ -654,6 +684,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }
     }
 

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -872,6 +872,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }])
         .unwrap();
         state.pipeline_runs.insert(

--- a/crates/ensemble-core/src/pipeline/dag.rs
+++ b/crates/ensemble-core/src/pipeline/dag.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::ensemble::{
     AffectedPathSource, ArtifactAccess, ArtifactSnapshotConfig, GateConfig, OnFailure,
-    ResolvedOutputSchema, StepApprovalConfig, StepConfig, StepKind,
+    ResolvedOutputSchema, StepApprovalConfig, StepAuthorizationConfig, StepConfig, StepKind,
 };
 use crate::error::PipelineError;
 
@@ -34,6 +34,8 @@ pub struct DagStep {
     pub artifact_access: ArtifactAccess,
     #[serde(default)]
     pub gate: Option<GateConfig>,
+    #[serde(default)]
+    pub authorization: Option<StepAuthorizationConfig>,
     pub depends: Vec<String>,
 }
 
@@ -156,6 +158,7 @@ pub fn build_dag(steps: &[StepConfig]) -> Result<StepDag, PipelineError> {
             artifact_inputs: step.artifact_inputs.clone(),
             artifact_access: step.artifact_access,
             gate: step.gate.clone(),
+            authorization: step.authorization.clone(),
             depends: deps,
         });
     }
@@ -256,6 +259,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }
     }
 
@@ -277,6 +281,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }
     }
 
@@ -439,6 +444,7 @@ mod tests {
                 artifact_inputs: Vec::new(),
                 artifact_access: Default::default(),
                 gate: None,
+                authorization: None,
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -457,6 +463,7 @@ mod tests {
                 artifact_inputs: Vec::new(),
                 artifact_access: Default::default(),
                 gate: None,
+                authorization: None,
             },
         ];
 
@@ -489,6 +496,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }];
 
         let dag = build_dag(&steps).unwrap();
@@ -518,6 +526,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }];
 
         let dag = build_dag(&steps).unwrap();
@@ -553,6 +562,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }];
 
         let dag = build_dag(&steps).unwrap();

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -6,7 +6,7 @@ use crate::acceptance::AcceptanceAttempt;
 use crate::artifact::{ArtifactAccessEvidence, ArtifactIntegrityViolation, ArtifactSnapshot};
 use crate::config::ensemble::{
     AffectedPathSource, ArtifactAccess, ArtifactSnapshotConfig, OnFailure, ResolvedOutputSchema,
-    StepKind,
+    StepAuthorizationConfig, StepKind,
 };
 use crate::orchestrator::resources::SchedulerReservation;
 use crate::pipeline::assessment::{
@@ -14,7 +14,7 @@ use crate::pipeline::assessment::{
 };
 use crate::pipeline::dag::{DagStep, StepDag};
 use crate::pipeline::verdict::{StepOutput, StepResult};
-use crate::tracker::OwnershipLease;
+use crate::tracker::{model::TrackerEvent, OwnershipLease};
 
 /// The execution state of a single pipeline step.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -138,6 +138,10 @@ pub struct PipelineRun {
     /// Content-free immutable Artifact evidence retained for restart recovery.
     pub artifact_integrity_violations: Vec<ArtifactIntegrityViolation>,
     pub artifact_access_evidence: Vec<ArtifactAccessEvidence>,
+    /// Selected immutable tracker event and exact Artifact binding for protected steps.
+    pub authorization_evidence: HashMap<String, AuthorizationEvidence>,
+    /// Durable intent and acknowledgement for automatic tracker handoffs.
+    automatic_transitions: HashMap<String, AutomaticTransitionState>,
     /// Deterministic assessment and adjudication evidence retained for each gate.
     pub gate_evidence: HashMap<String, GateEvidence>,
     /// Immutable consumers whose launch was durably committed. This authorizes
@@ -176,6 +180,10 @@ pub struct PipelineRunSnapshot {
     pub step_outputs: HashMap<String, StepOutput>,
     #[serde(default)]
     pub artifact_snapshots: HashMap<String, ArtifactSnapshot>,
+    #[serde(default)]
+    pub authorization_evidence: HashMap<String, AuthorizationEvidence>,
+    #[serde(default)]
+    pub automatic_transitions: HashMap<String, AutomaticTransitionState>,
     #[serde(flatten)]
     pub artifact_integrity_evidence: Box<ArtifactIntegrityEvidence>,
     /// Consumers whose launches were durably committed before a crash.
@@ -197,6 +205,26 @@ pub struct PipelineRunSnapshot {
     pub selected_workflow: Option<SelectedWorkflowSnapshot>,
     #[serde(default)]
     pub active_scheduler_reservations: HashMap<String, SchedulerReservation>,
+}
+
+/// Durable evidence that one protected step was authorized against one exact
+/// Artifact snapshot. The event remains adapter-normalized and opaque.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorizationEvidence {
+    pub event: TrackerEvent,
+    pub artifact_identity: String,
+    pub artifact_output_digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AutomaticTransitionState {
+    Pending {
+        target_state: String,
+        expected_state: String,
+    },
+    Applied {
+        target_state: String,
+    },
 }
 
 /// Heap-backed durable evidence so empty immutable Artifact support does not enlarge every
@@ -226,6 +254,8 @@ impl PipelineRun {
             artifact_snapshots: HashMap::new(),
             artifact_integrity_violations: Vec::new(),
             artifact_access_evidence: Vec::new(),
+            authorization_evidence: HashMap::new(),
+            automatic_transitions: HashMap::new(),
             gate_evidence: HashMap::new(),
             launched_immutable_consumers: HashSet::new(),
             acceptance_attempts: Vec::new(),
@@ -246,6 +276,8 @@ impl PipelineRun {
             step_states: self.step_states.clone(),
             step_outputs: self.step_outputs.clone(),
             artifact_snapshots: self.artifact_snapshots.clone(),
+            authorization_evidence: self.authorization_evidence.clone(),
+            automatic_transitions: self.automatic_transitions.clone(),
             artifact_integrity_evidence: Box::new(ArtifactIntegrityEvidence {
                 artifact_integrity_violations: self.artifact_integrity_violations.clone(),
                 artifact_access_evidence: self.artifact_access_evidence.clone(),
@@ -310,6 +342,139 @@ impl PipelineRun {
             .iter()
             .find(|step| step.name == step_name)
             .map(|step| (step.artifact_inputs.as_slice(), step.artifact_access))
+    }
+
+    pub(crate) fn authorization_for(&self, step_name: &str) -> Option<&StepAuthorizationConfig> {
+        self.dag
+            .steps
+            .iter()
+            .find(|step| step.name == step_name)
+            .and_then(|step| step.authorization.as_ref())
+    }
+
+    /// Choose a matching event deterministically and bind it to the configured
+    /// upstream Artifact. Missing publication time is legacy evidence and does
+    /// not satisfy an ordering requirement.
+    pub(crate) fn select_authorization_evidence(
+        &self,
+        step_name: &str,
+        events: &[TrackerEvent],
+    ) -> Option<AuthorizationEvidence> {
+        let authorization = self.authorization_for(step_name)?;
+        let artifact = self.artifact_snapshots.get(&authorization.artifact_step)?;
+        let mut identities = HashMap::new();
+        for event in events {
+            if let Some(previous) = identities.insert(&event.event_id, event) {
+                if previous != event {
+                    return None;
+                }
+            }
+        }
+        let mut matching = events
+            .iter()
+            .filter(|event| {
+                event.item_id == self.issue_id
+                    && event.field_id == authorization.event.field
+                    && event.value == authorization.event.value
+                    && authorization
+                        .event
+                        .actors
+                        .iter()
+                        .any(|actor| actor == &event.actor_id)
+                    && (!authorization.after_artifact
+                        || artifact
+                            .captured_at
+                            .is_some_and(|captured_at| event.occurred_at > captured_at))
+            })
+            .collect::<Vec<_>>();
+        matching.sort_by(|left, right| {
+            left.occurred_at
+                .cmp(&right.occurred_at)
+                .then_with(|| left.event_id.cmp(&right.event_id))
+        });
+        matching.last().map(|event| AuthorizationEvidence {
+            event: (*event).clone(),
+            artifact_identity: artifact.identity.clone(),
+            artifact_output_digest: artifact.output_digest.clone(),
+        })
+    }
+
+    pub(crate) fn authorization_evidence_is_current(
+        &self,
+        step_name: &str,
+        events: &[TrackerEvent],
+    ) -> bool {
+        self.authorization_evidence.get(step_name)
+            == self
+                .select_authorization_evidence(step_name, events)
+                .as_ref()
+    }
+
+    pub(crate) fn record_authorization_evidence(
+        &mut self,
+        step_name: &str,
+        evidence: AuthorizationEvidence,
+    ) {
+        self.authorization_evidence
+            .insert(step_name.to_string(), evidence);
+    }
+
+    pub(crate) fn clear_authorization_evidence(&mut self, step_name: &str) {
+        self.authorization_evidence.remove(step_name);
+    }
+
+    pub(crate) fn authorization_handoff(
+        &self,
+        step_name: &str,
+    ) -> Option<crate::config::ensemble::AuthorizationHandoffMode> {
+        self.authorization_for(step_name)
+            .map(|authorization| authorization.handoff)
+    }
+
+    pub(crate) fn automatic_transition_state(
+        &self,
+        step_name: &str,
+    ) -> Option<&AutomaticTransitionState> {
+        self.automatic_transitions.get(step_name)
+    }
+
+    pub(crate) fn set_automatic_transition_pending(
+        &mut self,
+        step_name: &str,
+        target_state: String,
+        expected_state: String,
+    ) {
+        self.automatic_transitions.insert(
+            step_name.to_string(),
+            AutomaticTransitionState::Pending {
+                target_state,
+                expected_state,
+            },
+        );
+    }
+
+    pub(crate) fn set_automatic_transition_applied(
+        &mut self,
+        step_name: &str,
+        target_state: String,
+    ) {
+        self.automatic_transitions.insert(
+            step_name.to_string(),
+            AutomaticTransitionState::Applied { target_state },
+        );
+    }
+
+    pub(crate) fn restore_automatic_transition_state(
+        &mut self,
+        step_name: &str,
+        previous: Option<AutomaticTransitionState>,
+    ) {
+        if let Some(previous) = previous {
+            self.automatic_transitions
+                .insert(step_name.to_string(), previous);
+        } else {
+            self.automatic_transitions.remove(step_name);
+        }
     }
 
     pub(crate) fn record_artifact_snapshot(&mut self, step_name: &str, snapshot: ArtifactSnapshot) {
@@ -378,6 +543,8 @@ impl PipelineRun {
             step_states: snapshot.step_states,
             step_outputs: snapshot.step_outputs,
             artifact_snapshots: snapshot.artifact_snapshots,
+            authorization_evidence: snapshot.authorization_evidence,
+            automatic_transitions: snapshot.automatic_transitions,
             artifact_integrity_violations: snapshot
                 .artifact_integrity_evidence
                 .artifact_integrity_violations,
@@ -694,6 +861,8 @@ impl PipelineRun {
             self.step_states.insert(step.clone(), StepState::Pending);
             self.step_outputs.remove(step);
             self.artifact_snapshots.remove(step);
+            self.authorization_evidence.remove(step);
+            self.automatic_transitions.remove(step);
             self.clear_immutable_consumer_launch_commitment(step);
         }
         for gate in reset_gates {
@@ -757,6 +926,7 @@ impl PipelineRun {
                         artifact_inputs: Vec::new(),
                         artifact_access: Default::default(),
                         gate: None,
+                        authorization: None,
                         depends: original_deps,
                     },
                 );
@@ -1152,8 +1322,9 @@ mod tests {
         ArtifactAccessEnforcement, ArtifactRepositoryObservation, ArtifactSnapshot,
     };
     use crate::config::ensemble::{
-        ArtifactSnapshotConfig, GateConfig, OnFailure, OutputSchemaConfig, StepApprovalConfig,
-        StepApprovalMode, StepConfig, StepKind,
+        ArtifactSnapshotConfig, AuthorizationHandoffMode, GateConfig, OnFailure,
+        OutputSchemaConfig, StepApprovalConfig, StepApprovalMode, StepAuthorizationConfig,
+        StepConfig, StepKind, TrackerEventPredicateConfig,
     };
     use crate::pipeline::dag::build_dag;
     use crate::pipeline::verdict::StepOutput;
@@ -1182,6 +1353,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }
     }
 
@@ -1203,6 +1375,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }
     }
 
@@ -1227,6 +1400,7 @@ mod tests {
                 assessment_steps: vec!["review".to_string()],
                 adjudication_step: "adjudicate".to_string(),
             }),
+            authorization: None,
         }
     }
 
@@ -1316,6 +1490,7 @@ mod tests {
                 producer_step: "build".to_string(),
                 attempt: 1,
                 output_digest: "output-1".to_string(),
+                captured_at: None,
                 repositories: vec![ArtifactRepositoryObservation {
                     repository: "app".to_string(),
                     head: "abc123".to_string(),
@@ -1645,6 +1820,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }];
         let mut run = make_run(&steps);
 
@@ -1683,6 +1859,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }
     }
 
@@ -1718,6 +1895,7 @@ mod tests {
             artifact_inputs: Vec::new(),
             artifact_access: Default::default(),
             gate: None,
+            authorization: None,
         }
     }
 
@@ -2471,6 +2649,7 @@ mod tests {
                 artifact_inputs: Vec::new(),
                 artifact_access: Default::default(),
                 gate: None,
+                authorization: None,
             },
             assessment_gate(),
             make_step("publish", "publisher", &["gate"]),
@@ -2512,6 +2691,7 @@ mod tests {
                 artifact_inputs: Vec::new(),
                 artifact_access: Default::default(),
                 gate: None,
+                authorization: None,
             },
             assessment_gate(),
         ];
@@ -2548,6 +2728,7 @@ mod tests {
                 artifact_inputs: Vec::new(),
                 artifact_access: Default::default(),
                 gate: None,
+                authorization: None,
             },
             assessment_gate(),
         ];
@@ -2611,6 +2792,7 @@ mod tests {
                 artifact_inputs: Vec::new(),
                 artifact_access: Default::default(),
                 gate: None,
+                authorization: None,
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -2629,6 +2811,7 @@ mod tests {
                 artifact_inputs: Vec::new(),
                 artifact_access: Default::default(),
                 gate: None,
+                authorization: None,
             },
         ];
         let mut run = make_run(&steps);
@@ -2774,6 +2957,7 @@ mod tests {
                     producer_step: producer_step.to_string(),
                     attempt: 1,
                     output_digest: format!("output-{producer_step}"),
+                    captured_at: None,
                     repositories: Vec::new(),
                 },
             );
@@ -3034,5 +3218,68 @@ mod tests {
         let legacy: PipelineRunSnapshot = serde_json::from_value(legacy).unwrap();
         assert!(legacy.acceptance_attempts.is_empty());
         assert!(legacy.resolved_acceptance_plan.is_none());
+    }
+
+    #[test]
+    fn authorization_selects_latest_event_after_captured_artifact_and_rejects_conflicts() {
+        let mut producer = make_step("produce", "builder", &[]);
+        producer.artifact_snapshot = Some(ArtifactSnapshotConfig {
+            repositories: vec!["repo".to_string()],
+        });
+        let mut protected = make_step("protected", "reviewer", &["produce"]);
+        protected.authorization = Some(StepAuthorizationConfig {
+            artifact_step: "produce".to_string(),
+            event: TrackerEventPredicateConfig {
+                field: "field".to_string(),
+                value: "ready".to_string(),
+                actors: vec!["actor".to_string()],
+            },
+            after_artifact: true,
+            handoff: AuthorizationHandoffMode::WaitForEvent,
+        });
+        let mut run = make_run(&[producer, protected]);
+        run.record_artifact_snapshot(
+            "produce",
+            ArtifactSnapshot {
+                identity: "artifact-1".to_string(),
+                run_id: "issue-1".to_string(),
+                cycle: 1,
+                producer_step: "produce".to_string(),
+                attempt: 1,
+                output_digest: "digest-1".to_string(),
+                captured_at: Some("2026-08-15T10:00:00Z".parse().unwrap()),
+                repositories: Vec::new(),
+            },
+        );
+        let event = |id: &str, at: &str| TrackerEvent {
+            item_id: "issue-1".to_string(),
+            field_id: "field".to_string(),
+            previous_value: None,
+            value: "ready".to_string(),
+            actor_id: "actor".to_string(),
+            event_id: id.to_string(),
+            occurred_at: at.parse().unwrap(),
+        };
+
+        let selected = run
+            .select_authorization_evidence(
+                "protected",
+                &[
+                    event("stale", "2026-08-15T09:59:59Z"),
+                    event("later", "2026-08-15T10:01:00Z"),
+                ],
+            )
+            .unwrap();
+        assert_eq!(selected.event.event_id, "later");
+        assert_eq!(selected.artifact_identity, "artifact-1");
+        assert!(run
+            .select_authorization_evidence(
+                "protected",
+                &[
+                    event("duplicate", "2026-08-15T10:01:00Z"),
+                    event("duplicate", "2026-08-15T10:02:00Z")
+                ],
+            )
+            .is_none());
     }
 }

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet, VecDeque};
 use tracing::{debug, info, warn};
 
-use super::model::{BlockerRef, InteractionThreadRoot, Issue, TrackerComment};
+use super::model::{BlockerRef, InteractionThreadRoot, Issue, TrackerComment, TrackerEvent};
 use super::{IssueTracker, OwnershipClaim, OwnershipConflict, OwnershipLease, TrackerError};
 use crate::config::ensemble::{GithubClaimConfig, GithubTrackerConfig};
 use crate::workspace::key::issue_workspace_key;
@@ -123,6 +123,70 @@ impl GithubTracker {
             .delivery_adoption
             .as_ref()
             .map(|policy| policy.render_branch(&issue_workspace_key(&issue.id)))
+    }
+
+    async fn fetch_status_events(&self, issue_id: &str) -> Result<Vec<TrackerEvent>, TrackerError> {
+        let metadata = self.ensure_project_metadata().await?;
+        let mut cursor = None;
+        let mut events = Vec::new();
+        loop {
+            let data = self
+                .graphql::<graphql::IssueStatusEvents>(json!({
+                    "issueId": issue_id,
+                    "cursor": cursor,
+                }))
+                .await?;
+            let node = data.node.ok_or_else(|| TrackerError::UnexpectedPayload {
+                reason: "IssueStatusEvents response missing issue".to_string(),
+            })?;
+            for event in node.timeline_items.nodes.into_iter().flatten() {
+                let project_id = event.project.as_ref().map(|project| project.id.as_str());
+                if project_id != Some(metadata.project_id.as_str()) {
+                    continue;
+                }
+                let event_id = event.id.ok_or_else(|| TrackerError::UnexpectedPayload {
+                    reason: "IssueStatusEvents response has project event without ID".to_string(),
+                })?;
+                let occurred_at = event
+                    .created_at
+                    .as_deref()
+                    .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+                    .map(|value| value.with_timezone(&Utc))
+                    .ok_or_else(|| TrackerError::UnexpectedPayload {
+                        reason: format!(
+                            "IssueStatusEvents event '{event_id}' has invalid timestamp"
+                        ),
+                    })?;
+                let actor_id = event
+                    .actor
+                    .and_then(|actor| actor.id.or(actor.login))
+                    .filter(|actor| !actor.trim().is_empty())
+                    .ok_or_else(|| TrackerError::UnexpectedPayload {
+                        reason: format!(
+                            "IssueStatusEvents event '{event_id}' has no actor identity"
+                        ),
+                    })?;
+                let value = event
+                    .status
+                    .filter(|value| !value.trim().is_empty())
+                    .ok_or_else(|| TrackerError::UnexpectedPayload {
+                        reason: format!("IssueStatusEvents event '{event_id}' has no status"),
+                    })?;
+                events.push(TrackerEvent {
+                    item_id: issue_id.to_string(),
+                    field_id: metadata.status.id.clone(),
+                    previous_value: event.previous_status,
+                    value,
+                    actor_id,
+                    event_id,
+                    occurred_at,
+                });
+            }
+            cursor = node.timeline_items.page_info.next_cursor()?;
+            if cursor.is_none() {
+                return Ok(events);
+            }
+        }
     }
 
     /// Execute a GraphQL query against the configured endpoint.
@@ -1283,6 +1347,24 @@ impl IssueTracker for GithubTracker {
         Ok(())
     }
 
+    async fn validate_event_evidence(&self, field: &str) -> Result<(), TrackerError> {
+        let metadata = self.ensure_project_metadata().await?;
+        if metadata.status.id == field {
+            Ok(())
+        } else {
+            Err(TrackerError::EventEvidenceUnsupported {
+                field: field.to_string(),
+            })
+        }
+    }
+
+    async fn fetch_tracker_events(
+        &self,
+        issue_id: &str,
+    ) -> Result<Vec<TrackerEvent>, TrackerError> {
+        self.fetch_status_events(issue_id).await
+    }
+
     /// Fetch candidate issues in active states for dispatch.
     ///
     /// When project_number is set: queries project board items.
@@ -1996,6 +2078,58 @@ mod tests {
             metadata.status.option_ids.get("Todo"),
             Some(&"O_todo".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn status_event_history_paginates_and_filters_to_the_configured_project() {
+        let server = MockServer::start().await;
+        mount_project_discovery(&server, "P_configured").await;
+        let first = graphql_response(json!({
+            "node": { "timelineItems": {
+                "pageInfo": {"hasNextPage": true, "endCursor": "next"},
+                "nodes": [
+                    {"id":"E_foreign","createdAt":"2026-08-15T10:00:00Z","previousStatus":"A","status":"B","project":{"id":"P_other"},"actor":{"id":"U_other","login":"other"}},
+                    {"id":"E_authorized","createdAt":"2026-08-15T10:01:00Z","previousStatus":"A","status":"B","project":{"id":"P_configured"},"actor":{"id":"U_actor","login":"actor"}}
+                ]
+            }}
+        }));
+        let second = graphql_response(json!({
+            "node": { "timelineItems": {
+                "pageInfo": {"hasNextPage": false, "endCursor": null},
+                "nodes": [{"id":"E_later","createdAt":"2026-08-15T10:01:00Z","previousStatus":"B","status":"C","project":{"id":"P_configured"},"actor":{"id":"U_actor","login":"actor"}}]
+            }}
+        }));
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("timelineItems(first:"))
+            .and(body_string_contains("\"cursor\":null"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(first))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("timelineItems(first:"))
+            .and(body_string_contains("\"cursor\":\"next\""))
+            .respond_with(ResponseTemplate::new(200).set_body_json(second))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tracker = create_test_tracker(&server.uri(), Some(1));
+        tracker.validate_event_evidence("F_status").await.unwrap();
+        let events = tracker.fetch_tracker_events("I_1").await.unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_id, "E_authorized");
+        assert_eq!(events[0].field_id, "F_status");
+        assert_eq!(events[0].previous_value.as_deref(), Some("A"));
+        assert_eq!(events[1].event_id, "E_later");
+        assert_eq!(events[1].actor_id, "U_actor");
+        assert!(matches!(
+            tracker.validate_event_evidence("unsupported").await,
+            Err(TrackerError::EventEvidenceUnsupported { .. })
+        ));
     }
 
     // --- parse_owner_repo tests ---

--- a/crates/ensemble-core/src/tracker/github/graphql.rs
+++ b/crates/ensemble-core/src/tracker/github/graphql.rs
@@ -360,6 +360,55 @@ pub(super) struct IssueStatesData {
     pub(super) nodes: Vec<Option<IssueNode>>,
 }
 
+pub(super) struct IssueStatusEvents;
+
+impl Operation for IssueStatusEvents {
+    const NAME: &'static str = "IssueStatusEvents";
+    const QUERY: &'static str = ISSUE_STATUS_EVENTS_QUERY;
+    type Response = IssueStatusEventsData;
+}
+
+pub(super) const ISSUE_STATUS_EVENTS_QUERY: &str = r#"
+query($issueId: ID!, $cursor: String) {
+  node(id: $issueId) {
+    ... on Issue {
+      timelineItems(first: 100, after: $cursor, itemTypes: [PROJECT_V2_ITEM_STATUS_CHANGED_EVENT]) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          ... on ProjectV2ItemStatusChangedEvent {
+            id createdAt previousStatus status
+            project { id }
+            actor { id login }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct IssueStatusEventsData {
+    pub(super) node: Option<IssueStatusEventsNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct IssueStatusEventsNode {
+    pub(super) timeline_items: Connection<StatusChangedEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct StatusChangedEvent {
+    pub(super) id: Option<String>,
+    pub(super) created_at: Option<String>,
+    pub(super) previous_status: Option<String>,
+    pub(super) status: Option<String>,
+    pub(super) project: Option<ProjectRef>,
+    pub(super) actor: Option<User>,
+}
+
 pub(super) struct IssueBlockedBy;
 
 impl Operation for IssueBlockedBy {

--- a/crates/ensemble-core/src/tracker/mod.rs
+++ b/crates/ensemble-core/src/tracker/mod.rs
@@ -6,7 +6,7 @@ pub mod todo_file;
 
 use crate::config::ensemble::{EnsembleConfig, TrackerConfig};
 use async_trait::async_trait;
-use model::{InteractionThreadRoot, Issue, TrackerComment};
+use model::{InteractionThreadRoot, Issue, TrackerComment, TrackerEvent};
 use serde::{Deserialize, Serialize};
 
 /// Error type for tracker operations.
@@ -40,6 +40,8 @@ pub enum TrackerError {
     MissingEndCursor,
     #[error("tracker does not support write operations")]
     WritesNotSupported,
+    #[error("tracker does not support immutable event evidence for field '{field}'")]
+    EventEvidenceUnsupported { field: String },
 }
 
 /// Opaque conflict evidence returned by an adapter when ownership cannot be
@@ -82,6 +84,23 @@ pub trait IssueTracker: Send + Sync {
     /// Validate adapter-specific configuration before a new runtime generation activates.
     async fn validate_configuration(&self) -> Result<(), TrackerError> {
         Ok(())
+    }
+
+    /// Fail closed unless this adapter can prove the configured field's event history.
+    async fn validate_event_evidence(&self, field: &str) -> Result<(), TrackerError> {
+        Err(TrackerError::EventEvidenceUnsupported {
+            field: field.to_string(),
+        })
+    }
+
+    /// Read immutable event history scoped to one normalized tracker item.
+    async fn fetch_tracker_events(
+        &self,
+        _issue_id: &str,
+    ) -> Result<Vec<TrackerEvent>, TrackerError> {
+        Err(TrackerError::EventEvidenceUnsupported {
+            field: "event history".to_string(),
+        })
     }
 
     /// Fetch candidate issues in active states for dispatch.

--- a/crates/ensemble-core/src/tracker/model.rs
+++ b/crates/ensemble-core/src/tracker/model.rs
@@ -109,6 +109,20 @@ pub struct TrackerComment {
     pub updated_at: Option<DateTime<Utc>>,
 }
 
+/// Immutable, adapter-normalized evidence for a configured tracker event.
+/// The runtime intentionally gives field and value no tracker-specific meaning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerEvent {
+    pub item_id: String,
+    pub field_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_value: Option<String>,
+    pub value: String,
+    pub actor_id: String,
+    pub event_id: String,
+    pub occurred_at: DateTime<Utc>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,5 +159,23 @@ mod tests {
         assert_eq!(totals.output_tokens, 0);
         assert_eq!(totals.total_tokens, 0);
         assert_eq!(totals.seconds_running, 0.0);
+    }
+
+    #[test]
+    fn tracker_event_serialization_roundtrip_preserves_immutable_identity() {
+        let event = TrackerEvent {
+            item_id: "item-1".to_string(),
+            field_id: "field-1".to_string(),
+            previous_value: Some("before".to_string()),
+            value: "after".to_string(),
+            actor_id: "actor-1".to_string(),
+            event_id: "event-1".to_string(),
+            occurred_at: "2026-08-15T10:00:00Z".parse().unwrap(),
+        };
+
+        assert_eq!(
+            serde_json::from_str::<TrackerEvent>(&serde_json::to_string(&event).unwrap()).unwrap(),
+            event
+        );
     }
 }

--- a/crates/ensemble-core/tests/step_output_templates.rs
+++ b/crates/ensemble-core/tests/step_output_templates.rs
@@ -46,6 +46,7 @@ fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
         artifact_inputs: Vec::new(),
         artifact_access: Default::default(),
         gate: None,
+        authorization: None,
     }
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -292,6 +292,19 @@ Pipeline step definition:
     request approval via `.ensemble/approval-request.json`.
   - `state` (string, optional) — tracker state to mirror while waiting for approval. If set, the
     issue's tracker state is updated to this value during the approval hold.
+- `authorization` (StepAuthorizationConfig, optional) — pre-dispatch binding to one direct
+  Artifact producer and an adapter-normalized immutable event predicate. It is valid only for
+  dispatched `agent` or `synthesis` steps, not synchronous `gate` steps. Fields are:
+  - `artifact_step` (string) — a direct dependency that declares `artifact_snapshot`.
+  - `event` (object) — opaque `field`, `value`, and non-empty unique `actors` matched against
+    normalized immutable tracker events.
+  - `after_artifact` (bool, default `false`) — when true, the event must occur after the producer
+    Artifact capture.
+  - `handoff` (required) — `wait_for_event`, which writes nothing and forbids `tracker_state`, or
+    `automatic_transition`, which requires the protected step's `tracker_state` and writes it.
+    The runtime persists the selected event and exact Artifact identity/digest, then revalidates
+    both immediately before launch. Automatic handoff journals pending intent before the remote
+    write and opens dispatch only after its applied acknowledgement is durable.
 
 #### 4.1.5 Workspace
 
@@ -963,8 +976,9 @@ Pipeline step definitions forming a DAG. Each step is an object:
   - Required. References a named agent from `agents`.
 - `kind` (string, optional)
   - Default: `"agent"`.
-  - Step kind: `"agent"` for normal steps or `"synthesis"` for steps that merge/adjudicate direct
-    dependency outputs. Synthesis steps must declare `depends` explicitly.
+  - Step kind: `"agent"` for normal steps, `"synthesis"` for steps that merge/adjudicate direct
+    dependency outputs, or `"gate"` for deterministic non-agent assessment evaluation. Synthesis
+    steps must declare `depends` explicitly.
 - `depends` (list of strings, optional)
   - Step names this step depends on. The syntax can describe branches, but it does not guarantee
     parallel execution in the first release.
@@ -974,6 +988,10 @@ Pipeline step definitions forming a DAG. Each step is an object:
 - `tracker_state` (string, optional)
   - Tracker state to write when entering this step. For deferred multi-branch execution, a shared
     `tracker_state` is written once.
+- `authorization` (StepAuthorizationConfig, optional)
+  - Pre-dispatch authorization as specified in Section 4.1.4: a direct snapshot-producing
+    dependency, opaque event predicate, and explicit `wait_for_event` or
+    `automatic_transition` handoff constraints.
 
 #### 5.3.5 `on_success` (string)
 
@@ -1254,6 +1272,12 @@ Validation checks:
 - `steps` list is non-empty, all agent references resolve, all dependencies resolve, no cycles.
 - If any step has `tracker_state` or `on_success`/`on_failure` are set, the tracker must support
   writes (`supports_writes()` returns true).
+- Every `authorization` is valid only on a dispatched agent or synthesis step; its Artifact
+  producer is a direct dependency with `artifact_snapshot`, event field/value/actors are valid,
+  and its handoff's `tracker_state` constraint holds.
+- Before the configuration generation activates, the tracker validates immutable event evidence for
+  every configured authorization field. An unsupported field or event-history adapter is an
+  activation failure, not a dispatch-time bypass.
 - `on_success` and `on_failure` are present.
 
 ### 6.5 Config Fields Summary (Cheat Sheet)
@@ -1289,9 +1313,14 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `agents.<name>.prompt_template`: path, optional; file reference to prompt template (config-relative)
 - `steps[].name`: string, required; unique step identifier
 - `steps[].agent`: string, required; references a key in `agents`
-- `steps[].kind`: string, optional, default `"agent"`; `"agent"` or `"synthesis"`
+- `steps[].kind`: string, optional, default `"agent"`; `"agent"`, `"synthesis"`, or `"gate"`
 - `steps[].depends`: list of strings, optional; step dependencies for DAG
 - `steps[].tracker_state`: string, optional; tracker state to write on step entry
+- `steps[].authorization`: optional pre-dispatch contract for agent/synthesis steps only:
+  `{ artifact_step, event: { field, value, actors }, after_artifact: false, handoff }`; the
+  Artifact step is a direct snapshot-producing dependency. `handoff` is `wait_for_event` (no
+  write, no `tracker_state`) or `automatic_transition` (requires and writes `tracker_state`).
+  Adapter event evidence for every configured field must be supported at activation.
 - `on_success`: string, required; terminal tracker state on pipeline success
 - `on_failure`: string, required; terminal tracker state on pipeline failure/rejection
 - `concurrency.max_concurrent_agents`: integer, default `4`; global cap
@@ -2218,21 +2247,27 @@ Read operations:
 3. `fetch_issue_states_by_ids(issue_ids)`
    - Used for active-run reconciliation.
 
+4. `validate_event_evidence(field)` and `fetch_tracker_events(issue_id)`
+   - Required when configuration declares `steps[].authorization`.
+   - Activation must fail closed when the adapter cannot prove immutable history for a configured
+     opaque field. Event reads return normalized immutable `{ item_id, field_id, value, actor_id,
+     event_id, occurred_at }` records scoped to the issue; field and value remain adapter-opaque.
+
 Write operations:
 
-4. `supports_writes()`
+5. `supports_writes()`
    - Returns whether this tracker backend supports write operations.
    - Required for pipeline execution with `tracker_state`, `on_success`, or `on_failure`.
    - Backends that do not support writes should return false; the pipeline engine will fail fast
      at startup.
 
-5. `set_issue_state(issue_id, state)`
+6. `set_issue_state(issue_id, state)`
    - Transition an issue to the given state in the tracker.
    - Used by the pipeline engine at step boundaries (`tracker_state`), on pipeline success
      (`on_success`), and on pipeline failure/rejection (`on_failure`).
    - Default implementation returns `WritesNotSupported` error.
 
-6. `add_comment(issue_id, body)`
+7. `add_comment(issue_id, body)`
    - Add a comment to an issue in the tracker.
    - Used to surface pipeline results (for example failure summaries, rejection reasons).
    - Default implementation returns `WritesNotSupported` error.
@@ -2240,12 +2275,12 @@ Write operations:
 
 Optional interaction-thread operations (recommended for trackers with comment threads):
 
-7. `create_interaction_thread_root(issue_id, body)`
+8. `create_interaction_thread_root(issue_id, body)`
    - Creates the root comment used as the interaction thread anchor.
    - Returns tracker metadata (comment ID + URL) for later polling.
    - Backends that do not support this should return `WritesNotSupported`.
 
-8. `list_comments_after(issue_id, after_comment_id)`
+9. `list_comments_after(issue_id, after_comment_id)`
    - Lists comments newer than a given anchor comment.
    - Used by orchestrator ticks to ingest slash commands for open interactions.
    - Backends that do not support this should return `WritesNotSupported`.
@@ -2342,12 +2377,16 @@ Recommended error categories:
 - `github_unknown_payload`
 - `github_missing_end_cursor` (pagination integrity error)
 - `writes_not_supported` (tracker does not support write operations)
+- `event_evidence_unsupported` (tracker cannot prove immutable history for a configured
+  authorization field)
 
 Orchestrator behavior on tracker errors:
 
 - Candidate fetch failure: log and skip dispatch for this tick.
 - Running-state refresh failure: log and keep active workers running.
 - Startup terminal cleanup failure: log warning and continue startup.
+- Authorization-evidence validation failure: fail configuration activation closed; do not run a
+  protected dispatch with unproved event history.
 
 ### 11.5 Tracker Writes (Hybrid Model)
 
@@ -2365,6 +2404,9 @@ Orchestrator-driven writes:
 - **Pipeline failure/rejection**: When any step fails or returns a failed result, the orchestrator
   writes `on_failure` (for example "Needs Rework"). This is a terminal state from the pipeline's
   perspective — a human must intervene.
+- **Automatic authorization handoff**: The orchestrator journals pending intent, writes the
+  protected step's configured `tracker_state`, and journals applied acknowledgement before
+  dispatch. Recovery re-reads current state and does not repeat an already-applied write.
 
 Agent-driven writes:
 
@@ -3362,6 +3404,9 @@ resources; API saves return `409 Conflict` and watcher diagnostics expose no can
   one root step
 - Pipeline write validation: if steps use `tracker_state` or `on_success`/`on_failure`, tracker
   must support writes
+- Authorization validation rejects non-dispatched gate steps, non-direct or non-Artifact
+  producers, blank/duplicate event predicate fields, invalid handoff/state combinations, and
+  unsupported adapter event evidence at activation
 - Config defaults apply when optional values are missing
 - `tracker.kind` validation enforces currently supported kind (`github`)
 - `tracker.api_key` works (including `$VAR` indirection)
@@ -3400,6 +3445,8 @@ resources; API saves return `409 Conflict` and watcher diagnostics expose no can
 - Issue state refresh by ID returns minimal normalized issues
 - Issue state refresh query uses GitHub node IDs as specified in Section 11.2
 - Error mapping for request errors, non-200, GraphQL errors, malformed payloads
+- If authorization is configured, event-history validation fails closed for unsupported fields and
+  event reads normalize immutable item, field, value, actor, identity, and timestamp evidence
 
 ### 17.4 Orchestrator Dispatch, Reconciliation, and Retry
 
@@ -3433,6 +3480,12 @@ resources; API saves return `409 Conflict` and watcher diagnostics expose no can
 - If a snapshot API is implemented, it returns running rows, retry rows, token totals, and rate
   limits
 - If a snapshot API is implemented, timeout/unavailable cases are surfaced
+- Authorization selects and persists the exact qualifying event with its direct Artifact identity,
+  revalidates both before protected dispatch, and keeps dispatch pending on missing or changed
+  evidence
+- Automatic authorization journals pending before its remote state write, requires durable applied
+  acknowledgement before dispatch, and recovery does not duplicate a write already reflected by
+  the tracker
 
 ### 17.5 ACP Agent Client
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -653,6 +653,7 @@ Pipeline step definitions. Agent and synthesis steps invoke configured agents; g
 | `artifact_snapshot` | object | — | Producer declaration with a non-empty `repositories` list of configured repository keys to observe after output validation |
 | `artifact_inputs` | list of strings | `[]` | Direct producer dependencies whose completed Artifact snapshots this step consumes |
 | `artifact_access` | string | `mutable` | `immutable` verifies every declared input immediately before the step starts and halts on drift; `mutable` permits normal workspace mutation |
+| `authorization` | object | — | Optional immutable tracker-event evidence required before this step starts |
 | `gate` | object | — | Required only for `kind: gate`: ordered unique `assessment_steps` and one `adjudication_step`; a gate has no `agent` |
 
 See [Pipeline Guide](pipelines.md) for details on DAG construction and execution. For a complete
@@ -664,6 +665,11 @@ Schema Draft 2020-12 (an omitted `$schema` uses that dialect). `artifact_snapsho
 must contain unique configured repository keys. A step may declare either or both; an empty
 snapshot declaration is rejected during configuration activation.
 `artifact_inputs` entries must be unique direct dependencies that declare `artifact_snapshot`.
+`authorization` names one direct `artifact_step`, opaque `event.field`, `event.value`, and non-empty
+`event.actors`, plus explicit `handoff` of `wait_for_event` or `automatic_transition`.
+`after_artifact: true` requires event time after Artifact capture; automatic handoff requires the
+protected step's existing `tracker_state`, while `wait_for_event` forbids one and writes nothing.
+Activation rejects adapters that cannot prove the configured event history.
 For immutable consumers, their producer snapshots must select disjoint repository keys.
 `artifact_access: immutable` requires at least one input. ACPX consumers use read approval unless
 the configured agent explicitly uses `deny_all`; direct ACP has no equivalent launch-time

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -93,6 +93,23 @@ intervention rather than retrying automatically. A `step_launched` journal commi
 runtime gate; it authorizes launch, rather than proving the child executed instructions. ACPX
 receives read approval for such a consumer
 unless its configured mode is `deny_all`; direct ACP cannot offer an equivalent runtime guarantee.
+
+### Tracker-event authorization
+
+An `authorization` declaration binds dispatch to a direct Artifact producer and a
+tracker-normalized opaque field/value/actor event. Ensemble selects the latest qualifying event
+by timestamp and immutable event identity, persists it with the exact Artifact identity and output
+digest, and re-reads both before launch. Missing, changed, unsupported, or legacy Artifact evidence
+keeps the protected step pending. `wait_for_event` writes nothing; `automatic_transition` reuses
+the protected step's configured tracker state. Its pending intent is journaled before the remote
+write, and dispatch stays closed until the applied acknowledgement is durable; recovery observes an
+already-applied remote state without repeating the write. No tracker or development-method
+vocabulary enters the pipeline contract.
+
+Authorization is valid only for dispatched agent or synthesis steps. It is rejected on synchronous
+`gate` steps, which evaluate durable assessment evidence directly rather than opening a dispatch
+boundary.
+
 The durable violation records a sorted, bounded list of repository-relative changed paths plus an
 omitted-path count, never contents or absolute paths. Source contents, absolute paths, ignored
 files, workspace copies, and automatic cleanup are deliberately out of scope.


### PR DESCRIPTION
## Summary

- add generic configured tracker-event authorization bound to an exact upstream Artifact identity
- normalize and validate GitHub Project status-history evidence with deterministic selection and fail-closed adapter capability checks
- persist and revalidate selected evidence, with durable wait and automatic-transition handoff recovery
- add public-host GitHub/WireMock coverage for restart/no replay, journal ordering, automatic transition, and Artifact drift

## Validation

- `cargo test -p ensemble-core automatic_handoff_restart_after_remote_write_requires_durable_applied_record -- --nocapture`
- `cargo test -p ensemble-core state_worker_dispatch -- --nocapture`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture` (55 passed, 1 ignored)
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #512