### PR TITLE
Synchronize shutdown cancellation test

### DIFF
--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -24364,12 +24364,13 @@ agent:
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
             issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
         });
-        let (probe_tx, probe_rx) = tokio::sync::oneshot::channel();
-        let runner: Arc<dyn AgentRunner> = Arc::new(MockRunner {
-            delay_ms: 0,
-            observed_commands: None,
-            observed_timeouts: None,
-            cancellation_probe: Some(Arc::new(std::sync::Mutex::new(Some(probe_tx)))),
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (cancelled_tx, cancelled_rx) = tokio::sync::oneshot::channel();
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let runner: Arc<dyn AgentRunner> = Arc::new(BlockingDrainRunner {
+            started: std::sync::Mutex::new(Some(started_tx)),
+            cancellation_observed: std::sync::Mutex::new(Some(cancelled_tx)),
+            release: Arc::clone(&release),
         });
         let dir = tempfile::TempDir::new().unwrap();
         let workspace_mgr = WorkspaceManager::new(dir.path(), None).unwrap();
@@ -24402,23 +24403,19 @@ agent:
             orchestrator.run().await;
         });
 
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                if state.read().await.is_running("1") {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .unwrap();
-
-        shutdown_tx.send(()).await.unwrap();
-
-        tokio::time::timeout(Duration::from_secs(2), probe_rx)
+        tokio::time::timeout(Duration::from_secs(2), started_rx)
             .await
             .unwrap()
             .unwrap();
+        assert!(state.read().await.is_running("1"));
+
+        shutdown_tx.send(()).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), cancelled_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        release.add_permits(1);
         run_handle.await.unwrap();
     }
 


### PR DESCRIPTION
## Summary

- wait for the mock runner to actually start before sending shutdown
- observe cancellation through the existing blocking drain runner
- release the runner only after the cancellation assertion, keeping shutdown deterministic

## Root cause

The test previously used the issue's running state as a proxy for runner startup. Shutdown could arrive after the state transition but before the runner began, dropping the unused observation sender and producing RecvError.

## Validation

- focused shutdown cancellation test
- serialized non-desktop workspace test suite
- product E2E: 55 passed, 1 ignored
- clippy with warnings denied
- formatting and diff checks

A fully parallel local workspace run also exposed existing cross-test interference in the PATH-mutating artifact tests and transcript timing test; neither touches this change, and the serialized suite passes.