### PR TITLE
Keep action continuation off scheduler stack

### DIFF
--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -2915,7 +2915,18 @@ impl Orchestrator {
         }
     }
 
-    async fn handle_applied_action_outcome(
+    // Keep action continuation out of the active-pipeline dispatcher so its failure and terminal
+    // lifecycle branches do not inflate every scheduler dispatch frame.
+    fn handle_applied_action_outcome<'a>(
+        &'a self,
+        issue_id: &'a str,
+        action: PipelineAction,
+        permit: &'a DispatchPermit,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(self.handle_applied_action_outcome_inner(issue_id, action, permit))
+    }
+
+    async fn handle_applied_action_outcome_inner(
         &self,
         issue_id: &str,
         action: PipelineAction,


### PR DESCRIPTION
## Summary

- heap-allocate the post-output action continuation before it enters the active-pipeline dispatcher
- keep the existing low-stack acceptance-failure regression guard unchanged

PR #554 added an action continuation future that embeds pipeline failure and terminal lifecycle handling. That inflated each scheduler dispatch frame enough to overflow the deliberately constrained Tokio worker stack in two Product E2E acceptance-failure paths.

## Verification

- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture` (55 passed, 1 explicitly ignored)
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo fmt --all -- --check`

A local full workspace run also exposed the unrelated macOS-only `shutdown_signal_cancels_running_issue_tokens` race; the current main SHA passed the ordinary Rust Test job in GitHub CI.