### PR TITLE
Add durable post-output pipeline actions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,6 +55,11 @@ _Avoid_: Run, session
 The structured result by which a step reports success, failure, concern, summary, and downstream data.
 _Avoid_: Verdict
 
+**Post-output action**:
+A bounded configured effect resolved from one producer's schema-validated Step output and durably
+acknowledged before that producer can satisfy downstream dependencies.
+_Avoid_: Replan, workflow mode, command
+
 **Artifact snapshot**:
 An immutable identity for material exposed by one step to downstream evaluation, ensuring sibling evaluators assess the same subject.
 _Avoid_: Current workspace, live files

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -52,6 +52,21 @@ struct GithubMutationResponder {
     calls: Arc<AtomicUsize>,
 }
 
+struct GithubCommentResponder {
+    calls: Arc<AtomicUsize>,
+}
+
+impl Respond for GithubCommentResponder {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "addComment": { "commentEdge": { "node": {
+                "id": "comment-action", "url": "https://github.example/comment-action"
+            }}}}
+        }))
+    }
+}
+
 impl Respond for GithubMutationResponder {
     fn respond(&self, _request: &Request) -> ResponseTemplate {
         self.calls.fetch_add(1, Ordering::SeqCst);
@@ -716,6 +731,7 @@ async fn github_wait_for_event_survives_restart_without_replaying_the_artifact_p
         "protected step ran before external tracker evidence: {prompts_before_restart}"
     );
     assert_eq!(fixture.mutations.load(Ordering::SeqCst), 0);
+    assert_eq!(fixture.comments.load(Ordering::SeqCst), 1);
 
     drop(first);
     let restarted = spawn_web(&fixture.fixture, port);
@@ -727,6 +743,11 @@ async fn github_wait_for_event_survives_restart_without_replaying_the_artifact_p
         "restart must retain the completed Artifact producer and pending handoff"
     );
     assert_eq!(fixture.mutations.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        fixture.comments.load(Ordering::SeqCst),
+        1,
+        "restart must not replay the marker-bound comment action"
+    );
 
     fixture.event_visible.store(true, Ordering::SeqCst);
     let completed = wait_for_history_step(&client, &base_url, "protected").await;
@@ -804,6 +825,7 @@ struct GithubAuthorizationFixture {
     _server: MockServer,
     event_visible: Arc<AtomicBool>,
     mutations: Arc<AtomicUsize>,
+    comments: Arc<AtomicUsize>,
 }
 
 impl GithubAuthorizationFixture {
@@ -811,7 +833,14 @@ impl GithubAuthorizationFixture {
         let server = MockServer::start().await;
         let event_visible = Arc::new(AtomicBool::new(false));
         let mutations = Arc::new(AtomicUsize::new(0));
-        mount_github_authorization_api(&server, event_visible.clone(), mutations.clone()).await;
+        let comments = Arc::new(AtomicUsize::new(0));
+        mount_github_authorization_api(
+            &server,
+            event_visible.clone(),
+            mutations.clone(),
+            comments.clone(),
+        )
+        .await;
         let fixture =
             TestFixture::new_with_github_authorization(&server.uri(), automatic_transition)?;
         Ok(Self {
@@ -819,6 +848,7 @@ impl GithubAuthorizationFixture {
             _server: server,
             event_visible,
             mutations,
+            comments,
         })
     }
 }
@@ -844,6 +874,19 @@ impl TestFixture {
         fs::write(
             root.join("config.yaml"),
             config_yaml(&todo_path, &workspace_root, &repo_path, acceptance_run),
+        )?;
+        fs::write(
+            root.join("outcome-schema.json"),
+            r#"{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["artifact", "comment", "summary", "remedy", "references"],
+  "properties": {
+    "artifact": {"type": "string"}, "comment": {"type": "string"},
+    "summary": {"type": "string"}, "remedy": {"type": "string"},
+    "references": {"type": "array", "items": {"type": "string"}}
+  }
+}"#,
         )?;
         fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
 
@@ -949,6 +992,19 @@ impl TestFixture {
                 &repo_path,
                 automatic_transition,
             ),
+        )?;
+        fs::write(
+            root.join("outcome-schema.json"),
+            r#"{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["artifact", "comment", "summary", "remedy", "references"],
+  "properties": {
+    "artifact": {"type": "string"}, "comment": {"type": "string"},
+    "summary": {"type": "string"}, "remedy": {"type": "string"},
+    "references": {"type": "array", "items": {"type": "string"}}
+  }
+}"#,
         )?;
         fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
         #[cfg(unix)]
@@ -1159,7 +1215,16 @@ agents:
 steps:
   - name: produce
     agent: producer
+    output_schema: {{ path: outcome-schema.json }}
     artifact_snapshot: {{ repositories: [source] }}
+    actions:
+      - type: tracker_comment
+        body: /comment
+      - type: operator_attention
+        kind: ensemble.outcome
+        summary: /summary
+        remedy: /remedy
+        references: /references
   - name: review_a
     agent: reviewer
     depends: [produce]
@@ -1231,7 +1296,16 @@ agents:
 steps:
   - name: produce
     agent: producer
+    output_schema: {{ path: outcome-schema.json }}
     artifact_snapshot: {{ repositories: [source] }}
+    actions:
+      - type: tracker_comment
+        body: /comment
+      - type: operator_attention
+        kind: ensemble.outcome
+        summary: /summary
+        remedy: /remedy
+        references: /references
   - name: protected
     agent: protected
     depends: [produce]
@@ -1262,6 +1336,7 @@ async fn mount_github_authorization_api(
     server: &MockServer,
     event_visible: Arc<AtomicBool>,
     mutations: Arc<AtomicUsize>,
+    comments: Arc<AtomicUsize>,
 ) {
     let discovery = serde_json::json!({ "data": { "repository": { "projectV2": {
         "id": "P_configured",
@@ -1277,6 +1352,24 @@ async fn mount_github_authorization_api(
         .and(path("/"))
         .and(body_string_contains("projectNumber"))
         .respond_with(ResponseTemplate::new(200).set_body_json(discovery))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("comments(first: 100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "node": { "comments": {
+                "pageInfo": { "hasNextPage": false, "endCursor": null }, "nodes": []
+            }}}
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("addComment"))
+        .respond_with(GithubCommentResponder { calls: comments })
         .mount(server)
         .await;
 
@@ -1510,6 +1603,8 @@ if [[ " $* " == *" prompt "* ]]; then
     verdict='{"invalid":"repair"}'
   elif [[ "${ENSEMBLE_E2E_CONCERN_PUBLISH:-}" == "1" && "$prompt" == *"Evaluation publish"* ]]; then
     verdict='{"result":"concern","summary":"operator should approve","output":{"artifact":"mock"}}'
+  elif [[ "$prompt" == *"GitHub producer"* ]]; then
+    verdict='{"result":"succeeded","summary":"GitHub producer completed","output":{"artifact":"mock","comment":"Artifact ready","summary":"Artifact ready","remedy":"Review it","references":["artifact:mock"]}}'
   elif [[ "$prompt" == *"Evaluation reviewer"* ]]; then
     severity="${ENSEMBLE_E2E_FINDING_SEVERITY:-non_blocking}"
     verdict="{\"result\":\"succeeded\",\"summary\":\"assessment\",\"output\":{\"assessment\":{\"findings\":[{\"id\":\"finding-1\",\"severity\":\"$severity\",\"summary\":\"Minor concern\",\"evidence\":{\"path\":\"README.md\"}}]}}}"

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -875,19 +875,6 @@ impl TestFixture {
             root.join("config.yaml"),
             config_yaml(&todo_path, &workspace_root, &repo_path, acceptance_run),
         )?;
-        fs::write(
-            root.join("outcome-schema.json"),
-            r#"{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "required": ["artifact", "comment", "summary", "remedy", "references"],
-  "properties": {
-    "artifact": {"type": "string"}, "comment": {"type": "string"},
-    "summary": {"type": "string"}, "remedy": {"type": "string"},
-    "references": {"type": "array", "items": {"type": "string"}}
-  }
-}"#,
-        )?;
         fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
 
         #[cfg(unix)]
@@ -1215,16 +1202,7 @@ agents:
 steps:
   - name: produce
     agent: producer
-    output_schema: {{ path: outcome-schema.json }}
     artifact_snapshot: {{ repositories: [source] }}
-    actions:
-      - type: tracker_comment
-        body: /comment
-      - type: operator_attention
-        kind: ensemble.outcome
-        summary: /summary
-        remedy: /remedy
-        references: /references
   - name: review_a
     agent: reviewer
     depends: [produce]

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -762,6 +762,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prepare_runtime_rejects_operator_attention_without_history_store() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("outcome.schema.json"),
+            r#"{"type":"object","required":["summary","remedy"],"properties":{"summary":{"type":"string"},"remedy":{"type":"string"}}}"#,
+        )
+        .unwrap();
+        let yaml = valid_config_yaml(None).replace(
+            "    agent: builder",
+            "    agent: builder\n    output_schema: { path: outcome.schema.json }\n    actions:\n      - type: operator_attention\n        kind: ensemble.review\n        summary: /summary\n        remedy: /remedy",
+        );
+        let state = parse_raw_yaml(temp.path().join("config.yaml"), yaml);
+        assert!(state.active_config.is_some());
+        let mut app = crate::api::test_helpers::app_state_with_document_state(state.clone());
+        app.history_store = None;
+        let error = match prepare_orchestrator_runtime(&app, &state).await {
+            Err(error) => error,
+            Ok(_) => panic!("operator attention requires durable history storage"),
+        };
+        assert!(error
+            .to_string()
+            .contains("operator_attention actions require durable history storage"));
+    }
+
+    #[tokio::test]
     async fn build_app_state_uses_config_values_when_document_is_runnable() {
         let config_path = PathBuf::from("/tmp/config.yaml");
         let document_state = parse_raw_yaml(

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -314,6 +314,11 @@ pub(crate) async fn prepare_orchestrator_runtime(
     let tracker: Arc<dyn IssueTracker> = Arc::from(create_tracker_for_runtime(&config)?);
     let config = Arc::new(RwLock::new(config));
     tracker.validate_configuration().await?;
+    if config.read().await.has_tracker_comment_actions()
+        && !tracker.supports_idempotent_comment_publication()
+    {
+        return Err(crate::tracker::TrackerError::IdempotentCommentPublicationUnsupported.into());
+    }
     for field in authorization_event_fields {
         tracker.validate_event_evidence(&field).await?;
     }

--- a/crates/ensemble-core/src/api/bootstrap.rs
+++ b/crates/ensemble-core/src/api/bootstrap.rs
@@ -311,6 +311,12 @@ pub(crate) async fn prepare_orchestrator_runtime(
     };
 
     let authorization_event_fields = config.authorization_event_fields();
+    if config.has_operator_attention_actions() && app_state.history_store.is_none() {
+        return Err(crate::error::ConfigError::ConfigWriteRejected {
+            reason: "operator_attention actions require durable history storage".to_string(),
+        }
+        .into());
+    }
     let tracker: Arc<dyn IssueTracker> = Arc::from(create_tracker_for_runtime(&config)?);
     let config = Arc::new(RwLock::new(config));
     tracker.validate_configuration().await?;

--- a/crates/ensemble-core/src/api/controls.rs
+++ b/crates/ensemble-core/src/api/controls.rs
@@ -1071,6 +1071,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }])
         .unwrap();
 

--- a/crates/ensemble-core/src/api/handlers.rs
+++ b/crates/ensemble-core/src/api/handlers.rs
@@ -1333,6 +1333,7 @@ on_failure: Failed
                     artifact_integrity_violations: Vec::new(),
                     artifact_access_evidence: Vec::new(),
                     gate_evidence: Default::default(),
+                    applied_actions: Vec::new(),
                 }),
             })
             .await
@@ -1371,6 +1372,7 @@ on_failure: Failed
             artifact_integrity_violations: Vec::new(),
             artifact_access_evidence: Vec::new(),
             gate_evidence: Default::default(),
+            applied_actions: Vec::new(),
         };
         history_artifacts.gate_evidence.insert(
             "gate".into(),
@@ -1422,6 +1424,7 @@ on_failure: Failed
             artifact_integrity_violations: Vec::new(),
             artifact_access_evidence: Vec::new(),
             gate_evidence: Default::default(),
+            applied_actions: Vec::new(),
         };
         {
             let mut state = app_state.orchestrator_state.write().await;
@@ -1494,6 +1497,7 @@ on_failure: Failed
                     artifact_integrity_violations: Vec::new(),
                     artifact_access_evidence: Vec::new(),
                     gate_evidence: Default::default(),
+                    applied_actions: Vec::new(),
                 }),
             })
             .await

--- a/crates/ensemble-core/src/attention/model.rs
+++ b/crates/ensemble-core/src/attention/model.rs
@@ -49,6 +49,12 @@ impl AttentionIdentity {
     }
 }
 
+/// Validate a configured attention kind using the same contract as durable
+/// attention identities, before a pipeline can start waiting on an effect.
+pub(crate) fn validate_configured_kind(kind: &str) -> Result<(), AttentionError> {
+    AttentionIdentity::new("configured-action", "configured-action", kind).map(|_| ())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct AttentionPresentation {
     pub summary: String,

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -1177,6 +1177,22 @@ impl EnsembleConfig {
                     .any(|action| matches!(action, StepActionConfig::TrackerComment { .. }))
             })
     }
+
+    /// Whether activation requires the durable operator-attention store.
+    pub fn has_operator_attention_actions(&self) -> bool {
+        self.steps
+            .iter()
+            .chain(
+                self.pipelines
+                    .values()
+                    .flat_map(|pipeline| pipeline.steps.iter()),
+            )
+            .any(|step| {
+                step.actions
+                    .iter()
+                    .any(|action| matches!(action, StepActionConfig::OperatorAttention { .. }))
+            })
+    }
     pub fn uses_workflow_selection(&self) -> bool {
         !self.workflow_selection.is_empty()
     }

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -2425,7 +2425,7 @@ fn validate_step_actions(steps: &[StepConfig]) -> Result<(), PipelineError> {
                     remedy,
                     references,
                 } => {
-                    if !is_namespaced_action_kind(kind)
+                    if crate::attention::model::validate_configured_kind(kind).is_err()
                         || !is_valid_json_pointer(summary)
                         || !is_valid_json_pointer(remedy)
                         || !required_string_at(schema, summary)
@@ -2442,10 +2442,6 @@ fn validate_step_actions(steps: &[StepConfig]) -> Result<(), PipelineError> {
         }
     }
     Ok(())
-}
-
-fn is_namespaced_action_kind(kind: &str) -> bool {
-    kind.split('.').count() >= 2 && kind.split('.').all(|segment| !segment.trim().is_empty())
 }
 
 fn required_schema_value_at<'a>(
@@ -3009,6 +3005,17 @@ mod tests {
         assert!(matches!(
             validate_step_actions(&[invalid_pointer]),
             Err(PipelineError::InvalidStepConfig { reason, .. }) if reason.contains("required string")
+        ));
+
+        let invalid_attention_kind = action_producer(vec![StepActionConfig::OperatorAttention {
+            kind: "Ensemble review\n".to_string(),
+            summary: "/summary".to_string(),
+            remedy: "/remedy".to_string(),
+            references: Some("/references".to_string()),
+        }]);
+        assert!(matches!(
+            validate_step_actions(&[invalid_attention_kind]),
+            Err(PipelineError::InvalidStepConfig { reason, .. }) if reason.contains("operator_attention")
         ));
 
         let mut route = valid;

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -677,6 +677,27 @@ pub struct StepConfig {
     /// Static branch-selection metadata for an agentless route step.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub route: Option<RouteConfig>,
+    /// Ordered, durable effects applied after this step has produced a valid output.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub actions: Vec<StepActionConfig>,
+}
+
+/// A bounded effect selected from one validated step output. Values remain
+/// opaque configuration data; the runtime only understands their shape and
+/// durability requirements.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum StepActionConfig {
+    TrackerComment {
+        body: String,
+    },
+    OperatorAttention {
+        kind: String,
+        summary: String,
+        remedy: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        references: Option<String>,
+    },
 }
 
 /// The source output inspected by a route step.
@@ -1141,6 +1162,21 @@ pub(crate) fn read_dotenv(path: &Path) -> HashMap<String, String> {
 }
 
 impl EnsembleConfig {
+    /// Whether activation must verify marker-based tracker comment capability.
+    pub fn has_tracker_comment_actions(&self) -> bool {
+        self.steps
+            .iter()
+            .chain(
+                self.pipelines
+                    .values()
+                    .flat_map(|pipeline| pipeline.steps.iter()),
+            )
+            .any(|step| {
+                step.actions
+                    .iter()
+                    .any(|action| matches!(action, StepActionConfig::TrackerComment { .. }))
+            })
+    }
     pub fn uses_workflow_selection(&self) -> bool {
         !self.workflow_selection.is_empty()
     }
@@ -2345,8 +2381,111 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         validate_gate_configs(steps, &dag)?;
         validate_route_configs(steps, &dag)?;
         validate_authorization_configs(steps, &dag)?;
+        validate_step_actions(steps)?;
     }
     Ok(())
