### PR TITLE
Project delivery facts into tracker state

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -3313,7 +3313,8 @@ repos:
     finalize:
       mode: push_and_pr
       approval_required: false
-      review_state: In review
+delivery_states:
+  waiting: In review
 agents:
   builder:
     acpx_agent: {}
@@ -5631,7 +5632,7 @@ fn live_dogfood_marker_artifact_and_config_are_run_scoped() {
     assert!(config.contains("max_step_parallelism: 1"));
     assert!(config.contains("mode: push_and_pr"));
     assert!(config.contains("approval_required: false"));
-    assert!(config.contains("review_state: In review"));
+    assert!(config.contains("delivery_states:\n  waiting: In review"));
     assert!(!config.contains("api_key:"));
 }
 

--- a/crates/ensemble-core/src/config/draft.rs
+++ b/crates/ensemble-core/src/config/draft.rs
@@ -1,4 +1,6 @@
-use crate::config::ensemble::{read_dotenv, validate_config, EnsembleConfig};
+use crate::config::ensemble::{
+    read_dotenv, reject_removed_finalize_review_state, validate_config, EnsembleConfig,
+};
 use crate::error::{ConfigError, PipelineError};
 use crate::pipeline::dag::build_dag;
 use serde::{Deserialize, Serialize};
@@ -110,10 +112,12 @@ pub(crate) fn parse_raw_yaml_with_dotenv(
             let typed: Result<EnsembleConfig, ConfigError> =
                 crate::config::ensemble::reject_unsupported_agent_max_turns(&document).and_then(
                     |_| {
-                        serde_yaml::from_value(document.clone()).map_err(|e| {
-                            ConfigError::ConfigParseError {
-                                reason: e.to_string(),
-                            }
+                        reject_removed_finalize_review_state(&document).and_then(|_| {
+                            serde_yaml::from_value(document.clone()).map_err(|e| {
+                                ConfigError::ConfigParseError {
+                                    reason: e.to_string(),
+                                }
+                            })
                         })
                     },
                 );
@@ -191,6 +195,27 @@ pub fn validate_document(document: &serde_yaml::Value) -> DraftValidationReport 
     let mut seen_sections = HashSet::new();
 
     if let Some(mapping) = document.as_mapping() {
+        if mapping
+            .get("repos")
+            .and_then(serde_yaml::Value::as_sequence)
+            .is_some_and(|repositories| {
+                repositories.iter().any(|repository| {
+                    repository
+                        .as_mapping()
+                        .and_then(|repository| repository.get("finalize"))
+                        .and_then(serde_yaml::Value::as_mapping)
+                        .is_some_and(|finalize| finalize.contains_key("review_state"))
+                })
+            })
+        {
+            issues.push(ValidationIssue {
+                kind: ValidationIssueKind::Config,
+                message: "repos[].finalize.review_state has been removed; migrate it to delivery_states.waiting".to_string(),
+                section: "workflow".to_string(),
+                field: Some("delivery_states.waiting".to_string()),
+                path: Some("delivery_states.waiting".to_string()),
+            });
+        }
         // Validate presence of required top-level sections
         let selected_mode = mapping
             .get("workflow_selection")

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -24,6 +24,9 @@ pub struct EnsembleConfig {
     pub on_success: String,
     #[serde(default)]
     pub on_failure: String,
+    /// Optional tracker-state projections for durable delivery facts in the legacy pipeline.
+    #[serde(default)]
+    pub delivery_states: DeliveryStates,
     /// Neutral named pipelines used only when `workflow_selection` is non-empty.
     #[serde(default)]
     pub pipelines: BTreeMap<String, PipelineConfig>,
@@ -58,6 +61,26 @@ pub struct PipelineConfig {
     pub steps: Vec<StepConfig>,
     pub on_success: String,
     pub on_failure: String,
+    #[serde(default)]
+    pub delivery_states: DeliveryStates,
+}
+
+/// Optional non-terminal tracker-state targets for durable delivery facts.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DeliveryStates {
+    #[serde(default)]
+    pub waiting: Option<String>,
+    #[serde(default)]
+    pub checks_failed: Option<String>,
+    #[serde(default)]
+    pub changes_requested: Option<String>,
+    #[serde(default)]
+    pub approved: Option<String>,
+    #[serde(default)]
+    pub closed_without_merge: Option<String>,
+    #[serde(default)]
+    pub merged: Option<String>,
 }
 
 /// Scheduler configuration for selected workflows.
@@ -1255,6 +1278,9 @@ impl EnsembleConfig {
         effective.steps = pipeline.steps.clone();
         effective.on_success.clone_from(&pipeline.on_success);
         effective.on_failure.clone_from(&pipeline.on_failure);
+        effective
+            .delivery_states
+            .clone_from(&pipeline.delivery_states);
         Ok(effective)
     }
 
@@ -1465,6 +1491,7 @@ pub fn parse_config(yaml: &str) -> Result<EnsembleConfig, crate::error::ConfigEr
     reject_unsupported_agent_max_turns(&value)?;
     reject_legacy_agent_permission_policy(&value)?;
     reject_legacy_notion_tracker_keys(&value)?;
+    reject_removed_finalize_review_state(&value)?;
     let config: EnsembleConfig =
         serde_yaml::from_value(value).map_err(|e| crate::error::ConfigError::ConfigParseError {
             reason: e.to_string(),
@@ -1476,6 +1503,33 @@ pub fn parse_config(yaml: &str) -> Result<EnsembleConfig, crate::error::ConfigEr
         }
     })?;
     Ok(config)
+}
+
+pub(crate) fn reject_removed_finalize_review_state(
+    value: &serde_yaml::Value,
+) -> Result<(), crate::error::ConfigError> {
+    let Some(repositories) = value
+        .as_mapping()
+        .and_then(|root| root.get("repos"))
+        .and_then(serde_yaml::Value::as_sequence)
+    else {
+        return Ok(());
+    };
+
+    if repositories.iter().any(|repository| {
+        repository
+            .as_mapping()
+            .and_then(|repository| repository.get("finalize"))
+            .and_then(serde_yaml::Value::as_mapping)
+            .is_some_and(|finalize| finalize.contains_key("review_state"))
+    }) {
+        return Err(crate::error::ConfigError::ConfigParseError {
+            reason: "repos[].finalize.review_state has been removed; migrate it to delivery_states.waiting"
+                .to_string(),
+        });
+    }
+
+    Ok(())
 }
 
 fn validate_producer_declarations(config: &EnsembleConfig) -> Result<(), PipelineError> {
@@ -1899,95 +1953,76 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         }
     }
 
-    let effective_pipelines: Vec<(&str, &[StepConfig], &str, &str)> = if selected_mode {
-        config
-            .pipelines
-            .iter()
-            .map(|(name, pipeline)| {
-                (
-                    name.as_str(),
-                    pipeline.steps.as_slice(),
-                    pipeline.on_success.as_str(),
-                    pipeline.on_failure.as_str(),
-                )
-            })
-            .collect()
-    } else {
-        vec![(
-            "<legacy>",
-            config.steps.as_slice(),
-            config.on_success.as_str(),
-            config.on_failure.as_str(),
-        )]
-    };
+    let effective_pipelines: Vec<(&str, &[StepConfig], &str, &str, &DeliveryStates)> =
+        if selected_mode {
+            config
+                .pipelines
+                .iter()
+                .map(|(name, pipeline)| {
+                    (
+                        name.as_str(),
+                        pipeline.steps.as_slice(),
+                        pipeline.on_success.as_str(),
+                        pipeline.on_failure.as_str(),
+                        &pipeline.delivery_states,
+                    )
+                })
+                .collect()
+        } else {
+            vec![(
+                "<legacy>",
+                config.steps.as_slice(),
+                config.on_success.as_str(),
+                config.on_failure.as_str(),
+                &config.delivery_states,
+            )]
+        };
 
-    for (name, _, on_success, on_failure) in &effective_pipelines {
+    for (name, _, on_success, on_failure, delivery_states) in &effective_pipelines {
         if name.trim().is_empty() || on_success.trim().is_empty() || on_failure.trim().is_empty() {
             return Err(PipelineError::InvalidNamedPipeline {
                 pipeline: (*name).to_string(),
                 reason: "name, on_success, and on_failure must be non-blank".to_string(),
             });
         }
-    }
-
-    let mut review_state: Option<&str> = None;
-    for (index, repo) in config.repos.iter().enumerate() {
-        let Some(target) = repo.finalize.review_state.as_deref() else {
-            continue;
-        };
-        let repo_key = repository_key(repo, index);
-        if target.trim().is_empty() {
-            return Err(PipelineError::InvalidFinalizeConfig {
-                repo: repo_key,
-                reason: "review_state must not be empty".to_string(),
-            });
-        }
-        if repo.finalize.mode != crate::workspace::finalize::FinalizeMode::PushAndPr {
-            return Err(PipelineError::InvalidFinalizeConfig {
-                repo: repo_key,
-                reason: "review_state is valid only with push_and_pr finalization".to_string(),
-            });
-        }
-        if effective_pipelines
-            .iter()
-            .any(|(_, _, on_success, _)| target.eq_ignore_ascii_case(on_success))
-        {
-            return Err(PipelineError::InvalidFinalizeConfig {
-                repo: repo_key,
-                reason: "review_state must not equal on_success".to_string(),
-            });
-        }
-        if config
-            .tracker
-            .terminal_states
-            .iter()
-            .any(|state| target.eq_ignore_ascii_case(state))
-        {
-            return Err(PipelineError::InvalidFinalizeConfig {
-                repo: repo_key,
-                reason: "review_state must not be a configured terminal state".to_string(),
-            });
-        }
-        if let Some(existing) = review_state {
-            if !target.eq_ignore_ascii_case(existing) {
-                return Err(PipelineError::InvalidFinalizeConfig {
-                    repo: repo_key,
-                    reason: "all review_state values must use the same value".to_string(),
+        for (fact, target) in [
+            ("waiting", &delivery_states.waiting),
+            ("checks_failed", &delivery_states.checks_failed),
+            ("changes_requested", &delivery_states.changes_requested),
+            ("approved", &delivery_states.approved),
+            (
+                "closed_without_merge",
+                &delivery_states.closed_without_merge,
+            ),
+        ] {
+            let Some(target) = target else {
+                continue;
+            };
+            if target.trim().is_empty() {
+                return Err(PipelineError::InvalidNamedPipeline {
+                    pipeline: (*name).to_string(),
+                    reason: format!("delivery_states.{fact} must not be blank"),
                 });
             }
-        } else {
-            review_state = Some(target);
-        }
-    }
-    if review_state.is_some() {
-        for (index, repo) in config.repos.iter().enumerate() {
-            if repo.finalize.mode == crate::workspace::finalize::FinalizeMode::PushAndPr
-                && repo.finalize.review_state.is_none()
+            if config
+                .tracker
+                .terminal_states
+                .iter()
+                .any(|state| target.eq_ignore_ascii_case(state))
             {
-                return Err(PipelineError::InvalidFinalizeConfig {
-                    repo: repository_key(repo, index),
-                    reason: "all push_and_pr repositories must opt in to the review_state"
-                        .to_string(),
+                return Err(PipelineError::InvalidNamedPipeline {
+                    pipeline: (*name).to_string(),
+                    reason: format!(
+                        "delivery_states.{fact} must not be a configured terminal state"
+                    ),
+                });
+            }
+        }
+        if let Some(target) = &delivery_states.merged {
+            if target != "on_success" {
+                return Err(PipelineError::InvalidNamedPipeline {
+                    pipeline: (*name).to_string(),
+                    reason: "delivery_states.merged must equal on_success".to_string(),
                 });
             }
         }
@@ -2093,7 +2128,7 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         validate_name(&mut acceptance_names, "handoff", &rule.name)?;
         if effective_pipelines
             .iter()
-            .any(|(_, steps, _, _)| !steps.iter().any(|step| step.name == rule.step))
+            .any(|(_, steps, _, _, _)| !steps.iter().any(|step| step.name == rule.step))
         {
             return Err(PipelineError::InvalidAcceptanceRequirement {
                 kind: "handoff".to_string(),
@@ -2258,7 +2293,7 @@ pub fn validate_config(config: &EnsembleConfig) -> Result<(), PipelineError> {
         });
     }
 
-    for (pipeline_name, steps, _, _) in effective_pipelines {
+    for (pipeline_name, steps, _, _, _) in effective_pipelines {
         let mut seen_names = std::collections::HashSet::new();
         for step in steps {
             if !seen_names.insert(&step.name) {
@@ -3206,7 +3241,11 @@ on_failure: Failed
             branch("escalate"),
         ];
 
-        assert!(validate_config(&config).is_ok());
+        assert!(
+            validate_config(&config).is_ok(),
+            "{:?}",
+            validate_config(&config)
+        );
         let serialized = serde_yaml::to_string(&config).unwrap();
         assert!(serialized.contains("kind: route"));
         assert!(serialized.contains("pointer: /decision"));
@@ -3312,7 +3351,11 @@ on_failure: Failed
             agent("escalation_join", vec!["escalate", "escalation_review"]),
         ];
 
-        assert!(validate_config(&config).is_ok());
+        assert!(
+            validate_config(&config).is_ok(),
+            "{:?}",
+            validate_config(&config)
+        );
 
         config.steps[0].output_schema.as_mut().unwrap().schema = Some(serde_json::json!({
             "type": "object",
@@ -3899,28 +3942,22 @@ workflow_selection:
     }
 
     #[test]
-    fn review_state_requires_one_non_terminal_push_and_pr_target() {
+    fn delivery_states_are_validated_for_legacy_and_named_pipelines() {
         let valid = format!(
-            "{}\nrepos:\n  - path: /tmp/ensemble\n    branch: main\n    finalize:\n      mode: push_and_pr\n      review_state: In review\n",
+            "{}\ndelivery_states:\n  waiting: In review\n  checks_failed: CI failed\n  changes_requested: Changes requested\n  approved: Approved\n  closed_without_merge: Closed without merge\n  merged: on_success\n",
             minimal_yaml()
         );
         let config = parse_config(&valid).unwrap();
-        assert_eq!(
-            config.repos[0].finalize.review_state.as_deref(),
-            Some("In review")
-        );
         assert!(validate_config(&config).is_ok());
 
         let cases = [
-            ("blank", "mode: push_and_pr\n      review_state: '  '", "must not be empty"),
-            ("push", "mode: push\n      review_state: In review", "push_and_pr"),
-            ("success", "mode: push_and_pr\n      review_state: Done", "on_success"),
-            ("partial", "mode: push_and_pr\n      review_state: In review\n  - path: /tmp/other\n    branch: main\n    finalize:\n      mode: push_and_pr", "must opt in"),
-            ("conflict", "mode: push_and_pr\n      review_state: In review\n  - path: /tmp/other\n    branch: main\n    finalize:\n      mode: push_and_pr\n      review_state: Needs review", "same value"),
+            ("blank", "waiting: '  '", "must not be blank"),
+            ("terminal", "waiting: Done", "configured terminal state"),
+            ("merged target", "merged: Done", "must equal on_success"),
         ];
-        for (label, finalize, expected) in cases {
+        for (label, delivery_states, expected) in cases {
             let yaml = format!(
-                "{}\nrepos:\n  - path: /tmp/ensemble\n    branch: main\n    finalize:\n      {finalize}\n",
+                "{}\ndelivery_states:\n  {delivery_states}\n",
                 minimal_yaml()
             );
             let config = parse_config(&yaml).unwrap();
@@ -3928,14 +3965,48 @@ workflow_selection:
             assert!(error.to_string().contains(expected), "{label}: {error}");
         }
 
-        let terminal = format!(
-            "{}\nrepos:\n  - path: /tmp/ensemble\n    branch: main\n    finalize:\n      mode: push_and_pr\n      review_state: Failed\n",
+        let named = r#"
+tracker:
+  kind: todo_file
+  path: TODO.md
+agents:
+  build:
+    executor: claude-code
+    model: claude-opus-4-6
+    prompt: Build the thing.
+workflow_selection:
+  - name: selected
+    precedence: 1
+    pipeline: delivery
+    lane: default
+    order_by: [identifier]
+scheduler:
+  lanes:
+    default: {}
+pipelines:
+  delivery:
+    steps:
+      - name: build
+        agent: build
+    on_success: Done
+    on_failure: Failed
+    delivery_states:
+      waiting: In review
+      merged: on_success
+"#;
+        let config = parse_config(&named).unwrap();
+        assert!(
+            validate_config(&config).is_ok(),
+            "{:?}",
+            validate_config(&config)
+        );
+
+        let legacy = format!(
+            "{}\nrepos:\n  - path: /tmp/ensemble\n    branch: main\n    finalize:\n      mode: push_and_pr\n      review_state: In review\n",
             minimal_yaml()
         );
-        let mut config = parse_config(&terminal).unwrap();
-        config.tracker.terminal_states.push("Failed".to_string());
-        let error = validate_config(&config).unwrap_err();
-        assert!(error.to_string().contains("terminal"));
+        let error = parse_config(&legacy).unwrap_err();
+        assert!(error.to_string().contains("delivery_states.waiting"));
     }
 
     #[test]

--- a/crates/ensemble-core/src/observability/snapshot.rs
+++ b/crates/ensemble-core/src/observability/snapshot.rs
@@ -1069,6 +1069,7 @@ mod tests {
     fn test_config_with_steps() -> std::sync::Arc<EnsembleConfig> {
         std::sync::Arc::new(EnsembleConfig {
             pipelines: Default::default(),
+            delivery_states: Default::default(),
             scheduler: Default::default(),
             workflow_selection: Default::default(),
             tracker: TrackerConfig {

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -91,6 +91,9 @@ pub(crate) struct DeliveryRecord {
     /// Success target copied from the selected pipeline with the delivery policy.
     #[serde(default)]
     pub success_state: Option<String>,
+    /// Failure target copied from the selected pipeline with the delivery policy.
+    #[serde(default)]
+    pub failure_state: Option<String>,
     /// Closure without merge is retained for explicit operator recovery.
     #[serde(default)]
     pub closed_without_merge_parked: bool,
@@ -168,6 +171,19 @@ impl DeliveryStates {
 }
 
 impl DeliveryRecord {
+    fn is_frozen_delivery_state(&self, observed_state: &str) -> bool {
+        [
+            self.delivery_states.waiting.as_deref(),
+            self.delivery_states.checks_failed.as_deref(),
+            self.delivery_states.changes_requested.as_deref(),
+            self.delivery_states.approved.as_deref(),
+            self.delivery_states.closed_without_merge.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|state| state.eq_ignore_ascii_case(observed_state))
+    }
+
     pub(crate) fn delivery_state_fact(&self) -> Option<DeliveryStateFact> {
         if !self.review_ready() {
             return None;
@@ -354,9 +370,10 @@ fn terminal_delivery_outcome(
         .as_deref()
         .or(legacy_success_state)
         .expect("terminal delivery has a frozen or legacy success state");
+    let failure_state = delivery.failure_state.as_deref().or(legacy_failure_state);
     if observed_state.eq_ignore_ascii_case(success_state) {
         (TerminalOutcome::Succeeded, HISTORY_OUTCOME_SUCCEEDED)
-    } else if legacy_failure_state.is_some_and(|state| observed_state.eq_ignore_ascii_case(state)) {
+    } else if failure_state.is_some_and(|state| observed_state.eq_ignore_ascii_case(state)) {
         (TerminalOutcome::Failed, HISTORY_OUTCOME_FAILED)
     } else {
         (TerminalOutcome::Failed, HISTORY_OUTCOME_STOPPED)
@@ -1585,7 +1602,9 @@ impl Orchestrator {
                         continue;
                     }
                 };
-                let legacy_pipeline_config = if delivery.success_state.is_none() {
+                let legacy_pipeline_config = if delivery.success_state.is_none()
+                    || delivery.failure_state.is_none()
+                {
                     match self.current_config_for_snapshot(snapshot.as_ref()).await {
                         Ok(config) => Some(config),
                         Err(error) => {
@@ -1891,9 +1910,6 @@ impl Orchestrator {
         if !self.delivery_remote.supports_delivery_observation() {
             return delivery;
         }
-        if self.config.read().await.tracker.kind != "github" {
-            return delivery;
-        }
         let eligible = delivery.repositories.iter().any(|(_, repository)| {
             repository.mode == DeliveryMode::PushAndPr
                 && repository.phase == DeliveryPhase::Waiting
@@ -2157,7 +2173,7 @@ impl Orchestrator {
             .iter()
             .any(|state| state.eq_ignore_ascii_case(&observed.state));
         drop(config);
-        if terminal || !active {
+        if terminal || (!active && !candidate.is_frozen_delivery_state(&observed.state)) {
             return self
                 .block_review_projection(
                     candidate,
@@ -3220,11 +3236,17 @@ impl Orchestrator {
                 },
             );
         }
-        let (delivery_states, success_state) = {
+        let (delivery_states, success_state, failure_state) = {
             let state = self.state.read().await;
             state
                 .get_pipeline_config(issue_id)
-                .map(|config| (config.delivery_states.clone(), config.on_success.clone()))
+                .map(|config| {
+                    (
+                        config.delivery_states.clone(),
+                        config.on_success.clone(),
+                        config.on_failure.clone(),
+                    )
+                })
                 .unwrap_or_default()
         };
         Ok((
@@ -3237,6 +3259,7 @@ impl Orchestrator {
                 review_projection: None,
                 delivery_states,
                 success_state: Some(success_state),
+                failure_state: Some(failure_state),
                 closed_without_merge_parked: false,
                 selected_delivery_state: None,
             },
@@ -3363,6 +3386,7 @@ mod tests {
             review_projection: None,
             delivery_states: Default::default(),
             success_state: None,
+            failure_state: None,
             closed_without_merge_parked: false,
             selected_delivery_state: None,
         }
@@ -3470,6 +3494,23 @@ mod tests {
     }
 
     #[test]
+    fn terminal_recovery_uses_frozen_failure_state_after_config_drift() {
+        let mut record = delivery_with_observations(vec![observation_facts()]);
+        record.success_state = Some("Frozen done".to_string());
+        record.failure_state = Some("Frozen failed".to_string());
+
+        assert_eq!(
+            terminal_delivery_outcome(
+                &record,
+                "Frozen failed",
+                Some("Reloaded done"),
+                Some("Reloaded failed"),
+            ),
+            (TerminalOutcome::Failed, HISTORY_OUTCOME_FAILED)
+        );
+    }
+
+    #[test]
     fn merged_terminal_handoff_waits_for_an_in_flight_projection() {
         let mut record = delivery_with_observations(vec![observation_facts()]);
         record.review_projection = Some(ReviewProjection {
@@ -3548,6 +3589,7 @@ mod tests {
             review_projection: None,
             delivery_states: Default::default(),
             success_state: None,
+            failure_state: None,
             closed_without_merge_parked: false,
             selected_delivery_state: None,
         };
@@ -3581,6 +3623,7 @@ mod tests {
             }),
             delivery_states: Default::default(),
             success_state: None,
+            failure_state: None,
             closed_without_merge_parked: false,
             selected_delivery_state: None,
         };
@@ -3611,6 +3654,7 @@ mod tests {
             }),
             delivery_states: Default::default(),
             success_state: None,
+            failure_state: None,
             closed_without_merge_parked: false,
             selected_delivery_state: None,
         };
@@ -3649,6 +3693,7 @@ mod tests {
             }),
             delivery_states: Default::default(),
             success_state: None,
+            failure_state: None,
             closed_without_merge_parked: false,
             selected_delivery_state: None,
         };

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -15,13 +15,14 @@ use super::{
     FinalizeApprovalError, FinalizeRetryError, Orchestrator, HISTORY_OUTCOME_FAILED,
     HISTORY_OUTCOME_STOPPED, HISTORY_OUTCOME_SUCCEEDED,
 };
+use crate::config::ensemble::DeliveryStates;
 use crate::history::model::HistoryRecord;
 use crate::observability::events::PipelineEvent;
 use crate::orchestrator::delivery_observation::{
-    BaseFreshness, CheckConclusion, CheckStatus, DeliveryCheck, DeliveryObservation,
+    BaseFreshness, CheckConclusion, CheckStatus, CheckSummary, DeliveryCheck, DeliveryObservation,
     DeliveryObservationFacts, DeliveryObservationFailure, DeliveryObservationFailureKind,
-    DeliveryObservationRead, DeliveryObservationRetry, Mergeability, PullRequestTerminalState,
-    ReviewDecision,
+    DeliveryObservationRead, DeliveryObservationRetry, Mergeability, ObservationFreshness,
+    PullRequestTerminalState, ReviewDecision,
 };
 use crate::pipeline::engine::{PipelineRun, PipelineRunSnapshot};
 use crate::tracker::OwnershipConflict;
@@ -84,6 +85,26 @@ pub(crate) struct DeliveryRecord {
     pub terminal_history: Option<Box<HistoryRecord>>,
     #[serde(default)]
     pub review_projection: Option<ReviewProjection>,
+    /// Policy copied from the selected pipeline before any delivery I/O.
+    #[serde(default)]
+    pub delivery_states: DeliveryStates,
+    /// Success target copied from the selected pipeline with the delivery policy.
+    #[serde(default)]
+    pub success_state: Option<String>,
+    /// Closure without merge is retained for explicit operator recovery.
+    #[serde(default)]
+    pub closed_without_merge_parked: bool,
+    /// The exact fact and target selected from the frozen delivery policy before tracker I/O.
+    #[serde(default)]
+    pub selected_delivery_state: Option<DeliveryStateProjection>,
+}
+
+/// A versioned durable selection made from delivery evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DeliveryStateProjection {
+    pub schema_version: u8,
+    pub fact: DeliveryStateFact,
+    pub target: String,
 }
 
 /// The durable issue-level tracker projection owned by finalization delivery.
@@ -121,7 +142,108 @@ pub(crate) enum DeliveryAggregate {
     Blocked,
 }
 
+/// The single, precedence-ordered fact projected from retained delivery evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DeliveryStateFact {
+    Waiting,
+    ChecksFailed,
+    ChangesRequested,
+    Approved,
+    Merged,
+    ClosedWithoutMerge,
+}
+
+impl DeliveryStates {
+    fn target_for(&self, fact: DeliveryStateFact) -> Option<&str> {
+        match fact {
+            DeliveryStateFact::Waiting => self.waiting.as_deref(),
+            DeliveryStateFact::ChecksFailed => self.checks_failed.as_deref(),
+            DeliveryStateFact::ChangesRequested => self.changes_requested.as_deref(),
+            DeliveryStateFact::Approved => self.approved.as_deref(),
+            DeliveryStateFact::Merged => None,
+            DeliveryStateFact::ClosedWithoutMerge => self.closed_without_merge.as_deref(),
+        }
+    }
+}
+
 impl DeliveryRecord {
+    pub(crate) fn delivery_state_fact(&self) -> Option<DeliveryStateFact> {
+        if !self.review_ready() {
+            return None;
+        }
+        let repositories = self.repositories.values().collect::<Vec<_>>();
+        let observations = repositories
+            .iter()
+            .filter(|repository| repository.mode == DeliveryMode::PushAndPr)
+            .map(|repository| repository.observation.as_ref())
+            .collect::<Option<Vec<_>>>();
+        let Some(observations) = observations else {
+            return Some(DeliveryStateFact::Waiting);
+        };
+        if observations.iter().any(|observation| {
+            observation.freshness != ObservationFreshness::Fresh
+                || observation
+                    .facts
+                    .as_ref()
+                    .is_none_or(|facts| !facts.matches_delivery || facts.head_diverged)
+        }) {
+            return Some(DeliveryStateFact::Waiting);
+        }
+        let facts = observations
+            .iter()
+            .filter_map(|observation| observation.facts.as_ref())
+            .collect::<Vec<_>>();
+        if facts
+            .iter()
+            .any(|facts| facts.terminal_state == PullRequestTerminalState::ClosedWithoutMerge)
+        {
+            return Some(DeliveryStateFact::ClosedWithoutMerge);
+        }
+        let open_facts = facts
+            .iter()
+            .copied()
+            .filter(|facts| facts.terminal_state == PullRequestTerminalState::Open)
+            .collect::<Vec<_>>();
+        if open_facts
+            .iter()
+            .any(|facts| facts.review_decision == ReviewDecision::ChangesRequested)
+        {
+            return Some(DeliveryStateFact::ChangesRequested);
+        }
+        if open_facts
+            .iter()
+            .any(|facts| facts.check_summary == CheckSummary::Failing)
+        {
+            return Some(DeliveryStateFact::ChecksFailed);
+        }
+        if repositories.iter().all(|repository| match repository.mode {
+            DeliveryMode::Push => repository.phase == DeliveryPhase::Published,
+            DeliveryMode::PushAndPr => repository
+                .observation
+                .as_ref()
+                .and_then(|observation| observation.facts.as_ref())
+                .is_some_and(|facts| facts.terminal_state == PullRequestTerminalState::Merged),
+        }) {
+            return Some(DeliveryStateFact::Merged);
+        }
+        if repositories.iter().all(|repository| match repository.mode {
+            DeliveryMode::Push => repository.phase == DeliveryPhase::Published,
+            DeliveryMode::PushAndPr => repository
+                .observation
+                .as_ref()
+                .and_then(|observation| observation.facts.as_ref())
+                .is_some_and(|facts| {
+                    facts.terminal_state == PullRequestTerminalState::Merged
+                        || (facts.terminal_state == PullRequestTerminalState::Open
+                            && facts.review_decision == ReviewDecision::Approved
+                            && facts.check_summary == CheckSummary::Passing)
+                }),
+        }) {
+            return Some(DeliveryStateFact::Approved);
+        }
+        Some(DeliveryStateFact::Waiting)
+    }
     pub(crate) fn aggregate(&self) -> DeliveryAggregate {
         if self
             .review_projection
@@ -193,6 +315,51 @@ impl DeliveryRecord {
                         | DeliveryPhase::Published
                 )
             })
+    }
+
+    fn has_in_flight_review_projection(&self) -> bool {
+        self.review_projection
+            .as_ref()
+            .is_some_and(|projection| projection.phase == ReviewProjectionPhase::InFlight)
+    }
+
+    fn has_fresh_nonclosed_delivery_evidence(&self) -> bool {
+        self.review_ready()
+            && self
+                .repositories
+                .values()
+                .filter(|repository| repository.mode == DeliveryMode::PushAndPr)
+                .all(|repository| {
+                    repository.observation.as_ref().is_some_and(|observation| {
+                        observation.freshness == ObservationFreshness::Fresh
+                            && observation.facts.as_ref().is_some_and(|facts| {
+                                facts.matches_delivery
+                                    && !facts.head_diverged
+                                    && facts.terminal_state
+                                        != PullRequestTerminalState::ClosedWithoutMerge
+                            })
+                    })
+                })
+    }
+}
+
+fn terminal_delivery_outcome(
+    delivery: &DeliveryRecord,
+    observed_state: &str,
+    legacy_success_state: Option<&str>,
+    legacy_failure_state: Option<&str>,
+) -> (TerminalOutcome, &'static str) {
+    let success_state = delivery
+        .success_state
+        .as_deref()
+        .or(legacy_success_state)
+        .expect("terminal delivery has a frozen or legacy success state");
+    if observed_state.eq_ignore_ascii_case(success_state) {
+        (TerminalOutcome::Succeeded, HISTORY_OUTCOME_SUCCEEDED)
+    } else if legacy_failure_state.is_some_and(|state| observed_state.eq_ignore_ascii_case(state)) {
+        (TerminalOutcome::Failed, HISTORY_OUTCOME_FAILED)
+    } else {
+        (TerminalOutcome::Failed, HISTORY_OUTCOME_STOPPED)
     }
 }
 
@@ -1246,6 +1413,20 @@ impl Orchestrator {
 
         let mut candidate = current;
         let mut changed = false;
+        if candidate.closed_without_merge_parked {
+            // An operator retry does not replay publication. It only discards the retained
+            // closed observation and projection so recovery must obtain fresh PR evidence.
+            candidate.review_projection = None;
+            candidate.selected_delivery_state = None;
+            for repository in candidate.repositories.values_mut() {
+                if repository.mode == DeliveryMode::PushAndPr
+                    && repository.phase == DeliveryPhase::Waiting
+                {
+                    repository.observation = None;
+                }
+            }
+            changed = true;
+        }
         for repository in candidate.repositories.values_mut() {
             if repository.phase != DeliveryPhase::Blocked {
                 continue;
@@ -1404,34 +1585,33 @@ impl Orchestrator {
                         continue;
                     }
                 };
-                let pipeline_config = match self
-                    .current_config_for_snapshot(snapshot.as_ref())
-                    .await
-                {
-                    Ok(config) => config,
-                    Err(error) => {
-                        warn!(
-                            issue_id = %delivery.issue_id,
-                            error = %error,
-                            "terminal delivery reconciliation could not resolve its selected workflow"
-                        );
-                        continue;
+                let legacy_pipeline_config = if delivery.success_state.is_none() {
+                    match self.current_config_for_snapshot(snapshot.as_ref()).await {
+                        Ok(config) => Some(config),
+                        Err(error) => {
+                            warn!(
+                                issue_id = %delivery.issue_id,
+                                error = %error,
+                                "terminal delivery reconciliation could not resolve its legacy selected workflow"
+                            );
+                            continue;
+                        }
                     }
-                };
-                let success_state = &pipeline_config.on_success;
-                let failure_state = &pipeline_config.on_failure;
-                let outcome = if issue.state.eq_ignore_ascii_case(success_state) {
-                    TerminalOutcome::Succeeded
                 } else {
-                    TerminalOutcome::Failed
+                    None
                 };
-                let history_outcome = if issue.state.eq_ignore_ascii_case(success_state) {
-                    HISTORY_OUTCOME_SUCCEEDED
-                } else if issue.state.eq_ignore_ascii_case(failure_state) {
-                    HISTORY_OUTCOME_FAILED
-                } else {
-                    HISTORY_OUTCOME_STOPPED
-                };
+                let legacy_success_state = legacy_pipeline_config
+                    .as_ref()
+                    .map(|config| config.on_success.as_str());
+                let legacy_failure_state = legacy_pipeline_config
+                    .as_ref()
+                    .map(|config| config.on_failure.as_str());
+                let (outcome, history_outcome) = terminal_delivery_outcome(
+                    &delivery,
+                    &issue.state,
+                    legacy_success_state,
+                    legacy_failure_state,
+                );
                 self.reconcile_terminal_delivery_owner(&delivery, issue, outcome, history_outcome)
                     .await;
             } else {
@@ -1560,7 +1740,16 @@ impl Orchestrator {
             let delivery = self
                 .evaluate_post_final_acceptance(delivery, snapshot.as_ref())
                 .await;
-            let delivery = self.advance_review_projection(delivery).await;
+            // Records created before delivery-state projection retain the original projection
+            // without a selected fact. Reconcile that durable in-flight write before reading
+            // newer delivery facts, so an upgrade cannot abandon an ambiguous tracker mutation.
+            let delivery = if delivery.selected_delivery_state.is_none()
+                && delivery.review_projection.is_some()
+            {
+                self.advance_review_projection(delivery).await
+            } else {
+                delivery
+            };
             if delivery.aggregate() == DeliveryAggregate::Published {
                 self.complete_published_delivery(&delivery, snapshot.as_ref())
                     .await;
@@ -1569,6 +1758,76 @@ impl Orchestrator {
             let delivery = self
                 .reconcile_delivery_observations(delivery, snapshot.as_ref())
                 .await;
+            let fact = delivery.delivery_state_fact();
+            let delivery = if fact != Some(DeliveryStateFact::ClosedWithoutMerge)
+                && delivery.has_fresh_nonclosed_delivery_evidence()
+            {
+                self.clear_closed_without_merge_park(delivery).await
+            } else {
+                delivery
+            };
+            if fact == Some(DeliveryStateFact::Merged)
+                && delivery.delivery_states.merged.as_deref() == Some("on_success")
+            {
+                if delivery.has_in_flight_review_projection() {
+                    // A previously persisted intermediate write remains ambiguous until its
+                    // exact target has been reconciled. Never begin terminal cleanup first.
+                    self.advance_review_projection(delivery).await;
+                    continue;
+                }
+                let Some(target_state) = delivery.success_state.clone() else {
+                    warn!(issue_id = %delivery.issue_id, "merged delivery has no frozen success target");
+                    continue;
+                };
+                let selection = DeliveryStateProjection {
+                    schema_version: 1,
+                    fact: DeliveryStateFact::Merged,
+                    target: target_state.clone(),
+                };
+                let delivery = if delivery.selected_delivery_state.as_ref() != Some(&selection) {
+                    let mut updated = delivery;
+                    updated.selected_delivery_state = Some(selection);
+                    if self.persist_delivery_record(&updated, None).await.is_err() {
+                        continue;
+                    }
+                    updated
+                } else {
+                    delivery
+                };
+                let Some(history) = self
+                    .projected_terminal_history(&delivery, HISTORY_OUTCOME_SUCCEEDED)
+                    .await
+                else {
+                    warn!(
+                        issue_id = %delivery.issue_id,
+                        "merged delivery has no durable completion history"
+                    );
+                    continue;
+                };
+                self.begin_terminal_transition_for_identity(
+                    &delivery.issue_id,
+                    &delivery.identifier,
+                    None,
+                    TerminalOutcome::Succeeded,
+                    target_state,
+                    Some(history),
+                )
+                .await;
+                continue;
+            }
+            if fact == Some(DeliveryStateFact::ClosedWithoutMerge) {
+                let delivery = self.park_closed_without_merge(delivery).await;
+                let delivery = self.advance_delivery_state_projection(delivery).await;
+                self.project_delivery_artifacts(&delivery.issue_id, &delivery)
+                    .await;
+                let finalize = Self::finalize_state_from_delivery(&delivery);
+                self.state
+                    .write()
+                    .await
+                    .set_finalize_state(&delivery.issue_id, finalize);
+                continue;
+            }
+            let delivery = self.advance_delivery_state_projection(delivery).await;
             if matches!(
                 delivery.aggregate(),
                 DeliveryAggregate::Waiting | DeliveryAggregate::Blocked
@@ -1967,6 +2226,112 @@ impl Orchestrator {
                 .await
             }
         }
+    }
+
+    async fn advance_delivery_state_projection(
+        &self,
+        mut delivery: DeliveryRecord,
+    ) -> DeliveryRecord {
+        let Some(fact) = delivery.delivery_state_fact() else {
+            return delivery;
+        };
+        let Some(target) = delivery.delivery_states.target_for(fact) else {
+            return delivery;
+        };
+        let selection = DeliveryStateProjection {
+            schema_version: 1,
+            fact,
+            target: target.to_string(),
+        };
+        let selection_changed = delivery.selected_delivery_state.as_ref() != Some(&selection);
+        if selection_changed
+            && delivery
+                .review_projection
+                .as_ref()
+                .is_some_and(|projection| projection.phase == ReviewProjectionPhase::InFlight)
+        {
+            // An ambiguous tracker write must reconcile the durable in-flight target before
+            // newer remote facts are allowed to select another projection.
+            return self.advance_review_projection(delivery).await;
+        }
+        if delivery.review_projection.is_none() || selection_changed {
+            let history_record = delivery
+                .terminal_history
+                .as_deref()
+                .cloned()
+                .map(|mut record| {
+                    record.outcome = "delivery_projected".to_string();
+                    record
+                });
+            delivery.review_projection = Some(ReviewProjection {
+                target: target.to_string(),
+                repositories: delivery.repositories.keys().cloned().collect(),
+                phase: ReviewProjectionPhase::Pending,
+                diagnostic: None,
+                last_observed_state: None,
+                history_record,
+                history_persisted: false,
+            });
+            delivery.selected_delivery_state = Some(selection);
+            if self.persist_delivery_record(&delivery, None).await.is_err() {
+                return delivery;
+            }
+        }
+        self.advance_review_projection(delivery).await
+    }
+
+    pub(super) async fn park_closed_without_merge(
+        &self,
+        mut delivery: DeliveryRecord,
+    ) -> DeliveryRecord {
+        if !delivery.closed_without_merge_parked {
+            delivery.closed_without_merge_parked = true;
+            if self.persist_delivery_record(&delivery, None).await.is_err() {
+                return delivery;
+            }
+        }
+        let Some(reporter) = self.attention_reporter.as_ref() else {
+            return delivery;
+        };
+        let observation = closed_without_merge_attention(&delivery);
+        match observation {
+            Ok(observation) => {
+                if let Err(error) = reporter.upsert_open(observation).await {
+                    warn!(issue_id = %delivery.issue_id, error = %error, "failed to persist closed-without-merge operator attention");
+                }
+            }
+            Err(error) => {
+                warn!(issue_id = %delivery.issue_id, error = %error, "could not create closed-without-merge operator attention")
+            }
+        }
+        delivery
+    }
+
+    pub(super) async fn clear_closed_without_merge_park(
+        &self,
+        mut delivery: DeliveryRecord,
+    ) -> DeliveryRecord {
+        if !delivery.closed_without_merge_parked {
+            return delivery;
+        }
+        if let Some(reporter) = self.attention_reporter.as_ref() {
+            let close = match closed_without_merge_attention_close(&delivery) {
+                Ok(close) => close,
+                Err(error) => {
+                    warn!(issue_id = %delivery.issue_id, error = %error, "could not create closed-without-merge attention resolution");
+                    return delivery;
+                }
+            };
+            if let Err(error) = reporter.resolve(close).await {
+                warn!(issue_id = %delivery.issue_id, error = %error, "failed to resolve closed-without-merge operator attention");
+                return delivery;
+            }
+        }
+        delivery.closed_without_merge_parked = false;
+        if self.persist_delivery_record(&delivery, None).await.is_err() {
+            return delivery;
+        }
+        delivery
     }
 
     async fn block_review_projection(
@@ -2746,7 +3111,7 @@ impl Orchestrator {
             retry: None,
             snapshot,
             terminal_transition: None,
-            delivery: Some(delivery.clone()),
+            delivery: Some(Box::new(delivery.clone())),
         };
         let transaction = self
             .pipeline_journal
@@ -2855,26 +3220,13 @@ impl Orchestrator {
                 },
             );
         }
-        let review_state = repository_keys.iter().find_map(|repository_key| {
-            configured_repositories
-                .get(repository_key)
-                .and_then(|config| config.finalize.review_state.clone())
-        });
-        let mut review_repositories = configured_repositories
-            .iter()
-            .filter_map(|(repository_key, config)| {
-                (config.finalize.enabled && config.finalize.mode != FinalizeMode::None)
-                    .then_some(repository_key.clone())
-            })
-            .collect::<Vec<_>>();
-        review_repositories.sort();
-        let review_history = terminal_history.clone().map(|mut record| {
-            record.outcome = "in_review".to_string();
-            record
-        });
-        if review_state.is_some() && review_history.is_none() {
-            return Err("review projection requires a live run history record".to_string());
-        }
+        let (delivery_states, success_state) = {
+            let state = self.state.read().await;
+            state
+                .get_pipeline_config(issue_id)
+                .map(|config| (config.delivery_states.clone(), config.on_success.clone()))
+                .unwrap_or_default()
+        };
         Ok((
             DeliveryRecord {
                 issue_id: issue_id.to_string(),
@@ -2882,19 +3234,53 @@ impl Orchestrator {
                 run_id,
                 repositories,
                 terminal_history: terminal_history.map(Box::new),
-                review_projection: review_state.map(|target| ReviewProjection {
-                    target,
-                    repositories: review_repositories,
-                    phase: ReviewProjectionPhase::Pending,
-                    diagnostic: None,
-                    last_observed_state: None,
-                    history_record: review_history,
-                    history_persisted: false,
-                }),
+                review_projection: None,
+                delivery_states,
+                success_state: Some(success_state),
+                closed_without_merge_parked: false,
+                selected_delivery_state: None,
             },
             snapshot,
         ))
     }
+}
+
+fn closed_without_merge_attention(
+    delivery: &DeliveryRecord,
+) -> Result<crate::attention::AttentionUpsert, crate::attention::AttentionError> {
+    Ok(crate::attention::AttentionUpsert::new(
+        crate::attention::AttentionIdentity::new(
+            "runtime.delivery",
+            &delivery.issue_id,
+            "runtime.delivery.closed_without_merge",
+        )?,
+        crate::attention::AttentionPresentation::new(
+            format!("{} has a pull request closed without merge", delivery.identifier),
+            "Resolve the pull request externally, then explicitly retry finalization to obtain fresh delivery evidence.",
+            vec![],
+        )?,
+        crate::attention::AttentionEvidence::new(format!(
+            "run:{}:closed_without_merge",
+            delivery.run_id
+        ))?,
+    ))
+}
+
+fn closed_without_merge_attention_close(
+    delivery: &DeliveryRecord,
+) -> Result<crate::attention::AttentionClose, crate::attention::AttentionError> {
+    crate::attention::AttentionClose::new(
+        crate::attention::AttentionIdentity::new(
+            "runtime.delivery",
+            &delivery.issue_id,
+            "runtime.delivery.closed_without_merge",
+        )?,
+        format!("run:{}:closed_without_merge", delivery.run_id),
+        crate::attention::AttentionEvidence::new(format!(
+            "run:{}:closed_without_merge:recovered",
+            delivery.run_id
+        ))?,
+    )
 }
 
 #[cfg(test)]
@@ -2937,6 +3323,192 @@ mod tests {
         }
     }
 
+    fn observed_repository(facts: DeliveryObservationFacts) -> DeliveryRepository {
+        let mut repository = repository(DeliveryPhase::Waiting);
+        repository.observed_remote_sha = Some(repository.local_sha.clone());
+        repository.pr_number = Some(facts.pull_request_number);
+        repository.pr_url = Some(facts.pull_request_url.clone());
+        repository.observation = Some(DeliveryObservation::successful(facts, Utc::now()));
+        repository
+    }
+
+    fn observation_facts() -> DeliveryObservationFacts {
+        DeliveryObservationFacts {
+            pull_request_number: 420,
+            pull_request_url: "https://github.com/example/project/pull/420".to_string(),
+            head_sha: "0123456789abcdef".to_string(),
+            matches_delivery: true,
+            head_diverged: false,
+            terminal_state: PullRequestTerminalState::Open,
+            mergeability: Mergeability::Mergeable,
+            base_freshness: BaseFreshness::UpToDate,
+            checks: vec![],
+            check_summary: CheckSummary::Passing,
+            review_decision: ReviewDecision::ReviewRequired,
+        }
+    }
+
+    fn delivery_with_observations(observations: Vec<DeliveryObservationFacts>) -> DeliveryRecord {
+        let repositories = observations
+            .into_iter()
+            .enumerate()
+            .map(|(index, facts)| (format!("repo-{index}"), observed_repository(facts)))
+            .collect();
+        DeliveryRecord {
+            issue_id: "issue-420".to_string(),
+            identifier: "ensemble#420".to_string(),
+            run_id: "run-420".to_string(),
+            repositories,
+            terminal_history: None,
+            review_projection: None,
+            delivery_states: Default::default(),
+            success_state: None,
+            closed_without_merge_parked: false,
+            selected_delivery_state: None,
+        }
+    }
+
+    #[test]
+    fn delivery_state_facts_use_documented_precedence() {
+        let mut closed = observation_facts();
+        closed.terminal_state = PullRequestTerminalState::ClosedWithoutMerge;
+        let mut changes_requested = observation_facts();
+        changes_requested.review_decision = ReviewDecision::ChangesRequested;
+        let mut failed = observation_facts();
+        failed.check_summary = CheckSummary::Failing;
+        let mut merged = observation_facts();
+        merged.terminal_state = PullRequestTerminalState::Merged;
+        let mut approved = observation_facts();
+        approved.review_decision = ReviewDecision::Approved;
+
+        assert_eq!(
+            delivery_with_observations(vec![closed, changes_requested.clone(), failed.clone()])
+                .delivery_state_fact(),
+            Some(DeliveryStateFact::ClosedWithoutMerge)
+        );
+        assert_eq!(
+            delivery_with_observations(vec![changes_requested, failed.clone()])
+                .delivery_state_fact(),
+            Some(DeliveryStateFact::ChangesRequested)
+        );
+        assert_eq!(
+            delivery_with_observations(vec![failed]).delivery_state_fact(),
+            Some(DeliveryStateFact::ChecksFailed)
+        );
+        assert_eq!(
+            delivery_with_observations(vec![merged]).delivery_state_fact(),
+            Some(DeliveryStateFact::Merged)
+        );
+        assert_eq!(
+            delivery_with_observations(vec![approved]).delivery_state_fact(),
+            Some(DeliveryStateFact::Approved)
+        );
+        let mut merged_with_stale_blocker = observation_facts();
+        merged_with_stale_blocker.terminal_state = PullRequestTerminalState::Merged;
+        merged_with_stale_blocker.review_decision = ReviewDecision::ChangesRequested;
+        let mut still_open_and_approved = observation_facts();
+        still_open_and_approved.review_decision = ReviewDecision::Approved;
+        assert_eq!(
+            delivery_with_observations(vec![merged_with_stale_blocker.clone()])
+                .delivery_state_fact(),
+            Some(DeliveryStateFact::Merged)
+        );
+        assert_eq!(
+            delivery_with_observations(vec![merged_with_stale_blocker, still_open_and_approved])
+                .delivery_state_fact(),
+            Some(DeliveryStateFact::Approved)
+        );
+        assert_eq!(
+            delivery_with_observations(vec![observation_facts()]).delivery_state_fact(),
+            Some(DeliveryStateFact::Waiting)
+        );
+    }
+
+    #[test]
+    fn stale_or_incomplete_observations_select_waiting() {
+        let mut record = delivery_with_observations(vec![observation_facts()]);
+        record.repositories.get_mut("repo-0").unwrap().observation = None;
+
+        assert_eq!(
+            record.delivery_state_fact(),
+            Some(DeliveryStateFact::Waiting)
+        );
+    }
+
+    #[test]
+    fn selected_delivery_fact_and_target_round_trip_durably() {
+        let mut record = delivery_with_observations(vec![observation_facts()]);
+        record.selected_delivery_state = Some(DeliveryStateProjection {
+            schema_version: 1,
+            fact: DeliveryStateFact::Waiting,
+            target: "In review".to_string(),
+        });
+
+        let restored =
+            serde_json::from_str::<DeliveryRecord>(&serde_json::to_string(&record).unwrap())
+                .unwrap();
+        assert_eq!(
+            restored.selected_delivery_state,
+            record.selected_delivery_state
+        );
+    }
+
+    #[test]
+    fn terminal_recovery_uses_frozen_success_state_after_config_drift() {
+        let mut record = delivery_with_observations(vec![observation_facts()]);
+        record.success_state = Some("Frozen done".to_string());
+
+        assert_eq!(
+            terminal_delivery_outcome(
+                &record,
+                "Frozen done",
+                Some("Reloaded done"),
+                Some("Reloaded failed"),
+            ),
+            (TerminalOutcome::Succeeded, HISTORY_OUTCOME_SUCCEEDED)
+        );
+    }
+
+    #[test]
+    fn merged_terminal_handoff_waits_for_an_in_flight_projection() {
+        let mut record = delivery_with_observations(vec![observation_facts()]);
+        record.review_projection = Some(ReviewProjection {
+            target: "In review".to_string(),
+            repositories: vec!["repo-0".to_string()],
+            phase: ReviewProjectionPhase::InFlight,
+            diagnostic: None,
+            last_observed_state: None,
+            history_record: None,
+            history_persisted: false,
+        });
+
+        assert!(record.has_in_flight_review_projection());
+    }
+
+    #[test]
+    fn closed_without_merge_attention_is_idempotent_across_restart() {
+        let record = delivery_with_observations(vec![observation_facts()]);
+
+        let first = closed_without_merge_attention(&record).unwrap();
+        let restored =
+            serde_json::from_str::<DeliveryRecord>(&serde_json::to_string(&record).unwrap())
+                .unwrap();
+        let second = closed_without_merge_attention(&restored).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.identity.kind, "runtime.delivery.closed_without_merge");
+    }
+
+    #[test]
+    fn closed_without_merge_attention_can_be_resolved_after_recovery() {
+        let record = delivery_with_observations(vec![observation_facts()]);
+        let open = closed_without_merge_attention(&record).unwrap();
+        let close = closed_without_merge_attention_close(&record).unwrap();
+
+        assert_eq!(close.identity, open.identity);
+        assert_eq!(close.expected_fingerprint, open.evidence.fingerprint);
+    }
+
     #[test]
     fn legacy_status_contexts_contribute_to_the_complete_check_summary() {
         let success = serde_json::json!({"context": "ci", "state": "SUCCESS"});
@@ -2974,6 +3546,10 @@ mod tests {
             repositories,
             terminal_history: None,
             review_projection: None,
+            delivery_states: Default::default(),
+            success_state: None,
+            closed_without_merge_parked: false,
+            selected_delivery_state: None,
         };
 
         assert_eq!(record.aggregate(), DeliveryAggregate::Waiting);
@@ -3003,6 +3579,10 @@ mod tests {
                 history_record: None,
                 history_persisted: false,
             }),
+            delivery_states: Default::default(),
+            success_state: None,
+            closed_without_merge_parked: false,
+            selected_delivery_state: None,
         };
 
         assert!(record.review_ready());
@@ -3029,6 +3609,10 @@ mod tests {
                 history_record: None,
                 history_persisted: false,
             }),
+            delivery_states: Default::default(),
+            success_state: None,
+            closed_without_merge_parked: false,
+            selected_delivery_state: None,
         };
 
         assert!(!record.review_ready());
@@ -3063,6 +3647,10 @@ mod tests {
                 history_record: None,
                 history_persisted: false,
             }),
+            delivery_states: Default::default(),
+            success_state: None,
+            closed_without_merge_parked: false,
+            selected_delivery_state: None,
         };
 
         assert!(!record.review_ready());

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -15955,6 +15955,7 @@ mod tests {
             review_projection: None,
             delivery_states: Default::default(),
             success_state: None,
+            failure_state: None,
             closed_without_merge_parked: false,
             selected_delivery_state: None,
         };
@@ -16246,6 +16247,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn review_projection_advances_from_an_earlier_frozen_delivery_state() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, delivery) =
+            recovery_test_orchestrator(remote).await;
+        let tracker = Arc::new(ReviewProjectionTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "In review")])),
+            journal: orchestrator.pipeline_journal.clone(),
+            issue_id: "1".to_string(),
+            writes: AtomicUsize::new(0),
+            saw_in_flight_before_write: AtomicBool::new(false),
+            fail_reads: false,
+        });
+        orchestrator.tracker = tracker.clone();
+        let mut delivery = review_ready_delivery(delivery);
+        delivery.delivery_states.waiting = Some("In review".to_string());
+        delivery.delivery_states.checks_failed = Some("CI failed".to_string());
+        delivery.selected_delivery_state =
+            Some(crate::orchestrator::delivery::DeliveryStateProjection {
+                schema_version: 1,
+                fact: crate::orchestrator::delivery::DeliveryStateFact::ChecksFailed,
+                target: "CI failed".to_string(),
+            });
+        delivery.review_projection.as_mut().unwrap().target = "CI failed".to_string();
+        orchestrator
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+
+        let applied = orchestrator.advance_review_projection(delivery).await;
+
+        assert_eq!(
+            applied.review_projection.as_ref().unwrap().phase,
+            crate::orchestrator::delivery::ReviewProjectionPhase::Applied
+        );
+        assert_eq!(tracker.writes.load(Ordering::SeqCst), 1);
+        assert_eq!(tracker.issues.read().await[0].state, "CI failed");
+    }
+
+    #[tokio::test]
     async fn review_projection_retains_unreadable_and_unexpected_observations_as_blocked() {
         for (state, fail_reads) in [("In Progress", true), ("Done", false)] {
             let remote = Arc::new(RecoveryDeliveryRemote {
@@ -16418,7 +16463,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn closed_delivery_retry_keeps_attention_until_fresh_open_observation() {
+    async fn closed_delivery_retry_observes_github_pr_with_todo_tracker() {
         let inner = Arc::new(RecoveryDeliveryRemote {
             pull_requests: std::sync::Mutex::new(Vec::new()),
             pushes: AtomicUsize::new(0),
@@ -16475,7 +16520,7 @@ mod tests {
             inner: inner.clone(),
             observations: std::sync::Mutex::new(vec![retryable, open]),
         });
-        orchestrator.config.write().await.tracker.kind = "github".to_string();
+        assert_eq!(orchestrator.config.read().await.tracker.kind, "todo_file");
         let workspace = orchestrator
             .workspace_mgr
             .prepare_workspace("1", "repo#1")
@@ -17827,6 +17872,7 @@ mod tests {
             review_projection: None,
             delivery_states: Default::default(),
             success_state: None,
+            failure_state: None,
             closed_without_merge_parked: false,
             selected_delivery_state: None,
         }

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -9322,7 +9322,7 @@ impl Orchestrator {
                 .issue_run_ids
                 .insert(record.issue_id.clone(), delivery.run_id.clone());
             state.set_finalize_state(&record.issue_id, finalize);
-            state.delivery.insert(record.issue_id.clone(), delivery);
+            state.delivery.insert(record.issue_id.clone(), *delivery);
             return Ok(());
         }
         let snapshot = record
@@ -13214,6 +13214,10 @@ mod tests {
         InteractionKind, InteractionRequest, InteractionResponse, InteractionResumeStrategy,
         InteractionStatus, InteractionStore,
     };
+    use crate::orchestrator::delivery_observation::{
+        BaseFreshness, CheckSummary, DeliveryObservation, DeliveryObservationFacts, Mergeability,
+        PullRequestTerminalState, ReviewDecision,
+    };
     use crate::orchestrator::pipeline_journal::{PipelineTransitionInput, PipelineTransitionKind};
     use crate::orchestrator::retry::current_time_ms;
     use crate::pipeline::verdict::{StepOutput, StepResult};
@@ -15139,7 +15143,6 @@ mod tests {
                     enabled: true,
                     mode: FinalizeMode::Push,
                     approval_required: true,
-                    review_state: None,
                 },
             },
         )
@@ -15246,8 +15249,9 @@ mod tests {
         let (repo_temp, mut repo_config) = create_finalize_repo().await;
         repo_config.finalize.mode = FinalizeMode::PushAndPr;
         repo_config.finalize.approval_required = false;
-        repo_config.finalize.review_state = Some("In review".to_string());
-        let config = Arc::new(RwLock::new(make_config()));
+        let mut config = make_config();
+        config.delivery_states.waiting = Some("In review".to_string());
+        let config = Arc::new(RwLock::new(config));
         let issue = test_issue("1", "Todo");
         let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
             issues: Arc::new(RwLock::new(vec![issue.clone()])),
@@ -15317,10 +15321,14 @@ mod tests {
         );
         assert_eq!(delivery.repositories["source-repo"].pr_number, Some(420));
         assert!(delivery.terminal_history.is_some());
-        assert_eq!(
-            delivery.review_projection.as_ref().unwrap().phase,
-            crate::orchestrator::delivery::ReviewProjectionPhase::Applied
-        );
+        assert!(matches!(
+            delivery.review_projection.as_ref(),
+            Some(crate::orchestrator::delivery::ReviewProjection {
+                target,
+                phase: crate::orchestrator::delivery::ReviewProjectionPhase::Applied,
+                ..
+            }) if target == "In review"
+        ));
         assert!(!state.is_running(&issue.id));
         assert!(state.is_claimed(&issue.id));
         assert!(!state.completed.contains_key(&issue.id));
@@ -15603,6 +15611,13 @@ mod tests {
         identity_failures: AtomicUsize,
     }
 
+    struct SequencedObservationRemote {
+        inner: Arc<RecoveryDeliveryRemote>,
+        observations: std::sync::Mutex<
+            Vec<crate::orchestrator::delivery_observation::DeliveryObservationRead>,
+        >,
+    }
+
     struct ReviewProjectionTracker {
         issues: Arc<RwLock<Vec<Issue>>>,
         journal: PipelineRunJournal,
@@ -15754,6 +15769,66 @@ mod tests {
     }
 
     #[async_trait]
+    impl crate::orchestrator::delivery::DeliveryRemote for SequencedObservationRemote {
+        fn supports_delivery_observation(&self) -> bool {
+            true
+        }
+        async fn local_identity(
+            &self,
+            path: &Path,
+        ) -> Result<crate::orchestrator::delivery::LocalRepositoryIdentity, String> {
+            self.inner.local_identity(path).await
+        }
+        async fn remote_head(
+            &self,
+            path: &Path,
+            remote: &str,
+            head: &str,
+        ) -> Result<Option<String>, String> {
+            self.inner.remote_head(path, remote, head).await
+        }
+        async fn push(
+            &self,
+            path: &Path,
+            remote: &str,
+            head: &str,
+            sha: &str,
+        ) -> Result<(), String> {
+            self.inner.push(path, remote, head, sha).await
+        }
+        async fn list_pull_requests(
+            &self,
+            path: &Path,
+            key: &str,
+            policy: Option<&crate::orchestrator::delivery::PullRequestAdoptionPolicy>,
+        ) -> Result<Vec<crate::orchestrator::delivery::RemotePullRequest>, String> {
+            self.inner.list_pull_requests(path, key, policy).await
+        }
+        async fn create_pull_request(
+            &self,
+            path: &Path,
+            base: &str,
+            head: &str,
+            marker: &str,
+        ) -> Result<(), String> {
+            self.inner
+                .create_pull_request(path, base, head, marker)
+                .await
+        }
+        async fn observe_pull_request(
+            &self,
+            _path: &Path,
+            _number: u64,
+            _url: &str,
+            _base: &str,
+            _head: &str,
+            _remote: &str,
+        ) -> crate::orchestrator::delivery_observation::DeliveryObservationRead {
+            self.observations.lock().unwrap().remove(0)
+        }
+    }
+
+    #[async_trait]
     impl crate::orchestrator::delivery::DeliveryRemote for FailOnceIdentityRemote {
         async fn local_identity(
             &self,
@@ -15878,6 +15953,10 @@ mod tests {
             .collect(),
             terminal_history: Some(Box::new(review_projection_history())),
             review_projection: None,
+            delivery_states: Default::default(),
+            success_state: None,
+            closed_without_merge_parked: false,
+            selected_delivery_state: None,
         };
         orchestrator
             .persist_delivery_record(&delivery, None)
@@ -16062,6 +16141,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn merged_delivery_without_durable_history_retains_ownership() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(remote).await;
+        let tracker = Arc::new(ReviewProjectionTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "In Progress")])),
+            journal: orchestrator.pipeline_journal.clone(),
+            issue_id: "1".to_string(),
+            writes: AtomicUsize::new(0),
+            saw_in_flight_before_write: AtomicBool::new(false),
+            fail_reads: false,
+        });
+        orchestrator.tracker = tracker.clone();
+        orchestrator.config.write().await.delivery_states.merged = Some("on_success".to_string());
+        orchestrator.config.write().await.on_success = "Done".to_string();
+
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
+        repository.observation = Some(DeliveryObservation::successful(
+            DeliveryObservationFacts {
+                pull_request_number: 420,
+                pull_request_url: "https://github.com/example/project/pull/420".to_string(),
+                head_sha: repository.local_sha.clone(),
+                matches_delivery: true,
+                head_diverged: false,
+                terminal_state: PullRequestTerminalState::Merged,
+                mergeability: Mergeability::Mergeable,
+                base_freshness: BaseFreshness::UpToDate,
+                checks: vec![],
+                check_summary: CheckSummary::Passing,
+                review_decision: ReviewDecision::Approved,
+            },
+            Utc::now(),
+        ));
+        delivery.terminal_history = None;
+        delivery.review_projection = None;
+        delivery.delivery_states.merged = Some("on_success".to_string());
+        delivery.success_state = Some("Done".to_string());
+        orchestrator
+            .persist_delivery_record(&delivery, None)
+            .await
+            .unwrap();
+
+        orchestrator.reconcile_and_recover_deliveries().await;
+
+        let state = orchestrator.state.read().await;
+        assert!(state.delivery.contains_key("1"));
+        assert!(state.is_claimed("1"));
+        assert!(!state.pending_terminal_transitions.contains_key("1"));
+        assert!(!state.completed.contains_key("1"));
+        drop(state);
+        assert_eq!(tracker.writes.load(Ordering::SeqCst), 0);
+        assert!(workspace.path().exists());
+        let records = orchestrator
+            .pipeline_journal
+            .read_records_for_issue("1")
+            .await
+            .unwrap();
+        assert!(records
+            .iter()
+            .all(|record| record.kind != PipelineTransitionKind::Released));
+    }
+
+    #[tokio::test]
     async fn review_projection_adopts_already_target_state_without_write() {
         let remote = Arc::new(RecoveryDeliveryRemote {
             pull_requests: std::sync::Mutex::new(Vec::new()),
@@ -16176,6 +16326,188 @@ mod tests {
         );
         assert!(projection.diagnostic.is_none());
         assert_eq!(state.finalize["1"].status, FinalizeStatus::InProgress);
+    }
+
+    #[tokio::test]
+    async fn finalize_retry_requeues_a_closed_delivery_without_republishing() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(remote.clone()).await;
+        let reporter = orchestrator.attention_reporter.clone().unwrap();
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
+        repository.observation = Some(DeliveryObservation::successful(
+            DeliveryObservationFacts {
+                pull_request_number: 420,
+                pull_request_url: "https://github.com/example/project/pull/420".to_string(),
+                head_sha: repository.local_sha.clone(),
+                matches_delivery: true,
+                head_diverged: false,
+                terminal_state: PullRequestTerminalState::ClosedWithoutMerge,
+                mergeability: Mergeability::Mergeable,
+                base_freshness: BaseFreshness::UpToDate,
+                checks: vec![],
+                check_summary: CheckSummary::Passing,
+                review_decision: ReviewDecision::Approved,
+            },
+            Utc::now(),
+        ));
+        delivery.closed_without_merge_parked = false;
+        delivery.review_projection = Some(crate::orchestrator::delivery::ReviewProjection {
+            target: "Closed without merge".to_string(),
+            repositories: vec!["source-repo".to_string()],
+            phase: crate::orchestrator::delivery::ReviewProjectionPhase::Applied,
+            diagnostic: None,
+            last_observed_state: Some("Closed without merge".to_string()),
+            history_record: None,
+            history_persisted: false,
+        });
+        let delivery = orchestrator.park_closed_without_merge(delivery).await;
+        assert_eq!(reporter.items_for_subject("1").await.unwrap().len(), 1);
+
+        assert_eq!(
+            orchestrator
+                .retry_finalize_delivery("1", &delivery.identifier)
+                .await,
+            Ok(())
+        );
+
+        let retained = orchestrator.state.read().await.delivery["1"].clone();
+        let repository = &retained.repositories["source-repo"];
+        assert!(retained.closed_without_merge_parked);
+        assert!(retained.review_projection.is_none());
+        assert!(retained.selected_delivery_state.is_none());
+        assert!(repository.observation.is_none());
+        assert_eq!(repository.pr_number, Some(420));
+        assert_eq!(repository.phase, DeliveryPhase::Waiting);
+        assert_eq!(remote.pushes.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(remote.lists.load(Ordering::SeqCst), 0);
+
+        let mut fresh = retained;
+        fresh
+            .repositories
+            .get_mut("source-repo")
+            .unwrap()
+            .observation = Some(DeliveryObservation::successful(
+            DeliveryObservationFacts {
+                pull_request_number: 420,
+                pull_request_url: "https://github.com/example/project/pull/420".to_string(),
+                head_sha: "0123456789abcdef".to_string(),
+                matches_delivery: true,
+                head_diverged: false,
+                terminal_state: PullRequestTerminalState::Open,
+                mergeability: Mergeability::Mergeable,
+                base_freshness: BaseFreshness::UpToDate,
+                checks: vec![],
+                check_summary: CheckSummary::Passing,
+                review_decision: ReviewDecision::ReviewRequired,
+            },
+            Utc::now(),
+        ));
+        let resolved = orchestrator.clear_closed_without_merge_park(fresh).await;
+        assert!(!resolved.closed_without_merge_parked);
+        assert!(reporter.items_for_subject("1").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn closed_delivery_retry_keeps_attention_until_fresh_open_observation() {
+        let inner = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(inner.clone()).await;
+        let reporter = orchestrator.attention_reporter.clone().unwrap();
+        let repository = delivery.repositories.get_mut("source-repo").unwrap();
+        repository.phase = DeliveryPhase::Waiting;
+        repository.pr_number = Some(420);
+        repository.pr_url = Some("https://github.com/example/project/pull/420".to_string());
+        repository.observation = Some(DeliveryObservation::successful(
+            DeliveryObservationFacts {
+                pull_request_number: 420,
+                pull_request_url: "https://github.com/example/project/pull/420".to_string(),
+                head_sha: repository.local_sha.clone(),
+                matches_delivery: true,
+                head_diverged: false,
+                terminal_state: PullRequestTerminalState::ClosedWithoutMerge,
+                mergeability: Mergeability::Mergeable,
+                base_freshness: BaseFreshness::UpToDate,
+                checks: vec![],
+                check_summary: CheckSummary::Passing,
+                review_decision: ReviewDecision::Approved,
+            },
+            Utc::now(),
+        ));
+        let delivery = orchestrator.park_closed_without_merge(delivery).await;
+        assert_eq!(reporter.items_for_subject("1").await.unwrap().len(), 1);
+        orchestrator
+            .retry_finalize_delivery("1", &delivery.identifier)
+            .await
+            .unwrap();
+        let retryable = crate::orchestrator::delivery_observation::DeliveryObservationRead::Retryable(
+            crate::orchestrator::delivery_observation::DeliveryObservationFailure::new(crate::orchestrator::delivery_observation::DeliveryObservationFailureKind::Transport, "retry"));
+        let open = crate::orchestrator::delivery_observation::DeliveryObservationRead::Observed(
+            DeliveryObservationFacts {
+                pull_request_number: 420,
+                pull_request_url: "https://github.com/example/project/pull/420".to_string(),
+                head_sha: "0123456789abcdef".to_string(),
+                matches_delivery: true,
+                head_diverged: false,
+                terminal_state: PullRequestTerminalState::Open,
+                mergeability: Mergeability::Mergeable,
+                base_freshness: BaseFreshness::UpToDate,
+                checks: vec![],
+                check_summary: CheckSummary::Passing,
+                review_decision: ReviewDecision::ReviewRequired,
+            },
+        );
+        orchestrator.delivery_remote = Arc::new(SequencedObservationRemote {
+            inner: inner.clone(),
+            observations: std::sync::Mutex::new(vec![retryable, open]),
+        });
+        orchestrator.config.write().await.tracker.kind = "github".to_string();
+        let workspace = orchestrator
+            .workspace_mgr
+            .prepare_workspace("1", "repo#1")
+            .await
+            .unwrap();
+        assert!(workspace.worktrees.contains_key("source-repo"));
+        orchestrator.reconcile_and_recover_deliveries().await;
+        assert!(orchestrator.state.read().await.delivery["1"].closed_without_merge_parked);
+        assert_eq!(reporter.items_for_subject("1").await.unwrap().len(), 1);
+        let mut due = orchestrator.state.read().await.delivery["1"].clone();
+        due.repositories
+            .get_mut("source-repo")
+            .unwrap()
+            .observation
+            .as_mut()
+            .unwrap()
+            .retry
+            .as_mut()
+            .unwrap()
+            .due_at = Utc::now();
+        orchestrator
+            .persist_delivery_record(&due, None)
+            .await
+            .unwrap();
+        orchestrator.reconcile_and_recover_deliveries().await;
+        let retained = orchestrator.state.read().await.delivery["1"].clone();
+        assert!(!retained.closed_without_merge_parked);
+        assert_eq!(retained.repositories["source-repo"].pr_number, Some(420));
+        assert!(reporter.items_for_subject("1").await.unwrap().is_empty());
+        assert_eq!(inner.pushes.load(Ordering::SeqCst), 0);
+        assert_eq!(inner.creates.load(Ordering::SeqCst), 0);
+        assert_eq!(inner.lists.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -17493,6 +17825,10 @@ mod tests {
             .collect(),
             terminal_history: Some(Box::new(review_projection_history())),
             review_projection: None,
+            delivery_states: Default::default(),
+            success_state: None,
+            closed_without_merge_parked: false,
+            selected_delivery_state: None,
         }
     }
 
@@ -28487,6 +28823,7 @@ agent:
                 steps: config.steps.clone(),
                 on_success: config.on_success.clone(),
                 on_failure: config.on_failure.clone(),
+                delivery_states: Default::default(),
             },
         );
         config.scheduler = SchedulerConfig {

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -194,7 +194,7 @@ pub struct PipelineTransitionRecord {
     #[serde(default)]
     pub terminal_transition: Option<PendingTerminalTransition>,
     #[serde(default)]
-    pub(crate) delivery: Option<DeliveryRecord>,
+    pub(crate) delivery: Option<Box<DeliveryRecord>>,
     pub written_at: DateTime<Utc>,
 }
 
@@ -226,7 +226,7 @@ pub struct PipelineTransitionInput {
     pub retry: Option<RetryEntry>,
     pub snapshot: Option<PipelineRunSnapshot>,
     pub terminal_transition: Option<PendingTerminalTransition>,
-    pub(crate) delivery: Option<DeliveryRecord>,
+    pub(crate) delivery: Option<Box<DeliveryRecord>>,
 }
 
 #[derive(Debug, Clone)]
@@ -753,6 +753,10 @@ mod tests {
             .collect(),
             terminal_history: None,
             review_projection: None,
+            delivery_states: Default::default(),
+            success_state: None,
+            closed_without_merge_parked: false,
+            selected_delivery_state: None,
         };
 
         journal
@@ -767,7 +771,7 @@ mod tests {
                 retry: None,
                 snapshot: None,
                 terminal_transition: None,
-                delivery: Some(delivery.clone()),
+                delivery: Some(Box::new(delivery.clone())),
             })
             .await
             .unwrap();
@@ -777,7 +781,7 @@ mod tests {
             .await
             .unwrap()
             .expect("delivery remains a live owner");
-        assert_eq!(latest.delivery, Some(delivery));
+        assert_eq!(latest.delivery, Some(Box::new(delivery)));
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
+++ b/crates/ensemble-core/src/orchestrator/pipeline_journal.rs
@@ -755,6 +755,7 @@ mod tests {
             review_projection: None,
             delivery_states: Default::default(),
             success_state: None,
+            failure_state: None,
             closed_without_merge_parked: false,
             selected_delivery_state: None,
         };

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -1684,6 +1684,7 @@ mod tests {
             review_projection: None,
             delivery_states: Default::default(),
             success_state: None,
+            failure_state: None,
             closed_without_merge_parked: false,
             selected_delivery_state: None,
         };

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -1682,6 +1682,10 @@ mod tests {
             .collect(),
             terminal_history: None,
             review_projection: None,
+            delivery_states: Default::default(),
+            success_state: None,
+            closed_without_merge_parked: false,
+            selected_delivery_state: None,
         };
         state
             .write()

--- a/crates/ensemble-core/src/workspace/finalize.rs
+++ b/crates/ensemble-core/src/workspace/finalize.rs
@@ -26,9 +26,6 @@ pub struct RepoFinalizeConfig {
     pub mode: FinalizeMode,
     #[serde(default)]
     pub approval_required: bool,
-    /// Optional non-terminal tracker state projected after durable pull-request delivery.
-    #[serde(default)]
-    pub review_state: Option<String>,
 }
 
 impl Default for RepoFinalizeConfig {
@@ -37,7 +34,6 @@ impl Default for RepoFinalizeConfig {
             enabled: default_finalize_enabled(),
             mode: FinalizeMode::None,
             approval_required: false,
-            review_state: None,
         }
     }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -441,7 +441,8 @@ Pipeline run recovery:
   retained for operator recovery. A fully `published` push-only delivery continues the existing
   durable terminal-transition protocol; it does not republish the branch.
 - A durable `push_and_pr` repository with an exact pull-request number and URL is observed on the
-  delivery recovery tick through one authenticated, read-only GitHub query. The version-1
+  delivery recovery tick through one authenticated, read-only GitHub query, independently of the
+  configured issue-tracker adapter. The version-1
   observation records complete pull-request facts (head identity, terminal state, mergeability,
   base freshness, checks, and review decision) together with freshness, retry, and typed
   non-secret failure metadata. A successful read replaces all facts atomically; transient reads
@@ -458,8 +459,9 @@ Pipeline run recovery:
   the configured failure state, or stopped for any other terminal state. Release removes the owned
   workspace and durable delivery claim before another candidate can dispatch.
 - Optional selected-pipeline `delivery_states` map durable delivery facts to opaque non-terminal
-  tracker states. The policy and selected fact/target are frozen in the delivery record; omitted
-  facts do not write the tracker. `merged: on_success` uses the existing durable terminal-success
+  tracker states. The policy, selected fact/target, and terminal success/failure targets are frozen
+  in the delivery record; omitted facts do not write the tracker. `merged: on_success` uses the
+  existing durable terminal-success
   transition. `closed_without_merge` retains the claim and durable operator attention for explicit
   recovery. Its journal phase is `pending`, `in_flight`, `applied`, or `blocked`; Ensemble persists
   `in_flight` before the tracker write and applies only after an exact target-state read. Read

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -450,20 +450,21 @@ Pipeline run recovery:
   A returned head other than the durable local SHA is recorded as `head_diverged` and blocks
   delivery without adopting the remote head.
 - Observing `merged` or `closed_without_merge` is evidence only. It does not create, update,
-  merge, queue, or close a pull request; project a tracker state; complete a run; release a claim
-  or workspace; or redispatch pipeline work. A blocked observation is retried only through the
-  existing explicit finalization retry path.
+  merge, queue, or close a pull request or redispatch pipeline work. Configured delivery-state
+  projection and terminal reconciliation remain journal-owned.
 - If the tracker moves a retained delivery to any configured terminal state, delivery recovery
   stops remote mutation and enters the same durable terminal-transition protocol using the
   observed state. It persists the prepared history as succeeded for the success state, failed for
   the configured failure state, or stopped for any other terminal state. Release removes the owned
   workspace and durable delivery claim before another candidate can dispatch.
-- An optional `push_and_pr` `review_state` is an issue-level retained projection, never a terminal
-  outcome. Its journal phase is `pending`, `in_flight`, `applied`, or `blocked`; Ensemble persists
-  `in_flight` before the tracker write and applies only after an exact target-state read. It writes
-  only after every configured repository is non-active and every pull request is uniquely durable
-  at its stored SHA. Read failures, terminal states, and unexpected states block the delivery while
-  retaining the claim, workspace, branch, SHA, pull request, and artifacts without redispatch.
+- Optional selected-pipeline `delivery_states` map durable delivery facts to opaque non-terminal
+  tracker states. The policy and selected fact/target are frozen in the delivery record; omitted
+  facts do not write the tracker. `merged: on_success` uses the existing durable terminal-success
+  transition. `closed_without_merge` retains the claim and durable operator attention for explicit
+  recovery. Its journal phase is `pending`, `in_flight`, `applied`, or `blocked`; Ensemble persists
+  `in_flight` before the tracker write and applies only after an exact target-state read. Read
+  failures, terminal states, and unexpected states retain the claim, workspace, branch, SHA, pull
+  request, and artifacts without redispatch.
 - Required pull-request checks run only after the retained delivery identity reaches `waiting` or
   `published`. Results form one ordered suffix batch per evaluation. Restart resumes a partial
   batch without push, creation, or discovery; an explicit finalize retry appends a complete new

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,7 +239,14 @@ repos:
     finalize:
       mode: push_and_pr
       approval_required: true
-      review_state: In review
+
+delivery_states:
+  waiting: In review
+  checks_failed: CI failed
+  changes_requested: Changes requested
+  approved: Approved
+  closed_without_merge: Closed without merge
+  merged: on_success
 
 agents:
   builder:
@@ -505,7 +512,6 @@ List of repositories for workspace setup. Paths can be absolute or relative to t
 | `finalize.enabled` | bool | `true` | Whether post-pipeline finalization is enabled for this repo |
 | `finalize.mode` | string | `none` | Finalization action: `none`, `push`, or `push_and_pr` |
 | `finalize.approval_required` | bool | `false` | Requires explicit approval from web/desktop UI before finalize runs |
-| `finalize.review_state` | string | none | Optional non-terminal tracker state projected after exact `push_and_pr` delivery |
 
 `finalize.mode` defaults to `none`, so Ensemble does not push branches or open pull requests unless
 you opt in per repo. Ensemble still records durable run artifacts for each completed issue,
@@ -516,17 +522,17 @@ For `push` and `push_and_pr`, Ensemble durably records the exact repository, bra
 remote identity before mutation. Restart recovery reconciles that stored identity with the remote
 before retrying, so an ambiguous push or pull request response cannot silently duplicate
 publication. A `push_and_pr` repository remains claimed in a non-capacity-consuming waiting state
-after its uniquely matching pull request is found; merging or closing that pull request does not by
-itself project the issue to `on_success`.
+after its uniquely matching pull request is found. A merge projects the issue through the durable
+terminal-success transition only when frozen `delivery_states.merged` is `on_success`; a pull
+request closed without merge remains retained for operator recovery.
 
-`finalize.review_state` is valid only with `push_and_pr`. It must be non-blank, must not be
-`on_success` or a configured terminal state, and every opt-in pull-request repository for one
-delivery must select the same target. Ensemble persists the issue-level projection as `pending`,
-`in_flight`, `applied`, or `blocked`. It persists `in_flight` before writing to the tracker and
-reconciles the exact target after every write. An unreadable, terminal, or unexpected observed
-state blocks the retained delivery; a confirmed active-state absence may retry on a later poll.
-The branch, SHA, pull-request identity, workspace, and claim remain retained throughout; this
-state consumes no agent capacity and never uses `on_success` or cleanup.
+`delivery_states` belongs beside a legacy pipeline's `on_success` and `on_failure`, or inside a
+named pipeline. Its optional non-terminal targets are `waiting`, `checks_failed`,
+`changes_requested`, `approved`, and `closed_without_merge`; `merged` accepts only `on_success`.
+Blank or terminal targets are rejected. The selected policy is copied into the retained delivery,
+so reloading configuration cannot reinterpret work already owned by the journal. Omitted entries
+leave tracker state unchanged. `repos[].finalize.review_state` has been removed; migrate it to
+`delivery_states.waiting`.
 
 **Headless behavior:** if `finalize.approval_required: true` and Ensemble is running headless, startup emits a warning and finalize is skipped for that repo.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -436,12 +436,15 @@ retains their exact delivery and pull-request identity. An explicit finalize ret
 new suffix batch; a passing retry returns the delivery to `waiting`, while failure remains blocked.
 This path does not consume pipeline cycles or use `max_cycles`.
 
-When `repos[].finalize.review_state` is configured, review is a separate delivery-owned,
-non-terminal projection. Only after every repository has durable non-active publication evidence
-and each pull request is uniquely reconciled at its stored SHA may Ensemble write the configured
-review state. The journal records `pending`, then `in_flight` before the tracker write, and
-`applied` only after an exact tracker read. Ambiguous or unexpected reconciliation blocks the
-retained delivery without another branch, pull request, terminal transition, or agent dispatch.
+`delivery_states` is a separate delivery-owned, non-terminal projection policy. Once durable
+delivery evidence is available, Ensemble selects one fact in fixed order: closed without merge,
+requested changes, failed checks, all-repository merge, all-repository approval, then waiting.
+`merged: on_success` enters the existing durable terminal-success transition; closed without merge
+keeps the delivery claimed and upserts operator attention until recovery observes a different fact.
+The journal records `pending`, then `in_flight` before a configured tracker write, and `applied`
+only after an exact tracker read. Omitted mappings leave the tracker unchanged; ambiguous or
+unexpected reconciliation retains delivery without another branch, pull request, terminal
+transition, or agent dispatch.
 
 ## Retries and cycles
 


### PR DESCRIPTION
Fixes #422

## Summary

- add pipeline-level `delivery_states` configuration and remove `finalize.review_state` with migration diagnostics
- freeze delivery fact/target policy in the durable delivery record and project reconciled waiting, checks, review, merge, and closure facts safely
- route merged delivery through the existing terminal tracker/history/cleanup protocol and park closed-without-merge delivery with recoverable operator attention
- document the configuration, precedence, restart, and ownership-release contracts

## Verification

- `cargo test --workspace --exclude ensemble-desktop --quiet` (1,497 core tests passed)
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e -- --nocapture` (55 passed, 1 ignored live dogfood test)
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Residual risk

- the explicitly provisioned live Bamboon dogfood test remains intentionally ignored by default; deterministic product and recovery coverage is green