+}
+
+fn validate_step_actions(steps: &[StepConfig]) -> Result<(), PipelineError> {
+    for step in steps {
+        if step.actions.is_empty() {
+            continue;
+        }
+        let invalid = |reason: &str| PipelineError::InvalidStepConfig {
+            step: step.name.clone(),
+            reason: reason.to_string(),
+        };
+        if !step.kind.requires_agent() {
+            return Err(invalid(
+                "actions are valid only for agent or synthesis steps",
+            ));
+        }
+        let schema = step
+            .output_schema
+            .as_ref()
+            .and_then(|schema| schema.schema.as_ref())
+            .ok_or_else(|| invalid("actions require a resolved output_schema"))?;
+        let mut identities = std::collections::HashSet::new();
+        for action in &step.actions {
+            let identity = serde_json::to_string(action).map_err(|error| {
+                invalid(&format!("could not serialize action identity: {error}"))
+            })?;
+            if !identities.insert(identity) {
+                return Err(invalid("actions must not contain duplicate declarations"));
+            }
+            match action {
+                StepActionConfig::TrackerComment { body } => {
+                    if !is_valid_json_pointer(body) || !required_string_at(schema, body) {
+                        return Err(invalid("tracker_comment body must be a valid non-empty JSON Pointer to a required string in output_schema"));
+                    }
+                }
+                StepActionConfig::OperatorAttention {
+                    kind,
+                    summary,
+                    remedy,
+                    references,
+                } => {
+                    if !is_namespaced_action_kind(kind)
+                        || !is_valid_json_pointer(summary)
+                        || !is_valid_json_pointer(remedy)
+                        || !required_string_at(schema, summary)
+                        || !required_string_at(schema, remedy)
+                        || references.as_ref().is_some_and(|pointer| {
+                            !is_valid_json_pointer(pointer)
+                                || !required_string_array_at(schema, pointer)
+                        })
+                    {
+                        return Err(invalid("operator_attention requires a namespaced kind, required string summary/remedy pointers, and an optional required string-array references pointer"));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_namespaced_action_kind(kind: &str) -> bool {
+    kind.split('.').count() >= 2 && kind.split('.').all(|segment| !segment.trim().is_empty())
+}
+
+fn required_schema_value_at<'a>(
+    schema: &'a serde_json::Value,
+    pointer: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut current = schema;
+    for segment in pointer.strip_prefix('/')?.split('/') {
+        let segment = segment.replace("~1", "/").replace("~0", "~");
+        if current.get("type")?.as_str()? != "object"
+            || !current
+                .get("required")?
+                .as_array()?
+                .iter()
+                .any(|value| value.as_str() == Some(&segment))
+        {
+            return None;
+        }
+        current = current.get("properties")?.get(segment)?;
+    }
+    Some(current)
+}
+
+fn required_string_at(schema: &serde_json::Value, pointer: &str) -> bool {
+    required_schema_value_at(schema, pointer)
+        .and_then(|value| value.get("type"))
+        .and_then(serde_json::Value::as_str)
+        == Some("string")
+}
+
+fn required_string_array_at(schema: &serde_json::Value, pointer: &str) -> bool {
+    let Some(value) = required_schema_value_at(schema, pointer) else {
+        return false;
+    };
+    value.get("type").and_then(serde_json::Value::as_str) == Some("array")
+        && value
+            .get("items")
+            .and_then(|items| items.get("type"))
+            .and_then(serde_json::Value::as_str)
+            == Some("string")
 }
 
 fn validate_authorization_configs(
@@ -2800,6 +2939,86 @@ mod tests {
         "ENSEMBLE_TEST_REPO",
     ];
 
+    fn action_producer(actions: Vec<StepActionConfig>) -> StepConfig {
+        StepConfig {
+            name: "produce".to_string(),
+            kind: StepKind::Agent,
+            agent: "builder".to_string(),
+            depends: Some(vec![]),
+            tracker_state: None,
+            timeout_ms: None,
+            approval: None,
+            on_failure: OnFailure::RetryIssue,
+            fixup_agent: None,
+            resource_requests: BTreeMap::new(),
+            affected_paths: None,
+            output_schema: Some(OutputSchemaConfig {
+                path: "outcome.json".into(),
+                schema: Some(serde_json::json!({
+                    "type": "object",
+                    "required": ["comment", "summary", "remedy", "references"],
+                    "properties": {
+                        "comment": {"type": "string"},
+                        "summary": {"type": "string"},
+                        "remedy": {"type": "string"},
+                        "references": {"type": "array", "items": {"type": "string"}}
+                    }
+                })),
+            }),
+            artifact_snapshot: None,
+            artifact_inputs: Vec::new(),
+            artifact_access: ArtifactAccess::Mutable,
+            gate: None,
+            authorization: None,
+            route: None,
+            actions,
+        }
+    }
+
+    #[test]
+    fn actions_require_declared_bounded_output_sources_and_unique_declarations() {
+        let valid = action_producer(vec![
+            StepActionConfig::TrackerComment {
+                body: "/comment".to_string(),
+            },
+            StepActionConfig::OperatorAttention {
+                kind: "ensemble.review".to_string(),
+                summary: "/summary".to_string(),
+                remedy: "/remedy".to_string(),
+                references: Some("/references".to_string()),
+            },
+        ]);
+        assert!(validate_step_actions(&[valid.clone()]).is_ok());
+
+        let duplicate = action_producer(vec![
+            StepActionConfig::TrackerComment {
+                body: "/comment".to_string(),
+            },
+            StepActionConfig::TrackerComment {
+                body: "/comment".to_string(),
+            },
+        ]);
+        assert!(matches!(
+            validate_step_actions(&[duplicate]),
+            Err(PipelineError::InvalidStepConfig { reason, .. }) if reason.contains("duplicate")
+        ));
+
+        let invalid_pointer = action_producer(vec![StepActionConfig::TrackerComment {
+            body: "/missing".to_string(),
+        }]);
+        assert!(matches!(
+            validate_step_actions(&[invalid_pointer]),
+            Err(PipelineError::InvalidStepConfig { reason, .. }) if reason.contains("required string")
+        ));
+
+        let mut route = valid;
+        route.kind = StepKind::Route;
+        assert!(matches!(
+            validate_step_actions(&[route]),
+            Err(PipelineError::InvalidStepConfig { reason, .. }) if reason.contains("agent or synthesis")
+        ));
+    }
+
     struct EnvGuard {
         _guard: std::sync::MutexGuard<'static, ()>,
         saved: Vec<(&'static str, Option<String>)>,
@@ -2901,6 +3120,7 @@ on_failure: Failed
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         };
         let route = StepConfig {
             name: "choose_review_path".to_string(),
@@ -2933,6 +3153,7 @@ on_failure: Failed
                     ("disagreement".to_string(), vec!["escalate".to_string()]),
                 ]),
             }),
+            actions: Vec::new(),
         };
         let branch = |name: &str| StepConfig {
             name: name.to_string(),
@@ -2953,6 +3174,7 @@ on_failure: Failed
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         };
         config.steps = vec![
             compare,
@@ -3004,6 +3226,7 @@ on_failure: Failed
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         };
         config.steps = vec![
             StepConfig {
@@ -3028,6 +3251,7 @@ on_failure: Failed
                 gate: None,
                 authorization: None,
                 route: None,
+                actions: Vec::new(),
             },
             StepConfig {
                 name: "choose_path".to_string(),
@@ -3057,6 +3281,7 @@ on_failure: Failed
                         ("escalation".to_string(), vec!["escalate".to_string()]),
                     ]),
                 }),
+                actions: Vec::new(),
             },
             agent("accept", vec!["choose_path"]),
             agent("escalate", vec!["choose_path"]),

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -932,6 +932,7 @@ fn build_setup_dag(steps: &[SetupStep]) -> Result<crate::pipeline::dag::StepDag,
                 gate: step.gate.clone(),
                 authorization: None,
                 route: step.route.clone(),
+                actions: Vec::new(),
             })
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/ensemble-core/src/history/artifacts.rs
+++ b/crates/ensemble-core/src/history/artifacts.rs
@@ -20,6 +20,8 @@ pub struct RunArtifacts {
     pub artifact_access_evidence: Vec<ArtifactAccessEvidence>,
     #[serde(default)]
     pub gate_evidence: BTreeMap<String, crate::pipeline::assessment::GateEvidence>,
+    #[serde(default)]
+    pub applied_actions: Vec<crate::pipeline::engine::AppliedStepActionEvidence>,
 }
 
 /// Merge durable pipeline evidence into the public artifact envelope used by
@@ -35,6 +37,7 @@ pub fn with_pipeline_evidence(
         && run.artifact_integrity_violations.is_empty()
         && run.artifact_access_evidence.is_empty()
         && run.gate_evidence.is_empty()
+        && run.applied_action_evidence().is_empty()
     {
         return artifacts;
     }
@@ -52,6 +55,7 @@ pub fn with_pipeline_evidence(
             artifacts.artifact_integrity_violations = run.artifact_integrity_violations.clone();
             artifacts.artifact_access_evidence = run.artifact_access_evidence.clone();
             artifacts.gate_evidence = gate_evidence;
+            artifacts.applied_actions = run.applied_action_evidence();
         }
         None => {
             artifacts = Some(RunArtifacts {
@@ -63,6 +67,7 @@ pub fn with_pipeline_evidence(
                 artifact_integrity_violations: run.artifact_integrity_violations.clone(),
                 artifact_access_evidence: run.artifact_access_evidence.clone(),
                 gate_evidence,
+                applied_actions: run.applied_action_evidence(),
             });
         }
     }

--- a/crates/ensemble-core/src/history/writer.rs
+++ b/crates/ensemble-core/src/history/writer.rs
@@ -271,6 +271,7 @@ mod tests {
             artifact_integrity_violations: Vec::new(),
             artifact_access_evidence: Vec::new(),
             gate_evidence: Default::default(),
+            applied_actions: Vec::new(),
         });
 
         writer.append(&record).await.unwrap();

--- a/crates/ensemble-core/src/history_store/attention.rs
+++ b/crates/ensemble-core/src/history_store/attention.rs
@@ -26,6 +26,14 @@ impl HistoryStore {
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .map_err(io::Error::other)?;
             let current = select_item(&tx, &observation.identity)?;
+            if let Some(item) = current
+                .as_ref()
+                .filter(|item| item.state != AttentionLifecycleState::Open)
+                .cloned()
+            {
+                tx.commit().map_err(io::Error::other)?;
+                return Ok(item);
+            }
             let unchanged = current.as_ref().is_some_and(|item| {
                 item.state == AttentionLifecycleState::Open
                     && item.presentation == observation.presentation
@@ -412,6 +420,48 @@ mod tests {
             .unwrap();
 
         assert!(open.is_empty());
+        assert_eq!(resolved.events.len(), 1);
+        assert_eq!(resolved.events[0].evidence.fingerprint, "resolved-v1");
+    }
+
+    #[tokio::test]
+    async fn replay_after_resolution_preserves_the_terminal_attention_state() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let reporter = AttentionReporter::new(
+            HistoryStore::new(dir.path().join(".ensemble/history.db"))
+                .await
+                .unwrap(),
+        );
+        let observation = observation("open-v1");
+        reporter.upsert_open(observation.clone()).await.unwrap();
+        reporter
+            .resolve(
+                AttentionClose::new(
+                    observation.identity.clone(),
+                    "open-v1",
+                    AttentionEvidence::new("resolved-v1").unwrap(),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let replayed = reporter.upsert_open(observation).await.unwrap();
+        let resolved = reporter
+            .history(
+                None,
+                Some(crate::attention::AttentionLifecycleState::Resolved),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            replayed.state,
+            crate::attention::AttentionLifecycleState::Resolved
+        );
+        assert!(reporter.open_items().await.unwrap().is_empty());
         assert_eq!(resolved.events.len(), 1);
         assert_eq!(resolved.events[0].evidence.fingerprint, "resolved-v1");
     }

--- a/crates/ensemble-core/src/history_store/attention.rs
+++ b/crates/ensemble-core/src/history_store/attention.rs
@@ -333,7 +333,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn history_retains_one_event_for_an_idempotent_observation() {
+    async fn operator_attention_action_replay_upserts_once_with_stable_identity() {
         let dir = tempfile::TempDir::new().unwrap();
         let reporter = AttentionReporter::new(
             HistoryStore::new(dir.path().join(".ensemble/history.db"))
@@ -342,10 +342,12 @@ mod tests {
         );
         let observation = observation("open-v1");
 
-        reporter.upsert_open(observation.clone()).await.unwrap();
-        reporter.upsert_open(observation).await.unwrap();
+        let first = reporter.upsert_open(observation.clone()).await.unwrap();
+        let replayed = reporter.upsert_open(observation).await.unwrap();
 
         let history = reporter.history(None, None, None, None).await.unwrap();
+        assert_eq!(first.identity, replayed.identity);
+        assert_eq!(replayed.identity.producer_key, "producer-a");
         assert_eq!(history.events.len(), 1);
     }
 

--- a/crates/ensemble-core/src/history_store/store.rs
+++ b/crates/ensemble-core/src/history_store/store.rs
@@ -438,7 +438,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn append_history_record_round_trips_artifacts() {
+    async fn completed_history_round_trips_bounded_applied_action_evidence() {
         let dir = tempfile::TempDir::new().unwrap();
         let store = HistoryStore::new(dir.path().join("history.db"))
             .await
@@ -486,6 +486,13 @@ mod tests {
                     }),
                 },
             )]),
+            applied_actions: vec![crate::pipeline::engine::AppliedStepActionEvidence {
+                step: "notify_operator".into(),
+                identity: "action:abc".into(),
+                source_output_digest: "digest-123".into(),
+                kind: "operator_attention".into(),
+                receipt: "action:abc".into(),
+            }],
         });
 
         store.append_history_record("run-1", &record).await.unwrap();
@@ -497,6 +504,9 @@ mod tests {
             Some("https://github.com/acme/repo/pull/12")
         );
         assert_eq!(artifacts.transcripts[0].step_name, "build");
+        assert_eq!(artifacts.applied_actions.len(), 1);
+        assert_eq!(artifacts.applied_actions[0].identity, "action:abc");
+        assert_eq!(artifacts.applied_actions[0].kind, "operator_attention");
         assert_eq!(
             artifacts.gate_evidence["gate"]
                 .human_resolution

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -388,7 +388,9 @@ pub fn extract_step_detail_state(
                         StepState::Failed { .. } => "failed",
                         StepState::Errored { .. } => "failed",
                         StepState::BlockedOnHuman { .. } => "waiting",
-                        StepState::AwaitingApproval { .. } => "waiting",
+                        StepState::AwaitingApproval { .. } | StepState::AwaitingActions { .. } => {
+                            "waiting"
+                        }
                     })
                     .unwrap_or("pending")
                     .to_string();
@@ -692,7 +694,9 @@ pub async fn build_issue_snapshot(
                         StepState::Failed { .. } => "failed",
                         StepState::Errored { .. } => "failed",
                         StepState::BlockedOnHuman { .. } => "waiting",
-                        StepState::AwaitingApproval { .. } => "waiting",
+                        StepState::AwaitingApproval { .. } | StepState::AwaitingActions { .. } => {
+                            "waiting"
+                        }
                     })
                     .unwrap_or("pending");
                 WorkflowStepInfo {
@@ -1103,6 +1107,7 @@ mod tests {
                     gate: None,
                     authorization: None,
                     route: None,
+                    actions: Vec::new(),
                 },
                 StepConfig {
                     name: "review".to_string(),
@@ -1123,6 +1128,7 @@ mod tests {
                     gate: None,
                     authorization: None,
                     route: None,
+                    actions: Vec::new(),
                 },
             ],
             on_success: "finalize".to_string(),

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -17625,6 +17625,162 @@ agent:
     }
 
     #[tokio::test]
+    async fn action_acknowledgement_cannot_overwrite_a_parallel_sibling_completion() {
+        let mut config = make_config();
+        config.steps[0].depends = Some(vec![]);
+        config.steps[0].actions = vec![crate::config::ensemble::StepActionConfig::TrackerComment {
+            body: "/comment".to_string(),
+        }];
+        let mut sibling = config.steps[0].clone();
+        sibling.name = "sibling".to_string();
+        sibling.actions.clear();
+        let mut blocker = sibling.clone();
+        blocker.name = "blocker".to_string();
+        config.steps.extend([sibling, blocker]);
+        let config = Arc::new(RwLock::new(config));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Arc::new(Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            WorkspaceManager::new(dir.path(), None).unwrap(),
+            dir.path(),
+            shutdown_rx,
+        ));
+        let issue = test_issue("action-race", "Todo");
+        let mut run = PipelineRun::new(
+            issue.id.clone(),
+            1,
+            build_dag(&config.read().await.steps).unwrap(),
+        );
+        run.start();
+        for step in ["build", "sibling", "blocker"] {
+            run.mark_running(step, format!("session-{step}"));
+        }
+        run.step_completed(
+            "build",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(serde_json::json!({"comment": "ready"})),
+            },
+            false,
+        );
+        let pending_identity = run.pending_action("build").unwrap().identity.clone();
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, Some(1));
+            state.insert_pipeline_run(&issue.id, run, Arc::new(config.read().await.clone()));
+        }
+
+        let action_lock = orchestrator.action_mutation_lock(&issue.id);
+        let action_guard = action_lock.lock().await;
+        let mut action_candidate = orchestrator
+            .state
+            .read()
+            .await
+            .get_pipeline_run(&issue.id)
+            .unwrap()
+            .clone();
+        assert_eq!(
+            action_candidate.acknowledge_action(
+                "build",
+                &pending_identity,
+                StepActionReceipt::TrackerComment {
+                    receipt: pending_identity.clone(),
+                },
+            ),
+            PipelineAction::Waiting
+        );
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let sibling_orchestrator = Arc::clone(&orchestrator);
+        let issue_id = issue.id.clone();
+        let mut sibling_exit = tokio::spawn(async move {
+            let _ = started_tx.send(());
+            sibling_orchestrator
+                .handle_worker_exit(
+                    &issue_id,
+                    "sibling",
+                    WorkerResult::Success {
+                        output: succeeded_step_output(),
+                        approval_request: None,
+                    },
+                )
+                .await;
+        });
+        started_rx.await.unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut sibling_exit)
+                .await
+                .is_err(),
+            "same-issue sibling completion must wait for action acknowledgement publication"
+        );
+
+        let transition = {
+            let state = orchestrator.state.read().await;
+            Orchestrator::transition_input_for_snapshot(
+                &state,
+                &action_candidate,
+                PipelineTransitionTarget {
+                    issue_id: &issue.id,
+                    identifier: &issue.identifier,
+                },
+                PipelineTransitionKind::ActionApplied,
+                Some("build".to_string()),
+                Some(pending_identity.clone()),
+                None,
+            )
+            .unwrap()
+        };
+        orchestrator
+            .pipeline_journal
+            .append(transition)
+            .await
+            .unwrap();
+        orchestrator
+            .state
+            .write()
+            .await
+            .pipeline_runs
+            .insert(issue.id.clone(), action_candidate);
+        drop(action_guard);
+        sibling_exit.await.unwrap();
+
+        let state = orchestrator.state.read().await;
+        let live = state.get_pipeline_run(&issue.id).unwrap();
+        assert_eq!(live.step_states["build"], StepState::Passed);
+        assert_eq!(live.step_states["sibling"], StepState::Passed);
+        assert!(live.step_outputs.contains_key("sibling"));
+        assert_eq!(live.applied_action_evidence()[0].identity, pending_identity);
+        drop(state);
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue(&issue.id)
+            .await
+            .unwrap();
+        let recovered =
+            PipelineRun::from_snapshot(records.last().unwrap().snapshot.clone().unwrap()).unwrap();
+        assert_eq!(recovered.step_states["build"], StepState::Passed);
+        assert_eq!(recovered.step_states["sibling"], StepState::Passed);
+        assert!(recovered.step_outputs.contains_key("sibling"));
+        assert_eq!(
+            recovered.applied_action_evidence()[0].identity,
+            pending_identity
+        );
+    }
+
+    #[tokio::test]
     async fn transient_action_failure_retains_owner_output_workspace_and_retries_without_producer_rerun(
     ) {
         let mut config = make_config();

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -13528,6 +13528,12 @@ mod tests {
         comments: Arc<RwLock<Vec<(String, String)>>>,
     }
 
+    struct ActionPublicationTracker {
+        issues: Arc<RwLock<Vec<Issue>>>,
+        failures_remaining: AtomicUsize,
+        publications: AtomicUsize,
+    }
+
     #[async_trait]
     impl IssueTracker for CommentRecordingTracker {
         async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
@@ -13565,6 +13571,71 @@ mod tests {
                 .await
                 .push((id.to_string(), body.to_string()));
             Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl IssueTracker for ActionPublicationTracker {
+        async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>, TrackerError> {
+            Ok(self.issues.read().await.clone())
+        }
+
+        async fn fetch_issues_by_states(
+            &self,
+            states: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            let states = states
+                .iter()
+                .map(|state| state.to_lowercase())
+                .collect::<Vec<_>>();
+            Ok(self
+                .issues
+                .read()
+                .await
+                .iter()
+                .filter(|issue| states.contains(&issue.state.to_lowercase()))
+                .cloned()
+                .collect())
+        }
+
+        async fn fetch_issue_states_by_ids(
+            &self,
+            ids: &[String],
+        ) -> Result<Vec<Issue>, TrackerError> {
+            Ok(self
+                .issues
+                .read()
+                .await
+                .iter()
+                .filter(|issue| ids.contains(&issue.id))
+                .cloned()
+                .collect())
+        }
+
+        fn supports_idempotent_comment_publication(&self) -> bool {
+            true
+        }
+
+        async fn publish_comment(
+            &self,
+            _id: &str,
+            publication: crate::tracker::model::TrackerCommentPublication,
+        ) -> Result<crate::tracker::model::TrackerCommentReceipt, TrackerError> {
+            if self
+                .failures_remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(TrackerError::ApiRequestFailed {
+                    reason: "transient action failure".to_string(),
+                });
+            }
+            self.publications.fetch_add(1, Ordering::SeqCst);
+            Ok(crate::tracker::model::TrackerCommentReceipt {
+                receipt: publication.marker,
+            })
         }
     }
 
@@ -14197,6 +14268,10 @@ mod tests {
         });
         let config_dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(config_dir.path(), None).unwrap();
+        workspace_mgr
+            .prepare_workspace("1", "repo#1")
+            .await
+            .unwrap();
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
         let orchestrator = Orchestrator::new(
             Arc::clone(&config),
@@ -17490,6 +17565,110 @@ agent:
   stall_timeout_ms: 300000
 "#;
         parse_config(yaml).unwrap()
+    }
+
+    #[tokio::test]
+    async fn transient_action_failure_retains_owner_output_workspace_and_retries_without_producer_rerun(
+    ) {
+        let mut config = make_config();
+        config.steps[0].actions = vec![crate::config::ensemble::StepActionConfig::TrackerComment {
+            body: "/comment".to_string(),
+        }];
+        let mut downstream = config.steps[0].clone();
+        downstream.name = "downstream".to_string();
+        downstream.depends = Some(vec!["build".to_string()]);
+        downstream.actions.clear();
+        config.steps.push(downstream);
+        let config = Arc::new(RwLock::new(config));
+        let issue = test_issue("action-failure", "Todo");
+        let tracker = Arc::new(ActionPublicationTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+            failures_remaining: AtomicUsize::new(1),
+            publications: AtomicUsize::new(0),
+        });
+        let runner_runs = Arc::new(AtomicUsize::new(0));
+        let runner: Arc<dyn AgentRunner> = Arc::new(CountingRunner {
+            runs: runner_runs.clone(),
+        });
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_mgr = WorkspaceManager::new(temp.path(), None).unwrap();
+        workspace_mgr
+            .prepare_workspace(&issue.id, &issue.identifier)
+            .await
+            .unwrap();
+        let workspace_path = workspace_mgr.workspace_path(&issue.id);
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker.clone(),
+            runner,
+            workspace_mgr,
+            temp.path(),
+            shutdown_rx,
+        );
+        let mut run = PipelineRun::new(
+            issue.id.clone(),
+            1,
+            build_dag(&config.read().await.steps).unwrap(),
+        );
+        run.start();
+        run.set_ownership_lease(OwnershipLease {
+            id: "lease-action".to_string(),
+            branch_name: None,
+        });
+        run.step_completed(
+            "build",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(serde_json::json!({"comment": "ready"})),
+            },
+            false,
+        );
+        let pending_identity = run.pending_action("build").unwrap().identity.clone();
+        let config_snapshot = Arc::new(config.read().await.clone());
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, Some(1));
+            state.insert_pipeline_run(&issue.id, run, config_snapshot);
+        }
+
+        orchestrator.apply_pending_step_actions(&issue.id).await;
+        {
+            let state = orchestrator.state.read().await;
+            let retained = state.get_pipeline_run(&issue.id).unwrap();
+            assert_eq!(
+                retained.step_outputs["build"].output,
+                Some(serde_json::json!({"comment": "ready"}))
+            );
+            assert!(matches!(
+                retained.step_states["build"],
+                StepState::AwaitingActions { .. }
+            ));
+            assert_eq!(
+                retained.pending_action("build").unwrap().identity,
+                pending_identity
+            );
+            assert_eq!(retained.step_states["downstream"], StepState::Pending);
+            assert!(state.is_running(&issue.id));
+            assert!(state.is_claimed(&issue.id));
+        }
+        assert!(workspace_path.exists());
+        assert_eq!(runner_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(tracker.publications.load(Ordering::SeqCst), 0);
+
+        orchestrator.apply_pending_step_actions(&issue.id).await;
+        let state = orchestrator.state.read().await;
+        let recovered = state.get_pipeline_run(&issue.id).unwrap();
+        assert_eq!(
+            recovered.applied_action_evidence()[0].identity,
+            pending_identity
+        );
+        assert_eq!(recovered.step_states["build"], StepState::Passed);
+        assert!(state.is_running(&issue.id));
+        assert!(state.is_claimed(&issue.id));
+        assert_eq!(runner_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(tracker.publications.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -26198,7 +26377,8 @@ agent:
     }
 
     #[tokio::test]
-    async fn terminal_tracker_transition_failure_retains_recoverable_failed_run() {
+    async fn terminal_tracker_transition_failure_retains_applied_action_evidence_claim_and_workspace(
+    ) {
         let config = Arc::new(RwLock::new(make_always_approval_config(1)));
         let tracker: Arc<dyn IssueTracker> = Arc::new(FailingWriteTracker {
             issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
@@ -26211,6 +26391,11 @@ agent:
         });
         let config_dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(config_dir.path(), None).unwrap();
+        workspace_mgr
+            .prepare_workspace("1", "repo#1")
+            .await
+            .unwrap();
+        let workspace_path = workspace_mgr.workspace_path("1");
         let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let orchestrator = Orchestrator::new(
@@ -26269,7 +26454,13 @@ agent:
                 artifact_integrity_violations: Vec::new(),
                 artifact_access_evidence: Vec::new(),
                 gate_evidence: Default::default(),
-                applied_actions: Vec::new(),
+                applied_actions: vec![crate::pipeline::engine::AppliedStepActionEvidence {
+                    step: "build".to_string(),
+                    identity: "action:terminal".to_string(),
+                    source_output_digest: "digest-terminal".to_string(),
+                    kind: "tracker_comment".to_string(),
+                    receipt: "action:terminal".to_string(),
+                }],
             },
         );
 
@@ -26283,6 +26474,7 @@ agent:
         assert!(state.is_claimed("1"));
         assert!(state.get_pipeline_run("1").is_some());
         assert!(state.artifacts.contains_key("1"));
+        assert!(workspace_path.exists());
         let pending = state.pending_terminal_transitions.get("1").unwrap();
         assert_eq!(pending.transition.target_state, "Failed");
         assert_eq!(pending.transition.outcome, TerminalOutcome::Failed);
@@ -26294,6 +26486,19 @@ agent:
             .as_ref()
             .and_then(|record| record.artifacts.as_ref())
             .is_some());
+        assert_eq!(
+            pending
+                .transition
+                .history_record
+                .as_ref()
+                .unwrap()
+                .artifacts
+                .as_ref()
+                .unwrap()
+                .applied_actions[0]
+                .identity,
+            "action:terminal"
+        );
         drop(state);
 
         let records = orchestrator

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -91,11 +91,12 @@ use crate::pipeline::assessment::{DispositionKind, GateEvidence};
 use crate::pipeline::dag::build_dag;
 use crate::pipeline::engine::{
     AutomaticTransitionState, DispatchRequest, PipelineAction, PipelineRun, PipelineRunSnapshot,
-    RouteDecisionEvidence, SelectedWorkflowSnapshot, StepOutputTemplateContext, StepState,
+    ResolvedStepAction, RouteDecisionEvidence, SelectedWorkflowSnapshot, StepActionReceipt,
+    StepOutputTemplateContext, StepState,
 };
 use crate::pipeline::verdict::{StepOutput, StepResult};
 use crate::timeline::persistence::TimelinePersistence;
-use crate::tracker::model::{Issue, RetryEntry, RunningEntry};
+use crate::tracker::model::{Issue, RetryEntry, RunningEntry, TrackerCommentPublication};
 use crate::tracker::{IssueTracker, OwnershipClaim, OwnershipLease};
 use crate::transcript::events::TranscriptEventBus;
 use crate::transcript::model::TranscriptRecordKind;
@@ -2280,6 +2281,7 @@ impl Orchestrator {
                         }
                     }
                     PipelineAction::Waiting
+                    | PipelineAction::AwaitingAction { .. }
                     | PipelineAction::Failed { .. }
                     | PipelineAction::BlockedOnHuman { .. }
                     | PipelineAction::AwaitingApproval { .. } => {}
@@ -2726,6 +2728,7 @@ impl Orchestrator {
         active_issue_ids.sort();
 
         for (_, issue_id) in active_issue_ids {
+            self.apply_pending_step_actions(&issue_id).await;
             if self
                 .pending_run_started_transitions
                 .lock()
@@ -2742,6 +2745,145 @@ impl Orchestrator {
                 break;
             }
             self.dispatch_ready_steps_for_issue(&issue_id, permit).await;
+        }
+    }
+
+    /// Execute durable configured effects before normal ready-step dispatch.
+    /// Failures leave the pending snapshot and issue ownership in place so the
+    /// next scheduler tick retries the effect, never its producer.
+    async fn apply_pending_step_actions(&self, issue_id: &str) {
+        loop {
+            let Some((identifier, step_name, pending, transition)) = ({
+                let state = self.state.read().await;
+                let Some(run) = state.get_pipeline_run(issue_id) else {
+                    return;
+                };
+                let Some((step_name, pending)) = run.workflow_steps().find_map(|step| {
+                    run.pending_action(&step.name)
+                        .cloned()
+                        .map(|pending| (step.name.clone(), pending))
+                }) else {
+                    return;
+                };
+                let identifier = state
+                    .get_running(issue_id)
+                    .map(|entry| entry.identifier.clone())
+                    .unwrap_or_else(|| issue_id.to_string());
+                let Some(transition) = Self::transition_input_for_snapshot(
+                    &state,
+                    run,
+                    PipelineTransitionTarget {
+                        issue_id,
+                        identifier: &identifier,
+                    },
+                    PipelineTransitionKind::ActionPending,
+                    Some(step_name.clone()),
+                    Some(pending.identity.clone()),
+                    None,
+                ) else {
+                    return;
+                };
+                Some((identifier, step_name, pending, transition))
+            }) else {
+                return;
+            };
+            if let Err(error) = self.pipeline_journal.append(transition).await {
+                warn!(issue_id = %issue_id, step = %step_name, error = %error, "failed to checkpoint configured action before execution");
+                return;
+            }
+            let receipt = match pending.action.clone() {
+                ResolvedStepAction::TrackerComment { body } => self
+                    .tracker
+                    .publish_comment(
+                        issue_id,
+                        TrackerCommentPublication {
+                            marker: pending.identity.clone(),
+                            body,
+                        },
+                    )
+                    .await
+                    .map(|receipt| StepActionReceipt::TrackerComment {
+                        receipt: receipt.receipt,
+                    })
+                    .map_err(|error| error.to_string()),
+                ResolvedStepAction::OperatorAttention {
+                    kind,
+                    summary,
+                    remedy,
+                    references,
+                } => {
+                    let Some(reporter) = self.attention_reporter.as_ref() else {
+                        warn!(issue_id = %issue_id, step = %step_name, "configured attention action requires durable history storage");
+                        return;
+                    };
+                    let observation = AttentionIdentity::new(&pending.identity, issue_id, kind)
+                        .and_then(|identity| {
+                            AttentionPresentation::new(summary, remedy, references).and_then(
+                                |presentation| {
+                                    AttentionEvidence::new(&pending.source_output_digest).map(
+                                        |evidence| {
+                                            AttentionUpsert::new(identity, presentation, evidence)
+                                        },
+                                    )
+                                },
+                            )
+                        });
+                    match observation {
+                        Ok(observation) => reporter
+                            .upsert_open(observation)
+                            .await
+                            .map(|item| StepActionReceipt::OperatorAttention {
+                                receipt: item.identity.producer_key,
+                            })
+                            .map_err(|error| error.to_string()),
+                        Err(error) => Err(error.to_string()),
+                    }
+                }
+            };
+            let receipt = match receipt {
+                Ok(receipt) => receipt,
+                Err(error) => {
+                    warn!(issue_id = %issue_id, step = %step_name, error = %error, "configured action remains pending for retry");
+                    return;
+                }
+            };
+            let Some((candidate, transition)) = ({
+                let state = self.state.read().await;
+                let Some(run) = state.get_pipeline_run(issue_id) else {
+                    return;
+                };
+                let mut candidate = run.clone();
+                candidate.acknowledge_action(&step_name, receipt);
+                let Some(transition) = Self::transition_input_for_snapshot(
+                    &state,
+                    &candidate,
+                    PipelineTransitionTarget {
+                        issue_id,
+                        identifier: &identifier,
+                    },
+                    PipelineTransitionKind::ActionApplied,
+                    Some(step_name.clone()),
+                    Some(pending.identity.clone()),
+                    None,
+                ) else {
+                    return;
+                };
+                Some((candidate, transition))
+            }) else {
+                return;
+            };
+            if let Err(error) = self.pipeline_journal.append(transition).await {
+                warn!(issue_id = %issue_id, step = %step_name, error = %error, "effect completed but receipt was not durable; marker reconciliation will retry it");
+                return;
+            }
+            let mut state = self.state.write().await;
+            let still_pending = state
+                .get_pipeline_run(issue_id)
+                .and_then(|run| run.pending_action(&step_name))
+                .is_some_and(|current| current.identity == pending.identity);
+            if still_pending {
+                state.pipeline_runs.insert(issue_id.to_string(), candidate);
+            }
         }
     }
 
@@ -6455,7 +6597,7 @@ impl Orchestrator {
                                 self.commit_whole_issue_failure_retry(terminal).await;
                             }
                         }
-                        PipelineAction::Waiting => {
+                        PipelineAction::Waiting | PipelineAction::AwaitingAction { .. } => {
                             debug!(issue_id = %issue_id, "pipeline waiting for other steps");
                             drop(state);
                             if let Err(error) = self
@@ -10214,7 +10356,9 @@ impl Orchestrator {
             PipelineAction::Failed { .. } => PipelineTransitionKind::StepFailed,
             PipelineAction::BlockedOnHuman { .. } => PipelineTransitionKind::StepBlockedOnHuman,
             PipelineAction::AwaitingApproval { .. } => PipelineTransitionKind::StepAwaitingApproval,
-            PipelineAction::Waiting => PipelineTransitionKind::StepCompleted,
+            PipelineAction::Waiting | PipelineAction::AwaitingAction { .. } => {
+                PipelineTransitionKind::StepCompleted
+            }
         }
     }
 
@@ -12023,7 +12167,9 @@ impl Orchestrator {
                     } => {
                         nested_approval = Some((step, approval_state));
                     }
-                    PipelineAction::Waiting | PipelineAction::BlockedOnHuman { .. } => {}
+                    PipelineAction::Waiting
+                    | PipelineAction::AwaitingAction { .. }
+                    | PipelineAction::BlockedOnHuman { .. } => {}
                 }
             }
         }
@@ -20960,6 +21106,7 @@ agent:
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }])
         .unwrap();
         let stale_run = PipelineRun::new(issue.id.clone(), 1, stale_dag);

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -1522,7 +1522,7 @@ impl Orchestrator {
         // Give already-claimed pipelines the first opportunity to consume
         // newly available worker capacity before admitting new issues.
         if let Some(permit) = self.quiescing.begin_dispatch() {
-            Box::pin(self.dispatch_ready_active_pipelines(&permit)).await;
+            self.dispatch_ready_active_pipelines(&permit).await;
         }
 
         // Durable journal owners always win. Only after they have had an
@@ -2733,36 +2733,41 @@ impl Orchestrator {
         }
     }
 
-    async fn dispatch_ready_active_pipelines(&self, permit: &DispatchPermit) {
-        let mut active_issue_ids = {
-            let state = self.state.read().await;
-            state
-                .running
-                .values()
-                .map(|entry| (entry.identifier.clone(), entry.issue_id.clone()))
-                .collect::<Vec<_>>()
-        };
-        active_issue_ids.sort();
+    fn dispatch_ready_active_pipelines<'a>(
+        &'a self,
+        permit: &'a DispatchPermit,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            let mut active_issue_ids = {
+                let state = self.state.read().await;
+                state
+                    .running
+                    .values()
+                    .map(|entry| (entry.identifier.clone(), entry.issue_id.clone()))
+                    .collect::<Vec<_>>()
+            };
+            active_issue_ids.sort();
 
-        for (_, issue_id) in active_issue_ids {
-            self.apply_pending_step_actions(&issue_id).await;
-            if self
-                .pending_run_started_transitions
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .contains_key(&issue_id)
-            {
-                continue;
+            for (_, issue_id) in active_issue_ids {
+                self.apply_pending_step_actions(&issue_id).await;
+                if self
+                    .pending_run_started_transitions
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .contains_key(&issue_id)
+                {
+                    continue;
+                }
+                let max_workers = self.config.read().await.concurrency.max_concurrent_agents;
+                if !has_available_worker_slots(
+                    live_worker_count(&self.cancellation_registry),
+                    max_workers,
+                ) {
+                    break;
+                }
+                self.dispatch_ready_steps_for_issue(&issue_id, permit).await;
             }
-            let max_workers = self.config.read().await.concurrency.max_concurrent_agents;
-            if !has_available_worker_slots(
-                live_worker_count(&self.cancellation_registry),
-                max_workers,
-            ) {
-                break;
-            }
-            self.dispatch_ready_steps_for_issue(&issue_id, permit).await;
-        }
+        })
     }
 
     /// Execute durable configured effects before normal ready-step dispatch.

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -2748,8 +2748,14 @@ impl Orchestrator {
             };
             active_issue_ids.sort();
 
+            for (_, issue_id) in &active_issue_ids {
+                if let Some(action) = self.apply_pending_step_actions(issue_id).await {
+                    self.handle_applied_action_outcome(issue_id, action, permit)
+                        .await;
+                }
+            }
+
             for (_, issue_id) in active_issue_ids {
-                self.apply_pending_step_actions(&issue_id).await;
                 if self
                     .pending_run_started_transitions
                     .lock()
@@ -2773,27 +2779,23 @@ impl Orchestrator {
     /// Execute durable configured effects before normal ready-step dispatch.
     /// Failures leave the pending snapshot and issue ownership in place so the
     /// next scheduler tick retries the effect, never its producer.
-    async fn apply_pending_step_actions(&self, issue_id: &str) {
+    async fn apply_pending_step_actions(&self, issue_id: &str) -> Option<PipelineAction> {
         let action_lock = self.action_mutation_lock(issue_id);
         let _action_guard = action_lock.lock().await;
         loop {
-            let Some((identifier, step_name, pending, transition)) = ({
+            let (identifier, step_name, pending, transition) = {
                 let state = self.state.read().await;
-                let Some(run) = state.get_pipeline_run(issue_id) else {
-                    return;
-                };
-                let Some((step_name, pending)) = run.workflow_steps().find_map(|step| {
+                let run = state.get_pipeline_run(issue_id)?;
+                let (step_name, pending) = run.workflow_steps().find_map(|step| {
                     run.pending_action(&step.name)
                         .cloned()
                         .map(|pending| (step.name.clone(), pending))
-                }) else {
-                    return;
-                };
+                })?;
                 let identifier = state
                     .get_running(issue_id)
                     .map(|entry| entry.identifier.clone())
                     .unwrap_or_else(|| issue_id.to_string());
-                let Some(transition) = Self::transition_input_for_snapshot(
+                let transition = Self::transition_input_for_snapshot(
                     &state,
                     run,
                     PipelineTransitionTarget {
@@ -2804,16 +2806,12 @@ impl Orchestrator {
                     Some(step_name.clone()),
                     Some(pending.identity.clone()),
                     None,
-                ) else {
-                    return;
-                };
-                Some((identifier, step_name, pending, transition))
-            }) else {
-                return;
+                )?;
+                (identifier, step_name, pending, transition)
             };
             if let Err(error) = self.pipeline_journal.append(transition).await {
                 warn!(issue_id = %issue_id, step = %step_name, error = %error, "failed to checkpoint configured action before execution");
-                return;
+                return None;
             }
             let receipt = match pending.action.clone() {
                 ResolvedStepAction::TrackerComment { body } => self
@@ -2838,7 +2836,7 @@ impl Orchestrator {
                 } => {
                     let Some(reporter) = self.attention_reporter.as_ref() else {
                         warn!(issue_id = %issue_id, step = %step_name, "configured attention action requires durable history storage");
-                        return;
+                        return None;
                     };
                     let observation = AttentionIdentity::new(&pending.identity, issue_id, kind)
                         .and_then(|identity| {
@@ -2868,23 +2866,21 @@ impl Orchestrator {
                 Ok(receipt) => receipt,
                 Err(error) => {
                     warn!(issue_id = %issue_id, step = %step_name, error = %error, "configured action remains pending for retry");
-                    return;
+                    return None;
                 }
             };
-            let Some((candidate, transition)) = ({
+            let (candidate, transition, action) = {
                 let state = self.state.read().await;
-                let Some(run) = state.get_pipeline_run(issue_id) else {
-                    return;
-                };
+                let run = state.get_pipeline_run(issue_id)?;
                 let mut candidate = run.clone();
-                candidate.acknowledge_action(&step_name, &pending.identity, receipt);
+                let action = candidate.acknowledge_action(&step_name, &pending.identity, receipt);
                 if candidate
                     .pending_action(&step_name)
                     .is_some_and(|current| current.identity == pending.identity)
                 {
-                    return;
+                    return None;
                 }
-                let Some(transition) = Self::transition_input_for_snapshot(
+                let transition = Self::transition_input_for_snapshot(
                     &state,
                     &candidate,
                     PipelineTransitionTarget {
@@ -2895,16 +2891,12 @@ impl Orchestrator {
                     Some(step_name.clone()),
                     Some(pending.identity.clone()),
                     None,
-                ) else {
-                    return;
-                };
-                Some((candidate, transition))
-            }) else {
-                return;
+                )?;
+                (candidate, transition, action)
             };
             if let Err(error) = self.pipeline_journal.append(transition).await {
                 warn!(issue_id = %issue_id, step = %step_name, error = %error, "effect completed but receipt was not durable; marker reconciliation will retry it");
-                return;
+                return None;
             }
             let mut state = self.state.write().await;
             let still_pending = state
@@ -2913,7 +2905,71 @@ impl Orchestrator {
                 .is_some_and(|current| current.identity == pending.identity);
             if still_pending {
                 state.pipeline_runs.insert(issue_id.to_string(), candidate);
+                drop(state);
+                if !matches!(action, PipelineAction::AwaitingAction { .. }) {
+                    return Some(action);
+                }
+            } else {
+                return None;
             }
+        }
+    }
+
+    async fn handle_applied_action_outcome(
+        &self,
+        issue_id: &str,
+        action: PipelineAction,
+        permit: &DispatchPermit,
+    ) {
+        match action {
+            PipelineAction::Succeeded => {
+                let issue = self
+                    .state
+                    .read()
+                    .await
+                    .get_running(issue_id)
+                    .map(|entry| entry.issue.clone());
+                if let Some(issue) = issue {
+                    self.dispatch_issue_with_permit(&issue, None, permit).await;
+                }
+            }
+            PipelineAction::Failed { step, reason } => {
+                self.handle_pipeline_step_failure(issue_id, &step, reason, false)
+                    .await;
+            }
+            PipelineAction::AwaitingApproval {
+                step,
+                approval_state,
+            } => {
+                let issue = self
+                    .state
+                    .read()
+                    .await
+                    .get_running(issue_id)
+                    .map(|entry| entry.issue.clone());
+                if let Err(error) = self
+                    .handle_post_step_approval(
+                        issue_id,
+                        &step,
+                        approval_state,
+                        None,
+                        issue.as_ref(),
+                    )
+                    .await
+                {
+                    self.handle_pipeline_step_failure(
+                        issue_id,
+                        &step,
+                        format!("failed to create post-step approval checkpoint: {error}"),
+                        false,
+                    )
+                    .await;
+                }
+            }
+            PipelineAction::Waiting
+            | PipelineAction::AwaitingAction { .. }
+            | PipelineAction::Dispatch(_)
+            | PipelineAction::BlockedOnHuman { .. } => {}
         }
     }
 
@@ -6670,7 +6726,16 @@ impl Orchestrator {
 
                             if action_is_pending_effect {
                                 drop(action_mutation_guard);
-                                self.apply_pending_step_actions(issue_id).await;
+                                if let Some(action) =
+                                    self.apply_pending_step_actions(issue_id).await
+                                {
+                                    self.handle_applied_action_outcome(
+                                        issue_id,
+                                        action,
+                                        worker_exit_permit,
+                                    )
+                                    .await;
+                                }
                             }
 
                             let mut state = self.state.write().await;
@@ -13555,6 +13620,7 @@ mod tests {
         issues: Arc<RwLock<Vec<Issue>>>,
         failures_remaining: AtomicUsize,
         publications: AtomicUsize,
+        state_writes: Arc<RwLock<Vec<(String, String)>>>,
     }
 
     #[async_trait]
@@ -13637,6 +13703,18 @@ mod tests {
 
         fn supports_idempotent_comment_publication(&self) -> bool {
             true
+        }
+
+        fn supports_writes(&self) -> bool {
+            true
+        }
+
+        async fn set_issue_state(&self, id: &str, state: &str) -> Result<(), TrackerError> {
+            self.state_writes
+                .write()
+                .await
+                .push((id.to_string(), state.to_string()));
+            Ok(())
         }
 
         async fn publish_comment(
@@ -17786,6 +17864,156 @@ agent:
     }
 
     #[tokio::test]
+    async fn final_action_acknowledgement_runs_the_terminal_lifecycle() {
+        let mut config = make_config();
+        config.steps[0].actions = vec![crate::config::ensemble::StepActionConfig::TrackerComment {
+            body: "/comment".to_string(),
+        }];
+        let config = Arc::new(RwLock::new(config));
+        let issue = test_issue("terminal-action", "Todo");
+        let state_writes = Arc::new(RwLock::new(Vec::new()));
+        let tracker = Arc::new(ActionPublicationTracker {
+            issues: Arc::new(RwLock::new(vec![issue.clone()])),
+            failures_remaining: AtomicUsize::new(0),
+            publications: AtomicUsize::new(0),
+            state_writes: Arc::clone(&state_writes),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let temp = tempfile::TempDir::new().unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker.clone(),
+            runner,
+            WorkspaceManager::new(temp.path(), None).unwrap(),
+            temp.path(),
+            shutdown_rx,
+        );
+        let mut run = PipelineRun::new(
+            issue.id.clone(),
+            1,
+            build_dag(&config.read().await.steps).unwrap(),
+        );
+        run.start();
+        run.step_completed(
+            "build",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(serde_json::json!({"comment": "complete"})),
+            },
+            false,
+        );
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&issue, Some(1));
+            state.insert_pipeline_run(&issue.id, run, Arc::new(config.read().await.clone()));
+        }
+
+        let permit = orchestrator.quiescing.begin_dispatch().unwrap();
+        orchestrator.dispatch_ready_active_pipelines(&permit).await;
+
+        assert_eq!(tracker.publications.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            state_writes.read().await.as_slice(),
+            &[(issue.id.clone(), "Done".to_string())]
+        );
+        let state = orchestrator.state.read().await;
+        assert!(!state.is_running(&issue.id));
+        assert!(state.get_pipeline_run(&issue.id).is_none());
+    }
+
+    #[tokio::test]
+    async fn saturated_worker_capacity_does_not_starve_pending_actions() {
+        let mut raw_config = make_config();
+        raw_config.concurrency.max_concurrent_agents = 1;
+        raw_config.steps[0].actions =
+            vec![crate::config::ensemble::StepActionConfig::TrackerComment {
+                body: "/comment".to_string(),
+            }];
+        let mut downstream = raw_config.steps[0].clone();
+        downstream.name = "downstream".to_string();
+        downstream.depends = Some(vec!["build".to_string()]);
+        downstream.actions.clear();
+        raw_config.steps.push(downstream);
+        let config = Arc::new(RwLock::new(raw_config));
+        let busy_issue = test_issue("1", "Todo");
+        let action_issue = test_issue("2", "Todo");
+        let tracker = Arc::new(ActionPublicationTracker {
+            issues: Arc::new(RwLock::new(vec![busy_issue.clone(), action_issue.clone()])),
+            failures_remaining: AtomicUsize::new(0),
+            publications: AtomicUsize::new(0),
+            state_writes: Arc::new(RwLock::new(Vec::new())),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let temp = tempfile::TempDir::new().unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker.clone(),
+            runner,
+            WorkspaceManager::new(temp.path(), None).unwrap(),
+            temp.path(),
+            shutdown_rx,
+        );
+        let dag = build_dag(&config.read().await.steps).unwrap();
+        let mut busy_run = PipelineRun::new(busy_issue.id.clone(), 1, dag.clone());
+        busy_run.start();
+        busy_run.mark_running("build", "busy-session".to_string());
+        let mut action_run = PipelineRun::new(action_issue.id.clone(), 1, dag);
+        action_run.start();
+        action_run.step_completed(
+            "build",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(serde_json::json!({"comment": "ready"})),
+            },
+            false,
+        );
+        let config_snapshot = Arc::new(config.read().await.clone());
+        {
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&busy_issue, Some(1));
+            state.insert_pipeline_run(&busy_issue.id, busy_run, Arc::clone(&config_snapshot));
+            state.add_running(&action_issue, Some(1));
+            state.insert_pipeline_run(&action_issue.id, action_run, config_snapshot);
+        }
+        let (_, completion) = watch::channel(false);
+        crate::agent::cancellation::register_worker(
+            &orchestrator.cancellation_registry,
+            WorkerIdentity {
+                issue_id: busy_issue.id.clone(),
+                run_id: "busy-run".to_string(),
+                cycle: 1,
+                step_name: "build".to_string(),
+                started_at: Utc::now(),
+            },
+            tokio_util::sync::CancellationToken::new(),
+            completion,
+        );
+
+        let permit = orchestrator.quiescing.begin_dispatch().unwrap();
+        orchestrator.dispatch_ready_active_pipelines(&permit).await;
+
+        assert_eq!(tracker.publications.load(Ordering::SeqCst), 1);
+        let state = orchestrator.state.read().await;
+        let run = state.get_pipeline_run(&action_issue.id).unwrap();
+        assert_eq!(run.step_states["build"], StepState::Passed);
+        assert_eq!(run.step_states["downstream"], StepState::Pending);
+    }
+
+    #[tokio::test]
     async fn transient_action_failure_retains_owner_output_workspace_and_retries_without_producer_rerun(
     ) {
         let mut config = make_config();
@@ -17803,6 +18031,7 @@ agent:
             issues: Arc::new(RwLock::new(vec![issue.clone()])),
             failures_remaining: AtomicUsize::new(1),
             publications: AtomicUsize::new(0),
+            state_writes: Arc::new(RwLock::new(Vec::new())),
         });
         let runner_runs = Arc::new(AtomicUsize::new(0));
         let runner: Arc<dyn AgentRunner> = Arc::new(CountingRunner {
@@ -17851,7 +18080,7 @@ agent:
             state.insert_pipeline_run(&issue.id, run, config_snapshot);
         }
 
-        orchestrator.apply_pending_step_actions(&issue.id).await;
+        let _ = orchestrator.apply_pending_step_actions(&issue.id).await;
         {
             let state = orchestrator.state.read().await;
             let retained = state.get_pipeline_run(&issue.id).unwrap();
@@ -17875,7 +18104,7 @@ agent:
         assert_eq!(runner_runs.load(Ordering::SeqCst), 0);
         assert_eq!(tracker.publications.load(Ordering::SeqCst), 0);
 
-        orchestrator.apply_pending_step_actions(&issue.id).await;
+        let _ = orchestrator.apply_pending_step_actions(&issue.id).await;
         let state = orchestrator.state.read().await;
         let recovered = state.get_pipeline_run(&issue.id).unwrap();
         assert_eq!(

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -685,8 +685,9 @@ pub struct Orchestrator {
     refresh_requested: Arc<tokio::sync::Notify>,
     cancellation_registry: CancellationRegistry,
     history_write_lock: Arc<tokio::sync::Mutex<()>>,
-    /// Serializes publication and acknowledgement of an action across host ticks.
-    pending_action_write_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Per-issue mutation boundaries shared by worker completion and durable actions.
+    action_mutation_locks:
+        Arc<std::sync::Mutex<HashMap<String, std::sync::Weak<tokio::sync::Mutex<()>>>>>,
     history_store: Option<HistoryStore>,
     attention_reporter: Option<AttentionReporter>,
     attention_reconciled_on_startup: AtomicBool,
@@ -815,6 +816,19 @@ struct RejectedGateOwnerSnapshot {
 }
 
 impl Orchestrator {
+    fn action_mutation_lock(&self, issue_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self
+            .action_mutation_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(issue_id).and_then(std::sync::Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        locks.insert(issue_id.to_string(), Arc::downgrade(&lock));
+        lock
+    }
     fn drain_snapshot(state: &OrchestratorState) -> ResidualWorkSummary {
         let mut summary = ResidualWorkSummary {
             runnable: state.running.keys().cloned().collect(),
@@ -1034,7 +1048,7 @@ impl Orchestrator {
             refresh_requested: parts.refresh_requested,
             cancellation_registry: parts.cancellation_registry,
             history_write_lock: Arc::new(tokio::sync::Mutex::new(())),
-            pending_action_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+            action_mutation_locks: Arc::new(std::sync::Mutex::new(HashMap::new())),
             history_store,
             attention_reporter,
             attention_reconciled_on_startup: AtomicBool::new(false),
@@ -2755,7 +2769,8 @@ impl Orchestrator {
     /// Failures leave the pending snapshot and issue ownership in place so the
     /// next scheduler tick retries the effect, never its producer.
     async fn apply_pending_step_actions(&self, issue_id: &str) {
-        let _action_guard = self.pending_action_write_lock.lock().await;
+        let action_lock = self.action_mutation_lock(issue_id);
+        let _action_guard = action_lock.lock().await;
         loop {
             let Some((identifier, step_name, pending, transition)) = ({
                 let state = self.state.read().await;
@@ -5804,6 +5819,8 @@ impl Orchestrator {
         workspace_capture_held: bool,
         worker_exit_permit: &DispatchPermit,
     ) {
+        let action_lock = self.action_mutation_lock(issue_id);
+        let action_mutation_guard = action_lock.lock().await;
         // Get the issue snapshot for potential re-dispatch
         let issue_snapshot = {
             let state = self.state.read().await;
@@ -6647,6 +6664,7 @@ impl Orchestrator {
                             }
 
                             if action_is_pending_effect {
+                                drop(action_mutation_guard);
                                 self.apply_pending_step_actions(issue_id).await;
                             }
 
@@ -17565,6 +17583,45 @@ agent:
   stall_timeout_ms: 300000
 "#;
         parse_config(yaml).unwrap()
+    }
+
+    #[tokio::test]
+    async fn action_mutation_locks_serialize_one_issue_without_blocking_another() {
+        let config = Arc::new(RwLock::new(make_config()));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
+            delay_ms: 0,
+            observed_commands: None,
+            observed_timeouts: None,
+            cancellation_probe: None,
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let orchestrator = Orchestrator::new(
+            config,
+            tracker,
+            runner,
+            WorkspaceManager::new(dir.path(), None).unwrap(),
+            dir.path(),
+            shutdown_rx,
+        );
+        let same = orchestrator.action_mutation_lock("same");
+        let held = same.lock().await;
+        let second = orchestrator.action_mutation_lock("same");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), second.lock())
+                .await
+                .is_err()
+        );
+        let other = orchestrator.action_mutation_lock("other");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), other.lock())
+                .await
+                .is_ok()
+        );
+        drop(held);
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -5842,6 +5842,8 @@ impl Orchestrator {
                         .sum())
                         .map(|_| Self::run_context_for_issue(&mut state, issue_id))
                         .collect::<Vec<_>>();
+                    let action_is_pending_effect =
+                        matches!(&action, PipelineAction::AwaitingAction { .. });
                     match action {
                         PipelineAction::Dispatch(requests) => {
                             // Collect output contexts while state lock is still held
@@ -6632,6 +6634,10 @@ impl Orchestrator {
                                 self.recover_unpublished_route_candidate(issue_id, step_name)
                                     .await;
                                 return;
+                            }
+
+                            if action_is_pending_effect {
+                                self.apply_pending_step_actions(issue_id).await;
                             }
 
                             let mut state = self.state.write().await;

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -16553,6 +16553,7 @@ mod tests {
                 artifact_integrity_violations: Vec::new(),
                 artifact_access_evidence: Vec::new(),
                 gate_evidence: Default::default(),
+                applied_actions: Vec::new(),
             });
         let snapshot = {
             let config = orchestrator.config.read().await;
@@ -16734,6 +16735,7 @@ mod tests {
             artifact_integrity_violations: Vec::new(),
             artifact_access_evidence: Vec::new(),
             gate_evidence: Default::default(),
+            applied_actions: Vec::new(),
         });
         let snapshot = {
             let config = orchestrator.config.read().await;
@@ -22297,6 +22299,7 @@ agent:
                     artifact_integrity_violations: Vec::new(),
                     artifact_access_evidence: Vec::new(),
                     gate_evidence: Default::default(),
+                    applied_actions: Vec::new(),
                 },
             );
         }
@@ -24051,6 +24054,7 @@ agent:
                     artifact_integrity_violations: Vec::new(),
                     artifact_access_evidence: Vec::new(),
                     gate_evidence: Default::default(),
+                    applied_actions: Vec::new(),
                 },
             );
         }
@@ -26265,6 +26269,7 @@ agent:
                 artifact_integrity_violations: Vec::new(),
                 artifact_access_evidence: Vec::new(),
                 gate_evidence: Default::default(),
+                applied_actions: Vec::new(),
             },
         );
 
@@ -31299,6 +31304,7 @@ agent:
             artifact_integrity_violations: Vec::new(),
             artifact_access_evidence: Vec::new(),
             gate_evidence: Default::default(),
+            applied_actions: Vec::new(),
         };
         let mut state = orchestrator.state.write().await;
         state.add_running(&test_issue("1", "Todo"), None);

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -685,6 +685,8 @@ pub struct Orchestrator {
     refresh_requested: Arc<tokio::sync::Notify>,
     cancellation_registry: CancellationRegistry,
     history_write_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Serializes publication and acknowledgement of an action across host ticks.
+    pending_action_write_lock: Arc<tokio::sync::Mutex<()>>,
     history_store: Option<HistoryStore>,
     attention_reporter: Option<AttentionReporter>,
     attention_reconciled_on_startup: AtomicBool,
@@ -1032,6 +1034,7 @@ impl Orchestrator {
             refresh_requested: parts.refresh_requested,
             cancellation_registry: parts.cancellation_registry,
             history_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+            pending_action_write_lock: Arc::new(tokio::sync::Mutex::new(())),
             history_store,
             attention_reporter,
             attention_reconciled_on_startup: AtomicBool::new(false),
@@ -2752,6 +2755,7 @@ impl Orchestrator {
     /// Failures leave the pending snapshot and issue ownership in place so the
     /// next scheduler tick retries the effect, never its producer.
     async fn apply_pending_step_actions(&self, issue_id: &str) {
+        let _action_guard = self.pending_action_write_lock.lock().await;
         loop {
             let Some((identifier, step_name, pending, transition)) = ({
                 let state = self.state.read().await;
@@ -2853,7 +2857,13 @@ impl Orchestrator {
                     return;
                 };
                 let mut candidate = run.clone();
-                candidate.acknowledge_action(&step_name, receipt);
+                candidate.acknowledge_action(&step_name, &pending.identity, receipt);
+                if candidate
+                    .pending_action(&step_name)
+                    .is_some_and(|current| current.identity == pending.identity)
+                {
+                    return;
+                }
                 let Some(transition) = Self::transition_input_for_snapshot(
                     &state,
                     &candidate,

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -34,6 +34,8 @@ fn requires_durable_sync(kind: PipelineTransitionKind, created: bool) -> bool {
                 | PipelineTransitionKind::StepRunning
                 | PipelineTransitionKind::StepAwaitingApproval
                 | PipelineTransitionKind::RouteSelected
+                | PipelineTransitionKind::ActionPending
+                | PipelineTransitionKind::ActionApplied
         )
 }
 
@@ -124,6 +126,10 @@ pub enum PipelineTransitionKind {
     StepCompleted,
     /// A deterministic route selection and its skipped descendants were persisted.
     RouteSelected,
+    /// A configured post-output effect is present in the persisted snapshot before execution.
+    ActionPending,
+    /// An effect receipt was persisted before enabling dependent work.
+    ActionApplied,
     StepFailed,
     StepBlockedOnHuman,
     StepAwaitingApproval,
@@ -703,6 +709,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }
     }
 

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -976,6 +976,7 @@ mod tests {
                 },
                 cases: std::collections::BTreeMap::new(),
             }),
+            actions: Vec::new(),
         }])
         .unwrap();
         state.pipeline_runs.insert(

--- a/crates/ensemble-core/src/orchestrator/state.rs
+++ b/crates/ensemble-core/src/orchestrator/state.rs
@@ -779,7 +779,8 @@ fn completed_step_state_for_name(step_name: &str, run: &PipelineRun) -> String {
             crate::pipeline::engine::StepState::Skipped { .. } => "skipped",
             crate::pipeline::engine::StepState::Failed { .. } => "failed",
             crate::pipeline::engine::StepState::BlockedOnHuman { .. } => "waiting",
-            crate::pipeline::engine::StepState::AwaitingApproval { .. } => "waiting",
+            crate::pipeline::engine::StepState::AwaitingApproval { .. }
+            | crate::pipeline::engine::StepState::AwaitingActions { .. } => "waiting",
             crate::pipeline::engine::StepState::Errored { .. } => "failed",
         })
         .unwrap_or("pending")

--- a/crates/ensemble-core/src/pipeline/dag.rs
+++ b/crates/ensemble-core/src/pipeline/dag.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::ensemble::{
     AffectedPathSource, ArtifactAccess, ArtifactSnapshotConfig, GateConfig, OnFailure,
-    ResolvedOutputSchema, RouteConfig, StepApprovalConfig, StepAuthorizationConfig, StepConfig,
-    StepKind,
+    ResolvedOutputSchema, RouteConfig, StepActionConfig, StepApprovalConfig,
+    StepAuthorizationConfig, StepConfig, StepKind,
 };
 use crate::error::PipelineError;
 
@@ -39,6 +39,8 @@ pub struct DagStep {
     pub authorization: Option<StepAuthorizationConfig>,
     #[serde(default)]
     pub route: Option<RouteConfig>,
+    #[serde(default)]
+    pub actions: Vec<StepActionConfig>,
     pub depends: Vec<String>,
 }
 
@@ -163,6 +165,7 @@ pub fn build_dag(steps: &[StepConfig]) -> Result<StepDag, PipelineError> {
             gate: step.gate.clone(),
             authorization: step.authorization.clone(),
             route: step.route.clone(),
+            actions: step.actions.clone(),
             depends: deps,
         });
     }
@@ -265,6 +268,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }
     }
 
@@ -288,6 +292,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }
     }
 
@@ -452,6 +457,7 @@ mod tests {
                 gate: None,
                 authorization: None,
                 route: None,
+                actions: Vec::new(),
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -472,6 +478,7 @@ mod tests {
                 gate: None,
                 authorization: None,
                 route: None,
+                actions: Vec::new(),
             },
         ];
 
@@ -506,6 +513,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }];
 
         let dag = build_dag(&steps).unwrap();
@@ -537,6 +545,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }];
 
         let dag = build_dag(&steps).unwrap();
@@ -574,6 +583,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }];
 
         let dag = build_dag(&steps).unwrap();

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -4546,6 +4546,10 @@ mod tests {
             .step_states
             .insert("produce".to_string(), StepState::Passed);
         assert!(PipelineRun::from_snapshot(snapshot).is_err());
+
+        let mut snapshot = run.to_snapshot();
+        snapshot.generation.clear();
+        assert!(PipelineRun::from_snapshot(snapshot).is_err());
     }
 
     #[test]
@@ -4578,7 +4582,7 @@ mod tests {
             },
         );
 
-        let mut later = PipelineRun::new("issue-1".to_string(), 2, build_dag(&[producer]).unwrap());
+        let mut later = PipelineRun::new("issue-1".to_string(), 1, build_dag(&[producer]).unwrap());
         assert!(later.route_decisions.is_empty());
         assert!(later.action_states.is_empty());
         later.start();
@@ -4594,6 +4598,12 @@ mod tests {
         assert_ne!(
             later.pending_action("produce").unwrap().identity,
             first_identity
+        );
+        let snapshot = later.to_snapshot();
+        let recovered = PipelineRun::from_snapshot(snapshot).unwrap();
+        assert_eq!(
+            recovered.pending_action("produce").unwrap().identity,
+            later.pending_action("produce").unwrap().identity
         );
     }
 

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -7,6 +7,7 @@ use sha2::{Digest, Sha256};
 
 use crate::acceptance::AcceptanceAttempt;
 use crate::artifact::{ArtifactAccessEvidence, ArtifactIntegrityViolation, ArtifactSnapshot};
+use crate::attention::AttentionPresentation;
 use crate::config::ensemble::{
     AffectedPathSource, ArtifactAccess, ArtifactSnapshotConfig, OnFailure, ResolvedOutputSchema,
     RouteConfig, StepActionConfig, StepAuthorizationConfig, StepKind,
@@ -1039,8 +1040,18 @@ fn resolve_actions_for_step(
                                     .ok_or_else(|| format!("step '{step_name}' action {index} references contained an empty or non-string value")))
                                 .collect::<Result<Vec<_>, _>>()
                         }).transpose()?.unwrap_or_default();
+                        let presentation = AttentionPresentation::new(
+                            string_at(summary)?,
+                            string_at(remedy)?,
+                            references,
+                        ).map_err(|error| format!(
+                            "step '{step_name}' action {index} has invalid operator attention presentation: {error}"
+                        ))?;
                         ResolvedStepAction::OperatorAttention {
-                            kind: kind.clone(), summary: string_at(summary)?, remedy: string_at(remedy)?, references,
+                            kind: kind.clone(),
+                            summary: presentation.summary,
+                            remedy: presentation.remedy,
+                            references: presentation.references,
                         }
                     }
                 };
@@ -4321,6 +4332,44 @@ mod tests {
         ));
         assert_eq!(run.step_states.get("accept"), Some(&StepState::Pending));
         assert!(run.pending_action("accept").is_none());
+    }
+
+    #[test]
+    fn invalid_attention_presentation_fails_before_the_action_becomes_pending() {
+        let mut producer = make_step("produce", "builder", &[]);
+        producer.actions = vec![StepActionConfig::OperatorAttention {
+            kind: "ensemble.review".to_string(),
+            summary: "/summary".to_string(),
+            remedy: "/remedy".to_string(),
+            references: Some("/references".to_string()),
+        }];
+        let mut run = make_run(&[producer]);
+        run.start();
+
+        let action = run.step_completed(
+            "produce",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(json!({
+                    "summary": "needs review",
+                    "remedy": "inspect the artifact",
+                    "references": ["artifact:1", "artifact:1"]
+                })),
+            },
+            false,
+        );
+
+        assert!(matches!(
+            action,
+            PipelineAction::Failed { step, reason }
+                if step == "produce" && reason.contains("must not contain duplicate entries")
+        ));
+        assert!(matches!(
+            run.step_states.get("produce"),
+            Some(StepState::Errored { .. })
+        ));
+        assert!(run.pending_action("produce").is_none());
     }
 
     #[test]

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -845,6 +845,7 @@ impl PipelineRun {
     pub fn acknowledge_action(
         &mut self,
         step_name: &str,
+        expected_identity: &str,
         receipt: StepActionReceipt,
     ) -> PipelineAction {
         let Some(states) = self.action_states.get_mut(step_name) else {
@@ -859,6 +860,11 @@ impl PipelineRun {
         let StepActionState::Pending(pending) = states[index].clone() else {
             unreachable!("pending action index must contain a pending action");
         };
+        if pending.identity != expected_identity
+            || !receipt_matches_action(&receipt, &pending.action)
+        {
+            return PipelineAction::Waiting;
+        }
         states[index] = StepActionState::Applied {
             identity: pending.identity,
             source_output_digest: pending.source_output_digest,
@@ -937,18 +943,42 @@ impl PipelineRun {
                 "completed step '{step_name}' is not in the pipeline"
             ));
         };
-        let Some(value) = output.output.as_ref() else {
-            return step
-                .actions
-                .is_empty()
-                .then(Vec::new)
-                .ok_or_else(|| format!("step '{step_name}' has actions but no structured output"));
-        };
-        let source_output_digest = format!(
-            "{:x}",
-            Sha256::digest(serde_json::to_vec(value).map_err(|error| error.to_string())?)
-        );
-        step.actions
+        resolve_actions_for_step(&self.issue_id, self.cycle, step_name, step, output)
+    }
+}
+
+fn receipt_matches_action(receipt: &StepActionReceipt, action: &ResolvedStepAction) -> bool {
+    matches!(
+        (receipt, action),
+        (
+            StepActionReceipt::TrackerComment { .. },
+            ResolvedStepAction::TrackerComment { .. }
+        ) | (
+            StepActionReceipt::OperatorAttention { .. },
+            ResolvedStepAction::OperatorAttention { .. }
+        )
+    )
+}
+
+fn resolve_actions_for_step(
+    issue_id: &str,
+    cycle: u32,
+    step_name: &str,
+    step: &DagStep,
+    output: &StepOutput,
+) -> Result<Vec<PendingStepAction>, String> {
+    let Some(value) = output.output.as_ref() else {
+        return step
+            .actions
+            .is_empty()
+            .then(Vec::new)
+            .ok_or_else(|| format!("step '{step_name}' has actions but no structured output"));
+    };
+    let source_output_digest = format!(
+        "{:x}",
+        Sha256::digest(serde_json::to_vec(value).map_err(|error| error.to_string())?)
+    );
+    step.actions
             .iter()
             .enumerate()
             .map(|(index, config)| {
@@ -977,7 +1007,7 @@ impl PipelineRun {
                         }
                     }
                 };
-                let identity_material = format!("{}:{}:{step_name}:{index}:{source_output_digest}", self.issue_id, self.cycle);
+                let identity_material = format!("{issue_id}:{cycle}:{step_name}:{index}:{source_output_digest}");
                 Ok(PendingStepAction {
                     identity: format!("action:{:x}", Sha256::digest(identity_material.as_bytes())),
                     source_output_digest: source_output_digest.clone(),
@@ -985,8 +1015,9 @@ impl PipelineRun {
                 })
             })
             .collect()
-    }
+}
 
+impl PipelineRun {
     /// Bind an approval interaction request to a step that is awaiting
     /// approval.
     pub fn bind_approval_interaction(
@@ -1701,25 +1732,31 @@ fn validate_snapshot(snapshot: &PipelineRunSnapshot) -> Result<(), crate::error:
                 ),
             });
         }
-        let mut identities = HashSet::new();
-        for action in actions {
-            let (identity, digest) = match action {
-                StepActionState::Pending(action) => {
-                    (&action.identity, &action.source_output_digest)
-                }
+        let output = snapshot.step_outputs.get(step_name).expect("checked above");
+        let expected =
+            resolve_actions_for_step(&snapshot.issue_id, snapshot.cycle, step_name, step, output)
+                .map_err(|reason| crate::error::PipelineError::InvalidSnapshot {
+                reason: format!(
+                    "action state for step '{step_name}' cannot be recomputed: {reason}"
+                ),
+            })?;
+        for (index, (state, expected)) in actions.iter().zip(expected.iter()).enumerate() {
+            let valid = match state {
+                StepActionState::Pending(actual) => actual == expected,
                 StepActionState::Applied {
                     identity,
                     source_output_digest,
-                    ..
-                } => (identity, source_output_digest),
+                    receipt,
+                } => {
+                    identity == &expected.identity
+                        && source_output_digest == &expected.source_output_digest
+                        && receipt_matches_action(receipt, &expected.action)
+                }
             };
-            if identity.trim().is_empty()
-                || digest.trim().is_empty()
-                || !identities.insert(identity.as_str())
-            {
+            if !valid {
                 return Err(crate::error::PipelineError::InvalidSnapshot {
                     reason: format!(
-                        "action state for step '{step_name}' has invalid identity evidence"
+                        "action state for step '{step_name}' action {index} does not match its output and declaration"
                     ),
                 });
             }
@@ -4002,7 +4039,10 @@ mod tests {
             },
             cases: BTreeMap::from([("agreement".to_string(), vec!["accept".to_string()])]),
         });
-        let accept = make_step("accept", "handler", &["choose"]);
+        let mut accept = make_step("accept", "handler", &["choose"]);
+        accept.actions = vec![StepActionConfig::TrackerComment {
+            body: "/comment".to_string(),
+        }];
         let mut run = make_run(&[compare, route, accept]);
 
         run.start();
@@ -4212,10 +4252,11 @@ mod tests {
             Some(StepState::Failed { .. })
         ));
         assert_eq!(run.step_states.get("accept"), Some(&StepState::Pending));
+        assert!(run.pending_action("accept").is_none());
     }
 
     #[test]
-    fn completed_producer_blocks_dependents_until_ordered_actions_are_acknowledged() {
+    fn partial_ordered_action_receipts_survive_restart_and_resume_only_remaining_action() {
         let mut producer = make_step("produce", "builder", &[]);
         producer.actions = vec![
             StepActionConfig::TrackerComment {
@@ -4258,6 +4299,7 @@ mod tests {
         let snapshot = run.to_snapshot();
         let mut recovered = PipelineRun::from_snapshot(snapshot).unwrap();
         let first = recovered.pending_action("produce").unwrap();
+        let first_identity = first.identity.clone();
         assert!(matches!(
             first.action,
             ResolvedStepAction::TrackerComment { .. }
@@ -4265,18 +4307,191 @@ mod tests {
         assert!(matches!(
             recovered.acknowledge_action(
                 "produce",
+                &first_identity,
                 StepActionReceipt::TrackerComment {
                     receipt: "comment-1".to_string()
                 },
             ),
             PipelineAction::AwaitingAction { .. }
         ));
+        let snapshot = recovered.to_snapshot();
+        let mut recovered = PipelineRun::from_snapshot(snapshot).unwrap();
+        let second_identity = recovered
+            .pending_action("produce")
+            .unwrap()
+            .identity
+            .clone();
         assert!(matches!(
             recovered.acknowledge_action(
                 "produce",
+                &second_identity,
                 StepActionReceipt::OperatorAttention { receipt: "attention-1".to_string() },
             ),
             PipelineAction::Dispatch(requests) if requests[0].step_name == "consume"
         ));
+    }
+
+    #[test]
+    fn action_receipt_rejects_wrong_identity_or_effect_kind_without_advancing_producer() {
+        let mut producer = make_step("produce", "builder", &[]);
+        producer.actions = vec![StepActionConfig::TrackerComment {
+            body: "/comment".to_string(),
+        }];
+        let downstream = make_step("consume", "reviewer", &["produce"]);
+        let mut run = make_run(&[producer, downstream]);
+        run.start();
+        run.step_completed(
+            "produce",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(json!({"comment": "ready"})),
+            },
+            false,
+        );
+        let identity = run.pending_action("produce").unwrap().identity.clone();
+
+        assert!(matches!(
+            run.acknowledge_action(
+                "produce",
+                "another-action",
+                StepActionReceipt::TrackerComment {
+                    receipt: "comment".to_string()
+                },
+            ),
+            PipelineAction::Waiting
+        ));
+        assert!(matches!(
+            run.acknowledge_action(
+                "produce",
+                &identity,
+                StepActionReceipt::OperatorAttention {
+                    receipt: "attention".to_string()
+                },
+            ),
+            PipelineAction::Waiting
+        ));
+        assert_eq!(
+            run.step_states["produce"],
+            StepState::AwaitingActions {
+                approval_requested: false
+            }
+        );
+        assert_eq!(run.pending_action("produce").unwrap().identity, identity);
+        assert_eq!(run.step_states["consume"], StepState::Pending);
+    }
+
+    #[test]
+    fn snapshot_rejects_tampered_action_identity_action_or_receipt_type() {
+        let mut producer = make_step("produce", "builder", &[]);
+        producer.actions = vec![StepActionConfig::TrackerComment {
+            body: "/comment".to_string(),
+        }];
+        let mut run = make_run(&[producer]);
+        run.start();
+        run.step_completed(
+            "produce",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(json!({"comment": "ready"})),
+            },
+            false,
+        );
+        let mut snapshot = run.to_snapshot();
+        let StepActionState::Pending(pending) =
+            &mut snapshot.action_states.get_mut("produce").unwrap()[0]
+        else {
+            unreachable!()
+        };
+        pending.identity = "tampered".to_string();
+        assert!(PipelineRun::from_snapshot(snapshot).is_err());
+
+        let mut snapshot = run.to_snapshot();
+        let StepActionState::Pending(pending) =
+            &mut snapshot.action_states.get_mut("produce").unwrap()[0]
+        else {
+            unreachable!()
+        };
+        pending.action = ResolvedStepAction::TrackerComment {
+            body: "tampered".to_string(),
+        };
+        assert!(PipelineRun::from_snapshot(snapshot).is_err());
+
+        let mut snapshot = run.to_snapshot();
+        let StepActionState::Pending(pending) =
+            snapshot.action_states.get_mut("produce").unwrap()[0].clone()
+        else {
+            unreachable!()
+        };
+        snapshot.action_states.get_mut("produce").unwrap()[0] = StepActionState::Applied {
+            identity: pending.identity,
+            source_output_digest: pending.source_output_digest,
+            receipt: StepActionReceipt::OperatorAttention {
+                receipt: "wrong-kind".to_string(),
+            },
+        };
+        assert!(PipelineRun::from_snapshot(snapshot).is_err());
+    }
+
+    #[test]
+    fn route_selected_branch_creates_actions_only_for_the_selected_step() {
+        let producer = make_step("produce", "builder", &[]);
+        let mut route = make_step("choose", "", &["produce"]);
+        route.kind = StepKind::Route;
+        route.on_failure = OnFailure::Halt;
+        route.route = Some(RouteConfig {
+            source: RouteSource {
+                step: "produce".to_string(),
+                pointer: "/outcome".to_string(),
+            },
+            cases: BTreeMap::from([
+                ("continue".to_string(), vec!["continue".to_string()]),
+                ("stop".to_string(), vec!["stop".to_string()]),
+            ]),
+        });
+        let mut continue_step = make_step("continue", "handler", &["choose"]);
+        continue_step.actions = vec![StepActionConfig::TrackerComment {
+            body: "/comment".to_string(),
+        }];
+        let mut stop_step = make_step("stop", "handler", &["choose"]);
+        stop_step.actions = vec![StepActionConfig::TrackerComment {
+            body: "/comment".to_string(),
+        }];
+        let mut run = make_run(&[producer, route, continue_step, stop_step]);
+
+        run.start();
+        assert!(matches!(
+            run.step_completed(
+                "produce",
+                StepOutput {
+                    result: StepResult::Succeeded,
+                    summary: None,
+                    output: Some(json!({"outcome": "continue"})),
+                },
+                false,
+            ),
+            PipelineAction::Dispatch(requests) if requests[0].step_name == "continue"
+        ));
+        assert!(matches!(
+            run.step_states.get("stop"),
+            Some(StepState::Skipped { .. })
+        ));
+        assert!(run.pending_action("stop").is_none());
+
+        assert!(matches!(
+            run.step_completed(
+                "continue",
+                StepOutput {
+                    result: StepResult::Succeeded,
+                    summary: None,
+                    output: Some(json!({"comment": "continue"})),
+                },
+                false,
+            ),
+            PipelineAction::AwaitingAction { .. }
+        ));
+        assert!(run.pending_action("continue").is_some());
+        assert!(run.pending_action("stop").is_none());
     }
 }

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -16,6 +18,19 @@ use crate::pipeline::assessment::{
 use crate::pipeline::dag::{DagStep, StepDag};
 use crate::pipeline::verdict::{StepOutput, StepResult};
 use crate::tracker::{model::TrackerEvent, OwnershipLease};
+
+static RUN_GENERATION_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn new_run_generation() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!(
+        "{nanos:x}-{:x}",
+        RUN_GENERATION_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
 
 /// The execution state of a single pipeline step.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -209,6 +224,7 @@ pub struct PipelineRun {
     pub issue_id: String,
     /// The current cycle number (incremented on retry).
     pub cycle: u32,
+    generation: String,
     /// Current state of each step, keyed by step name.
     pub step_states: HashMap<String, StepState>,
     /// Stored outputs from completed steps.
@@ -260,6 +276,8 @@ pub struct SelectedWorkflowSnapshot {
 pub struct PipelineRunSnapshot {
     pub issue_id: String,
     pub cycle: u32,
+    #[serde(default)]
+    pub generation: String,
     pub step_states: HashMap<String, StepState>,
     pub step_outputs: HashMap<String, StepOutput>,
     #[serde(default)]
@@ -337,6 +355,7 @@ impl PipelineRun {
         Self {
             issue_id,
             cycle,
+            generation: new_run_generation(),
             step_states,
             step_outputs: HashMap::new(),
             artifact_snapshots: HashMap::new(),
@@ -363,6 +382,7 @@ impl PipelineRun {
         PipelineRunSnapshot {
             issue_id: self.issue_id.clone(),
             cycle: self.cycle,
+            generation: self.generation.clone(),
             step_states: self.step_states.clone(),
             step_outputs: self.step_outputs.clone(),
             artifact_snapshots: self.artifact_snapshots.clone(),
@@ -632,6 +652,7 @@ impl PipelineRun {
         Ok(Self {
             issue_id: snapshot.issue_id,
             cycle: snapshot.cycle,
+            generation: snapshot.generation,
             step_states: snapshot.step_states,
             step_outputs: snapshot.step_outputs,
             artifact_snapshots: snapshot.artifact_snapshots,
@@ -990,7 +1011,14 @@ impl PipelineRun {
                 "completed step '{step_name}' is not in the pipeline"
             ));
         };
-        resolve_actions_for_step(&self.issue_id, self.cycle, step_name, step, output)
+        resolve_actions_for_step(
+            &self.issue_id,
+            self.cycle,
+            &self.generation,
+            step_name,
+            step,
+            output,
+        )
     }
 }
 
@@ -1010,6 +1038,7 @@ fn receipt_matches_action(receipt: &StepActionReceipt, action: &ResolvedStepActi
 fn resolve_actions_for_step(
     issue_id: &str,
     cycle: u32,
+    generation: &str,
     step_name: &str,
     step: &DagStep,
     output: &StepOutput,
@@ -1054,7 +1083,7 @@ fn resolve_actions_for_step(
                         }
                     }
                 };
-                let identity_material = format!("{issue_id}:{cycle}:{step_name}:{index}:{source_output_digest}");
+                let identity_material = format!("{issue_id}:{cycle}:{generation}:{step_name}:{index}:{source_output_digest}");
                 Ok(PendingStepAction {
                     identity: format!("action:{:x}", Sha256::digest(identity_material.as_bytes())),
                     source_output_digest: source_output_digest.clone(),
@@ -1780,13 +1809,17 @@ fn validate_snapshot(snapshot: &PipelineRunSnapshot) -> Result<(), crate::error:
             });
         }
         let output = snapshot.step_outputs.get(step_name).expect("checked above");
-        let expected =
-            resolve_actions_for_step(&snapshot.issue_id, snapshot.cycle, step_name, step, output)
-                .map_err(|reason| crate::error::PipelineError::InvalidSnapshot {
-                reason: format!(
-                    "action state for step '{step_name}' cannot be recomputed: {reason}"
-                ),
-            })?;
+        let expected = resolve_actions_for_step(
+            &snapshot.issue_id,
+            snapshot.cycle,
+            &snapshot.generation,
+            step_name,
+            step,
+            output,
+        )
+        .map_err(|reason| crate::error::PipelineError::InvalidSnapshot {
+            reason: format!("action state for step '{step_name}' cannot be recomputed: {reason}"),
+        })?;
         for (index, (state, expected)) in actions.iter().zip(expected.iter()).enumerate() {
             let valid = match state {
                 StepActionState::Pending(actual) => actual == expected,
@@ -1807,6 +1840,33 @@ fn validate_snapshot(snapshot: &PipelineRunSnapshot) -> Result<(), crate::error:
                     ),
                 });
             }
+        }
+    }
+    for step in &snapshot.dag_steps {
+        if step.actions.is_empty() {
+            continue;
+        }
+        let completed = snapshot.step_outputs.contains_key(&step.name)
+            && matches!(
+                snapshot.step_states.get(&step.name),
+                Some(
+                    StepState::AwaitingActions { .. }
+                        | StepState::AwaitingApproval { .. }
+                        | StepState::Passed
+                )
+            );
+        if completed && !snapshot.action_states.contains_key(&step.name) {
+            return Err(crate::error::PipelineError::InvalidSnapshot {
+                reason: format!(
+                    "action-bearing completed step '{}' has no action state",
+                    step.name
+                ),
+            });
+        }
+        if completed && snapshot.generation.is_empty() {
+            return Err(crate::error::PipelineError::InvalidSnapshot {
+                reason: "action-bearing snapshot has no durable run generation".to_string(),
+            });
         }
     }
     for (step_name, state) in &snapshot.step_states {
@@ -4478,6 +4538,13 @@ mod tests {
                 receipt: "wrong-kind".to_string(),
             },
         };
+        assert!(PipelineRun::from_snapshot(snapshot).is_err());
+
+        let mut snapshot = run.to_snapshot();
+        snapshot.action_states.remove("produce");
+        snapshot
+            .step_states
+            .insert("produce".to_string(), StepState::Passed);
         assert!(PipelineRun::from_snapshot(snapshot).is_err());
     }
 

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -7,7 +7,7 @@ use crate::acceptance::AcceptanceAttempt;
 use crate::artifact::{ArtifactAccessEvidence, ArtifactIntegrityViolation, ArtifactSnapshot};
 use crate::config::ensemble::{
     AffectedPathSource, ArtifactAccess, ArtifactSnapshotConfig, OnFailure, ResolvedOutputSchema,
-    RouteConfig, StepAuthorizationConfig, StepKind,
+    RouteConfig, StepActionConfig, StepAuthorizationConfig, StepKind,
 };
 use crate::orchestrator::resources::SchedulerReservation;
 use crate::pipeline::assessment::{
@@ -32,6 +32,9 @@ pub enum StepState {
     AwaitingApproval {
         interaction_request_id: Option<String>,
     },
+    /// A completed producer has durable effects that must finish before it can
+    /// satisfy downstream dependencies. These effects never occupy an agent slot.
+    AwaitingActions { approval_requested: bool },
     /// Step completed and was approved.
     Passed,
     /// Step was intentionally excluded by one or more completed route decisions.
@@ -86,12 +89,56 @@ pub enum PipelineAction {
         step: String,
         approval_state: Option<String>,
     },
+    /// A completed step has an ordered durable effect ready for the host to execute.
+    AwaitingAction { step: String },
     /// All steps have passed — pipeline completed successfully.
     Succeeded,
     /// A step failed or errored — pipeline halted.
     Failed { step: String, reason: String },
     /// No steps are ready right now; waiting for running steps to finish.
     Waiting,
+}
+
+/// Values resolved from a producer's schema-validated output. The action keeps
+/// configuration vocabulary opaque while allowing the host to execute bounded
+/// effects without rereading or rerunning the producer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResolvedStepAction {
+    TrackerComment {
+        body: String,
+    },
+    OperatorAttention {
+        kind: String,
+        summary: String,
+        remedy: String,
+        references: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingStepAction {
+    pub identity: String,
+    pub source_output_digest: String,
+    pub action: ResolvedStepAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StepActionReceipt {
+    TrackerComment { receipt: String },
+    OperatorAttention { receipt: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum StepActionState {
+    Pending(PendingStepAction),
+    Applied {
+        identity: String,
+        source_output_digest: String,
+        receipt: StepActionReceipt,
+    },
 }
 
 /// Durable evidence that a route selected a case from one validated producer output.
@@ -168,6 +215,8 @@ pub struct PipelineRun {
     pub gate_evidence: HashMap<String, GateEvidence>,
     /// Frozen selections, keyed by route step, used for recovery and downstream retries.
     pub route_decisions: HashMap<String, RouteDecisionEvidence>,
+    /// Ordered effects retained with the producer output until each external acknowledgement is durable.
+    action_states: HashMap<String, Vec<StepActionState>>,
     /// Immutable consumers whose launch was durably committed. This authorizes
     /// launch; it does not claim that the child processed any instructions.
     launched_immutable_consumers: HashSet<String>,
@@ -217,6 +266,8 @@ pub struct PipelineRunSnapshot {
     pub gate_evidence: Box<HashMap<String, GateEvidence>>,
     #[serde(default)]
     pub route_decisions: HashMap<String, RouteDecisionEvidence>,
+    #[serde(default)]
+    pub action_states: HashMap<String, Vec<StepActionState>>,
     #[serde(default)]
     pub acceptance_attempts: Vec<AcceptanceAttempt>,
     #[serde(default)]
@@ -284,6 +335,7 @@ impl PipelineRun {
             automatic_transitions: HashMap::new(),
             gate_evidence: HashMap::new(),
             route_decisions: HashMap::new(),
+            action_states: HashMap::new(),
             launched_immutable_consumers: HashSet::new(),
             acceptance_attempts: Vec::new(),
             resolved_acceptance_plan: None,
@@ -312,6 +364,7 @@ impl PipelineRun {
             launched_immutable_consumers: self.launched_immutable_consumers.clone(),
             gate_evidence: Box::new(self.gate_evidence.clone()),
             route_decisions: self.route_decisions.clone(),
+            action_states: self.action_states.clone(),
             acceptance_attempts: self.acceptance_attempts.clone(),
             resolved_acceptance_plan: self.resolved_acceptance_plan.clone(),
             dag_steps: self.dag.steps.clone(),
@@ -582,6 +635,7 @@ impl PipelineRun {
             launched_immutable_consumers: snapshot.launched_immutable_consumers,
             gate_evidence: *snapshot.gate_evidence,
             route_decisions: snapshot.route_decisions,
+            action_states: snapshot.action_states,
             acceptance_attempts: snapshot.acceptance_attempts,
             resolved_acceptance_plan: snapshot.resolved_acceptance_plan,
             dag: StepDag {
@@ -682,7 +736,40 @@ impl PipelineRun {
         self.clear_active_scheduler_reservation(step_name);
         self.clear_immutable_consumer_launch_commitment(step_name);
         let result = output.result.clone();
+        let actions = matches!(result, StepResult::Succeeded | StepResult::Concern { .. })
+            .then(|| self.resolve_actions(step_name, &output))
+            .transpose();
         self.step_outputs.insert(step_name.to_string(), output);
+        let actions = match actions {
+            Ok(actions) => actions,
+            Err(reason) => {
+                self.step_states.insert(
+                    step_name.to_string(),
+                    StepState::Errored {
+                        error: reason.clone(),
+                    },
+                );
+                return PipelineAction::Failed {
+                    step: step_name.to_string(),
+                    reason,
+                };
+            }
+        };
+        if let Some(actions) = actions {
+            if !actions.is_empty() {
+                self.action_states.insert(
+                    step_name.to_string(),
+                    actions.into_iter().map(StepActionState::Pending).collect(),
+                );
+                self.step_states.insert(
+                    step_name.to_string(),
+                    StepState::AwaitingActions { approval_requested },
+                );
+                return PipelineAction::AwaitingAction {
+                    step: step_name.to_string(),
+                };
+            }
+        }
         match result {
             StepResult::Succeeded | StepResult::Concern { .. } => {
                 match self.gate_check(step_name, approval_requested) {
@@ -739,6 +826,165 @@ impl PipelineRun {
                 }
             }
         }
+    }
+
+    /// Return the next ordered, unresolved effect for a producer. The returned
+    /// data comes entirely from the durably retained output snapshot.
+    pub fn pending_action(&self, step_name: &str) -> Option<&PendingStepAction> {
+        self.action_states
+            .get(step_name)?
+            .iter()
+            .find_map(|state| match state {
+                StepActionState::Pending(action) => Some(action),
+                StepActionState::Applied { .. } => None,
+            })
+    }
+
+    /// Record one durable external-effect receipt and advance the producer only
+    /// after its full declared sequence has been acknowledged.
+    pub fn acknowledge_action(
+        &mut self,
+        step_name: &str,
+        receipt: StepActionReceipt,
+    ) -> PipelineAction {
+        let Some(states) = self.action_states.get_mut(step_name) else {
+            return PipelineAction::Waiting;
+        };
+        let Some(index) = states
+            .iter()
+            .position(|state| matches!(state, StepActionState::Pending(_)))
+        else {
+            return PipelineAction::Waiting;
+        };
+        let StepActionState::Pending(pending) = states[index].clone() else {
+            unreachable!("pending action index must contain a pending action");
+        };
+        states[index] = StepActionState::Applied {
+            identity: pending.identity,
+            source_output_digest: pending.source_output_digest,
+            receipt,
+        };
+        if states
+            .iter()
+            .any(|state| matches!(state, StepActionState::Pending(_)))
+        {
+            return PipelineAction::AwaitingAction {
+                step: step_name.to_string(),
+            };
+        }
+        let approval_requested = matches!(
+            self.step_states.get(step_name),
+            Some(StepState::AwaitingActions {
+                approval_requested: true
+            })
+        );
+        self.finish_completed_step(step_name, approval_requested)
+    }
+
+    fn finish_completed_step(
+        &mut self,
+        step_name: &str,
+        approval_requested: bool,
+    ) -> PipelineAction {
+        match self.gate_check(step_name, approval_requested) {
+            ApprovalGateCheck::EligibleGating => {
+                let approval_state = self.approval_state_for(step_name);
+                self.step_states.insert(
+                    step_name.to_string(),
+                    StepState::AwaitingApproval {
+                        interaction_request_id: None,
+                    },
+                );
+                PipelineAction::AwaitingApproval {
+                    step: step_name.to_string(),
+                    approval_state,
+                }
+            }
+            ApprovalGateCheck::UnconfiguredButRequested => {
+                let reason = format!(
+                    "step '{step_name}' has no approval configuration but the worker requested one"
+                );
+                self.step_states.insert(
+                    step_name.to_string(),
+                    StepState::Errored {
+                        error: reason.clone(),
+                    },
+                );
+                PipelineAction::Failed {
+                    step: step_name.to_string(),
+                    reason,
+                }
+            }
+            ApprovalGateCheck::NotRequested => {
+                self.step_states
+                    .insert(step_name.to_string(), StepState::Passed);
+                if self.all_passed() {
+                    PipelineAction::Succeeded
+                } else {
+                    self.find_dispatchable()
+                }
+            }
+        }
+    }
+
+    fn resolve_actions(
+        &self,
+        step_name: &str,
+        output: &StepOutput,
+    ) -> Result<Vec<PendingStepAction>, String> {
+        let Some(step) = self.step(step_name) else {
+            return Err(format!(
+                "completed step '{step_name}' is not in the pipeline"
+            ));
+        };
+        let Some(value) = output.output.as_ref() else {
+            return step
+                .actions
+                .is_empty()
+                .then(Vec::new)
+                .ok_or_else(|| format!("step '{step_name}' has actions but no structured output"));
+        };
+        let source_output_digest = format!(
+            "{:x}",
+            Sha256::digest(serde_json::to_vec(value).map_err(|error| error.to_string())?)
+        );
+        step.actions
+            .iter()
+            .enumerate()
+            .map(|(index, config)| {
+                let action = match config {
+                    StepActionConfig::TrackerComment { body } => ResolvedStepAction::TrackerComment {
+                        body: value.pointer(body).and_then(serde_json::Value::as_str)
+                            .filter(|body| !body.is_empty())
+                            .ok_or_else(|| format!("step '{step_name}' action {index} body pointer did not resolve to a non-empty string"))?
+                            .to_string(),
+                    },
+                    StepActionConfig::OperatorAttention { kind, summary, remedy, references } => {
+                        let string_at = |pointer: &str| value.pointer(pointer)
+                            .and_then(serde_json::Value::as_str)
+                            .filter(|value| !value.is_empty())
+                            .map(str::to_string)
+                            .ok_or_else(|| format!("step '{step_name}' action {index} pointer '{pointer}' did not resolve to a non-empty string"));
+                        let references = references.as_ref().map(|pointer| {
+                            value.pointer(pointer).and_then(serde_json::Value::as_array)
+                                .ok_or_else(|| format!("step '{step_name}' action {index} references pointer did not resolve to an array"))?
+                                .iter().map(|value| value.as_str().filter(|value| !value.is_empty()).map(str::to_string)
+                                    .ok_or_else(|| format!("step '{step_name}' action {index} references contained an empty or non-string value")))
+                                .collect::<Result<Vec<_>, _>>()
+                        }).transpose()?.unwrap_or_default();
+                        ResolvedStepAction::OperatorAttention {
+                            kind: kind.clone(), summary: string_at(summary)?, remedy: string_at(remedy)?, references,
+                        }
+                    }
+                };
+                let identity_material = format!("{}:{}:{step_name}:{index}:{source_output_digest}", self.issue_id, self.cycle);
+                Ok(PendingStepAction {
+                    identity: format!("action:{:x}", Sha256::digest(identity_material.as_bytes())),
+                    source_output_digest: source_output_digest.clone(),
+                    action,
+                })
+            })
+            .collect()
     }
 
     /// Bind an approval interaction request to a step that is awaiting
@@ -892,6 +1138,7 @@ impl PipelineRun {
             self.artifact_snapshots.remove(step);
             self.authorization_evidence.remove(step);
             self.automatic_transitions.remove(step);
+            self.action_states.remove(step);
             self.clear_immutable_consumer_launch_commitment(step);
         }
         self.route_decisions.retain(|route, decision| {
@@ -960,6 +1207,7 @@ impl PipelineRun {
                         gate: None,
                         authorization: None,
                         route: None,
+                        actions: Vec::new(),
                         depends: original_deps,
                     },
                 );
@@ -1432,6 +1680,68 @@ fn validate_snapshot(snapshot: &PipelineRunSnapshot) -> Result<(), crate::error:
         }
     }
 
+    for (step_name, actions) in &snapshot.action_states {
+        let Some(step) = snapshot
+            .dag_steps
+            .iter()
+            .find(|step| step.name == *step_name)
+        else {
+            return Err(crate::error::PipelineError::InvalidSnapshot {
+                reason: format!("action state references missing step '{step_name}'"),
+            });
+        };
+        if !step.kind.requires_agent()
+            || step.actions.len() != actions.len()
+            || !snapshot.step_outputs.contains_key(step_name)
+            || actions.is_empty()
+        {
+            return Err(crate::error::PipelineError::InvalidSnapshot {
+                reason: format!(
+                    "action state for step '{step_name}' is inconsistent with its producer"
+                ),
+            });
+        }
+        let mut identities = HashSet::new();
+        for action in actions {
+            let (identity, digest) = match action {
+                StepActionState::Pending(action) => {
+                    (&action.identity, &action.source_output_digest)
+                }
+                StepActionState::Applied {
+                    identity,
+                    source_output_digest,
+                    ..
+                } => (identity, source_output_digest),
+            };
+            if identity.trim().is_empty()
+                || digest.trim().is_empty()
+                || !identities.insert(identity.as_str())
+            {
+                return Err(crate::error::PipelineError::InvalidSnapshot {
+                    reason: format!(
+                        "action state for step '{step_name}' has invalid identity evidence"
+                    ),
+                });
+            }
+        }
+    }
+    for (step_name, state) in &snapshot.step_states {
+        if matches!(state, StepState::AwaitingActions { .. })
+            && !snapshot
+                .action_states
+                .get(step_name)
+                .is_some_and(|actions| {
+                    actions
+                        .iter()
+                        .any(|action| matches!(action, StepActionState::Pending(_)))
+                })
+        {
+            return Err(crate::error::PipelineError::InvalidSnapshot {
+                reason: format!("action-waiting step '{step_name}' has no pending action"),
+            });
+        }
+    }
+
     for step in &snapshot.dag_steps {
         if !snapshot.step_states.contains_key(&step.name) {
             return Err(crate::error::PipelineError::InvalidSnapshot {
@@ -1527,8 +1837,9 @@ mod tests {
     };
     use crate::config::ensemble::{
         ArtifactSnapshotConfig, AuthorizationHandoffMode, GateConfig, OnFailure,
-        OutputSchemaConfig, RouteConfig, RouteSource, StepApprovalConfig, StepApprovalMode,
-        StepAuthorizationConfig, StepConfig, StepKind, TrackerEventPredicateConfig,
+        OutputSchemaConfig, RouteConfig, RouteSource, StepActionConfig, StepApprovalConfig,
+        StepApprovalMode, StepAuthorizationConfig, StepConfig, StepKind,
+        TrackerEventPredicateConfig,
     };
     use crate::pipeline::dag::build_dag;
     use crate::pipeline::verdict::StepOutput;
@@ -1559,6 +1870,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }
     }
 
@@ -1582,6 +1894,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }
     }
 
@@ -1608,6 +1921,7 @@ mod tests {
             }),
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }
     }
 
@@ -2029,6 +2343,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }];
         let mut run = make_run(&steps);
 
@@ -2069,6 +2384,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }
     }
 
@@ -2106,6 +2422,7 @@ mod tests {
             gate: None,
             authorization: None,
             route: None,
+            actions: Vec::new(),
         }
     }
 
@@ -2889,6 +3206,7 @@ mod tests {
                 gate: None,
                 authorization: None,
                 route: None,
+                actions: Vec::new(),
             },
             assessment_gate(),
             make_step("publish", "publisher", &["gate"]),
@@ -2932,6 +3250,7 @@ mod tests {
                 gate: None,
                 authorization: None,
                 route: None,
+                actions: Vec::new(),
             },
             assessment_gate(),
         ];
@@ -2970,6 +3289,7 @@ mod tests {
                 gate: None,
                 authorization: None,
                 route: None,
+                actions: Vec::new(),
             },
             assessment_gate(),
         ];
@@ -3035,6 +3355,7 @@ mod tests {
                 gate: None,
                 authorization: None,
                 route: None,
+                actions: Vec::new(),
             },
             StepConfig {
                 name: "synthesize".to_string(),
@@ -3055,6 +3376,7 @@ mod tests {
                 gate: None,
                 authorization: None,
                 route: None,
+                actions: Vec::new(),
             },
         ];
         let mut run = make_run(&steps);
@@ -3890,5 +4212,71 @@ mod tests {
             Some(StepState::Failed { .. })
         ));
         assert_eq!(run.step_states.get("accept"), Some(&StepState::Pending));
+    }
+
+    #[test]
+    fn completed_producer_blocks_dependents_until_ordered_actions_are_acknowledged() {
+        let mut producer = make_step("produce", "builder", &[]);
+        producer.actions = vec![
+            StepActionConfig::TrackerComment {
+                body: "/comment".to_string(),
+            },
+            StepActionConfig::OperatorAttention {
+                kind: "ensemble.review".to_string(),
+                summary: "/summary".to_string(),
+                remedy: "/remedy".to_string(),
+                references: Some("/references".to_string()),
+            },
+        ];
+        let downstream = make_step("consume", "reviewer", &["produce"]);
+        let mut run = make_run(&[producer, downstream]);
+
+        assert!(matches!(run.start(), PipelineAction::Dispatch(_)));
+        let action = run.step_completed(
+            "produce",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(json!({
+                    "comment": "ready for review",
+                    "summary": "needs review",
+                    "remedy": "inspect the artifact",
+                    "references": ["artifact:1"]
+                })),
+            },
+            false,
+        );
+        assert!(matches!(action, PipelineAction::AwaitingAction { .. }));
+        assert_eq!(
+            run.step_states["produce"],
+            StepState::AwaitingActions {
+                approval_requested: false
+            }
+        );
+        assert!(matches!(run.start(), PipelineAction::Waiting));
+
+        let snapshot = run.to_snapshot();
+        let mut recovered = PipelineRun::from_snapshot(snapshot).unwrap();
+        let first = recovered.pending_action("produce").unwrap();
+        assert!(matches!(
+            first.action,
+            ResolvedStepAction::TrackerComment { .. }
+        ));
+        assert!(matches!(
+            recovered.acknowledge_action(
+                "produce",
+                StepActionReceipt::TrackerComment {
+                    receipt: "comment-1".to_string()
+                },
+            ),
+            PipelineAction::AwaitingAction { .. }
+        ));
+        assert!(matches!(
+            recovered.acknowledge_action(
+                "produce",
+                StepActionReceipt::OperatorAttention { receipt: "attention-1".to_string() },
+            ),
+            PipelineAction::Dispatch(requests) if requests[0].step_name == "consume"
+        ));
     }
 }

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -804,46 +804,7 @@ impl PipelineRun {
         }
         match result {
             StepResult::Succeeded | StepResult::Concern { .. } => {
-                match self.gate_check(step_name, approval_requested) {
-                    ApprovalGateCheck::EligibleGating => {
-                        let approval_state = self.approval_state_for(step_name);
-                        self.step_states.insert(
-                            step_name.to_string(),
-                            StepState::AwaitingApproval {
-                                interaction_request_id: None,
-                            },
-                        );
-                        PipelineAction::AwaitingApproval {
-                            step: step_name.to_string(),
-                            approval_state,
-                        }
-                    }
-                    ApprovalGateCheck::UnconfiguredButRequested => {
-                        self.step_states.insert(
-                        step_name.to_string(),
-                        StepState::Errored {
-                            error: format!(
-                                "worker requested approval for step '{step_name}' but it has no approval configuration"
-                            ),
-                        },
-                    );
-                        PipelineAction::Failed {
-                        step: step_name.to_string(),
-                        reason: format!(
-                            "step '{step_name}' has no approval configuration but the worker requested one"
-                        ),
-                    }
-                    }
-                    ApprovalGateCheck::NotRequested => {
-                        self.step_states
-                            .insert(step_name.to_string(), StepState::Passed);
-                        if self.all_passed() {
-                            PipelineAction::Succeeded
-                        } else {
-                            self.find_dispatchable()
-                        }
-                    }
-                }
+                self.finish_completed_step(step_name, approval_requested)
             }
             StepResult::Failed { summary } => {
                 self.step_states.insert(

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -141,6 +141,17 @@ pub enum StepActionState {
     },
 }
 
+/// Bounded completed-history evidence for one acknowledged external effect.
+/// It deliberately excludes resolved action bodies and attention presentation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct AppliedStepActionEvidence {
+    pub step: String,
+    pub identity: String,
+    pub source_output_digest: String,
+    pub kind: String,
+    pub receipt: String,
+}
+
 /// Durable evidence that a route selected a case from one validated producer output.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RouteDecisionEvidence {
@@ -838,6 +849,42 @@ impl PipelineRun {
                 StepActionState::Pending(action) => Some(action),
                 StepActionState::Applied { .. } => None,
             })
+    }
+
+    /// Project acknowledged effects without exposing action bodies into history.
+    pub fn applied_action_evidence(&self) -> Vec<AppliedStepActionEvidence> {
+        let mut evidence = self
+            .action_states
+            .iter()
+            .flat_map(|(step, states)| {
+                states.iter().filter_map(move |state| match state {
+                    StepActionState::Applied {
+                        identity,
+                        source_output_digest,
+                        receipt,
+                    } => {
+                        let (kind, receipt) = match receipt {
+                            StepActionReceipt::TrackerComment { receipt } => {
+                                ("tracker_comment", receipt)
+                            }
+                            StepActionReceipt::OperatorAttention { receipt } => {
+                                ("operator_attention", receipt)
+                            }
+                        };
+                        Some(AppliedStepActionEvidence {
+                            step: step.clone(),
+                            identity: identity.clone(),
+                            source_output_digest: source_output_digest.clone(),
+                            kind: kind.to_string(),
+                            receipt: receipt.clone(),
+                        })
+                    }
+                    StepActionState::Pending(_) => None,
+                })
+            })
+            .collect::<Vec<_>>();
+        evidence.sort_by(|left, right| left.identity.cmp(&right.identity));
+        evidence
     }
 
     /// Record one durable external-effect receipt and advance the producer only
@@ -4432,6 +4479,55 @@ mod tests {
             },
         };
         assert!(PipelineRun::from_snapshot(snapshot).is_err());
+    }
+
+    #[test]
+    fn later_tracker_selection_starts_a_fresh_pipeline_cycle_with_distinct_action_identity() {
+        let mut producer = make_step("produce", "builder", &[]);
+        producer.actions = vec![StepActionConfig::TrackerComment {
+            body: "/comment".to_string(),
+        }];
+        let mut first = PipelineRun::new(
+            "issue-1".to_string(),
+            1,
+            build_dag(&[producer.clone()]).unwrap(),
+        );
+        first.start();
+        first.step_completed(
+            "produce",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(json!({"comment": "first"})),
+            },
+            false,
+        );
+        let first_identity = first.pending_action("produce").unwrap().identity.clone();
+        first.acknowledge_action(
+            "produce",
+            &first_identity,
+            StepActionReceipt::TrackerComment {
+                receipt: "first".to_string(),
+            },
+        );
+
+        let mut later = PipelineRun::new("issue-1".to_string(), 2, build_dag(&[producer]).unwrap());
+        assert!(later.route_decisions.is_empty());
+        assert!(later.action_states.is_empty());
+        later.start();
+        later.step_completed(
+            "produce",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(json!({"comment": "first"})),
+            },
+            false,
+        );
+        assert_ne!(
+            later.pending_action("produce").unwrap().identity,
+            first_identity
+        );
     }
 
     #[test]

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -25,6 +25,8 @@ pub struct GithubTracker {
     project_fields: Option<GithubTrackerConfig>,
     project_metadata: tokio::sync::RwLock<Option<ProjectMetadata>>,
     authenticated_viewer: tokio::sync::RwLock<Option<AuthenticatedViewer>>,
+    /// Serializes list-then-add comment publication across concurrent host ticks.
+    comment_publication_lock: tokio::sync::Mutex<()>,
     hydrate_native_relationships: bool,
 }
 
@@ -102,6 +104,7 @@ impl GithubTracker {
             client,
             project_metadata: tokio::sync::RwLock::new(None),
             authenticated_viewer: tokio::sync::RwLock::new(None),
+            comment_publication_lock: tokio::sync::Mutex::new(()),
             hydrate_native_relationships: settings.hydrate_native_relationships,
         })
     }
@@ -1441,6 +1444,7 @@ impl IssueTracker for GithubTracker {
         id: &str,
         publication: crate::tracker::model::TrackerCommentPublication,
     ) -> Result<crate::tracker::model::TrackerCommentReceipt, TrackerError> {
+        let _publication_guard = self.comment_publication_lock.lock().await;
         let marker = format!("<!-- ensemble-action:{} -->", publication.marker);
         if self
             .list_comments_after(id, "")
@@ -1635,6 +1639,36 @@ mod tests {
                     "id": "I_issue", "number": 1, "title": "Issue", "state": "OPEN",
                     "url": "https://example.test/issues/1", "labels": labels
                 }]
+            })))
+        }
+    }
+
+    struct CommentPublicationSequence {
+        marker: String,
+        calls: AtomicUsize,
+    }
+
+    impl Respond for CommentPublicationSequence {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            let visible = self.calls.fetch_add(1, Ordering::SeqCst) > 0;
+            let nodes = if visible {
+                json!([{
+                    "id": "C_published",
+                    "body": format!("published\n\n{}", self.marker),
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "author": { "login": "ensemble" }
+                }])
+            } else {
+                json!([])
+            };
+            ResponseTemplate::new(200).set_body_json(graphql_response(json!({
+                "node": {
+                    "comments": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": nodes
+                    }
+                }
             })))
         }
     }
@@ -4017,6 +4051,96 @@ mod tests {
             .add_comment("ISSUE_NODE_1", "Hello")
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_comment_reconciles_an_existing_action_marker_without_duplicate_write() {
+        let server = MockServer::start().await;
+        let marker = "<!-- ensemble-action:run-1:build:0 -->";
+        let response = graphql_response(json!({
+            "node": {
+                "comments": {
+                    "pageInfo": { "hasNextPage": false, "endCursor": null },
+                    "nodes": [{
+                        "id": "C_1",
+                        "body": format!("already published\n\n{marker}"),
+                        "createdAt": "2026-01-01T00:00:00Z",
+                        "updatedAt": "2026-01-01T00:00:00Z",
+                        "author": { "login": "ensemble" }
+                    }]
+                }
+            }
+        }));
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("comments(first: 100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("addComment"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let receipt = create_test_tracker(&server.uri(), None)
+            .publish_comment(
+                "ISSUE_NODE_1",
+                crate::tracker::model::TrackerCommentPublication {
+                    marker: "run-1:build:0".to_string(),
+                    body: "publish this".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(receipt.receipt, "run-1:build:0");
+    }
+
+    #[tokio::test]
+    async fn publish_comment_reconciles_post_write_pre_ack_ambiguity_and_concurrent_replay_without_duplicate(
+    ) {
+        let server = MockServer::start().await;
+        let marker = "<!-- ensemble-action:run-1:build:0 -->";
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("comments(first: 100"))
+            .respond_with(CommentPublicationSequence {
+                marker: marker.to_string(),
+                calls: AtomicUsize::new(0),
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("addComment"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(graphql_response(json!({}))))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tracker = std::sync::Arc::new(create_test_tracker(&server.uri(), None));
+        let publication = crate::tracker::model::TrackerCommentPublication {
+            marker: "run-1:build:0".to_string(),
+            body: "publish this".to_string(),
+        };
+        let first = {
+            let tracker = std::sync::Arc::clone(&tracker);
+            let publication = publication.clone();
+            tokio::spawn(async move { tracker.publish_comment("ISSUE_NODE_1", publication).await })
+        };
+        let second = {
+            let tracker = std::sync::Arc::clone(&tracker);
+            tokio::spawn(async move { tracker.publish_comment("ISSUE_NODE_1", publication).await })
+        };
+        first.await.unwrap().unwrap();
+        let receipt = second.await.unwrap().unwrap();
+
+        assert_eq!(receipt.receipt, "run-1:build:0");
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/tracker/github.rs
+++ b/crates/ensemble-core/src/tracker/github.rs
@@ -1432,6 +1432,33 @@ impl IssueTracker for GithubTracker {
         true
     }
 
+    fn supports_idempotent_comment_publication(&self) -> bool {
+        true
+    }
+
+    async fn publish_comment(
+        &self,
+        id: &str,
+        publication: crate::tracker::model::TrackerCommentPublication,
+    ) -> Result<crate::tracker::model::TrackerCommentReceipt, TrackerError> {
+        let marker = format!("<!-- ensemble-action:{} -->", publication.marker);
+        if self
+            .list_comments_after(id, "")
+            .await?
+            .iter()
+            .any(|comment| comment.body.contains(&marker))
+        {
+            return Ok(crate::tracker::model::TrackerCommentReceipt {
+                receipt: publication.marker,
+            });
+        }
+        self.add_comment(id, &format!("{}\n\n{}", publication.body, marker))
+            .await?;
+        Ok(crate::tracker::model::TrackerCommentReceipt {
+            receipt: publication.marker,
+        })
+    }
+
     async fn add_comment(&self, id: &str, body: &str) -> Result<(), TrackerError> {
         let variables = json!({
             "subjectId": id,
@@ -1521,6 +1548,9 @@ impl IssueTracker for GithubTracker {
                 .cmp(&right.created_at)
                 .then_with(|| left.comment_id.cmp(&right.comment_id))
         });
+        if after_comment_id.is_empty() {
+            return Ok(comments);
+        }
         if let Some(anchor_index) = comments
             .iter()
             .position(|comment| comment.comment_id == after_comment_id)

--- a/crates/ensemble-core/src/tracker/mod.rs
+++ b/crates/ensemble-core/src/tracker/mod.rs
@@ -6,7 +6,10 @@ pub mod todo_file;
 
 use crate::config::ensemble::{EnsembleConfig, TrackerConfig};
 use async_trait::async_trait;
-use model::{InteractionThreadRoot, Issue, TrackerComment, TrackerEvent};
+use model::{
+    InteractionThreadRoot, Issue, TrackerComment, TrackerCommentPublication, TrackerCommentReceipt,
+    TrackerEvent,
+};
 use serde::{Deserialize, Serialize};
 
 /// Error type for tracker operations.
@@ -40,6 +43,8 @@ pub enum TrackerError {
     MissingEndCursor,
     #[error("tracker does not support write operations")]
     WritesNotSupported,
+    #[error("tracker cannot reconcile configured marker-bound comment publication")]
+    IdempotentCommentPublicationUnsupported,
     #[error("tracker does not support immutable event evidence for field '{field}'")]
     EventEvidenceUnsupported { field: String },
 }
@@ -153,6 +158,23 @@ pub trait IssueTracker: Send + Sync {
 
     /// Add a comment to an issue in the tracker.
     async fn add_comment(&self, _id: &str, _body: &str) -> Result<(), TrackerError> {
+        Err(TrackerError::WritesNotSupported)
+    }
+
+    /// Whether this adapter can reconcile a marker-bound comment after a
+    /// post-write crash. Configuration activation uses this capability before
+    /// accepting a configured comment action.
+    fn supports_idempotent_comment_publication(&self) -> bool {
+        false
+    }
+
+    /// Publish a marker-bound comment, returning the same receipt when the
+    /// effect was already visible from an earlier ambiguous attempt.
+    async fn publish_comment(
+        &self,
+        _id: &str,
+        _publication: TrackerCommentPublication,
+    ) -> Result<TrackerCommentReceipt, TrackerError> {
         Err(TrackerError::WritesNotSupported)
     }
 

--- a/crates/ensemble-core/src/tracker/model.rs
+++ b/crates/ensemble-core/src/tracker/model.rs
@@ -109,6 +109,20 @@ pub struct TrackerComment {
     pub updated_at: Option<DateTime<Utc>>,
 }
 
+/// A marker-bound tracker comment request. The marker is opaque runtime
+/// identity, allowing capable adapters to reconcile an ambiguous write before
+/// creating another visible comment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerCommentPublication {
+    pub marker: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerCommentReceipt {
+    pub receipt: String,
+}
+
 /// Immutable, adapter-normalized evidence for a configured tracker event.
 /// The runtime intentionally gives field and value no tracker-specific meaning.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ensemble-core/tests/outcome_routing_examples.rs
+++ b/crates/ensemble-core/tests/outcome_routing_examples.rs
@@ -1,0 +1,85 @@
+use std::path::{Path, PathBuf};
+
+use ensemble_core::config::ensemble::{
+    load_config, validate_config, ArtifactAccess, StepActionConfig, StepKind,
+};
+use ensemble_core::pipeline::verdict::{StepOutput, StepResult};
+
+fn example_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/examples/outcome-routing")
+}
+
+fn read_json(path: &Path) -> serde_json::Value {
+    serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+}
+
+#[test]
+fn outcome_routing_example_uses_only_generic_pipeline_contracts() {
+    let root = example_root();
+    let config = load_config(&root.join("config.yaml")).unwrap();
+    validate_config(&config).unwrap();
+
+    let producer = config
+        .steps
+        .iter()
+        .find(|step| step.name == "produce")
+        .unwrap();
+    assert_eq!(producer.actions.len(), 2);
+    assert!(matches!(
+        producer.actions[0],
+        StepActionConfig::TrackerComment { .. }
+    ));
+    assert!(matches!(
+        producer.actions[1],
+        StepActionConfig::OperatorAttention { .. }
+    ));
+    assert!(producer.artifact_snapshot.is_some());
+
+    let route = config
+        .steps
+        .iter()
+        .find(|step| step.name == "choose_outcome")
+        .unwrap();
+    assert_eq!(route.kind, StepKind::Route);
+    assert_eq!(
+        route
+            .route
+            .as_ref()
+            .unwrap()
+            .cases
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        ["operator_required", "revised_artifact"]
+    );
+    assert!(route.actions.is_empty());
+
+    let protected = config
+        .steps
+        .iter()
+        .find(|step| step.name == "publish_revision")
+        .unwrap();
+    assert_eq!(protected.artifact_inputs, ["produce"]);
+    assert_eq!(protected.artifact_access, ArtifactAccess::Immutable);
+    assert!(protected.authorization.is_some());
+
+    let schema = read_json(&root.join("schemas/outcome.schema.json"));
+    let validator = jsonschema::validator_for(&schema).unwrap();
+    for output in ["revised-artifact.json", "operator-required.json"] {
+        let output = read_json(&root.join("outputs").join(output));
+        assert!(validator.is_valid(&output));
+        let step_output = StepOutput {
+            result: StepResult::Succeeded,
+            summary: None,
+            output: Some(output),
+        };
+        assert!(step_output.output.is_some());
+    }
+
+    let guide = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/outcome-routing.md"),
+    )
+    .unwrap();
+    assert!(guide.contains("examples/outcome-routing/config.yaml"));
+    assert!(guide.contains("whole Run"));
+}

--- a/crates/ensemble-core/tests/outcome_routing_examples.rs
+++ b/crates/ensemble-core/tests/outcome_routing_examples.rs
@@ -3,7 +3,10 @@ use std::path::{Path, PathBuf};
 use ensemble_core::config::ensemble::{
     load_config, validate_config, ArtifactAccess, StepActionConfig, StepKind,
 };
+use ensemble_core::pipeline::dag::build_dag;
+use ensemble_core::pipeline::engine::{PipelineAction, PipelineRun, ResolvedStepAction, StepState};
 use ensemble_core::pipeline::verdict::{StepOutput, StepResult};
+use ensemble_core::tracker::create_tracker;
 
 fn example_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/examples/outcome-routing")
@@ -24,15 +27,7 @@ fn outcome_routing_example_uses_only_generic_pipeline_contracts() {
         .iter()
         .find(|step| step.name == "produce")
         .unwrap();
-    assert_eq!(producer.actions.len(), 2);
-    assert!(matches!(
-        producer.actions[0],
-        StepActionConfig::TrackerComment { .. }
-    ));
-    assert!(matches!(
-        producer.actions[1],
-        StepActionConfig::OperatorAttention { .. }
-    ));
+    assert!(producer.actions.is_empty());
     assert!(producer.artifact_snapshot.is_some());
 
     let route = config
@@ -62,6 +57,18 @@ fn outcome_routing_example_uses_only_generic_pipeline_contracts() {
     assert_eq!(protected.artifact_inputs, ["produce"]);
     assert_eq!(protected.artifact_access, ArtifactAccess::Immutable);
     assert!(protected.authorization.is_some());
+    assert_eq!(protected.actions.len(), 1);
+    assert!(matches!(
+        protected.actions[0],
+        StepActionConfig::TrackerComment { .. }
+    ));
+
+    let operator = config
+        .steps
+        .iter()
+        .find(|step| step.name == "notify_operator")
+        .unwrap();
+    assert_eq!(operator.actions.len(), 2);
 
     let schema = read_json(&root.join("schemas/outcome.schema.json"));
     let validator = jsonschema::validator_for(&schema).unwrap();
@@ -82,4 +89,81 @@ fn outcome_routing_example_uses_only_generic_pipeline_contracts() {
     .unwrap();
     assert!(guide.contains("examples/outcome-routing/config.yaml"));
     assert!(guide.contains("whole Run"));
+
+    // This is an activation-level capability check, not merely schema loading:
+    // the public reference must be runnable with its declared comment action.
+    let tracker = create_tracker(&config.tracker).unwrap();
+    assert!(tracker.supports_idempotent_comment_publication());
+}
+
+#[test]
+fn outcome_routing_example_executes_actions_only_on_the_selected_branch() {
+    let root = example_root();
+    let config = load_config(&root.join("config.yaml")).unwrap();
+    let run_for = |outcome: &str| {
+        let mut run = PipelineRun::new(
+            "example-1".to_string(),
+            1,
+            build_dag(&config.steps).unwrap(),
+        );
+        assert!(matches!(run.start(), PipelineAction::Dispatch(_)));
+        let action = run.step_completed(
+            "produce",
+            StepOutput {
+                result: StepResult::Succeeded,
+                summary: None,
+                output: Some(read_json(
+                    &root.join("outputs").join(format!("{outcome}.json")),
+                )),
+            },
+            false,
+        );
+        (run, action)
+    };
+
+    let (mut revised, action) = run_for("revised-artifact");
+    assert!(
+        matches!(action, PipelineAction::Dispatch(ref requests) if requests[0].step_name == "publish_revision")
+    );
+    assert!(matches!(
+        revised.step_states["notify_operator"],
+        StepState::Skipped { .. }
+    ));
+    revised.step_completed(
+        "publish_revision",
+        StepOutput {
+            result: StepResult::Succeeded,
+            summary: None,
+            output: Some(read_json(&root.join("outputs/publication.json"))),
+        },
+        false,
+    );
+    assert!(matches!(
+        revised.pending_action("publish_revision").unwrap().action,
+        ResolvedStepAction::TrackerComment { .. }
+    ));
+    assert!(revised.pending_action("notify_operator").is_none());
+
+    let (mut operator, action) = run_for("operator-required");
+    assert!(
+        matches!(action, PipelineAction::Dispatch(ref requests) if requests[0].step_name == "notify_operator")
+    );
+    assert!(matches!(
+        operator.step_states["publish_revision"],
+        StepState::Skipped { .. }
+    ));
+    operator.step_completed(
+        "notify_operator",
+        StepOutput {
+            result: StepResult::Succeeded,
+            summary: None,
+            output: Some(read_json(&root.join("outputs/operator-attention.json"))),
+        },
+        false,
+    );
+    assert!(matches!(
+        operator.pending_action("notify_operator").unwrap().action,
+        ResolvedStepAction::TrackerComment { .. }
+    ));
+    assert!(operator.pending_action("publish_revision").is_none());
 }

--- a/crates/ensemble-core/tests/step_output_templates.rs
+++ b/crates/ensemble-core/tests/step_output_templates.rs
@@ -48,6 +48,7 @@ fn make_step(name: &str, agent: &str, depends: &[&str]) -> StepConfig {
         gate: None,
         authorization: None,
         route: None,
+        actions: Vec::new(),
     }
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -305,6 +305,12 @@ Pipeline step definition:
     The runtime persists the selected event and exact Artifact identity/digest, then revalidates
     both immediately before launch. Automatic handoff journals pending intent before the remote
     write and opens dispatch only after its applied acknowledgement is durable.
+- `actions` (list, optional) — ordered bounded post-output effects valid only on `agent` and
+  `synthesis` steps with an output schema. `tracker_comment` has one required-string `body` JSON
+  Pointer. `operator_attention` has an opaque namespaced `kind`, required-string `summary` and
+  `remedy` pointers, and an optional required string-array `references` pointer. Intent and
+  acknowledgement receipts are durable; a pending action blocks downstream work and retries from
+  the retained output without rerunning the producer or consuming agent capacity.
 
 #### 4.1.5 Workspace
 
@@ -347,6 +353,8 @@ Step states:
 - `Running` — agent dispatched, session active
 - `AwaitingApproval` — step completed but blocked on an approval gate. The orchestrator
   holds the pipeline here until a `approve_gate` or `reject_gate` signal is received.
+- `AwaitingActions` — a producer has completed but one or more configured post-output effects
+  still lack durable receipts. It retains the Run, Workspace, and claim.
 - `Passed` — agent exited successfully with a `succeeded` or `concern` result, or was approved at
   an approval gate
 - `Skipped` — successful terminal work excluded by a durable static route selection; it has no
@@ -999,6 +1007,9 @@ Pipeline step definitions forming a DAG. Each step is an object:
   - Pre-dispatch authorization as specified in Section 4.1.4: a direct snapshot-producing
     dependency, opaque event predicate, and explicit `wait_for_event` or
     `automatic_transition` handoff constraints.
+- `actions` (list, optional)
+  - Ordered `tracker_comment` and `operator_attention` declarations as specified in Section
+    4.1.4. Routes and gates cannot declare actions; `Skipped` work has no action state.
 
 #### 5.3.5 `on_success` (string)
 
@@ -1323,6 +1334,8 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `steps[].kind`: string, optional, default `"agent"`; `"agent"`, `"synthesis"`, `"gate"`, or `"route"`
 - `steps[].route`: required for `kind: route`; `{ source: { step, pointer }, cases }` with an
   exact, required source string enum and direct-successor case partition
+- `steps[].actions`: optional ordered post-output actions on agent/synthesis steps with a resolved
+  output schema; every pointer must resolve to the declared bounded string or string-array shape
 - `steps[].depends`: list of strings, optional; step dependencies for DAG
 - `steps[].tracker_state`: string, optional; tracker state to write on step entry
 - `steps[].authorization`: optional pre-dispatch contract for agent/synthesis steps only:

--- a/docs/adr/0019-compose-durable-step-actions-from-configured-output.md
+++ b/docs/adr/0019-compose-durable-step-actions-from-configured-output.md
@@ -1,0 +1,18 @@
+---
+status: accepted
+---
+
+# Compose durable step actions from configured output
+
+Steps may emit bounded configured effects after their structured output has passed its declared
+schema. The runtime resolves each action from that immutable output, checkpoints intent before the
+external effect, and checkpoints a receipt before releasing dependent work.
+
+This keeps the Pipeline a static DAG. Actions do not select pipelines, add nodes, interpret tracker
+states, change claims, or own finalization. A failed effect retains the existing Run, Workspace,
+and claim for normal retained-run recovery; it never reruns the producer merely to recreate an
+effect. Marker reconciliation makes tracker comments safe across an ambiguous post-write crash,
+while operator attention uses the existing stable identity and fresh-evidence contract.
+
+The boundary deliberately leaves policy names in configuration and reference assets. The core only
+knows bounded action shapes, durable ordering, receipts, and adapter capability.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,8 +3,35 @@
 ## First-release configuration boundary
 
 Operator-attention reporting is a runtime primitive backed by the shared workspace history
-database. This release adds no `config.yaml` routing, kind, or development-method vocabulary for
-attention; configured branch adapters may use the generic reporter in a later change.
+database. Steps may also declare bounded generic post-output actions; action kinds and values are
+opaque configuration data and do not add a development-method runtime mode.
+
+## Post-output actions
+
+An `agent` or `synthesis` step with an `output_schema` may declare ordered `actions`. Each JSON
+Pointer is resolved only from that step's validated structured output. Pointers must name required
+strings (or, for optional `references`, a required array of strings), so activation rejects
+ambiguous data before dispatch.
+
+```yaml
+actions:
+  - type: tracker_comment
+    body: /comment
+  - type: operator_attention
+    kind: ensemble.review
+    summary: /summary
+    remedy: /remedy
+    references: /references
+```
+
+The runtime stores resolved values and an opaque marker identity with the producer output, then
+journals each effect before execution and its receipt before downstream work. A comment-capable
+tracker reconciles the marker after a crash before creating another comment; activation fails when
+a comment action is configured for an adapter that cannot prove this behavior. Attention uses the
+existing bounded, evidence-sensitive upsert store. Pending actions retain the Run, Workspace, and
+claim without rerunning their producer or consuming an agent slot.
+
+For a complete static-route composition, see [Outcome routing](outcome-routing.md).
 
 Configuration serves one trusted local operator. ACPX-backed agents and sequential pipelines are
 the supported first-release path. `agent.max_turns` is not a supported field and is rejected.

--- a/docs/examples/outcome-routing/config.yaml
+++ b/docs/examples/outcome-routing/config.yaml
@@ -1,8 +1,12 @@
 # A public composition of a static output route and generic durable actions.
 # All domain vocabulary is confined to this reference configuration.
 tracker:
-  kind: todo_file
-  path: TODO.md
+  # GitHub is used because marker-bound comments require idempotent publication.
+  kind: github
+  repository: example/ensemble
+  api_key: example-token-not-a-secret
+  github:
+    status_field: Status
 
 repos:
   - path: target
@@ -29,14 +33,6 @@ steps:
     output_schema: { path: schemas/outcome.schema.json }
     artifact_snapshot:
       repositories: [target]
-    actions:
-      - type: tracker_comment
-        body: /comment
-      - type: operator_attention
-        kind: ensemble.outcome
-        summary: /summary
-        remedy: /remedy
-        references: /references
   - name: choose_outcome
     kind: route
     depends: [produce]
@@ -56,9 +52,22 @@ steps:
       event: { field: review, value: approved, actors: [maintainer] }
       after_artifact: true
       handoff: wait_for_event
+    output_schema: { path: schemas/publication.schema.json }
+    actions:
+      - type: tracker_comment
+        body: /comment
   - name: notify_operator
     agent: operator
     depends: [choose_outcome]
+    output_schema: { path: schemas/operator-attention.schema.json }
+    actions:
+      - type: tracker_comment
+        body: /comment
+      - type: operator_attention
+        kind: ensemble.outcome
+        summary: /summary
+        remedy: /remedy
+        references: /references
 
 on_success: Done
 on_failure: Failed

--- a/docs/examples/outcome-routing/config.yaml
+++ b/docs/examples/outcome-routing/config.yaml
@@ -1,0 +1,64 @@
+# A public composition of a static output route and generic durable actions.
+# All domain vocabulary is confined to this reference configuration.
+tracker:
+  kind: todo_file
+  path: TODO.md
+
+repos:
+  - path: target
+    branch: main
+
+agents:
+  producer:
+    executor: example-agent
+    model: example-model
+    prompt: templates/produce.liquid
+  publisher:
+    executor: example-agent
+    model: example-model
+    prompt: templates/publish.liquid
+  operator:
+    executor: example-agent
+    model: example-model
+    prompt: templates/operator.liquid
+
+steps:
+  - name: produce
+    agent: producer
+    depends: []
+    output_schema: { path: schemas/outcome.schema.json }
+    artifact_snapshot:
+      repositories: [target]
+    actions:
+      - type: tracker_comment
+        body: /comment
+      - type: operator_attention
+        kind: ensemble.outcome
+        summary: /summary
+        remedy: /remedy
+        references: /references
+  - name: choose_outcome
+    kind: route
+    depends: [produce]
+    on_failure: halt
+    route:
+      source: { step: produce, pointer: /outcome }
+      cases:
+        revised_artifact: [publish_revision]
+        operator_required: [notify_operator]
+  - name: publish_revision
+    agent: publisher
+    depends: [choose_outcome, produce]
+    artifact_inputs: [produce]
+    artifact_access: immutable
+    authorization:
+      artifact_step: produce
+      event: { field: review, value: approved, actors: [maintainer] }
+      after_artifact: true
+      handoff: wait_for_event
+  - name: notify_operator
+    agent: operator
+    depends: [choose_outcome]
+
+on_success: Done
+on_failure: Failed

--- a/docs/examples/outcome-routing/outputs/operator-attention.json
+++ b/docs/examples/outcome-routing/outputs/operator-attention.json
@@ -1,0 +1,6 @@
+{
+  "comment": "An operator decision is required before continuing.",
+  "summary": "The selected outcome needs operator attention.",
+  "remedy": "Inspect the referenced artifact and decide the next whole Run policy.",
+  "references": ["artifact:target"]
+}

--- a/docs/examples/outcome-routing/outputs/operator-required.json
+++ b/docs/examples/outcome-routing/outputs/operator-required.json
@@ -1,7 +1,3 @@
 {
-  "outcome": "operator_required",
-  "comment": "An operator decision is required before continuing.",
-  "summary": "The selected outcome needs operator attention.",
-  "remedy": "Inspect the referenced artifact and decide the next whole Run policy.",
-  "references": ["artifact:target"]
+  "outcome": "operator_required"
 }

--- a/docs/examples/outcome-routing/outputs/operator-required.json
+++ b/docs/examples/outcome-routing/outputs/operator-required.json
@@ -1,0 +1,7 @@
+{
+  "outcome": "operator_required",
+  "comment": "An operator decision is required before continuing.",
+  "summary": "The selected outcome needs operator attention.",
+  "remedy": "Inspect the referenced artifact and decide the next whole Run policy.",
+  "references": ["artifact:target"]
+}

--- a/docs/examples/outcome-routing/outputs/publication.json
+++ b/docs/examples/outcome-routing/outputs/publication.json
@@ -1,0 +1,3 @@
+{
+  "comment": "Artifact is ready for the protected publication step."
+}

--- a/docs/examples/outcome-routing/outputs/revised-artifact.json
+++ b/docs/examples/outcome-routing/outputs/revised-artifact.json
@@ -1,7 +1,3 @@
 {
-  "outcome": "revised_artifact",
-  "comment": "Artifact is ready for the protected publication step.",
-  "summary": "A revised artifact is available.",
-  "remedy": "Review the artifact and record authorization when ready.",
-  "references": ["artifact:target"]
+  "outcome": "revised_artifact"
 }

--- a/docs/examples/outcome-routing/outputs/revised-artifact.json
+++ b/docs/examples/outcome-routing/outputs/revised-artifact.json
@@ -1,0 +1,7 @@
+{
+  "outcome": "revised_artifact",
+  "comment": "Artifact is ready for the protected publication step.",
+  "summary": "A revised artifact is available.",
+  "remedy": "Review the artifact and record authorization when ready.",
+  "references": ["artifact:target"]
+}

--- a/docs/examples/outcome-routing/schemas/operator-attention.schema.json
+++ b/docs/examples/outcome-routing/schemas/operator-attention.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["comment", "summary", "remedy", "references"],
+  "properties": {
+    "comment": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string", "minLength": 1 },
+    "remedy": { "type": "string", "minLength": 1 },
+    "references": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+  }
+}

--- a/docs/examples/outcome-routing/schemas/outcome.schema.json
+++ b/docs/examples/outcome-routing/schemas/outcome.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["outcome", "comment", "summary", "remedy", "references"],
+  "properties": {
+    "outcome": { "type": "string", "enum": ["revised_artifact", "operator_required"] },
+    "comment": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string", "minLength": 1 },
+    "remedy": { "type": "string", "minLength": 1 },
+    "references": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+  }
+}

--- a/docs/examples/outcome-routing/schemas/outcome.schema.json
+++ b/docs/examples/outcome-routing/schemas/outcome.schema.json
@@ -1,12 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": ["outcome", "comment", "summary", "remedy", "references"],
+  "required": ["outcome"],
   "properties": {
-    "outcome": { "type": "string", "enum": ["revised_artifact", "operator_required"] },
-    "comment": { "type": "string", "minLength": 1 },
-    "summary": { "type": "string", "minLength": 1 },
-    "remedy": { "type": "string", "minLength": 1 },
-    "references": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+    "outcome": { "type": "string", "enum": ["revised_artifact", "operator_required"] }
   }
 }

--- a/docs/examples/outcome-routing/schemas/publication.schema.json
+++ b/docs/examples/outcome-routing/schemas/publication.schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["comment"],
+  "properties": { "comment": { "type": "string", "minLength": 1 } }
+}

--- a/docs/examples/outcome-routing/templates/operator.liquid
+++ b/docs/examples/outcome-routing/templates/operator.liquid
@@ -1,0 +1,1 @@
+Prepare the bounded operator-facing follow-up for the selected outcome.

--- a/docs/examples/outcome-routing/templates/operator.liquid
+++ b/docs/examples/outcome-routing/templates/operator.liquid
@@ -1,1 +1,1 @@
-Prepare the bounded operator-facing follow-up for the selected outcome.
+Prepare the bounded operator-facing follow-up and return its comment, summary, remedy, and references.

--- a/docs/examples/outcome-routing/templates/produce.liquid
+++ b/docs/examples/outcome-routing/templates/produce.liquid
@@ -1,1 +1,1 @@
-Produce the artifact and return the schema-valid outcome, comment, summary, remedy, and references.
+Produce the Artifact and return the schema-valid selected outcome only.

--- a/docs/examples/outcome-routing/templates/produce.liquid
+++ b/docs/examples/outcome-routing/templates/produce.liquid
@@ -1,0 +1,1 @@
+Produce the artifact and return the schema-valid outcome, comment, summary, remedy, and references.

--- a/docs/examples/outcome-routing/templates/publish.liquid
+++ b/docs/examples/outcome-routing/templates/publish.liquid
@@ -1,1 +1,1 @@
-Publish only the immutable Artifact supplied after the configured authorization evidence is present.
+Publish only the immutable Artifact supplied after configured authorization, then return the publication comment.

--- a/docs/examples/outcome-routing/templates/publish.liquid
+++ b/docs/examples/outcome-routing/templates/publish.liquid
@@ -1,0 +1,1 @@
+Publish only the immutable Artifact supplied after the configured authorization evidence is present.

--- a/docs/outcome-routing.md
+++ b/docs/outcome-routing.md
@@ -4,10 +4,11 @@
 schema-validated producer, generic durable actions, and one static enum route. It deliberately
 keeps `revised_artifact` and `operator_required` in reference assets rather than runtime types.
 
-The producer snapshots an Artifact and reports one of the two schema values. Before either route
-branch becomes eligible, its marker-bound comment and attention upsert receive durable receipts.
-The `revised_artifact` branch waits for configured tracker-event authorization while retaining the
-same Run, Workspace, Artifact, and claim. The other branch is ordinary configured work. The
+The producer snapshots an Artifact and reports one of the two schema values. The selected branch,
+and only the selected branch, resolves and applies its declared actions: `revised_artifact` emits
+the publication comment after configured authorization, while `operator_required` emits the
+marker-bound comment and attention upsert. The `revised_artifact` branch waits for configured
+tracker-event authorization while retaining the same Run, Workspace, Artifact, and claim. The
 unselected branch is `Skipped` and has no action state.
 
 If external policy later wants another attempt, it selects a new whole Run after a fresh tracker

--- a/docs/outcome-routing.md
+++ b/docs/outcome-routing.md
@@ -1,0 +1,14 @@
+# Outcome routing example
+
+[`examples/outcome-routing/config.yaml`](examples/outcome-routing/config.yaml) composes a
+schema-validated producer, generic durable actions, and one static enum route. It deliberately
+keeps `revised_artifact` and `operator_required` in reference assets rather than runtime types.
+
+The producer snapshots an Artifact and reports one of the two schema values. Before either route
+branch becomes eligible, its marker-bound comment and attention upsert receive durable receipts.
+The `revised_artifact` branch waits for configured tracker-event authorization while retaining the
+same Run, Workspace, Artifact, and claim. The other branch is ordinary configured work. The
+unselected branch is `Skipped` and has no action state.
+
+If external policy later wants another attempt, it selects a new whole Run after a fresh tracker
+snapshot. The example does not loop, reinterpret a route choice, or create a runtime mode.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -211,7 +211,9 @@ producer, consume worker capacity, change `max_cycles`, or select a new Pipeline
 The public effects are marker-reconciled tracker comments and durable operator-attention upserts.
 Actions are invalid on routes and gates. Route-excluded `Skipped` steps have no output, action,
 receipt, artifact, attempt, or transcript. Retrying a producer clears its own and dependent action
-state together with their outputs.
+receipts. Completed history exposes only bounded applied-action evidence (identity, source digest,
+kind, and receipt); it never includes resolved comment bodies or attention presentation. Retrying
+a producer clears its own and dependent action state together with their outputs.
 
 The checked-in [outcome-routing example](outcome-routing.md) shows this composition with Artifact
 and authorization wiring while keeping its policy labels out of the runtime.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -200,6 +200,22 @@ downstream retry retain the choice. Resetting the source resets its descendants 
 route decisions. Missing or unmatched route evidence fails the route closed and halts; routes do
 not support automatic retry, fixup, defaults, coercion, predicates, dynamic nodes, or loops.
 
+## Durable post-output actions
+
+Ordinary agent and synthesis steps may have ordered generic actions sourced from their own
+schema-validated output. A producer is `AwaitingActions` until every declared effect has a durable
+receipt, so dependents, routes, approval, terminal state changes, and finalization cannot proceed
+early. A pending action is retried from its saved output after restart; it does not rerun the
+producer, consume worker capacity, change `max_cycles`, or select a new Pipeline.
+
+The public effects are marker-reconciled tracker comments and durable operator-attention upserts.
+Actions are invalid on routes and gates. Route-excluded `Skipped` steps have no output, action,
+receipt, artifact, attempt, or transcript. Retrying a producer clears its own and dependent action
+state together with their outputs.
+
+The checked-in [outcome-routing example](outcome-routing.md) shows this composition with Artifact
+and authorization wiring while keeping its policy labels out of the runtime.
+
 ## Clarification request style (batched by default)
 
 Ensemble now injects interaction-policy guidance into prompts by default. Agents are expected to:


### PR DESCRIPTION
Closes #513

## Summary

- add ordered, schema-backed post-output actions for idempotent tracker comments and durable operator attention
- persist action intent and receipts across restart while retaining the run, workspace, claim, and downstream gating
- ship a public outcome-routing example that composes static routes, artifacts, authorization, comments, and attention without adding replanning vocabulary to the runtime
- harden action recovery against snapshot tampering, fresh-run marker reuse, missing durable storage, and concurrent sibling completion

## Validation

- cargo clippy --workspace --exclude ensemble-desktop -- -D warnings
- cargo fmt --all -- --check
- SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui
- SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture (55 passed, 1 explicitly ignored live dogfood test)
- focused outcome-routing, action recovery, fresh-run identity, activation, and concurrent sibling tests
- cargo test --workspace --exclude ensemble-desktop reached 1,483 passing core tests; the unchanged shutdown_signal_cancels_running_issue_tokens test hit its existing RecvError race
