### PR TITLE
Ship GitHub Project drain reference configuration

### DIFF
--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -2571,7 +2571,7 @@ printf '%s\n' "$*" >> "${ENSEMBLE_E2E_HELPER_LOG:?missing helper log}"
 case "$*" in
   *ReferenceTriageSnapshot*)
     cat <<'JSON'
-{"data":{"repository":{"projectV2":{"id":"P_configured","fields":{"nodes":[{"id":"F_status","name":"Status","options":[{"id":"O_todo","name":"Todo"},{"id":"O_progress","name":"In progress"},{"id":"O_ready","name":"Ready to implement"}]}]}},"labels":{"nodes":[{"id":"L_todo","name":"Todo"},{"id":"L_ready","name":"ready-for-agent"}]},"issue":{"id":"E2E-1","number":1,"labels":{"nodes":[{"id":"L_todo","name":"Todo"}]},"projectItems":{"nodes":[{"id":"PVT_item","project":{"id":"P_configured"},"fieldValues":{"nodes":[{"name":"In progress","field":{"id":"F_status","name":"Status"}}]}}]}}}}}
+{"data":{"repository":{"projectV2":{"id":"P_configured","fields":{"nodes":[{"id":"F_status","name":"Status","options":[{"id":"O_todo","name":"Todo"},{"id":"O_progress","name":"In progress"},{"id":"O_ready","name":"Ready to implement"}]}]}},"labels":{"nodes":[{"id":"L_todo","name":"Todo"},{"id":"L_ready","name":"ready-for-agent"}],"pageInfo":{"hasNextPage":false,"endCursor":null}},"issue":{"id":"E2E-1","number":1,"labels":{"nodes":[{"id":"L_todo","name":"Todo"}]},"projectItems":{"nodes":[{"id":"PVT_item","project":{"id":"P_configured"},"fieldValues":{"nodes":[{"name":"In progress","field":{"id":"F_status","name":"Status"}}]}}]}}}}}
 JSON
     ;;
 esac

--- a/crates/ensemble-cli/tests/product_e2e.rs
+++ b/crates/ensemble-cli/tests/product_e2e.rs
@@ -9,7 +9,7 @@ use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 use wiremock::matchers::{body_string_contains, method, path};
@@ -21,8 +21,371 @@ const ISSUE_TITLE: &str = "Exercise product workflow";
 // growth cannot silently reintroduce platform-dependent stack overflows.
 const ACCEPTANCE_FAILURE_WORKER_STACK_BYTES: usize = 15 * 128 * 1024;
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_project_drain_reference_triage_waits_for_authorized_event() {
+    let fixture = GithubAuthorizationFixture::new_with_copied_reference()
+        .await
+        .expect("copied reference fixture");
+    let port = reserve_local_port().expect("reserve port");
+    let base_url = format!("http://127.0.0.1:{port}");
+    let guard = spawn_web(&fixture.fixture, port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url)
+        .await
+        .expect("server starts");
+    wait_for_reference_acpx_text(
+        &fixture.fixture,
+        &client,
+        &base_url,
+        "Draft a schema-valid triage patch",
+    )
+    .await
+    .expect("triage draft dispatches");
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    let before = fs::read_to_string(&fixture.fixture.acpx_log_path).unwrap();
+    assert!(
+        !before.contains("This step receives the immutable triage-draft Artifact"),
+        "triage applier started before its authorized status event: {before}"
+    );
+    assert!(
+        fs::read_to_string(reference_helper_log_path(&fixture.fixture))
+            .unwrap_or_default()
+            .is_empty(),
+        "triage helper ran before its authorized status event"
+    );
+    assert_eq!(fixture.mutations.load(Ordering::SeqCst), 1, "claim only");
+
+    fixture.event_visible.store(true, Ordering::SeqCst);
+    wait_for_reference_acpx_text(
+        &fixture.fixture,
+        &client,
+        &base_url,
+        "This step receives the immutable triage-draft Artifact",
+    )
+    .await
+    .expect("triage applier dispatches after authorization");
+    wait_for_acpx_text(
+        &reference_helper_log_path(&fixture.fixture),
+        "ReferenceTriageSetStatus",
+    )
+    .await;
+    let records = read_pipeline_journal_records(fixture.fixture.config_dir.path()).unwrap();
+    assert_journal_evidence_precedes_step(&records, "apply-triage-patch");
+    drop(guard);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_project_drain_reference_planning_revision_waits_for_authorized_event() {
+    let fixture = GithubAuthorizationFixture::new_with_copied_reference_state("Planning")
+        .await
+        .expect("copied reference fixture");
+    let port = reserve_local_port().expect("reserve port");
+    let base_url = format!("http://127.0.0.1:{port}");
+    let guard = spawn_web(&fixture.fixture, port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url)
+        .await
+        .expect("server starts");
+    wait_for_reference_acpx_text(
+        &fixture.fixture,
+        &client,
+        &base_url,
+        "Produce a versioned implementation plan",
+    )
+    .await
+    .expect("plan draft dispatches");
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    assert_eq!(
+        acpx_occurrences(
+            &fixture.fixture.acpx_log_path,
+            "Produce a versioned implementation plan"
+        ),
+        2,
+        "the planner acknowledgement must wait for the authorized status event"
+    );
+
+    fixture.event_visible.store(true, Ordering::SeqCst);
+    wait_for_reference_acpx_occurrences(
+        &fixture.fixture,
+        &client,
+        &base_url,
+        "Produce a versioned implementation plan",
+        3,
+    )
+    .await
+    .expect("planner acknowledgement dispatches after authorization");
+    let records = read_pipeline_journal_records(fixture.fixture.config_dir.path()).unwrap();
+    assert_journal_evidence_precedes_step(&records, "acknowledge-plan-revision");
+    drop(guard);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_project_drain_reference_planning_operator_required_records_only_attention() {
+    let fixture = GithubAuthorizationFixture::new_with_copied_reference_state("Planning")
+        .await
+        .expect("copied reference fixture");
+    replace_mock_acpx_output(
+        &fixture.fixture,
+        "\"outcome\":\"revision\"",
+        "\"outcome\":\"operator_required\"",
+    );
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let guard = spawn_web(&fixture.fixture, port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    wait_for_reference_acpx_text(
+        &fixture.fixture,
+        &client,
+        &base_url,
+        "Describe the operator action needed",
+    )
+    .await
+    .expect("operator-required route dispatches attention");
+    wait_for_counter(&fixture.comments, 1, "attention comment").await;
+    assert_eq!(
+        acpx_occurrences(
+            &fixture.fixture.acpx_log_path,
+            "Produce a versioned implementation plan"
+        ),
+        2,
+        "revision acknowledgement must not dispatch on operator_required"
+    );
+    wait_for_reference_journal_action(&fixture.fixture, "record-plan-attention").await;
+    drop(guard);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_project_drain_reference_epic_close_pauses_after_acknowledgement_producer() {
+    let fixture = GithubAuthorizationFixture::new_with_copied_reference_scenario(
+        "Ready to implement",
+        vec!["epic"],
+        "In progress",
+        false,
+    )
+    .await
+    .unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let guard = spawn_web(&fixture.fixture, port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    wait_for_acpx_occurrences(
+        &fixture.fixture.acpx_log_path,
+        "Return the configured closure outcome",
+        4,
+    )
+    .await;
+    wait_for_reference_interaction(&client, &base_url, "acknowledge-closure").await;
+    drop(guard);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_project_drain_reference_epic_attention_records_only_attention_actions() {
+    let fixture = GithubAuthorizationFixture::new_with_copied_reference_scenario(
+        "Ready to implement",
+        vec!["epic"],
+        "In progress",
+        false,
+    )
+    .await
+    .unwrap();
+    replace_mock_acpx_output(
+        &fixture.fixture,
+        "\"outcome\":\"close\"",
+        "\"outcome\":\"attention\"",
+    );
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let guard = spawn_web(&fixture.fixture, port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    wait_for_reference_acpx_text(
+        &fixture.fixture,
+        &client,
+        &base_url,
+        "Describe the operator action needed",
+    )
+    .await
+    .unwrap();
+    wait_for_counter(&fixture.comments, 1, "epic attention comment").await;
+    assert_eq!(
+        acpx_occurrences(
+            &fixture.fixture.acpx_log_path,
+            "Return the configured closure outcome"
+        ),
+        2,
+        "closure acknowledgement must be skipped for attention"
+    );
+    drop(guard);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_project_drain_reference_blocked_epic_is_not_claimed_or_dispatched() {
+    let fixture = GithubAuthorizationFixture::new_with_copied_reference_scenario(
+        "Ready to implement",
+        vec!["epic"],
+        "In progress",
+        true,
+    )
+    .await
+    .unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let guard = spawn_web(&fixture.fixture, port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(fs::read_to_string(&fixture.fixture.acpx_log_path)
+        .unwrap_or_default()
+        .is_empty());
+    assert_eq!(fixture.mutations.load(Ordering::SeqCst), 0);
+    drop(guard);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_project_drain_reference_delivery_requires_label_then_dispatches() {
+    let excluded = GithubAuthorizationFixture::new_with_copied_reference_scenario(
+        "Ready to implement",
+        vec![],
+        "In progress",
+        false,
+    )
+    .await
+    .unwrap();
+    let excluded_port = reserve_local_port().unwrap();
+    let excluded_url = format!("http://127.0.0.1:{excluded_port}");
+    let excluded_guard = spawn_web(&excluded.fixture, excluded_port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &excluded_url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(fs::read_to_string(&excluded.fixture.acpx_log_path)
+        .unwrap_or_default()
+        .is_empty());
+    assert_eq!(excluded.mutations.load(Ordering::SeqCst), 0);
+    drop(excluded_guard);
+
+    let admitted = GithubAuthorizationFixture::new_with_copied_reference_scenario(
+        "Ready to implement",
+        vec!["ready-for-agent"],
+        "In progress",
+        false,
+    )
+    .await
+    .unwrap();
+    let admitted_port = reserve_local_port().unwrap();
+    let admitted_url = format!("http://127.0.0.1:{admitted_port}");
+    let admitted_guard = spawn_web(&admitted.fixture, admitted_port);
+    wait_for_server(&client, &admitted_url).await.unwrap();
+    wait_for_reference_acpx_text(
+        &admitted.fixture,
+        &client,
+        &admitted_url,
+        "Implement the selected issue",
+    )
+    .await
+    .unwrap();
+    let records = read_pipeline_journal_records(admitted.fixture.config_dir.path()).unwrap();
+    assert!(records.iter().any(|record| {
+        record["kind"] == "run_started"
+            && record["snapshot"]["selected_workflow"]["pipeline"] == "delivery"
+            && record["snapshot"]["selected_workflow"]["lane"] == "delivery"
+    }));
+    drop(admitted_guard);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_project_drain_reference_human_attention_records_effects() {
+    let fixture = GithubAuthorizationFixture::new_with_copied_reference_scenario(
+        "Needs human",
+        vec!["ready-for-human"],
+        "In progress",
+        false,
+    )
+    .await
+    .unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let guard = spawn_web(&fixture.fixture, port);
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    wait_for_reference_acpx_text(
+        &fixture.fixture,
+        &client,
+        &base_url,
+        "Describe the operator action needed",
+    )
+    .await
+    .unwrap();
+    wait_for_counter(&fixture.comments, 1, "human attention comment").await;
+    wait_for_reference_journal_action(&fixture.fixture, "record-attention").await;
+    drop(guard);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_project_drain_reference_idle_triage_waits_for_and_follows_non_idle_planning() {
+    let fixture = GithubAuthorizationFixture::new_with_copied_reference_planning_and_triage()
+        .await
+        .unwrap();
+    let port = reserve_local_port().unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let planning_release =
+        PlanningReleaseGuard::new(fixture.fixture.config_dir.path().join("release-planning"));
+    let guard = spawn_web_with_planning_gate(&fixture.fixture, port, planning_release.path());
+    let client = reqwest::Client::new();
+    wait_for_server(&client, &base_url).await.unwrap();
+    wait_for_reference_acpx_text(
+        &fixture.fixture,
+        &client,
+        &base_url,
+        "Produce a versioned implementation plan",
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    assert!(
+        !fs::read_to_string(&fixture.fixture.acpx_log_path)
+            .unwrap()
+            .contains("Draft a schema-valid triage patch"),
+        "idle-only triage must not run while planning is live"
+    );
+
+    fixture.event_visible.store(true, Ordering::SeqCst);
+    planning_release.release().unwrap();
+    wait_for_acpx_occurrences(
+        &fixture.fixture.acpx_log_path,
+        "Produce a versioned implementation plan",
+        3,
+    )
+    .await;
+    wait_for_reference_acpx_text(
+        &fixture.fixture,
+        &client,
+        &base_url,
+        "Draft a schema-valid triage patch",
+    )
+    .await
+    .expect("triage becomes eligible after planning releases its lane");
+    drop(guard);
+}
+
+fn copy_reference_assets(source: &Path, destination: &Path) -> io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let destination_path = destination.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_reference_assets(&entry.path(), &destination_path)?;
+        } else {
+            fs::copy(entry.path(), destination_path)?;
+        }
+    }
+    Ok(())
+}
+
 struct GithubTimelineResponder {
     visible: Arc<AtomicBool>,
+    status: String,
 }
 
 impl Respond for GithubTimelineResponder {
@@ -34,7 +397,7 @@ impl Respond for GithubTimelineResponder {
                 // reject it until the fixture exposes it as tracker history.
                 "createdAt": "2099-01-01T00:00:00Z",
                 "previousStatus": "Todo",
-                "status": "In Progress",
+                "status": self.status,
                 "project": { "id": "P_configured" },
                 "actor": { "id": "U_operator", "login": "operator" }
             })
@@ -54,6 +417,228 @@ struct GithubMutationResponder {
 
 struct GithubCommentResponder {
     calls: Arc<AtomicUsize>,
+}
+
+struct GithubReferenceAssigneeResponder {
+    state: Arc<GithubReferenceState>,
+}
+
+impl Respond for GithubReferenceAssigneeResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let secondary =
+            self.state.secondary_triage && String::from_utf8_lossy(&request.body).contains("E2E-2");
+        let owned = if secondary {
+            self.state.secondary_assigned.load(Ordering::SeqCst)
+        } else {
+            self.state.assigned.load(Ordering::SeqCst)
+        };
+        let nodes = owned.then(|| serde_json::json!({ "id": "U_operator", "login": "operator" }));
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "node": { "id": ISSUE_ID, "assignees": {
+                "totalCount": usize::from(owned), "nodes": nodes.into_iter().collect::<Vec<_>>()
+            }}}
+        }))
+    }
+}
+
+struct GithubReferenceFreshIssueResponder {
+    state: Arc<GithubReferenceState>,
+}
+
+impl Respond for GithubReferenceFreshIssueResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        if self.state.secondary_triage && String::from_utf8_lossy(&request.body).contains("E2E-2") {
+            let status = self
+                .state
+                .secondary_status
+                .lock()
+                .expect("reference state")
+                .clone();
+            return ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "nodes": [{
+                    "id": "E2E-2", "number": 2, "title": "Deferred triage", "state": "OPEN",
+                    "url": "https://github.example/acme/repo/issues/2",
+                    "labels": { "nodes": [{"name":"Todo"}, {"name":status}] }
+                }] }
+            }));
+        }
+        let state = self.state.status.lock().expect("reference state").clone();
+        let labels = self.state.labels_with_status(&state);
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "nodes": [{
+                "id": ISSUE_ID, "number": 1, "title": ISSUE_TITLE, "state": "OPEN",
+                "url": "https://github.example/acme/repo/issues/1",
+                "labels": { "nodes": labels }
+            }] }
+        }))
+    }
+}
+
+struct GithubReferenceState {
+    assigned: AtomicBool,
+    status: Mutex<String>,
+    labels: Vec<String>,
+    blocked: bool,
+    secondary_triage: bool,
+    secondary_assigned: AtomicBool,
+    secondary_status: Mutex<String>,
+}
+
+impl GithubReferenceState {
+    fn labels_with_status(&self, status: &str) -> Vec<Value> {
+        self.labels
+            .iter()
+            .chain(std::iter::once(&status.to_string()))
+            .map(|label| serde_json::json!({ "name": label }))
+            .collect()
+    }
+}
+
+struct GithubReferenceProjectItemsResponder {
+    state: Arc<GithubReferenceState>,
+}
+
+struct GithubReferenceBlockerResponder {
+    state: Arc<GithubReferenceState>,
+}
+
+struct GithubReferenceProjectItemLookupResponder {
+    state: Arc<GithubReferenceState>,
+}
+
+impl Respond for GithubReferenceProjectItemLookupResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let secondary =
+            self.state.secondary_triage && String::from_utf8_lossy(&request.body).contains("E2E-2");
+        let item_id = if secondary { "PVT_item_2" } else { "PVT_item" };
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "node": { "projectItems": {
+                "nodes": [{ "id": item_id, "project": { "id": "P_configured" } }]
+            }}}
+        }))
+    }
+}
+
+impl Respond for GithubReferenceBlockerResponder {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let nodes = self.state.blocked.then(|| {
+            serde_json::json!({
+                "id": "blocked-item", "number": 2, "state": "OPEN",
+                "repository": { "nameWithOwner": "acme/repo" }
+            })
+        });
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "node": { "blockedBy": {
+                "pageInfo": { "hasNextPage": false, "endCursor": null },
+                "nodes": nodes.into_iter().collect::<Vec<_>>()
+            }}}
+        }))
+    }
+}
+
+impl Respond for GithubReferenceProjectItemsResponder {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let status = self.state.status.lock().expect("reference state").clone();
+        let option_id = if status == "In progress" {
+            "O_progress"
+        } else {
+            "O_todo"
+        };
+        let assigned = self.state.assigned.load(Ordering::SeqCst);
+        let labels = self.state.labels_with_status(&status);
+        let assignees =
+            assigned.then(|| serde_json::json!({ "id": "U_operator", "login": "operator" }));
+        if self.state.secondary_triage {
+            let secondary_status = self
+                .state
+                .secondary_status
+                .lock()
+                .expect("reference state")
+                .clone();
+            let secondary_assigned = self.state.secondary_assigned.load(Ordering::SeqCst);
+            return ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "node": { "items": {
+                    "pageInfo": { "hasNextPage": false, "endCursor": null },
+                    "edges": [
+                        { "cursor": "item-1", "node": {
+                            "fieldValues": { "nodes": [{"name":status,"optionId":option_id,"field":{"id":"F_status","name":"Status"}}]},
+                            "content": {"id":ISSUE_ID,"number":1,"title":ISSUE_TITLE,"body":"","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","url":"https://github.example/acme/repo/issues/1","labels":{"nodes":labels},"assignees":{"totalCount":usize::from(assigned),"nodes":assignees.into_iter().collect::<Vec<_>>()}}
+                        }},
+                        { "cursor": "item-2", "node": {
+                            "fieldValues": { "nodes": [{"name":secondary_status,"optionId":if secondary_status == "In progress" { "O_progress" } else { "O_todo" },"field":{"id":"F_status","name":"Status"}}]},
+                            "content": {"id":"E2E-2","number":2,"title":"Deferred triage","body":"","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","url":"https://github.example/acme/repo/issues/2","labels":{"nodes":[{"name":"Todo"},{"name":secondary_status}]},"assignees":{"totalCount":usize::from(secondary_assigned),"nodes":[]}}
+                        }}
+                    ]
+                }}}
+            }));
+        }
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "node": { "items": {
+                "pageInfo": { "hasNextPage": false, "endCursor": null },
+                "edges": [{ "cursor": "item-1", "node": {
+                    "fieldValues": { "nodes": [{
+                        "name": status, "optionId": option_id,
+                        "field": { "id": "F_status", "name": "Status" }
+                    }]},
+                    "content": {
+                        "id": ISSUE_ID, "number": 1, "title": ISSUE_TITLE, "body": "",
+                        "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+                        "url": "https://github.example/acme/repo/issues/1",
+                        "labels": { "nodes": labels },
+                        "assignees": { "totalCount": usize::from(assigned), "nodes": assignees.into_iter().collect::<Vec<_>>() }
+                    }
+                }}]
+            }}}
+        }))
+    }
+}
+
+struct GithubReferenceAssignResponder {
+    state: Arc<GithubReferenceState>,
+}
+
+impl Respond for GithubReferenceAssignResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        if self.state.secondary_triage && String::from_utf8_lossy(&request.body).contains("E2E-2") {
+            self.state.secondary_assigned.store(true, Ordering::SeqCst);
+        } else {
+            self.state.assigned.store(true, Ordering::SeqCst);
+        }
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "addAssigneesToAssignable": { "assignable": { "id": ISSUE_ID } } }
+        }))
+    }
+}
+
+struct GithubReferenceStatusMutationResponder {
+    calls: Arc<AtomicUsize>,
+    state: Arc<GithubReferenceState>,
+}
+
+impl Respond for GithubReferenceStatusMutationResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let body = String::from_utf8_lossy(&request.body);
+        let status = if body.contains("O_progress") {
+            "In progress"
+        } else if body.contains("O_ready") {
+            "Ready to implement"
+        } else if body.contains("O_todo") {
+            "Todo"
+        } else {
+            panic!("unexpected reference status mutation: {body}");
+        };
+        if self.state.secondary_triage && body.contains("PVT_item_2") {
+            *self.state.secondary_status.lock().expect("reference state") = status.to_string();
+        } else {
+            *self.state.status.lock().expect("reference state") = status.to_string();
+        }
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "updateProjectV2ItemFieldValue": {
+                "projectV2Item": { "id": "PVT_item" }
+            }}
+        }))
+    }
 }
 
 impl Respond for GithubCommentResponder {
@@ -80,6 +665,30 @@ impl Respond for GithubMutationResponder {
 
 struct ChildGuard {
     child: Child,
+}
+
+struct PlanningReleaseGuard {
+    path: PathBuf,
+}
+
+impl PlanningReleaseGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn release(&self) -> io::Result<()> {
+        fs::write(&self.path, "release\n")
+    }
+}
+
+impl Drop for PlanningReleaseGuard {
+    fn drop(&mut self) {
+        let _ = self.release();
+    }
 }
 
 impl ChildGuard {
@@ -817,6 +1426,8 @@ struct TestFixture {
     todo_path: PathBuf,
     workspace_root: PathBuf,
     acpx_log_path: PathBuf,
+    web_stdout_path: PathBuf,
+    web_stderr_path: PathBuf,
     mock_bin_dir: PathBuf,
 }
 
@@ -839,6 +1450,8 @@ impl GithubAuthorizationFixture {
             event_visible.clone(),
             mutations.clone(),
             comments.clone(),
+            None,
+            "In Progress",
         )
         .await;
         let fixture =
@@ -851,9 +1464,195 @@ impl GithubAuthorizationFixture {
             comments,
         })
     }
+
+    async fn new_with_copied_reference() -> io::Result<Self> {
+        Self::new_with_copied_reference_scenario("Todo", vec!["Todo"], "In progress", false).await
+    }
+
+    async fn new_with_copied_reference_state(initial_status: &str) -> io::Result<Self> {
+        let event_status = if initial_status == "Planning" {
+            "Ready to implement"
+        } else {
+            "In progress"
+        };
+        Self::new_with_copied_reference_scenario(
+            initial_status,
+            vec![initial_status],
+            event_status,
+            false,
+        )
+        .await
+    }
+
+    async fn new_with_copied_reference_scenario(
+        initial_status: &str,
+        labels: Vec<&str>,
+        event_status: &str,
+        blocked: bool,
+    ) -> io::Result<Self> {
+        let server = MockServer::start().await;
+        let event_visible = Arc::new(AtomicBool::new(false));
+        let mutations = Arc::new(AtomicUsize::new(0));
+        let comments = Arc::new(AtomicUsize::new(0));
+        let reference_state = Arc::new(GithubReferenceState {
+            assigned: AtomicBool::new(false),
+            status: Mutex::new(initial_status.to_string()),
+            labels: labels.into_iter().map(ToString::to_string).collect(),
+            blocked,
+            secondary_triage: false,
+            secondary_assigned: AtomicBool::new(false),
+            secondary_status: Mutex::new("Todo".to_string()),
+        });
+        mount_github_authorization_api(
+            &server,
+            event_visible.clone(),
+            mutations.clone(),
+            comments.clone(),
+            Some(reference_state),
+            event_status,
+        )
+        .await;
+        let fixture = TestFixture::new_with_copied_github_reference(&server.uri())?;
+        Ok(Self {
+            fixture,
+            _server: server,
+            event_visible,
+            mutations,
+            comments,
+        })
+    }
+
+    async fn new_with_copied_reference_planning_and_triage() -> io::Result<Self> {
+        let server = MockServer::start().await;
+        let event_visible = Arc::new(AtomicBool::new(false));
+        let mutations = Arc::new(AtomicUsize::new(0));
+        let comments = Arc::new(AtomicUsize::new(0));
+        let reference_state = Arc::new(GithubReferenceState {
+            assigned: AtomicBool::new(false),
+            status: Mutex::new("Planning".to_string()),
+            labels: vec!["Planning".to_string()],
+            blocked: false,
+            secondary_triage: true,
+            secondary_assigned: AtomicBool::new(false),
+            secondary_status: Mutex::new("Todo".to_string()),
+        });
+        mount_github_authorization_api(
+            &server,
+            event_visible.clone(),
+            mutations.clone(),
+            comments.clone(),
+            Some(reference_state),
+            "Ready to implement",
+        )
+        .await;
+        let fixture = TestFixture::new_with_copied_github_reference(&server.uri())?;
+        Ok(Self {
+            fixture,
+            _server: server,
+            event_visible,
+            mutations,
+            comments,
+        })
+    }
 }
 
 impl TestFixture {
+    fn new_with_copied_github_reference(endpoint: &str) -> io::Result<Self> {
+        let config_dir = TempDir::new()?;
+        let root = config_dir.path();
+        let workspace_root = root.join("workspaces");
+        let repo_path = root.join("source");
+        let mock_bin_dir = root.join("bin");
+        let acpx_log_path = root.join("mock-acpx.log");
+        let web_stdout_path = root.join("ensemble-web.stdout.log");
+        let web_stderr_path = root.join("ensemble-web.stderr.log");
+        fs::create_dir_all(&workspace_root)?;
+        fs::create_dir_all(&mock_bin_dir)?;
+        init_git_repo(&repo_path)?;
+        let reference =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/examples/github-project-drain");
+        copy_reference_assets(&reference, root)?;
+        let config_path = root.join("config.yaml");
+        let config = fs::read_to_string(&config_path)?
+            .replace("repository: example/ensemble", "repository: acme/repo")
+            .replace("project_number: 6", "project_number: 1")
+            .replace(
+                "api_key: $GITHUB_TOKEN",
+                "endpoint: 'REPLACE_ENDPOINT'\n  api_key: fixture-token",
+            )
+            .replace("REPLACE_ENDPOINT", endpoint)
+            .replace("PVTSSF_example_status", "F_status")
+            .replace("example-maintainer", "U_operator")
+            .replace("Backlog", "Todo")
+            .replace("Triage approved", "In progress")
+            .replace("needs-triage", "Todo")
+            .replace(
+                "\nrepos:\n",
+                &format!(
+                    "\nworkspace:\n  root: {}\nrepos:\n",
+                    yaml_quote(&workspace_root.display().to_string())
+                ),
+            )
+            .replace("\nagents:\n", "\npolling: { interval_ms: 100 }\nagents:\n")
+            .replace(
+                "- path: target",
+                &format!("- path: {}", yaml_quote(&repo_path.display().to_string())),
+            )
+            .replace("repositories: [target]", "repositories: [source]")
+            .replace(
+                "executor: example-agent, model: example-model, ",
+                "acpx_agent: builder, ",
+            );
+        fs::write(&config_path, config)?;
+        let triage_schema_path = root.join("schemas/triage-patch.schema.json");
+        fs::write(
+            &triage_schema_path,
+            fs::read_to_string(&triage_schema_path)?
+                .replace("\"Triage approved\"", "\"In progress\""),
+        )?;
+        let triage_draft_path = root.join("prompts/triage-draft.md");
+        fs::write(
+            &triage_draft_path,
+            fs::read_to_string(&triage_draft_path)?.replace("Triage approved", "In progress"),
+        )?;
+        let triage_helper_path = root.join("tools/apply-triage-patch.sh");
+        fs::write(
+            &triage_helper_path,
+            fs::read_to_string(&triage_helper_path)?.replace(
+                "approval_status='Triage approved'",
+                "approval_status='In progress'",
+            ),
+        )?;
+        let triage_apply_path = root.join("prompts/triage-apply.md");
+        fs::write(
+            &triage_apply_path,
+            fs::read_to_string(&triage_apply_path)?
+                .replace("Triage approved", "In progress")
+                .replace(
+                    "/absolute/path/to/github-project-drain/tools/apply-triage-patch.sh",
+                    &triage_helper_path.display().to_string(),
+                ),
+        )?;
+        fs::write(mock_bin_dir.join("acpx"), mock_acpx_script())?;
+        fs::write(mock_bin_dir.join("gh"), mock_reference_gh_script())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(mock_bin_dir.join("acpx"), fs::Permissions::from_mode(0o755))?;
+            fs::set_permissions(mock_bin_dir.join("gh"), fs::Permissions::from_mode(0o755))?;
+            fs::set_permissions(&triage_helper_path, fs::Permissions::from_mode(0o755))?;
+        }
+        let todo_path = root.join("unused-TODO.md");
+        Ok(Self {
+            config_dir,
+            todo_path,
+            workspace_root,
+            acpx_log_path,
+            web_stdout_path,
+            web_stderr_path,
+            mock_bin_dir,
+        })
+    }
     fn new() -> io::Result<Self> {
         Self::new_with_acceptance("yes x | head -c 40000")
     }
@@ -866,6 +1665,8 @@ impl TestFixture {
         let repo_path = root.join("source");
         let mock_bin_dir = root.join("bin");
         let acpx_log_path = root.join("mock-acpx.log");
+        let web_stdout_path = root.join("ensemble-web.stdout.log");
+        let web_stderr_path = root.join("ensemble-web.stderr.log");
 
         fs::create_dir_all(&workspace_root)?;
         fs::create_dir_all(&mock_bin_dir)?;
@@ -888,6 +1689,8 @@ impl TestFixture {
             todo_path,
             workspace_root,
             acpx_log_path,
+            web_stdout_path,
+            web_stderr_path,
             mock_bin_dir,
         })
     }
@@ -900,6 +1703,8 @@ impl TestFixture {
         let repo_path = root.join("source");
         let mock_bin_dir = root.join("bin");
         let acpx_log_path = root.join("mock-acpx.log");
+        let web_stdout_path = root.join("ensemble-web.stdout.log");
+        let web_stderr_path = root.join("ensemble-web.stderr.log");
 
         fs::create_dir_all(&workspace_root)?;
         fs::create_dir_all(&mock_bin_dir)?;
@@ -922,6 +1727,8 @@ impl TestFixture {
             todo_path,
             workspace_root,
             acpx_log_path,
+            web_stdout_path,
+            web_stderr_path,
             mock_bin_dir,
         })
     }
@@ -934,6 +1741,8 @@ impl TestFixture {
         let repo_path = root.join("source");
         let mock_bin_dir = root.join("bin");
         let acpx_log_path = root.join("mock-acpx.log");
+        let web_stdout_path = root.join("ensemble-web.stdout.log");
+        let web_stderr_path = root.join("ensemble-web.stderr.log");
         fs::create_dir_all(&workspace_root)?;
         fs::create_dir_all(&mock_bin_dir)?;
         init_git_repo(&repo_path)?;
@@ -953,6 +1762,8 @@ impl TestFixture {
             todo_path,
             workspace_root,
             acpx_log_path,
+            web_stdout_path,
+            web_stderr_path,
             mock_bin_dir,
         })
     }
@@ -968,6 +1779,8 @@ impl TestFixture {
         let repo_path = root.join("source");
         let mock_bin_dir = root.join("bin");
         let acpx_log_path = root.join("mock-acpx.log");
+        let web_stdout_path = root.join("ensemble-web.stdout.log");
+        let web_stderr_path = root.join("ensemble-web.stderr.log");
         fs::create_dir_all(&workspace_root)?;
         fs::create_dir_all(&mock_bin_dir)?;
         init_git_repo(&repo_path)?;
@@ -1004,6 +1817,8 @@ impl TestFixture {
             todo_path,
             workspace_root,
             acpx_log_path,
+            web_stdout_path,
+            web_stderr_path,
             mock_bin_dir,
         })
     }
@@ -1315,14 +2130,35 @@ async fn mount_github_authorization_api(
     event_visible: Arc<AtomicBool>,
     mutations: Arc<AtomicUsize>,
     comments: Arc<AtomicUsize>,
+    reference_state: Option<Arc<GithubReferenceState>>,
+    authorization_status: &str,
 ) {
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("viewer { id login }"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "viewer": { "id": "U_operator", "login": "operator" } }
+        })))
+        .mount(server)
+        .await;
+    let progress_status = if reference_state.is_some() {
+        "In progress"
+    } else {
+        "In Progress"
+    };
     let discovery = serde_json::json!({ "data": { "repository": { "projectV2": {
         "id": "P_configured",
         "fields": { "pageInfo": { "hasNextPage": false, "endCursor": null }, "nodes": [{
             "id": "F_status", "name": "Status", "options": [
                 { "id": "O_todo", "name": "Todo" },
-                { "id": "O_progress", "name": "In Progress" },
+                { "id": "O_progress", "name": progress_status },
+                { "id": "O_ready", "name": "Ready to implement" },
                 { "id": "O_done", "name": "Done" }
+            ]
+        }, {
+            "id": "F_priority", "name": "Priority", "options": [
+                { "id": "P0", "name": "P0" }, { "id": "P1", "name": "P1" },
+                { "id": "P2", "name": "P2" }, { "id": "P3", "name": "P3" }
             ]
         }] }
     }}}});
@@ -1362,55 +2198,146 @@ async fn mount_github_authorization_api(
                 "id": ISSUE_ID, "number": 1, "title": ISSUE_TITLE, "body": "",
                 "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
                 "url": "https://github.example/acme/repo/issues/1",
-                "labels": { "nodes": [] }, "assignees": { "totalCount": 0, "nodes": [] }
+                "labels": { "nodes": [{ "name": "Todo" }] }, "assignees": { "totalCount": 0, "nodes": [] }
             }
         }}]
     }}}});
-    Mock::given(method("POST"))
-        .and(path("/"))
-        .and(body_string_contains("orderBy: {field: POSITION"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(project_items))
-        .mount(server)
-        .await;
+    if let Some(state) = reference_state.as_ref() {
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("orderBy: {field: POSITION"))
+            .respond_with(GithubReferenceProjectItemsResponder {
+                state: state.clone(),
+            })
+            .mount(server)
+            .await;
+    } else {
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("orderBy: {field: POSITION"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(project_items))
+            .mount(server)
+            .await;
+    }
 
     Mock::given(method("POST"))
         .and(path("/"))
         .and(body_string_contains("timelineItems(first:"))
         .respond_with(GithubTimelineResponder {
             visible: event_visible,
+            status: authorization_status.to_string(),
         })
+        .mount(server)
+        .await;
+
+    if let Some(state) = reference_state.as_ref() {
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("blockedBy(first:"))
+            .respond_with(GithubReferenceBlockerResponder {
+                state: state.clone(),
+            })
+            .mount(server)
+            .await;
+    } else {
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("blockedBy(first:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "node": { "blockedBy": {
+                    "pageInfo": { "hasNextPage": false, "endCursor": null }, "nodes": []
+                }}}
+            })))
+            .mount(server)
+            .await;
+    }
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("subIssues(first:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "node": { "subIssues": {
+                "pageInfo": { "hasNextPage": false, "endCursor": null }, "nodes": []
+            }}}
+        })))
         .mount(server)
         .await;
 
     let project_item = serde_json::json!({ "data": { "node": { "projectItems": {
         "nodes": [{ "id": "PVT_item", "project": { "id": "P_configured" } }]
     }}}});
-    Mock::given(method("POST"))
-        .and(path("/"))
-        .and(body_string_contains("projectItems(first: 100)"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(project_item))
-        .mount(server)
-        .await;
+    if let Some(state) = reference_state.as_ref() {
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("projectItems(first: 100)"))
+            .respond_with(GithubReferenceProjectItemLookupResponder {
+                state: state.clone(),
+            })
+            .mount(server)
+            .await;
+    } else {
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("projectItems(first: 100)"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(project_item))
+            .mount(server)
+            .await;
+    }
 
-    let states = serde_json::json!({ "data": { "nodes": [{
-        "id": ISSUE_ID, "number": 1, "title": ISSUE_TITLE, "state": "OPEN",
-        "url": "https://github.example/acme/repo/issues/1",
-        "labels": { "nodes": [{ "name": "Todo" }] },
-        "assignees": { "totalCount": 0, "nodes": [] }
-    }]}});
-    Mock::given(method("POST"))
-        .and(path("/"))
-        .and(body_string_contains("nodes(ids:"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(states))
-        .mount(server)
-        .await;
-
-    Mock::given(method("POST"))
-        .and(path("/"))
-        .and(body_string_contains("updateProjectV2ItemFieldValue"))
-        .respond_with(GithubMutationResponder { calls: mutations })
-        .mount(server)
-        .await;
+    if let Some(state) = reference_state {
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("nodes(ids:"))
+            .respond_with(GithubReferenceFreshIssueResponder {
+                state: state.clone(),
+            })
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("query($issueId: ID!)"))
+            .respond_with(GithubReferenceAssigneeResponder {
+                state: state.clone(),
+            })
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("addAssigneesToAssignable"))
+            .respond_with(GithubReferenceAssignResponder {
+                state: state.clone(),
+            })
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("updateProjectV2ItemFieldValue"))
+            .respond_with(GithubReferenceStatusMutationResponder {
+                calls: mutations,
+                state,
+            })
+            .mount(server)
+            .await;
+    } else {
+        let states = serde_json::json!({ "data": { "nodes": [{
+            "id": ISSUE_ID, "number": 1, "title": ISSUE_TITLE, "state": "OPEN",
+            "url": "https://github.example/acme/repo/issues/1",
+            "labels": { "nodes": [{ "name": "Todo" }] },
+            "assignees": { "totalCount": 0, "nodes": [] }
+        }]}});
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("nodes(ids:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(states))
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("updateProjectV2ItemFieldValue"))
+            .respond_with(GithubMutationResponder { calls: mutations })
+            .mount(server)
+            .await;
+    }
 }
 
 fn init_git_repo(repo_path: &Path) -> io::Result<()> {
@@ -1583,6 +2510,30 @@ if [[ " $* " == *" prompt "* ]]; then
     verdict='{"result":"concern","summary":"operator should approve","output":{"artifact":"mock"}}'
   elif [[ "$prompt" == *"GitHub producer"* ]]; then
     verdict='{"result":"succeeded","summary":"GitHub producer completed","output":{"artifact":"mock","comment":"Artifact ready","summary":"Artifact ready","remedy":"Review it","references":["artifact:mock"]}}'
+  elif [[ "$prompt" == *"Produce a versioned implementation plan"* ]]; then
+    if [[ -n "${ENSEMBLE_E2E_PLANNING_RELEASE:-}" ]]; then
+      while [[ ! -f "${ENSEMBLE_E2E_PLANNING_RELEASE}" ]]; do
+        sleep 0.01
+      done
+    fi
+    verdict='{"result":"succeeded","summary":"plan revision","output":{"outcome":"revision","summary":"Plan is ready","comment":"Review the proposed plan."}}'
+  elif [[ "$prompt" == *"Return the configured closure outcome"* ]]; then
+    verdict='{"result":"succeeded","summary":"epic close","output":{"outcome":"close","summary":"All descendants are complete."}}'
+  elif [[ "$prompt" == *"Describe the operator action needed"* ]]; then
+    verdict='{"result":"succeeded","summary":"attention recorded","output":{"comment":"Operator action required.","summary":"Review the issue.","remedy":"Decide the next action.","references":["issue:1"]}}'
+  elif [[ "$prompt" == *"Implement the selected issue"* ]]; then
+    verdict='{"result":"succeeded","summary":"delivery implemented","output":{"outcome":"revision","summary":"Implementation is ready","comment":"Implementation complete."}}'
+  elif [[ "$prompt" == *"Draft a schema-valid triage patch"* ]]; then
+    verdict='{"result":"succeeded","summary":"triage draft","output":{"version":1,"comment":"Triage draft","expected_snapshot":{"issue_number":1,"project_id":"P_configured","status":"In progress","labels":["Todo"]},"operations":[{"type":"set_status","value":"Ready to implement"}]}}'
+  elif [[ "$prompt" == *"This step receives the immutable triage-draft Artifact"* ]]; then
+    patch="$cwd/.ensemble/reference-triage-patch.json"
+    printf '%s\n' "$prompt" | awk '
+      $0 == "BEGIN APPROVED TRIAGE PATCH" { capture = 1; next }
+      $0 == "END APPROVED TRIAGE PATCH" { capture = 0 }
+      capture { print }
+    ' > "$patch"
+    "${ENSEMBLE_E2E_TRIAGE_HELPER:?missing triage helper}" --repo acme/repo --project-number 1 --status-field Status --issue 1 --patch "$patch"
+    verdict='{"result":"succeeded","summary":"triage applied","output":{"summary":"applied"}}'
   elif [[ "$prompt" == *"Evaluation reviewer"* ]]; then
     severity="${ENSEMBLE_E2E_FINDING_SEVERITY:-non_blocking}"
     verdict="{\"result\":\"succeeded\",\"summary\":\"assessment\",\"output\":{\"assessment\":{\"findings\":[{\"id\":\"finding-1\",\"severity\":\"$severity\",\"summary\":\"Minor concern\",\"evidence\":{\"path\":\"README.md\"}}]}}}"
@@ -1613,8 +2564,40 @@ exit 2
 "#
 }
 
+fn mock_reference_gh_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${ENSEMBLE_E2E_HELPER_LOG:?missing helper log}"
+case "$*" in
+  *ReferenceTriageSnapshot*)
+    cat <<'JSON'
+{"data":{"repository":{"projectV2":{"id":"P_configured","fields":{"nodes":[{"id":"F_status","name":"Status","options":[{"id":"O_todo","name":"Todo"},{"id":"O_progress","name":"In progress"},{"id":"O_ready","name":"Ready to implement"}]}]}},"labels":{"nodes":[{"id":"L_todo","name":"Todo"},{"id":"L_ready","name":"ready-for-agent"}]},"issue":{"id":"E2E-1","number":1,"labels":{"nodes":[{"id":"L_todo","name":"Todo"}]},"projectItems":{"nodes":[{"id":"PVT_item","project":{"id":"P_configured"},"fieldValues":{"nodes":[{"name":"In progress","field":{"id":"F_status","name":"Status"}}]}}]}}}}}
+JSON
+    ;;
+esac
+"#
+}
+
 fn spawn_web(fixture: &TestFixture, port: u16) -> ChildGuard {
+    spawn_web_with_optional_planning_gate(fixture, port, None)
+}
+
+fn spawn_web_with_planning_gate(
+    fixture: &TestFixture,
+    port: u16,
+    planning_release: &Path,
+) -> ChildGuard {
+    spawn_web_with_optional_planning_gate(fixture, port, Some(planning_release))
+}
+
+fn spawn_web_with_optional_planning_gate(
+    fixture: &TestFixture,
+    port: u16,
+    planning_release: Option<&Path>,
+) -> ChildGuard {
     let mut command = Command::new(env!("CARGO_BIN_EXE_ensemble"));
+    let stdout = fs::File::create(&fixture.web_stdout_path).expect("create web stdout log");
+    let stderr = fs::File::create(&fixture.web_stderr_path).expect("create web stderr log");
     command
         .arg("web")
         .arg("--config-dir")
@@ -1625,9 +2608,27 @@ fn spawn_web(fixture: &TestFixture, port: u16) -> ChildGuard {
         .arg(port.to_string())
         .env("PATH", fixture.path_with_mock_bin())
         .env("ENSEMBLE_E2E_ACPX_LOG", &fixture.acpx_log_path)
-        .stdout(Stdio::null())
-        .stderr(Stdio::inherit());
+        .env(
+            "ENSEMBLE_E2E_TRIAGE_HELPER",
+            fixture
+                .config_dir
+                .path()
+                .join("tools/apply-triage-patch.sh"),
+        )
+        .env(
+            "ENSEMBLE_E2E_HELPER_LOG",
+            reference_helper_log_path(fixture),
+        )
+        .stdout(stdout)
+        .stderr(stderr);
+    if let Some(planning_release) = planning_release {
+        command.env("ENSEMBLE_E2E_PLANNING_RELEASE", planning_release);
+    }
     ChildGuard::new(command.spawn().expect("spawn ensemble web"))
+}
+
+fn reference_helper_log_path(fixture: &TestFixture) -> PathBuf {
+    fixture.config_dir.path().join("reference-helper.log")
 }
 
 async fn wait_for_acpx_text(path: &Path, text: &str) {
@@ -1643,6 +2644,176 @@ async fn wait_for_acpx_text(path: &Path, text: &str) {
         );
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+}
+
+fn acpx_occurrences(path: &Path, text: &str) -> usize {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .match_indices(text)
+        .count()
+}
+
+async fn wait_for_acpx_occurrences(path: &Path, text: &str, minimum: usize) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if acpx_occurrences(path, text) >= minimum {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {minimum} occurrences of {text:?} in {}",
+            path.display()
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn replace_mock_acpx_output(fixture: &TestFixture, from: &str, to: &str) {
+    let path = fixture.mock_bin_dir.join("acpx");
+    let script = fs::read_to_string(&path).expect("read copied mock acpx");
+    assert!(
+        script.contains(from),
+        "mock output token was absent: {from}"
+    );
+    fs::write(path, script.replacen(from, to, 1)).expect("rewrite copied mock acpx");
+}
+
+async fn wait_for_counter(counter: &AtomicUsize, minimum: usize, name: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if counter.load(Ordering::SeqCst) >= minimum {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {name}; observed {}",
+            counter.load(Ordering::SeqCst)
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_reference_journal_action(fixture: &TestFixture, step: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if read_pipeline_journal_records(fixture.config_dir.path())
+            .unwrap_or_default()
+            .iter()
+            .any(|record| record["kind"] == "action_applied" && record["step"] == step)
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "action receipt for {step} was not journaled"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_reference_interaction(client: &reqwest::Client, base_url: &str, step: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        let state = client
+            .get(format!("{base_url}/api/v1/state"))
+            .send()
+            .await
+            .expect("read reference state")
+            .json::<Value>()
+            .await
+            .expect("decode reference state");
+        if state["waiting_on_human"]
+            .as_array()
+            .is_some_and(|items| items.iter().any(|item| item["step_name"] == step))
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "interaction for {step} missing: {state:#?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_reference_acpx_text(
+    fixture: &TestFixture,
+    client: &reqwest::Client,
+    base_url: &str,
+    text: &str,
+) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if fs::read_to_string(&fixture.acpx_log_path)
+            .unwrap_or_default()
+            .contains(text)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timed out waiting for {text:?}: {}",
+                reference_runtime_diagnostics(fixture, client, base_url).await
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_reference_acpx_occurrences(
+    fixture: &TestFixture,
+    client: &reqwest::Client,
+    base_url: &str,
+    text: &str,
+    minimum: usize,
+) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if acpx_occurrences(&fixture.acpx_log_path, text) >= minimum {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "expected {minimum} occurrences of {text:?}: {}",
+                reference_runtime_diagnostics(fixture, client, base_url).await
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn reference_runtime_diagnostics(
+    fixture: &TestFixture,
+    client: &reqwest::Client,
+    base_url: &str,
+) -> String {
+    let api_state = match client.get(format!("{base_url}/api/v1/state")).send().await {
+        Ok(response) => response
+            .text()
+            .await
+            .unwrap_or_else(|error| error.to_string()),
+        Err(error) => error.to_string(),
+    };
+    let attention = match client
+        .get(format!("{base_url}/api/v1/{ISSUE_ID}"))
+        .send()
+        .await
+    {
+        Ok(response) => response
+            .text()
+            .await
+            .unwrap_or_else(|error| error.to_string()),
+        Err(error) => error.to_string(),
+    };
+    format!(
+        "acpx log:\n{}\nAPI state:\n{api_state}\nissue attention:\n{attention}\npipeline journal:\n{}\nweb stdout:\n{}\nweb stderr:\n{}",
+        fs::read_to_string(&fixture.acpx_log_path).unwrap_or_default(),
+        read_pipeline_journal_records(fixture.config_dir.path())
+            .map(|records| format!("{records:#?}"))
+            .unwrap_or_else(|error| error),
+        fs::read_to_string(&fixture.web_stdout_path).unwrap_or_default(),
+        fs::read_to_string(&fixture.web_stderr_path).unwrap_or_default(),
+    )
 }
 
 fn find_workspace_file(root: &Path, name: &str) -> io::Result<PathBuf> {

--- a/crates/ensemble-core/src/agent/mod.rs
+++ b/crates/ensemble-core/src/agent/mod.rs
@@ -2397,6 +2397,7 @@ on_failure: Todo
                 result: "succeeded".to_string(),
                 summary: None,
                 output: Some(json!({"risk":"low"})),
+                output_json: Some(r#"{"risk":"low"}"#.to_string()),
                 artifact_snapshot: None,
             },
         );
@@ -2464,6 +2465,7 @@ on_failure: Todo
                     result: "succeeded".to_string(),
                     summary: Some("risk is low".to_string()),
                     output: Some(serde_json::json!({"risk": "low"})),
+                    output_json: Some(r#"{"risk":"low"}"#.to_string()),
                     artifact_snapshot: None,
                 },
             )]),
@@ -2472,6 +2474,7 @@ on_failure: Todo
                 result: "succeeded".to_string(),
                 summary: Some("risk is low".to_string()),
                 output: Some(serde_json::json!({"risk": "low"})),
+                output_json: Some(r#"{"risk":"low"}"#.to_string()),
                 artifact_snapshot: None,
             }],
             output_schema: None,

--- a/crates/ensemble-core/src/config/ensemble.rs
+++ b/crates/ensemble-core/src/config/ensemble.rs
@@ -752,6 +752,17 @@ pub struct RouteSource {
 pub struct RouteConfig {
     pub source: RouteSource,
     pub cases: BTreeMap<String, Vec<String>>,
+    /// Optional terminal-state override for a successfully selected case.
+    /// Values are opaque tracker state identifiers resolved by the adapter.
+    #[serde(default)]
+    pub terminals: BTreeMap<String, RouteTerminalConfig>,
+}
+
+/// Opaque terminal state selected by one route case.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RouteTerminalConfig {
+    pub state: String,
 }
 
 /// Immutable upstream Artifact and tracker-event evidence required before one
@@ -2831,6 +2842,23 @@ fn validate_route_configs(
     steps: &[StepConfig],
     dag: &crate::pipeline::dag::StepDag,
 ) -> Result<(), PipelineError> {
+    let terminal_bearing_routes = steps
+        .iter()
+        .filter(|step| {
+            step.kind == StepKind::Route
+                && step
+                    .route
+                    .as_ref()
+                    .is_some_and(|route| !route.terminals.is_empty())
+        })
+        .count();
+    if terminal_bearing_routes > 1 {
+        return Err(PipelineError::InvalidStepConfig {
+            step: "routes".to_string(),
+            reason: "a pipeline may declare terminal mappings on at most one route step"
+                .to_string(),
+        });
+    }
     for route in steps.iter().filter(|step| step.kind == StepKind::Route) {
         let invalid = |reason: String| PipelineError::InvalidStepConfig {
             step: route.name.clone(),
@@ -2909,6 +2937,18 @@ fn validate_route_configs(
             return Err(invalid(
                 "route cases must exactly exhaust the source string enum".to_string(),
             ));
+        }
+        for (case, terminal) in &config.terminals {
+            if !config.cases.contains_key(case) {
+                return Err(invalid(format!(
+                    "route terminal mapping references unknown case '{case}'"
+                )));
+            }
+            if terminal.state.trim().is_empty() {
+                return Err(invalid(format!(
+                    "route terminal mapping for case '{case}' requires a non-blank state"
+                )));
+            }
         }
         let direct_successors = dag
             .steps
@@ -3271,6 +3311,7 @@ on_failure: Failed
                     ),
                     ("disagreement".to_string(), vec!["escalate".to_string()]),
                 ]),
+                terminals: BTreeMap::new(),
             }),
             actions: Vec::new(),
         };
@@ -3320,6 +3361,87 @@ on_failure: Failed
         assert!(
             matches!(validate_config(&config), Err(PipelineError::InvalidStepConfig { step, reason }) if step == "choose_review_path" && reason.contains("exactly exhaust"))
         );
+    }
+
+    #[test]
+    fn route_terminal_mapping_must_name_a_case_and_non_blank_state() {
+        let mut config = parse_config(minimal_yaml()).unwrap();
+        let mut compare = config.steps[0].clone();
+        compare.name = "compare".to_string();
+        compare.output_schema = Some(OutputSchemaConfig {
+            path: "decision.json".into(),
+            schema: Some(serde_json::json!({
+                "type": "object",
+                "required": ["decision"],
+                "properties": {"decision": {"type": "string", "enum": ["accept"]}}
+            })),
+        });
+        let mut route = compare.clone();
+        route.name = "choose".to_string();
+        route.kind = StepKind::Route;
+        route.agent.clear();
+        route.depends = Some(vec!["compare".to_string()]);
+        route.output_schema = None;
+        route.on_failure = OnFailure::Halt;
+        route.route = Some(RouteConfig {
+            source: RouteSource {
+                step: "compare".to_string(),
+                pointer: "/decision".to_string(),
+            },
+            cases: BTreeMap::from([("accept".to_string(), vec!["finish".to_string()])]),
+            terminals: BTreeMap::from([(
+                "unknown".to_string(),
+                RouteTerminalConfig {
+                    state: " ".to_string(),
+                },
+            )]),
+        });
+        let mut finish = compare.clone();
+        finish.name = "finish".to_string();
+        finish.depends = Some(vec!["choose".to_string()]);
+        finish.output_schema = None;
+        config.steps = vec![compare, route, finish];
+
+        assert!(matches!(
+            validate_config(&config),
+            Err(PipelineError::InvalidStepConfig { reason, .. }) if reason.contains("route terminal")
+        ));
+
+        config.steps[1].route.as_mut().unwrap().terminals = BTreeMap::from([(
+            "accept".to_string(),
+            RouteTerminalConfig {
+                state: " ".to_string(),
+            },
+        )]);
+        assert!(matches!(
+            validate_config(&config),
+            Err(PipelineError::InvalidStepConfig { reason, .. }) if reason.contains("non-blank")
+        ));
+
+        config.steps[1].route.as_mut().unwrap().terminals = BTreeMap::from([(
+            "accept".to_string(),
+            RouteTerminalConfig {
+                state: "Ready".to_string(),
+            },
+        )]);
+        assert!(validate_config(&config).is_ok());
+
+        let mut second_route = config.steps[1].clone();
+        second_route.name = "choose-again".to_string();
+        let mut second_finish = config.steps[2].clone();
+        second_finish.name = "finish-again".to_string();
+        second_finish.depends = Some(vec!["choose-again".to_string()]);
+        second_route
+            .route
+            .as_mut()
+            .unwrap()
+            .cases
+            .insert("accept".to_string(), vec!["finish-again".to_string()]);
+        config.steps.extend([second_route, second_finish]);
+        assert!(matches!(
+            validate_config(&config),
+            Err(PipelineError::InvalidStepConfig { reason, .. }) if reason.contains("at most one route step")
+        ));
     }
 
     #[test]
@@ -3403,6 +3525,7 @@ on_failure: Failed
                         ("agreement".to_string(), vec!["accept".to_string()]),
                         ("escalation".to_string(), vec!["escalate".to_string()]),
                     ]),
+                    terminals: BTreeMap::new(),
                 }),
                 actions: Vec::new(),
             },

--- a/crates/ensemble-core/src/config/setup.rs
+++ b/crates/ensemble-core/src/config/setup.rs
@@ -1637,6 +1637,7 @@ mod tests {
                             "agreement".to_string(),
                             vec!["publish".to_string()],
                         )]),
+                        terminals: BTreeMap::new(),
                     }),
                 },
             ],

--- a/crates/ensemble-core/src/config/template.rs
+++ b/crates/ensemble-core/src/config/template.rs
@@ -302,6 +302,7 @@ mod tests {
                 result: "succeeded".to_string(),
                 summary: Some("looks good".to_string()),
                 output: Some(json!({"risk":"low"})),
+                output_json: Some(r#"{"risk":"low"}"#.to_string()),
                 artifact_snapshot: None,
             },
         );
@@ -312,7 +313,7 @@ mod tests {
         };
 
         let rendered = render_prompt_with_context(
-            "{{ steps[\"review-a\"].summary }} / {{ dependency_outputs[0].output.risk }}",
+            "{{ steps[\"review-a\"].summary }} / {{ dependency_outputs[0].output.risk }} / {{ dependency_outputs[0].output_json }}",
             &test_issue(),
             None,
             None,
@@ -320,7 +321,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(rendered, "looks good / low");
+        assert_eq!(rendered, r#"looks good / low / {"risk":"low"}"#);
     }
 
     #[test]

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -5347,21 +5347,22 @@ impl Orchestrator {
         workspace: &crate::workspace::manager::WorkspaceResult,
         repository_keys: &[String],
     ) -> Result<(DeliveryRecord, Option<PipelineRunSnapshot>), String> {
-        let (run_id, snapshot, terminal_history, delivery_repair_capacity, route_success_state) = {
+        let (
+            live_run_id,
+            live_snapshot,
+            terminal_history,
+            live_pipeline_config,
+            live_delivery_repair_capacity,
+        ) = {
             let state = self.state.read().await;
             let run_id = state
                 .running
                 .get(issue_id)
                 .and_then(|entry| entry.run_id.clone())
-                .or_else(|| state.issue_run_ids.get(issue_id).cloned())
-                .ok_or_else(|| "delivery requires a stable run ID".to_string())?;
+                .or_else(|| state.issue_run_ids.get(issue_id).cloned());
             let snapshot = state
                 .get_pipeline_run(issue_id)
                 .map(PipelineRun::to_snapshot);
-            let route_success_state = state
-                .get_pipeline_run(issue_id)
-                .and_then(PipelineRun::selected_route_terminal)
-                .map(str::to_string);
             let terminal_history = self
                 .build_owned_history_record(
                     &state,
@@ -5371,28 +5372,63 @@ impl Orchestrator {
                     Utc::now(),
                 )
                 .or_else(|| state.finalize_terminal_history.get(issue_id).cloned());
-            let delivery_repair_capacity = snapshot
-                .as_ref()
-                .and_then(|snapshot| snapshot.selected_workflow.as_ref())
-                .map(|selected| DeliveryRepairCapacity::Lane {
-                    lane: selected.lane.clone(),
-                })
-                .or_else(|| {
-                    state
-                        .running
-                        .get(issue_id)
-                        .map(|running| DeliveryRepairCapacity::State {
-                            state: running.issue.state.clone(),
-                        })
-                });
+            let delivery_repair_capacity =
+                state
+                    .running
+                    .get(issue_id)
+                    .map(|running| DeliveryRepairCapacity::State {
+                        state: running.issue.state.clone(),
+                    });
             (
                 run_id,
                 snapshot,
                 terminal_history,
+                state.get_pipeline_config(issue_id).cloned(),
                 delivery_repair_capacity,
-                route_success_state,
             )
         };
+        // A pre-persistence delivery failure can remove the in-memory run before an explicit
+        // retry. Recover the last durable owner snapshot instead of falling back to changed
+        // runtime config or losing the route terminal selected by that snapshot.
+        let durable_record = if live_snapshot.is_none() {
+            self.pipeline_journal
+                .latest_live_record_for_issue(issue_id)
+                .await
+                .map_err(|error| format!("failed to recover delivery snapshot: {error}"))?
+        } else {
+            None
+        };
+        let run_id = live_run_id
+            .or_else(|| {
+                durable_record
+                    .as_ref()
+                    .and_then(|record| record.run_id.clone())
+            })
+            .ok_or_else(|| "delivery requires a stable run ID".to_string())?;
+        if durable_record
+            .as_ref()
+            .and_then(|record| record.run_id.as_deref())
+            .is_some_and(|durable_run_id| durable_run_id != run_id)
+        {
+            return Err("durable delivery snapshot belongs to a different run".to_string());
+        }
+        let snapshot = live_snapshot.or_else(|| durable_record.and_then(|record| record.snapshot));
+        let route_success_state = snapshot
+            .as_ref()
+            .map(|snapshot| {
+                PipelineRun::from_snapshot(snapshot.clone())
+                    .map(|run| run.selected_route_terminal().map(str::to_string))
+            })
+            .transpose()
+            .map_err(|error| format!("failed to recover delivery route terminal: {error}"))?
+            .flatten();
+        let delivery_repair_capacity = snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.selected_workflow.as_ref())
+            .map(|selected| DeliveryRepairCapacity::Lane {
+                lane: selected.lane.clone(),
+            })
+            .or(live_delivery_repair_capacity);
         let configured_repositories = self.workspace_mgr.repos();
         let mut repositories = std::collections::BTreeMap::new();
         for repository_key in repository_keys {
@@ -5435,20 +5471,19 @@ impl Orchestrator {
                 },
             );
         }
-        let (delivery_states, delivery_repair, success_state, failure_state) = {
-            let state = self.state.read().await;
-            state
-                .get_pipeline_config(issue_id)
-                .map(|config| {
-                    (
-                        config.delivery_states.clone(),
-                        config.delivery_repair.clone(),
-                        config.on_success.clone(),
-                        config.on_failure.clone(),
-                    )
-                })
-                .unwrap_or_default()
+        let pipeline_config = match live_pipeline_config {
+            Some(config) => config,
+            None => self
+                .current_config_for_snapshot(snapshot.as_ref())
+                .await
+                .map_err(|error| format!("failed to recover selected delivery config: {error}"))?,
         };
+        let (delivery_states, delivery_repair, success_state, failure_state) = (
+            pipeline_config.delivery_states.clone(),
+            pipeline_config.delivery_repair.clone(),
+            pipeline_config.on_success.clone(),
+            pipeline_config.on_failure.clone(),
+        );
         Ok((
             DeliveryRecord {
                 issue_id: issue_id.to_string(),

--- a/crates/ensemble-core/src/orchestrator/delivery.rs
+++ b/crates/ensemble-core/src/orchestrator/delivery.rs
@@ -158,6 +158,10 @@ pub(crate) struct DeliveryRecord {
     #[serde(default)]
     pub delivery_repair_suppressions: BTreeSet<DeliveryRepairIdentity>,
     /// Success target copied from the selected pipeline with the delivery policy.
+    ///
+    /// When a route selected a terminal, this is that route's terminal rather than the
+    /// pipeline's default `on_success`. Delivery may outlive the in-memory `PipelineRun`, so
+    /// completion and recovery must use this durable target rather than re-reading config.
     #[serde(default)]
     pub success_state: Option<String>,
     /// Failure target copied from the selected pipeline with the delivery policy.
@@ -4614,7 +4618,7 @@ impl Orchestrator {
         record.artifacts = artifacts;
     }
 
-    async fn complete_published_delivery(
+    pub(super) async fn complete_published_delivery(
         &self,
         delivery: &DeliveryRecord,
         snapshot: Option<&PipelineRunSnapshot>,
@@ -4629,13 +4633,13 @@ impl Orchestrator {
             );
             return;
         };
-        let config = match self.current_config_for_snapshot(snapshot).await {
-            Ok(config) => config,
+        let target_state = match self.delivery_success_target(delivery, snapshot).await {
+            Ok(target_state) => target_state,
             Err(error) => {
                 warn!(
                     issue_id = %delivery.issue_id,
                     error = %error,
-                    "published delivery could not resolve its selected workflow"
+                    "published delivery could not resolve its frozen success target"
                 );
                 return;
             }
@@ -4656,10 +4660,26 @@ impl Orchestrator {
             &delivery.identifier,
             issue,
             TerminalOutcome::Succeeded,
-            config.on_success.clone(),
+            target_state,
             Some(history_record),
         )
         .await;
+    }
+
+    /// Returns the target frozen when delivery began. Older records did not have this field, so
+    /// they retain their previous selected-workflow fallback during one recovery upgrade.
+    async fn delivery_success_target(
+        &self,
+        delivery: &DeliveryRecord,
+        snapshot: Option<&PipelineRunSnapshot>,
+    ) -> Result<String, String> {
+        if let Some(target) = delivery.success_state.clone() {
+            return Ok(target);
+        }
+        self.current_config_for_snapshot(snapshot)
+            .await
+            .map(|config| config.on_success.clone())
+            .map_err(|error| format!("could not resolve legacy selected workflow: {error}"))
     }
     pub(super) async fn project_delivery_artifacts(
         &self,
@@ -5327,7 +5347,7 @@ impl Orchestrator {
         workspace: &crate::workspace::manager::WorkspaceResult,
         repository_keys: &[String],
     ) -> Result<(DeliveryRecord, Option<PipelineRunSnapshot>), String> {
-        let (run_id, snapshot, terminal_history, delivery_repair_capacity) = {
+        let (run_id, snapshot, terminal_history, delivery_repair_capacity, route_success_state) = {
             let state = self.state.read().await;
             let run_id = state
                 .running
@@ -5338,6 +5358,10 @@ impl Orchestrator {
             let snapshot = state
                 .get_pipeline_run(issue_id)
                 .map(PipelineRun::to_snapshot);
+            let route_success_state = state
+                .get_pipeline_run(issue_id)
+                .and_then(PipelineRun::selected_route_terminal)
+                .map(str::to_string);
             let terminal_history = self
                 .build_owned_history_record(
                     &state,
@@ -5361,7 +5385,13 @@ impl Orchestrator {
                             state: running.issue.state.clone(),
                         })
                 });
-            (run_id, snapshot, terminal_history, delivery_repair_capacity)
+            (
+                run_id,
+                snapshot,
+                terminal_history,
+                delivery_repair_capacity,
+                route_success_state,
+            )
         };
         let configured_repositories = self.workspace_mgr.repos();
         let mut repositories = std::collections::BTreeMap::new();
@@ -5433,7 +5463,7 @@ impl Orchestrator {
                 delivery_repair_attempts_used: 0,
                 delivery_repair_capacity,
                 delivery_repair_suppressions: Default::default(),
-                success_state: Some(success_state),
+                success_state: Some(route_success_state.unwrap_or(success_state)),
                 failure_state: Some(failure_state),
                 closed_without_merge_parked: false,
                 selected_delivery_state: None,

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -10624,7 +10624,17 @@ impl Orchestrator {
         let target_state = match outcome {
             TerminalOutcome::Succeeded => {
                 let state = self.state.read().await;
-                terminal_target_for_outcome(config, outcome, state.get_pipeline_run(issue_id))
+                state
+                    .delivery
+                    .get(issue_id)
+                    .and_then(|delivery| delivery.success_state.clone())
+                    .unwrap_or_else(|| {
+                        terminal_target_for_outcome(
+                            config,
+                            outcome,
+                            state.get_pipeline_run(issue_id),
+                        )
+                    })
             }
             TerminalOutcome::Failed => terminal_target_for_outcome(config, outcome, None),
         };
@@ -11115,11 +11125,17 @@ impl Orchestrator {
             };
             let target_state = {
                 let state = self.state.read().await;
-                terminal_target_for_outcome(
-                    config_snapshot.as_ref(),
-                    outcome,
-                    state.get_pipeline_run(issue_id),
-                )
+                state
+                    .delivery
+                    .get(issue_id)
+                    .and_then(|delivery| delivery.success_state.clone())
+                    .unwrap_or_else(|| {
+                        terminal_target_for_outcome(
+                            config_snapshot.as_ref(),
+                            outcome,
+                            state.get_pipeline_run(issue_id),
+                        )
+                    })
             };
             if let Some(finalize_state) = self
                 .state
@@ -16331,6 +16347,114 @@ mod tests {
             .await
             .unwrap();
         (orchestrator, workspace_temp, repo_temp, delivery)
+    }
+
+    #[tokio::test]
+    async fn staged_finalization_uses_the_delivery_route_target_after_pipeline_removal() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(remote).await;
+        let config_snapshot = orchestrator.config.read().await.clone();
+        let run = PipelineRun::new(
+            delivery.issue_id.clone(),
+            1,
+            build_dag(&config_snapshot.steps).unwrap(),
+        );
+        let snapshot = run.to_snapshot();
+        delivery.success_state = Some("Route terminal".to_string());
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        orchestrator
+            .state
+            .write()
+            .await
+            .remove_pipeline_run(&delivery.issue_id);
+        orchestrator.config.write().await.on_success = "Drifted default".to_string();
+        orchestrator.tracker = Arc::new(FailingWriteTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+        });
+
+        let finalize = IssueFinalizeState {
+            issue_identifier: delivery.identifier.clone(),
+            status: FinalizeStatus::NotRequired,
+            repos: Vec::new(),
+        };
+        let config_after_drift = orchestrator.config.read().await.clone();
+        orchestrator
+            .stage_finalization_terminal_transition(
+                &delivery.issue_id,
+                &delivery.identifier,
+                &config_after_drift,
+                &finalize,
+            )
+            .await;
+
+        let latest = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue(&delivery.issue_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            latest.terminal_transition.unwrap().target_state,
+            "Route terminal"
+        );
+    }
+
+    #[tokio::test]
+    async fn published_delivery_uses_its_frozen_route_target_after_config_drift() {
+        let remote = Arc::new(RecoveryDeliveryRemote {
+            pull_requests: std::sync::Mutex::new(Vec::new()),
+            pushes: AtomicUsize::new(0),
+            creates: AtomicUsize::new(0),
+            lists: AtomicUsize::new(0),
+        });
+        let (mut orchestrator, _workspace, _repo, mut delivery) =
+            recovery_test_orchestrator(remote).await;
+        let config_snapshot = orchestrator.config.read().await.clone();
+        let run = PipelineRun::new(
+            delivery.issue_id.clone(),
+            1,
+            build_dag(&config_snapshot.steps).unwrap(),
+        );
+        let snapshot = run.to_snapshot();
+        delivery.success_state = Some("Route terminal".to_string());
+        delivery.repositories.get_mut("source-repo").unwrap().phase = DeliveryPhase::Published;
+        orchestrator
+            .persist_delivery_record(&delivery, Some(&snapshot))
+            .await
+            .unwrap();
+        orchestrator
+            .state
+            .write()
+            .await
+            .remove_pipeline_run(&delivery.issue_id);
+        orchestrator.config.write().await.on_success = "Drifted default".to_string();
+        orchestrator.tracker = Arc::new(FailingWriteTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+        });
+
+        orchestrator
+            .complete_published_delivery(&delivery, Some(&snapshot))
+            .await;
+
+        let latest = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue(&delivery.issue_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            latest.terminal_transition.unwrap().target_state,
+            "Route terminal"
+        );
     }
 
     #[tokio::test]

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -147,6 +147,20 @@ fn artifact_snapshot_capture_failure(error: impl std::fmt::Display) -> StepOutpu
     }
 }
 
+fn terminal_target_for_outcome(
+    config: &EnsembleConfig,
+    outcome: TerminalOutcome,
+    run: Option<&PipelineRun>,
+) -> String {
+    match outcome {
+        TerminalOutcome::Succeeded => run
+            .and_then(PipelineRun::selected_route_terminal)
+            .unwrap_or(&config.on_success)
+            .to_string(),
+        TerminalOutcome::Failed => config.on_failure.clone(),
+    }
+}
+
 fn worker_failure_output(error: String) -> StepOutput {
     StepOutput {
         result: StepResult::Failed {
@@ -2157,7 +2171,11 @@ impl Orchestrator {
                                 (
                                     Some(terminal_issue),
                                     Some(TerminalOutcome::Succeeded),
-                                    Some(config_snapshot.on_success.clone()),
+                                    Some(terminal_target_for_outcome(
+                                        &config_snapshot,
+                                        TerminalOutcome::Succeeded,
+                                        state.get_pipeline_run(&issue.id),
+                                    )),
                                     history_record,
                                 )
                             } else {
@@ -6243,7 +6261,11 @@ impl Orchestrator {
                                     FinalizeStatus::Succeeded | FinalizeStatus::NotRequired
                                 ) {
                                     (
-                                        Some(config_snapshot.on_success.clone()),
+                                        Some(terminal_target_for_outcome(
+                                            &config_snapshot,
+                                            TerminalOutcome::Succeeded,
+                                            state.get_pipeline_run(issue_id),
+                                        )),
                                         Some(TerminalOutcome::Succeeded),
                                         terminal_issue,
                                         history_record,
@@ -10600,8 +10622,11 @@ impl Orchestrator {
             | FinalizeStatus::Failed => return,
         };
         let target_state = match outcome {
-            TerminalOutcome::Succeeded => config.on_success.clone(),
-            TerminalOutcome::Failed => config.on_failure.clone(),
+            TerminalOutcome::Succeeded => {
+                let state = self.state.read().await;
+                terminal_target_for_outcome(config, outcome, state.get_pipeline_run(issue_id))
+            }
+            TerminalOutcome::Failed => terminal_target_for_outcome(config, outcome, None),
         };
         let last_error = finalize_state
             .repos
@@ -11088,7 +11113,14 @@ impl Orchestrator {
                     return;
                 }
             };
-            let target_state = config_snapshot.on_success.clone();
+            let target_state = {
+                let state = self.state.read().await;
+                terminal_target_for_outcome(
+                    config_snapshot.as_ref(),
+                    outcome,
+                    state.get_pipeline_run(issue_id),
+                )
+            };
             if let Some(finalize_state) = self
                 .state
                 .read()
@@ -12254,7 +12286,11 @@ impl Orchestrator {
                             ) {
                                 (
                                     Some(TerminalOutcome::Succeeded),
-                                    Some(pipeline_config.on_success.clone()),
+                                    Some(terminal_target_for_outcome(
+                                        &pipeline_config,
+                                        TerminalOutcome::Succeeded,
+                                        state.get_pipeline_run(&issue.id),
+                                    )),
                                     history_record,
                                 )
                             } else {
@@ -25684,6 +25720,7 @@ agent:
                 ("accept".to_string(), vec!["accept".to_string()]),
                 ("reject".to_string(), vec!["reject".to_string()]),
             ]),
+            terminals: BTreeMap::new(),
         });
         for name in ["accept", "reject"] {
             let mut branch = config.steps[0].clone();

--- a/crates/ensemble-core/src/orchestrator/mod.rs
+++ b/crates/ensemble-core/src/orchestrator/mod.rs
@@ -19721,6 +19721,149 @@ mod tests {
         drop(repo_temp);
     }
 
+    #[tokio::test]
+    async fn finalize_retry_reconstructs_the_route_terminal_before_delivery_persistence() {
+        let remote = Arc::new(FailOnceIdentityRemote {
+            inner: RecoveryDeliveryRemote {
+                pull_requests: std::sync::Mutex::new(Vec::new()),
+                pushes: AtomicUsize::new(0),
+                creates: AtomicUsize::new(0),
+                lists: AtomicUsize::new(0),
+            },
+            identity_failures: AtomicUsize::new(1),
+        });
+        let (repo_temp, mut repo_config) = create_finalize_repo().await;
+        repo_config.finalize.mode = FinalizeMode::PushAndPr;
+        repo_config.finalize.approval_required = true;
+        let mut initial_config = make_always_approval_route_config();
+        initial_config.steps[1]
+            .route
+            .as_mut()
+            .unwrap()
+            .terminals
+            .insert(
+                "accept".to_string(),
+                crate::config::ensemble::RouteTerminalConfig {
+                    state: "Route terminal".to_string(),
+                },
+            );
+        let config = Arc::new(RwLock::new(initial_config));
+        let tracker: Arc<dyn IssueTracker> = Arc::new(MockTracker {
+            issues: Arc::new(RwLock::new(vec![test_issue("1", "Todo")])),
+        });
+        let runner: Arc<dyn AgentRunner> = Arc::new(CountingRunner {
+            runs: Arc::new(AtomicUsize::new(0)),
+        });
+        let workspace_temp = tempfile::TempDir::new().unwrap();
+        let workspace_mgr =
+            WorkspaceManager::new(workspace_temp.path(), Some(vec![repo_config])).unwrap();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let mut orchestrator = Orchestrator::new(
+            Arc::clone(&config),
+            tracker,
+            runner,
+            workspace_mgr,
+            workspace_temp.path(),
+            shutdown_rx,
+        );
+        orchestrator.delivery_remote = remote.clone();
+        let (route_snapshot, route_run_id) = {
+            let cfg = config.read().await;
+            let dag = build_dag(&cfg.steps).unwrap();
+            let mut run = PipelineRun::new("1".to_string(), 1, dag);
+            run.start();
+            run.mark_running("build", "session-1".to_string());
+            run.step_completed("build", succeeded_step_output(), false);
+            run.route_decisions.insert(
+                "choose".to_string(),
+                RouteDecisionEvidence {
+                    source_step: "build".to_string(),
+                    pointer: "/decision".to_string(),
+                    selected_case: "accept".to_string(),
+                    source_output_digest: "frozen-route-output".to_string(),
+                },
+            );
+            let route_snapshot = run.to_snapshot();
+            let mut state = orchestrator.state.write().await;
+            state.add_running(&test_issue("1", "Todo"), None);
+            let route_run_id = state.running["1"].run_id.clone().unwrap();
+            state.insert_pipeline_run("1", run, Arc::new(cfg.clone()));
+            (route_snapshot, route_run_id)
+        };
+        orchestrator
+            .pipeline_journal
+            .append(PipelineTransitionInput {
+                kind: PipelineTransitionKind::StepCompleted,
+                issue_id: "1".to_string(),
+                identifier: "repo#1".to_string(),
+                run_id: Some(route_run_id),
+                cycle: route_snapshot.cycle,
+                step: Some("choose".to_string()),
+                reason: None,
+                retry: None,
+                snapshot: Some(route_snapshot),
+                terminal_transition: None,
+                delivery: None,
+            })
+            .await
+            .unwrap();
+        let config_snapshot = config.read().await.clone();
+        let finalize = orchestrator
+            .run_finalize_phase("1", "repo#1", &config_snapshot)
+            .await;
+        assert_eq!(finalize.status, FinalizeStatus::Failed);
+        assert!(orchestrator
+            .state
+            .read()
+            .await
+            .finalize_terminal_history
+            .contains_key("1"));
+        {
+            let mut state = orchestrator.state.write().await;
+            state.remove_running("1");
+            state.remove_pipeline_run("1");
+            state.set_finalize_state("1", finalize);
+        }
+        config.write().await.on_success = "Drifted default".to_string();
+
+        orchestrator
+            .retry_finalize_delivery("1", "repo#1")
+            .await
+            .unwrap();
+        orchestrator.process_finalize_retries().await;
+
+        let delivery = orchestrator.state.read().await.delivery["1"].clone();
+        assert_eq!(delivery.success_state.as_deref(), Some("Route terminal"));
+        assert_eq!(delivery.failure_state.as_deref(), Some("Failed"));
+        assert_eq!(
+            delivery.repositories["source-repo"].phase,
+            DeliveryPhase::AwaitingApproval
+        );
+        drop(delivery);
+
+        let finalize = IssueFinalizeState {
+            issue_identifier: "repo#1".to_string(),
+            status: FinalizeStatus::NotRequired,
+            repos: Vec::new(),
+        };
+        let config_after_drift = config.read().await.clone();
+        orchestrator
+            .stage_finalization_terminal_transition("1", "repo#1", &config_after_drift, &finalize)
+            .await;
+        let latest = orchestrator
+            .pipeline_journal
+            .latest_live_record_for_issue("1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            latest.terminal_transition.unwrap().target_state,
+            "Route terminal"
+        );
+
+        drop(repo_temp);
+    }
+
     fn post_finalize_acceptance_snapshot(
         rule_names: &[&str],
         results: Vec<crate::acceptance::AcceptanceResult>,

--- a/crates/ensemble-core/src/orchestrator/retry.rs
+++ b/crates/ensemble-core/src/orchestrator/retry.rs
@@ -975,6 +975,7 @@ mod tests {
                     pointer: "/decision".to_string(),
                 },
                 cases: std::collections::BTreeMap::new(),
+                terminals: std::collections::BTreeMap::new(),
             }),
             actions: Vec::new(),
         }])

--- a/crates/ensemble-core/src/pipeline/engine.rs
+++ b/crates/ensemble-core/src/pipeline/engine.rs
@@ -203,6 +203,8 @@ pub struct StepOutputTemplateEntry {
     pub result: String,
     pub summary: Option<String>,
     pub output: Option<serde_json::Value>,
+    /// Compact JSON for templates that must preserve the exact structured output.
+    pub output_json: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub artifact_snapshot: Option<ArtifactSnapshot>,
 }
@@ -406,6 +408,25 @@ impl PipelineRun {
             selected_workflow: self.selected_workflow.clone(),
             active_scheduler_reservations: self.active_scheduler_reservations.clone(),
         }
+    }
+
+    /// Returns the opaque terminal state selected by the persisted route evidence.
+    ///
+    /// Configuration validation permits at most one terminal-bearing route, so a
+    /// selected case is unambiguous. This deliberately reads the frozen DAG and
+    /// decision evidence rather than re-evaluating producer output.
+    pub fn selected_route_terminal(&self) -> Option<&str> {
+        self.dag.steps.iter().find_map(|step| {
+            let route = step.route.as_ref()?;
+            if route.terminals.is_empty() {
+                return None;
+            }
+            let decision = self.route_decisions.get(&step.name)?;
+            route
+                .terminals
+                .get(&decision.selected_case)
+                .map(|terminal| terminal.state.as_str())
+        })
     }
 
     pub(crate) fn scheduler_requirements_for(
@@ -1943,6 +1964,7 @@ fn template_entry(
         },
         summary: output.summary.clone(),
         output: output.output.clone(),
+        output_json: output.output.as_ref().map(serde_json::Value::to_string),
         artifact_snapshot,
     }
 }
@@ -3194,6 +3216,10 @@ mod tests {
         assert_eq!(context.dependency_outputs[0].step, "review-a");
         assert_eq!(context.dependency_outputs[1].step, "review-b");
         assert_eq!(context.steps["review-a"].summary.as_deref(), Some("a ok"));
+        assert_eq!(
+            context.steps["review-a"].output_json.as_deref(),
+            Some(r#"{"risk":"low"}"#)
+        );
     }
 
     #[test]
@@ -3992,6 +4018,7 @@ mod tests {
                 ),
                 ("disagreement".to_string(), vec!["escalate".to_string()]),
             ]),
+            terminals: BTreeMap::new(),
         });
         let accept = make_step(
             "accept_agreement",
@@ -4057,6 +4084,50 @@ mod tests {
     }
 
     #[test]
+    fn selected_route_terminal_survives_snapshot_recovery() {
+        let producer = make_step("produce", "builder", &[]);
+        let mut route = make_step("choose", "", &["produce"]);
+        route.kind = StepKind::Route;
+        route.on_failure = OnFailure::Halt;
+        route.route = Some(RouteConfig {
+            source: RouteSource {
+                step: "produce".to_string(),
+                pointer: "/outcome".to_string(),
+            },
+            cases: BTreeMap::from([
+                ("continue".to_string(), vec!["continue".to_string()]),
+                ("hold".to_string(), vec!["hold".to_string()]),
+            ]),
+            terminals: BTreeMap::from([(
+                "hold".to_string(),
+                crate::config::ensemble::RouteTerminalConfig {
+                    state: "Needs human".to_string(),
+                },
+            )]),
+        });
+        let continue_step = make_step("continue", "builder", &["choose"]);
+        let hold_step = make_step("hold", "builder", &["choose"]);
+        let mut run = make_run(&[producer, route, continue_step, hold_step]);
+        run.route_decisions.insert(
+            "choose".to_string(),
+            RouteDecisionEvidence {
+                source_step: "produce".to_string(),
+                pointer: "/outcome".to_string(),
+                selected_case: "hold".to_string(),
+                source_output_digest: "digest".to_string(),
+            },
+        );
+
+        assert_eq!(run.selected_route_terminal(), Some("Needs human"));
+        assert_eq!(
+            PipelineRun::from_snapshot(run.to_snapshot())
+                .unwrap()
+                .selected_route_terminal(),
+            Some("Needs human")
+        );
+    }
+
+    #[test]
     fn route_shared_gate_join_evaluates_after_selected_dependencies_settle() {
         let compare = make_step("compare", "comparator", &[]);
         let mut route = make_step("choose", "", &["compare"]);
@@ -4071,6 +4142,7 @@ mod tests {
                 ("review".to_string(), vec!["review".to_string()]),
                 ("skip".to_string(), vec!["skipped_branch".to_string()]),
             ]),
+            terminals: BTreeMap::new(),
         });
         let review = make_step("review", "reviewer", &["choose"]);
         let mut adjudicate = make_step("adjudicate", "synthesizer", &["review"]);
@@ -4119,6 +4191,7 @@ mod tests {
                 pointer: "/decision".to_string(),
             },
             cases: BTreeMap::from([("agreement".to_string(), vec!["accept".to_string()])]),
+            terminals: BTreeMap::new(),
         });
         let mut accept = make_step("accept", "handler", &["choose"]);
         accept.actions = vec![StepActionConfig::TrackerComment {
@@ -4167,6 +4240,7 @@ mod tests {
                     vec!["review_escalation".to_string()],
                 ),
             ]),
+            terminals: BTreeMap::new(),
         });
         let review_agreement = make_step("review_agreement", "reviewer", &["choose_primary"]);
         let review_escalation = make_step("review_escalation", "reviewer", &["choose_primary"]);
@@ -4182,6 +4256,7 @@ mod tests {
                 ("accept".to_string(), vec!["accept".to_string()]),
                 ("escalate".to_string(), vec!["escalate".to_string()]),
             ]),
+            terminals: BTreeMap::new(),
         });
         let accept = make_step("accept", "handler", &["choose_agreement"]);
         let escalate = make_step("escalate", "handler", &["choose_agreement"]);
@@ -4254,6 +4329,7 @@ mod tests {
                 ("agreement".to_string(), vec!["accept".to_string()]),
                 ("disagreement".to_string(), vec!["escalate".to_string()]),
             ]),
+            terminals: BTreeMap::new(),
         });
         let accept = make_step("accept", "handler", &["choose"]);
         let escalate = make_step("escalate", "handler", &["choose"]);
@@ -4308,6 +4384,7 @@ mod tests {
                 pointer: "/decision".to_string(),
             },
             cases: BTreeMap::from([("agreement".to_string(), vec!["accept".to_string()])]),
+            terminals: BTreeMap::new(),
         });
         let accept = make_step("accept", "handler", &["choose"]);
         let mut run = make_run(&[compare, route, accept]);
@@ -4634,6 +4711,7 @@ mod tests {
                 ("continue".to_string(), vec!["continue".to_string()]),
                 ("stop".to_string(), vec!["stop".to_string()]),
             ]),
+            terminals: BTreeMap::new(),
         });
         let mut continue_step = make_step("continue", "handler", &["choose"]);
         continue_step.actions = vec![StepActionConfig::TrackerComment {

--- a/crates/ensemble-core/tests/github_project_drain_reference.rs
+++ b/crates/ensemble-core/tests/github_project_drain_reference.rs
@@ -1,0 +1,498 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use ensemble_core::config::ensemble::{
+    load_config, validate_config, ArtifactAccess, AuthorizationHandoffMode, StepKind,
+};
+
+fn example_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/examples/github-project-drain")
+}
+
+#[test]
+fn github_project_drain_reference_is_a_complete_public_configuration_bundle() {
+    let root = example_root();
+    let config = load_config(&root.join("config.yaml")).expect("reference config loads");
+
+    assert!(config.uses_workflow_selection());
+    validate_config(&config).expect("reference config uses supported public contracts");
+    assert_eq!(
+        config
+            .pipelines
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        [
+            "delivery",
+            "epic-closure",
+            "human-attention",
+            "planning",
+            "triage"
+        ]
+    );
+
+    let planning = &config.pipelines["planning"];
+    let plan = planning
+        .steps
+        .iter()
+        .find(|step| step.name == "draft-plan")
+        .expect("planning drafts an Artifact");
+    assert!(plan.artifact_snapshot.is_some());
+    let plan_route = planning
+        .steps
+        .iter()
+        .find(|step| step.name == "route-plan-outcome")
+        .expect("planning routes the draft result");
+    assert_eq!(plan_route.kind, StepKind::Route);
+    assert_eq!(
+        plan_route
+            .route
+            .as_ref()
+            .unwrap()
+            .cases
+            .keys()
+            .collect::<Vec<_>>(),
+        ["operator_required", "revision"]
+    );
+    assert_eq!(
+        plan_route.route.as_ref().unwrap().terminals["revision"].state,
+        "Ready to implement"
+    );
+    assert_eq!(
+        plan_route.route.as_ref().unwrap().terminals["operator_required"].state,
+        "Needs human"
+    );
+    let acknowledgement = planning
+        .steps
+        .iter()
+        .find(|step| step.name == "acknowledge-plan-revision")
+        .expect("planning waits for acknowledgement");
+    assert_eq!(acknowledgement.artifact_inputs, ["draft-plan"]);
+    assert_eq!(acknowledgement.artifact_access, ArtifactAccess::Immutable);
+    assert_eq!(
+        acknowledgement
+            .authorization
+            .as_ref()
+            .expect("acknowledgement is status-event authorized")
+            .handoff,
+        AuthorizationHandoffMode::WaitForEvent
+    );
+
+    let delivery = &config.pipelines["delivery"];
+    let gate = delivery
+        .steps
+        .iter()
+        .find(|step| step.name == "delivery-gate")
+        .expect("delivery has a deterministic gate");
+    assert_eq!(gate.kind, StepKind::Gate);
+    for name in ["review", "verify"] {
+        let assessment = delivery
+            .steps
+            .iter()
+            .find(|step| step.name == name)
+            .expect("delivery assessment exists");
+        assert_eq!(assessment.artifact_inputs, ["implement"]);
+        assert_eq!(assessment.artifact_access, ArtifactAccess::Immutable);
+    }
+
+    let triage = &config.pipelines["triage"];
+    let triage_applier = triage
+        .steps
+        .iter()
+        .find(|step| step.name == "apply-triage-patch")
+        .expect("triage has an applier");
+    assert!(triage_applier.approval.is_none());
+    assert_eq!(triage_applier.artifact_inputs, ["draft-triage-patch"]);
+    assert_eq!(triage_applier.artifact_access, ArtifactAccess::Immutable);
+    let triage_authorization = triage_applier
+        .authorization
+        .as_ref()
+        .expect("triage applier is authorized before dispatch");
+    assert_eq!(
+        triage_authorization.handoff,
+        AuthorizationHandoffMode::WaitForEvent
+    );
+    assert!(triage_authorization.after_artifact);
+    assert_eq!(triage_authorization.event.value, "Triage approved");
+    assert_eq!(triage_authorization.event.actors, ["example-maintainer"]);
+    assert_eq!(triage.on_success, "Ready to implement");
+    assert!(config.scheduler.lanes["triage"].idle_only);
+    assert!(config.scheduler.lanes["human-attention"].idle_only);
+    for state in ["Triage approved", "Awaiting review", "Awaiting merge"] {
+        assert!(config.tracker.active_states.contains(&state.to_string()));
+    }
+    let epic = &config.pipelines["epic-closure"];
+    let epic_route = epic
+        .steps
+        .iter()
+        .find(|step| step.name == "route-epic-outcome")
+        .expect("epic closure has an outcome route");
+    assert_eq!(
+        epic_route.route.as_ref().unwrap().terminals["close"].state,
+        "Done"
+    );
+    assert_eq!(
+        epic_route.route.as_ref().unwrap().terminals["attention"].state,
+        "Needs human"
+    );
+    assert_eq!(config.pipelines["human-attention"].on_success, "Human hold");
+    let delivery_selection = config
+        .workflow_selection
+        .iter()
+        .find(|rule| rule.name == "delivery")
+        .expect("delivery selection exists");
+    assert_eq!(
+        delivery_selection.labels_none.as_deref(),
+        Some(["epic".to_string()].as_slice())
+    );
+    assert!(root.join("tools/apply-triage-patch.sh").is_file());
+    let helper =
+        fs::read_to_string(root.join("tools/apply-triage-patch.sh")).expect("triage helper exists");
+    assert!(helper.contains("-F labels[]"));
+    let triage_apply_prompt = fs::read_to_string(root.join("prompts/triage-apply.md"))
+        .expect("triage applier prompt exists");
+    assert!(triage_apply_prompt.contains("{{ dependency_outputs[0].output_json }}"));
+    let triage_schema: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(root.join("schemas/triage-patch.schema.json"))
+            .expect("triage schema exists"),
+    )
+    .expect("triage schema is JSON");
+    let triage_validator =
+        jsonschema::validator_for(&triage_schema).expect("triage schema compiles");
+    assert!(triage_validator
+        .validate(
+            &serde_json::from_str(&patch_document(
+                "Triage approved",
+                "set_status",
+                "Ready to implement",
+            ))
+            .unwrap(),
+        )
+        .is_ok());
+    assert!(triage_validator
+        .validate(
+            &serde_json::from_str(&patch_document("Triage approved", "set_status", "Backlog",))
+                .unwrap(),
+        )
+        .is_err());
+
+    let guide = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/github-project-drain.md"),
+    )
+    .expect("canonical guide exists");
+    for asset in [
+        "examples/github-project-drain/config.yaml",
+        "examples/github-project-drain/tools/apply-triage-patch.sh",
+        "PVTSSF_example_status",
+        "wait_for_event",
+        "automatic_transition",
+    ] {
+        assert!(guide.contains(asset), "guide links or explains {asset}");
+    }
+    for guide_name in ["configuration.md", "pipelines.md"] {
+        assert!(fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../docs")
+                .join(guide_name),
+        )
+        .expect("guide exists")
+        .contains("github-project-drain.md"));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn triage_helper_rejects_invalid_stale_and_out_of_policy_patches_before_mutation() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempfile::tempdir().expect("temporary fixture");
+    let patch_path = root.path().join("patch.json");
+    let log_path = root.path().join("gh.log");
+    let bin_dir = root.path().join("bin");
+    fs::create_dir(&bin_dir).expect("mock bin directory");
+    let gh_path = bin_dir.join("gh");
+    fs::write(
+        &gh_path,
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$GH_LOG"
+case "$*" in
+  *ReferenceTriageSnapshot*) cat "$GH_SNAPSHOT" ;;
+  *) exit 0 ;;
+esac
+"#,
+    )
+    .expect("mock gh");
+    fs::set_permissions(&gh_path, fs::Permissions::from_mode(0o755)).expect("executable gh");
+
+    let snapshot_path = root.path().join("snapshot.json");
+    fs::write(&snapshot_path, fixture_snapshot()).expect("snapshot response");
+    let script = example_root().join("tools/apply-triage-patch.sh");
+
+    let run = |patch: &str| {
+        fs::write(&patch_path, patch).expect("patch fixture");
+        let mut command = Command::new(&script);
+        command
+            .args([
+                "--repo",
+                "example/ensemble",
+                "--project-number",
+                "6",
+                "--status-field",
+                "Status",
+                "--issue",
+                "42",
+                "--patch",
+                patch_path.to_str().expect("utf-8 patch path"),
+            ])
+            .env("GH_LOG", &log_path)
+            .env("GH_SNAPSHOT", &snapshot_path)
+            .env(
+                "PATH",
+                format!("{}:{}", bin_dir.display(), std::env::var("PATH").unwrap()),
+            );
+        command.status().expect("helper starts")
+    };
+
+    assert!(!run("{not json").success());
+    assert!(fs::read_to_string(&log_path).unwrap_or_default().is_empty());
+
+    fs::write(&log_path, "").unwrap();
+    assert!(!run(&patch_document(
+        "Different status",
+        "set_status",
+        "Ready to implement"
+    ))
+    .success());
+    let stale_log = fs::read_to_string(&log_path).expect("stale read was logged");
+    assert!(stale_log.contains("ReferenceTriageSnapshot"));
+    assert!(!stale_log.contains("ReferenceTriageSetStatus"));
+
+    fs::write(&log_path, "").unwrap();
+    assert!(!run(&patch_document("Triage approved", "set_status", "Done")).success());
+    assert!(fs::read_to_string(&log_path).unwrap_or_default().is_empty());
+
+    fs::write(&log_path, "").unwrap();
+    assert!(!run(&patch_document("Triage approved", "set_status", "Backlog")).success());
+    assert!(fs::read_to_string(&log_path).unwrap_or_default().is_empty());
+
+    fs::write(&log_path, "").unwrap();
+    fs::write(
+        &snapshot_path,
+        fixture_snapshot().replace(
+            "        { \"id\": \"LABEL_agent\", \"name\": \"ready-for-agent\" },\n",
+            "",
+        ),
+    )
+    .unwrap();
+    assert!(!run(r#"{
+  "version": 1,
+  "comment": "Later target is unavailable.",
+  "expected_snapshot": {
+    "issue_number": 42,
+    "project_id": "PVT_reference",
+    "status": "Triage approved",
+    "labels": ["needs-triage"]
+  },
+  "operations": [
+    { "type": "set_status", "value": "Ready to implement" },
+    { "type": "add_label", "value": "ready-for-agent" }
+  ]
+}"#,)
+    .success());
+    let unavailable_log = fs::read_to_string(&log_path).unwrap();
+    assert!(unavailable_log.contains("ReferenceTriageSnapshot"));
+    assert!(!unavailable_log.contains("ReferenceTriageSetStatus"));
+
+    let assert_ambiguous_target_is_write_free = |snapshot: serde_json::Value, patch: String| {
+        fs::write(
+            &snapshot_path,
+            serde_json::to_vec_pretty(&snapshot).unwrap(),
+        )
+        .unwrap();
+        fs::write(&log_path, "").unwrap();
+        assert!(!run(&patch).success());
+        let log = fs::read_to_string(&log_path).unwrap();
+        assert!(log.contains("ReferenceTriageSnapshot"));
+        for mutation in [
+            "ReferenceTriageSetStatus",
+            "ReferenceTriageAddLabels",
+            "ReferenceTriageRemoveLabels",
+        ] {
+            assert!(
+                !log.contains(mutation),
+                "ambiguous target wrote via {mutation}"
+            );
+        }
+    };
+
+    let status_patch = patch_document("Triage approved", "set_status", "Ready to implement");
+    let label_patch = patch_document("Triage approved", "add_label", "ready-for-agent");
+
+    let mut duplicate_field: serde_json::Value = serde_json::from_str(fixture_snapshot()).unwrap();
+    let field = duplicate_field["data"]["repository"]["projectV2"]["fields"]["nodes"][0].clone();
+    duplicate_field["data"]["repository"]["projectV2"]["fields"]["nodes"]
+        .as_array_mut()
+        .unwrap()
+        .push(field);
+    assert_ambiguous_target_is_write_free(duplicate_field, status_patch.clone());
+
+    let mut duplicate_item: serde_json::Value = serde_json::from_str(fixture_snapshot()).unwrap();
+    let item = duplicate_item["data"]["repository"]["issue"]["projectItems"]["nodes"][0].clone();
+    duplicate_item["data"]["repository"]["issue"]["projectItems"]["nodes"]
+        .as_array_mut()
+        .unwrap()
+        .push(item);
+    assert_ambiguous_target_is_write_free(duplicate_item, status_patch.clone());
+
+    let mut duplicate_option: serde_json::Value = serde_json::from_str(fixture_snapshot()).unwrap();
+    let option = duplicate_option["data"]["repository"]["projectV2"]["fields"]["nodes"][0]
+        ["options"][2]
+        .clone();
+    duplicate_option["data"]["repository"]["projectV2"]["fields"]["nodes"][0]["options"]
+        .as_array_mut()
+        .unwrap()
+        .push(option);
+    assert_ambiguous_target_is_write_free(duplicate_option, status_patch);
+
+    let mut duplicate_label: serde_json::Value = serde_json::from_str(fixture_snapshot()).unwrap();
+    let label = duplicate_label["data"]["repository"]["labels"]["nodes"][1].clone();
+    duplicate_label["data"]["repository"]["labels"]["nodes"]
+        .as_array_mut()
+        .unwrap()
+        .push(label);
+    assert_ambiguous_target_is_write_free(duplicate_label, label_patch);
+}
+
+#[cfg(unix)]
+#[test]
+fn triage_helper_applies_only_the_configured_status_and_label_operations() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempfile::tempdir().expect("temporary fixture");
+    let patch_path = root.path().join("patch.json");
+    let log_path = root.path().join("gh.log");
+    let snapshot_path = root.path().join("snapshot.json");
+    let bin_dir = root.path().join("bin");
+    fs::create_dir(&bin_dir).expect("mock bin directory");
+    let gh_path = bin_dir.join("gh");
+    fs::write(
+        &gh_path,
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$GH_LOG"
+case "$*" in
+  *ReferenceTriageSnapshot*) cat "$GH_SNAPSHOT" ;;
+  *) exit 0 ;;
+esac
+"#,
+    )
+    .expect("mock gh");
+    fs::set_permissions(&gh_path, fs::Permissions::from_mode(0o755)).expect("executable gh");
+    fs::write(&snapshot_path, fixture_snapshot()).expect("snapshot response");
+    fs::write(
+        &patch_path,
+        r#"{
+  "version": 1,
+  "comment": "Approved triage patch.",
+  "expected_snapshot": {
+    "issue_number": 42,
+    "project_id": "PVT_reference",
+    "status": "Triage approved",
+    "labels": ["needs-triage"]
+  },
+  "operations": [
+    { "type": "set_status", "value": "Ready to implement" },
+    { "type": "remove_label", "value": "needs-triage" },
+    { "type": "add_label", "value": "ready-for-agent" }
+  ]
+}"#,
+    )
+    .expect("approved patch");
+
+    let status = Command::new(example_root().join("tools/apply-triage-patch.sh"))
+        .args([
+            "--repo",
+            "example/ensemble",
+            "--project-number",
+            "6",
+            "--status-field",
+            "Status",
+            "--issue",
+            "42",
+            "--patch",
+            patch_path.to_str().expect("utf-8 patch path"),
+        ])
+        .env("GH_LOG", &log_path)
+        .env("GH_SNAPSHOT", &snapshot_path)
+        .env(
+            "PATH",
+            format!("{}:{}", bin_dir.display(), std::env::var("PATH").unwrap()),
+        )
+        .status()
+        .expect("helper starts");
+    assert!(status.success());
+    let log = fs::read_to_string(log_path).expect("gh calls are logged");
+    for operation in [
+        "ReferenceTriageSnapshot",
+        "ReferenceTriageSetStatus",
+        "ReferenceTriageRemoveLabels",
+        "ReferenceTriageAddLabels",
+    ] {
+        assert!(log.contains(operation), "helper invokes {operation}: {log}");
+    }
+}
+
+fn patch_document(status: &str, operation: &str, value: &str) -> String {
+    format!(
+        r#"{{
+  "version": 1,
+  "comment": "Triage patch.",
+  "expected_snapshot": {{
+    "issue_number": 42,
+    "project_id": "PVT_reference",
+        "status": "{status}",
+    "labels": ["needs-triage"]
+  }},
+  "operations": [{{ "type": "{operation}", "value": "{value}" }}]
+}}"#
+    )
+}
+
+fn fixture_snapshot() -> &'static str {
+    r#"{
+  "data": {
+    "repository": {
+      "projectV2": {
+        "id": "PVT_reference",
+        "fields": { "nodes": [{
+          "id": "PVTSSF_reference_status",
+          "name": "Status",
+          "options": [
+            { "id": "OPT_backlog", "name": "Backlog" },
+            { "id": "OPT_triage_approved", "name": "Triage approved" },
+            { "id": "OPT_ready", "name": "Ready to implement" }
+          ]
+        }] }
+      },
+      "labels": { "nodes": [
+        { "id": "LABEL_triage", "name": "needs-triage" },
+        { "id": "LABEL_agent", "name": "ready-for-agent" },
+        { "id": "LABEL_human", "name": "ready-for-human" }
+      ] },
+      "issue": {
+        "id": "ISSUE_42",
+        "number": 42,
+        "labels": { "nodes": [{ "id": "LABEL_triage", "name": "needs-triage" }] },
+        "projectItems": { "nodes": [{
+          "id": "ITEM_42",
+          "project": { "id": "PVT_reference" },
+          "fieldValues": { "nodes": [{
+            "name": "Triage approved",
+            "field": { "id": "PVTSSF_reference_status", "name": "Status" }
+          }] }
+        }] }
+      }
+    }
+  }
+}"#
+}

--- a/crates/ensemble-core/tests/github_project_drain_reference.rs
+++ b/crates/ensemble-core/tests/github_project_drain_reference.rs
@@ -150,6 +150,7 @@ fn github_project_drain_reference_is_a_complete_public_configuration_bundle() {
     let helper =
         fs::read_to_string(root.join("tools/apply-triage-patch.sh")).expect("triage helper exists");
     assert!(helper.contains("-F labels[]"));
+    assert!(helper.contains("ReferenceTriageRepositoryLabels"));
     let triage_apply_prompt = fs::read_to_string(root.join("prompts/triage-apply.md"))
         .expect("triage applier prompt exists");
     assert!(triage_apply_prompt.contains("{{ dependency_outputs[0].output_json }}"));
@@ -442,6 +443,94 @@ esac
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn triage_helper_resolves_an_allowlisted_label_beyond_the_first_repository_page() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempfile::tempdir().expect("temporary fixture");
+    let patch_path = root.path().join("patch.json");
+    let log_path = root.path().join("gh.log");
+    let snapshot_path = root.path().join("snapshot.json");
+    let labels_page_path = root.path().join("labels-page.json");
+    let bin_dir = root.path().join("bin");
+    fs::create_dir(&bin_dir).expect("mock bin directory");
+    let gh_path = bin_dir.join("gh");
+    fs::write(
+        &gh_path,
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$GH_LOG"
+case "$*" in
+  *ReferenceTriageSnapshot*) cat "$GH_SNAPSHOT" ;;
+  *ReferenceTriageRepositoryLabels*) cat "$GH_LABELS_PAGE" ;;
+  *) exit 0 ;;
+esac
+"#,
+    )
+    .expect("mock gh");
+    fs::set_permissions(&gh_path, fs::Permissions::from_mode(0o755)).expect("executable gh");
+
+    let mut snapshot: serde_json::Value = serde_json::from_str(fixture_snapshot()).unwrap();
+    let first_page = (0..100)
+        .map(|index| serde_json::json!({ "id": format!("LABEL_{index}"), "name": format!("label-{index}") }))
+        .collect::<Vec<_>>();
+    snapshot["data"]["repository"]["labels"]["nodes"] = serde_json::Value::Array(first_page);
+    snapshot["data"]["repository"]["labels"]["pageInfo"] = serde_json::json!({
+        "hasNextPage": true,
+        "endCursor": "LABEL_CURSOR_1"
+    });
+    fs::write(&snapshot_path, serde_json::to_vec(&snapshot).unwrap()).expect("snapshot");
+    fs::write(
+        &labels_page_path,
+        serde_json::json!({
+            "data": {
+                "repository": {
+                    "labels": {
+                        "nodes": [{ "id": "LABEL_agent", "name": "ready-for-agent" }],
+                        "pageInfo": { "hasNextPage": false, "endCursor": null }
+                    }
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("second labels page");
+    fs::write(
+        &patch_path,
+        patch_document("Triage approved", "add_label", "ready-for-agent"),
+    )
+    .expect("approved patch");
+
+    let status = Command::new(example_root().join("tools/apply-triage-patch.sh"))
+        .args([
+            "--repo",
+            "example/ensemble",
+            "--project-number",
+            "6",
+            "--status-field",
+            "Status",
+            "--issue",
+            "42",
+            "--patch",
+            patch_path.to_str().expect("utf-8 patch path"),
+        ])
+        .env("GH_LOG", &log_path)
+        .env("GH_SNAPSHOT", &snapshot_path)
+        .env("GH_LABELS_PAGE", &labels_page_path)
+        .env(
+            "PATH",
+            format!("{}:{}", bin_dir.display(), std::env::var("PATH").unwrap()),
+        )
+        .status()
+        .expect("helper starts");
+
+    assert!(status.success());
+    let log = fs::read_to_string(log_path).expect("gh calls are logged");
+    assert!(log.contains("ReferenceTriageRepositoryLabels"));
+    assert!(log.contains("LABEL_CURSOR_1"));
+    assert!(log.contains("ReferenceTriageAddLabels"));
+}
+
 fn patch_document(status: &str, operation: &str, value: &str) -> String {
     format!(
         r#"{{
@@ -478,7 +567,7 @@ fn fixture_snapshot() -> &'static str {
         { "id": "LABEL_triage", "name": "needs-triage" },
         { "id": "LABEL_agent", "name": "ready-for-agent" },
         { "id": "LABEL_human", "name": "ready-for-human" }
-      ] },
+      ], "pageInfo": { "hasNextPage": false, "endCursor": null } },
       "issue": {
         "id": "ISSUE_42",
         "number": 42,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -645,8 +645,10 @@ There is no default-success result. A step must produce valid `StepOutput` throu
 
 Prompt templates for downstream steps receive:
 
-- `steps` — map of completed step name to `{ step, result, summary, output }`.
+- `steps` — map of completed step name to `{ step, result, summary, output, output_json }`.
 - `dependency_outputs` — ordered list of direct dependency outputs for the step being dispatched.
+  `output_json` is the exact compact JSON serialization of `output` for templates that must
+  materialize an immutable structured result without reconstructing it.
 
 #### 4.1.8 Run Attempt
 
@@ -1220,10 +1222,11 @@ Template input variables:
   - Integer on retry or continuation run.
 - `steps` (map of string to object, optional)
   - Present when upstream steps have completed. Each entry contains `step`, `result`, `summary`,
-    and `output` fields.
+    `output`, and `output_json` fields. `output_json` is the exact compact JSON serialization of
+    `output` when structured output exists.
 - `dependency_outputs` (list of objects, optional)
   - Ordered list of outputs from the step's direct dependencies. Each entry has the same shape as
-    `steps` entries: `{ step, result, summary, output }`.
+    `steps` entries: `{ step, result, summary, output, output_json }`.
 - `delivery_repair` (object, delivery-repair dispatches only)
   - Absent from ordinary pipeline steps.
   - Contains the frozen retained pull-request feedback snapshot:

--- a/docs/adr/0018-add-static-route-steps-to-pipelines.md
+++ b/docs/adr/0018-add-static-route-steps-to-pipelines.md
@@ -13,3 +13,9 @@ This avoids dynamic graph mutation and general conditional expressions: activati
 complete topology before work begins, recovery does not re-evaluate an earlier selection, and
 shared joins retain ordinary dependency semantics. Dynamic loops, predicates, coercion, defaults,
 provider routing, and routing from unvalidated text remain out of scope.
+
+One optional, statically validated `terminals` mapping may be attached to a route in a pipeline.
+It maps a selected case to opaque tracker state data after successful finalization; the immutable
+selected case already retained in the run snapshot supplies that target through restart recovery.
+Unmapped successful cases retain `on_success`, and failures retain `on_failure`. This is a generic
+outcome-routing primitive, not a development-method or tracker-specific runtime concept.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,8 @@ existing bounded, evidence-sensitive upsert store. Pending actions retain the Ru
 claim without rerunning their producer or consuming an agent slot.
 
 For a complete static-route composition, see [Outcome routing](outcome-routing.md).
+For a copyable GitHub Project composition built from the same generic contracts, see [GitHub
+Project reference configuration](github-project-drain.md).
 
 Configuration serves one trusted local operator. ACPX-backed agents and sequential pipelines are
 the supported first-release path. `agent.max_turns` is not a supported field and is rejected.
@@ -735,7 +737,7 @@ Pipeline step definitions. Agent and synthesis steps invoke configured agents; g
 | `artifact_access` | string | `mutable` | `immutable` verifies every declared input immediately before the step starts and halts on drift; `mutable` permits normal workspace mutation |
 | `authorization` | object | — | Optional immutable tracker-event evidence required before this step starts |
 | `gate` | object | — | Required only for `kind: gate`: ordered unique `assessment_steps` and one `adjudication_step`; a gate has no `agent` |
-| `route` | object | — | Required only for `kind: route`: a direct `source` (`step`, non-empty JSON Pointer) and exhaustive enum `cases`; a route has no `agent` and must use `on_failure: halt` |
+| `route` | object | — | Required only for `kind: route`: a direct `source` (`step`, non-empty JSON Pointer), exhaustive enum `cases`, and optional `terminals` case-to-opaque-state mapping. At most one route per pipeline may have terminal mappings; a route has no `agent` and must use `on_failure: halt` |
 
 See [Pipeline Guide](pipelines.md) for details on DAG construction and execution. For a complete
 fixture-backed composition of Artifact snapshots, immutable Assessment consumers, synthesis, and

--- a/docs/examples/github-project-drain/config.yaml
+++ b/docs/examples/github-project-drain/config.yaml
@@ -1,0 +1,269 @@
+# Copy this directory before adapting it. These names are reference policy data,
+# not an Ensemble runtime mode.
+tracker:
+  kind: github
+  repository: example/ensemble
+  project_number: 6
+  api_key: $GITHUB_TOKEN
+  active_states: [Backlog, Planning, Triage approved, Ready to implement, In progress, Awaiting review, Awaiting merge, Needs human, Human hold]
+  terminal_states: [Done, Cancelled]
+  github:
+    status_field: Status
+    priority:
+      field: Priority
+      options: [P0, P1, P2, P3]
+    ownership:
+      claim:
+        claimed_state: In progress
+        resume_states: [In progress]
+      delivery_adoption:
+        repository: example/ensemble
+        base_branch: main
+        branch_template: ensemble/{issue_workspace_key}
+        require_authenticated_author: true
+
+repos:
+  - path: target
+    branch: main
+    finalize:
+      mode: push_and_pr
+      merge:
+        mode: merge_queue
+
+scheduler:
+  lanes:
+    planning: { precedence: 1, capacity: 1 }
+    delivery: { precedence: 2, capacity: 2 }
+    triage: { precedence: 3, idle_only: true, capacity: 1 }
+    epic-closure: { precedence: 4, capacity: 1 }
+    human-attention: { precedence: 5, idle_only: true, capacity: 1 }
+  resources:
+    repository: { capacity: 1 }
+  recovery: { max_attempts: 2, max_backoff_ms: 30000 }
+  one_shot: { deadline_ms: 1800000 }
+
+agents:
+  planner: { executor: example-agent, model: example-model, prompt_template: prompts/planning.md }
+  implementer: { executor: example-agent, model: example-model, prompt_template: prompts/delivery.md }
+  reviewer: { executor: example-agent, model: example-model, prompt_template: prompts/review.md }
+  verifier: { executor: example-agent, model: example-model, prompt_template: prompts/verification.md }
+  synthesizer: { executor: example-agent, model: example-model, prompt_template: prompts/synthesis.md }
+  triager: { executor: example-agent, model: example-model, prompt_template: prompts/triage-draft.md }
+  triage-applier: { executor: example-agent, model: example-model, prompt_template: prompts/triage-apply.md }
+  epic-owner: { executor: example-agent, model: example-model, prompt_template: prompts/epic.md }
+  attention-owner: { executor: example-agent, model: example-model, prompt_template: prompts/attention.md }
+
+pipelines:
+  planning:
+    steps:
+      - name: draft-plan
+        agent: planner
+        depends: []
+        resource_requests: { repository: 1 }
+        output_schema: { path: schemas/plan.schema.json }
+        artifact_snapshot: { repositories: [target] }
+        actions:
+          - type: tracker_comment
+            body: /comment
+      - name: route-plan-outcome
+        kind: route
+        depends: [draft-plan]
+        on_failure: halt
+        route:
+          source: { step: draft-plan, pointer: /outcome }
+          cases:
+            revision: [acknowledge-plan-revision]
+            operator_required: [record-plan-attention]
+          terminals:
+            revision: { state: Ready to implement }
+            operator_required: { state: Needs human }
+      - name: acknowledge-plan-revision
+        agent: planner
+        depends: [route-plan-outcome, draft-plan]
+        artifact_inputs: [draft-plan]
+        artifact_access: immutable
+        output_schema: { path: schemas/plan.schema.json }
+        authorization:
+          artifact_step: draft-plan
+          event:
+            # Copy the opaque Project status-field node ID; a display name is not evidence.
+            field: PVTSSF_example_status
+            value: Ready to implement
+            actors: [example-maintainer]
+          after_artifact: true
+          handoff: wait_for_event
+      - name: record-plan-attention
+        agent: attention-owner
+        depends: [route-plan-outcome]
+        output_schema: { path: schemas/attention.schema.json }
+        actions:
+          - type: tracker_comment
+            body: /comment
+          - type: operator_attention
+            kind: ensemble.github_project_drain
+            summary: /summary
+            remedy: /remedy
+            references: /references
+    on_success: Ready to implement
+    on_failure: Planning
+  delivery:
+    steps:
+      - name: implement
+        agent: implementer
+        depends: []
+        resource_requests: { repository: 1 }
+        output_schema: { path: schemas/plan.schema.json }
+        artifact_snapshot: { repositories: [target] }
+      - name: review
+        agent: reviewer
+        depends: [implement]
+        artifact_inputs: [implement]
+        artifact_access: immutable
+        output_schema: { path: schemas/assessment.schema.json }
+      - name: verify
+        agent: verifier
+        depends: [implement]
+        artifact_inputs: [implement]
+        artifact_access: immutable
+        output_schema: { path: schemas/assessment.schema.json }
+      - name: adjudicate
+        kind: synthesis
+        agent: synthesizer
+        depends: [review, verify]
+        output_schema: { path: schemas/adjudication.schema.json }
+      - name: delivery-gate
+        kind: gate
+        depends: [adjudicate]
+        gate:
+          assessment_steps: [review, verify]
+          adjudication_step: adjudicate
+    on_success: Done
+    on_failure: In progress
+    delivery_repair: { agent: implementer, max_attempts: 2 }
+    delivery_states:
+      waiting: Awaiting review
+      checks_failed: In progress
+      changes_requested: In progress
+      approved: Awaiting merge
+      closed_without_merge: In progress
+      merged: on_success
+  triage:
+    steps:
+      - name: draft-triage-patch
+        agent: triager
+        depends: []
+        output_schema: { path: schemas/triage-patch.schema.json }
+        artifact_snapshot: { repositories: [target] }
+        actions:
+          - type: tracker_comment
+            body: /comment
+      - name: apply-triage-patch
+        agent: triage-applier
+        depends: [draft-triage-patch]
+        artifact_inputs: [draft-triage-patch]
+        artifact_access: immutable
+        output_schema: { path: schemas/triage-apply.schema.json }
+        authorization:
+          artifact_step: draft-triage-patch
+          event:
+            field: PVTSSF_example_status
+            value: Triage approved
+            actors: [example-maintainer]
+          after_artifact: true
+          handoff: wait_for_event
+    on_success: Ready to implement
+    on_failure: Backlog
+  epic-closure:
+    steps:
+      - name: choose-epic-outcome
+        agent: epic-owner
+        depends: []
+        output_schema: { path: schemas/closure.schema.json }
+      - name: route-epic-outcome
+        kind: route
+        depends: [choose-epic-outcome]
+        on_failure: halt
+        route:
+          source: { step: choose-epic-outcome, pointer: /outcome }
+          cases:
+            close: [acknowledge-closure]
+            attention: [record-epic-attention]
+          terminals:
+            close: { state: Done }
+            attention: { state: Needs human }
+      - name: acknowledge-closure
+        agent: epic-owner
+        depends: [route-epic-outcome]
+        approval: { mode: always }
+        output_schema: { path: schemas/closure.schema.json }
+      - name: record-epic-attention
+        agent: attention-owner
+        depends: [route-epic-outcome]
+        output_schema: { path: schemas/attention.schema.json }
+        actions:
+          - type: tracker_comment
+            body: /comment
+          - type: operator_attention
+            kind: ensemble.github_project_drain
+            summary: /summary
+            remedy: /remedy
+            references: /references
+    on_success: Done
+    on_failure: Needs human
+  human-attention:
+    steps:
+      - name: record-attention
+        agent: attention-owner
+        depends: []
+        output_schema: { path: schemas/attention.schema.json }
+        actions:
+          - type: tracker_comment
+            body: /comment
+          - type: operator_attention
+            kind: ensemble.github_project_drain
+            summary: /summary
+            remedy: /remedy
+            references: /references
+    on_success: Human hold
+    on_failure: Needs human
+
+workflow_selection:
+  - name: planning
+    precedence: 1
+    pipeline: planning
+    lane: planning
+    states: [Planning]
+    require_unblocked: true
+    order_by: [priority, tracker_position, identifier]
+  - name: delivery
+    precedence: 2
+    pipeline: delivery
+    lane: delivery
+    states: [Ready to implement]
+    labels_all: [ready-for-agent]
+    labels_none: [epic]
+    require_unblocked: true
+    order_by: [priority, tracker_position, identifier]
+  - name: triage
+    precedence: 3
+    pipeline: triage
+    lane: triage
+    states: [Backlog]
+    labels_all: [needs-triage]
+    require_unblocked: true
+    order_by: [priority, tracker_position, identifier]
+  - name: epic-closure
+    precedence: 4
+    pipeline: epic-closure
+    lane: epic-closure
+    states: [Ready to implement]
+    labels_all: [epic]
+    require_unblocked: true
+    order_by: [priority, tracker_position, identifier]
+  - name: human-attention
+    precedence: 5
+    pipeline: human-attention
+    lane: human-attention
+    states: [Needs human]
+    labels_all: [ready-for-human]
+    order_by: [priority, tracker_position, identifier]

--- a/docs/examples/github-project-drain/prompts/attention.md
+++ b/docs/examples/github-project-drain/prompts/attention.md
@@ -1,0 +1,2 @@
+Describe the operator action needed using the configured attention schema. Keep the summary,
+remedy, and references concrete and evidence-based.

--- a/docs/examples/github-project-drain/prompts/delivery.md
+++ b/docs/examples/github-project-drain/prompts/delivery.md
@@ -1,0 +1,2 @@
+Implement the selected issue in the issue workspace. Return the configured schema and preserve
+the immutable Artifact boundary for later review and verification.

--- a/docs/examples/github-project-drain/prompts/epic.md
+++ b/docs/examples/github-project-drain/prompts/epic.md
@@ -1,0 +1,2 @@
+Return the configured closure outcome. `close` needs the configured approval checkpoint; choose
+`attention` when a human decision remains necessary.

--- a/docs/examples/github-project-drain/prompts/planning.md
+++ b/docs/examples/github-project-drain/prompts/planning.md
@@ -1,0 +1,3 @@
+Produce a versioned implementation plan as the configured schema. Include the reviewed summary in
+`comment`; the configured action publishes it with an idempotent marker. Do not continue to
+implementation until the configured status event authorizes the acknowledgement step.

--- a/docs/examples/github-project-drain/prompts/review.md
+++ b/docs/examples/github-project-drain/prompts/review.md
@@ -1,0 +1,2 @@
+Review only the supplied immutable Artifact snapshot. Return assessment findings using the
+configured schema; do not modify the snapshot.

--- a/docs/examples/github-project-drain/prompts/synthesis.md
+++ b/docs/examples/github-project-drain/prompts/synthesis.md
@@ -1,0 +1,2 @@
+Account for every review and verification finding in the configured adjudication schema. Do not
+invent evidence or re-run implementation.

--- a/docs/examples/github-project-drain/prompts/triage-apply.md
+++ b/docs/examples/github-project-drain/prompts/triage-apply.md
@@ -1,0 +1,13 @@
+This step receives the immutable triage-draft Artifact only after the configured `Triage approved`
+status event is fresh, allowlisted, and durably authorized. The exact approved patch is between
+these markers:
+
+BEGIN APPROVED TRIAGE PATCH
+{{ dependency_outputs[0].output_json }}
+END APPROVED TRIAGE PATCH
+
+Write only that exact JSON value to a workspace file, then invoke
+`/absolute/path/to/github-project-drain/tools/apply-triage-patch.sh` with that file and the explicit
+repository, Project, status-field, and issue arguments. Replace this placeholder with the installed
+helper's absolute path when copying the bundle. Do not reconstruct or modify the patch, and do not
+use `gh` for any other mutation.

--- a/docs/examples/github-project-drain/prompts/triage-draft.md
+++ b/docs/examples/github-project-drain/prompts/triage-draft.md
@@ -1,0 +1,3 @@
+Draft a schema-valid triage patch after recording the configured `Triage approved` status that the
+authorized applier must reread. The patch must bind that expected issue and Project snapshot and
+use only the example's listed operations. Do not invoke GitHub mutation commands.

--- a/docs/examples/github-project-drain/prompts/verification.md
+++ b/docs/examples/github-project-drain/prompts/verification.md
@@ -1,0 +1,2 @@
+Verify only the supplied immutable Artifact snapshot. Return independent assessment evidence
+using the configured schema; do not modify the snapshot.

--- a/docs/examples/github-project-drain/schemas/adjudication.schema.json
+++ b/docs/examples/github-project-drain/schemas/adjudication.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["adjudication"],
+  "properties": {
+    "adjudication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dispositions"],
+      "properties": {
+        "dispositions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["source_step", "finding_id", "disposition", "rationale", "evidence"],
+            "properties": {
+              "source_step": { "type": "string", "minLength": 1 },
+              "finding_id": { "type": "string", "minLength": 1 },
+              "disposition": { "enum": ["upheld", "dismissed", "unresolved"] },
+              "rationale": { "type": "string", "minLength": 1 },
+              "evidence": { "type": "object", "minProperties": 1 }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/examples/github-project-drain/schemas/assessment.schema.json
+++ b/docs/examples/github-project-drain/schemas/assessment.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["assessment"],
+  "properties": {
+    "assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["findings"],
+      "properties": {
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "severity", "summary", "evidence"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "severity": { "enum": ["blocking", "non_blocking"] },
+              "summary": { "type": "string", "minLength": 1 },
+              "evidence": { "type": "object", "minProperties": 1 }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/examples/github-project-drain/schemas/attention.schema.json
+++ b/docs/examples/github-project-drain/schemas/attention.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["comment", "summary", "remedy", "references"],
+  "properties": {
+    "comment": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string", "minLength": 1 },
+    "remedy": { "type": "string", "minLength": 1 },
+    "references": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+  }
+}

--- a/docs/examples/github-project-drain/schemas/closure.schema.json
+++ b/docs/examples/github-project-drain/schemas/closure.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["outcome", "summary"],
+  "properties": {
+    "outcome": { "type": "string", "enum": ["close", "attention"] },
+    "summary": { "type": "string", "minLength": 1 }
+  }
+}

--- a/docs/examples/github-project-drain/schemas/plan.schema.json
+++ b/docs/examples/github-project-drain/schemas/plan.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["outcome", "summary", "comment"],
+  "properties": {
+    "outcome": { "type": "string", "enum": ["revision", "operator_required"] },
+    "summary": { "type": "string", "minLength": 1 },
+    "comment": { "type": "string", "minLength": 1 }
+  }
+}

--- a/docs/examples/github-project-drain/schemas/triage-apply.schema.json
+++ b/docs/examples/github-project-drain/schemas/triage-apply.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["summary"],
+  "properties": { "summary": { "type": "string", "minLength": 1 } }
+}

--- a/docs/examples/github-project-drain/schemas/triage-patch.schema.json
+++ b/docs/examples/github-project-drain/schemas/triage-patch.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "comment", "expected_snapshot", "operations"],
+  "properties": {
+    "version": { "const": 1 },
+    "comment": { "type": "string", "minLength": 1 },
+    "expected_snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issue_number", "project_id", "status", "labels"],
+      "properties": {
+        "issue_number": { "type": "integer", "minimum": 1 },
+        "project_id": { "type": "string", "minLength": 1 },
+        "status": { "const": "Triage approved" },
+        "labels": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true }
+      }
+    },
+    "operations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "value"],
+        "properties": {
+          "type": { "enum": ["set_status", "add_label", "remove_label"] },
+          "value": { "type": "string", "minLength": 1 }
+        },
+        "oneOf": [
+          {
+            "properties": {
+              "type": { "const": "set_status" },
+              "value": { "const": "Ready to implement" }
+            }
+          },
+          {
+            "properties": {
+              "type": { "enum": ["add_label", "remove_label"] },
+              "value": { "enum": ["needs-triage", "ready-for-agent", "ready-for-human"] }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/docs/examples/github-project-drain/tools/apply-triage-patch.sh
+++ b/docs/examples/github-project-drain/tools/apply-triage-patch.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# Applies one approved, reference-configured triage patch. This is intentionally
+# not an Ensemble runtime API or a generic GraphQL wrapper.
+set -eu
+
+usage() {
+  echo "usage: $0 --repo OWNER/REPO --project-number NUMBER --status-field NAME --issue NUMBER --patch FILE" >&2
+  exit 64
+}
+
+repo=
+project_number=
+status_field=
+issue_number=
+patch=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo) repo=${2-}; shift 2 ;;
+    --project-number) project_number=${2-}; shift 2 ;;
+    --status-field) status_field=${2-}; shift 2 ;;
+    --issue) issue_number=${2-}; shift 2 ;;
+    --patch) patch=${2-}; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[ -n "$repo" ] && [ -n "$project_number" ] && [ -n "$status_field" ] && [ -n "$issue_number" ] && [ -n "$patch" ] || usage
+[ -r "$patch" ] || { echo "patch is not readable: $patch" >&2; exit 65; }
+command -v gh >/dev/null 2>&1 || { echo "gh is required" >&2; exit 69; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 69; }
+
+# The checked-in reference intentionally has a finite policy. Copy and edit this
+# file with the configuration; do not turn it into an arbitrary mutation proxy.
+allowed_statuses='["Ready to implement"]'
+allowed_labels='["needs-triage","ready-for-agent","ready-for-human"]'
+approval_status='Triage approved'
+
+jq -e '
+  type == "object" and
+  (keys | sort) == ["comment", "expected_snapshot", "operations", "version"] and
+  .version == 1 and
+  (.comment | type == "string" and length > 0) and
+  (.expected_snapshot | type == "object" and
+    (keys | sort) == ["issue_number", "labels", "project_id", "status"] and
+    (.issue_number | type == "number" and floor == . and . > 0) and
+    (.project_id | type == "string" and length > 0) and
+    (.status | type == "string" and length > 0) and
+    (.labels | type == "array" and all(.[]; type == "string" and length > 0) and (length == (unique | length)))) and
+  (.operations | type == "array" and length > 0 and
+    all(.[]; type == "object" and (keys | sort) == ["type", "value"] and
+      (.type == "set_status" or .type == "add_label" or .type == "remove_label") and
+      (.value | type == "string" and length > 0)) and
+    ([.[] | [.type, .value] | @json] | length == (unique | length)))
+' "$patch" >/dev/null || { echo "patch does not satisfy triage-patch schema version 1" >&2; exit 65; }
+
+expected_issue=$(jq -r '.expected_snapshot.issue_number' "$patch")
+[ "$expected_issue" = "$issue_number" ] || { echo "patch issue does not match --issue" >&2; exit 65; }
+while IFS= read -r operation; do
+  type=$(printf '%s' "$operation" | jq -r '.type')
+  value=$(printf '%s' "$operation" | jq -r '.value')
+  case "$type" in
+    set_status) printf '%s' "$allowed_statuses" | jq -e --arg value "$value" 'index($value) != null' >/dev/null || { echo "status is outside reference allowlist" >&2; exit 65; } ;;
+    add_label|remove_label) printf '%s' "$allowed_labels" | jq -e --arg value "$value" 'index($value) != null' >/dev/null || { echo "label is outside reference allowlist" >&2; exit 65; } ;;
+  esac
+done <<EOF
+$(jq -c '.operations[]' "$patch")
+EOF
+
+owner=${repo%%/*}
+name=${repo#*/}
+[ -n "$owner" ] && [ -n "$name" ] && [ "$owner" != "$name" ] || { echo "--repo must be OWNER/REPO" >&2; exit 64; }
+
+# This authoritative reread supplies every identity used below. The patch binds
+# to it before any mutation is attempted, so stale drafts fail closed.
+snapshot_query='query ReferenceTriageSnapshot($owner: String!, $name: String!, $project: Int!, $issue: Int!) {
+  repository(owner: $owner, name: $name) {
+    projectV2(number: $project) {
+      id
+      fields(first: 100) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } }
+    }
+    labels(first: 100) { nodes { id name } }
+    issue(number: $issue) {
+      id number labels(first: 100) { nodes { id name } }
+      projectItems(first: 100) {
+        nodes {
+          id project { id }
+          fieldValues(first: 100) { nodes { ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2SingleSelectField { id name } } } } }
+        }
+      }
+    }
+  }
+}'
+snapshot=$(gh api graphql -f query="$snapshot_query" -F owner="$owner" -F name="$name" -F project="$project_number" -F issue="$issue_number")
+
+project_id=$(printf '%s' "$snapshot" | jq -er '.data.repository.projectV2.id')
+status_field_id=$(printf '%s' "$snapshot" | jq -er --arg name "$status_field" '[.data.repository.projectV2.fields.nodes[] | select(.name == $name) | .id] | if length == 1 then .[0] else error("status field must resolve exactly once") end')
+item_id=$(printf '%s' "$snapshot" | jq -er --arg project "$project_id" '[.data.repository.issue.projectItems.nodes[] | select(.project.id == $project) | .id] | if length == 1 then .[0] else error("project item must resolve exactly once") end')
+issue_id=$(printf '%s' "$snapshot" | jq -er '.data.repository.issue.id')
+actual_issue=$(printf '%s' "$snapshot" | jq -er '.data.repository.issue.number')
+actual_status=$(printf '%s' "$snapshot" | jq -er --arg item "$item_id" --arg field "$status_field_id" '[.data.repository.issue.projectItems.nodes[] | select(.id == $item) | .fieldValues.nodes[] | select(.field.id == $field) | .name] | if length == 1 then .[0] else error("current status must resolve exactly once") end')
+actual_labels=$(printf '%s' "$snapshot" | jq -ce '[.data.repository.issue.labels.nodes[].name] | sort')
+expected_project=$(jq -r '.expected_snapshot.project_id' "$patch")
+expected_status=$(jq -r '.expected_snapshot.status' "$patch")
+expected_labels=$(jq -c '.expected_snapshot.labels | sort' "$patch")
+
+[ "$actual_issue" = "$issue_number" ] && [ "$project_id" = "$expected_project" ] && [ "$expected_status" = "$approval_status" ] && [ "$actual_status" = "$expected_status" ] && [ "$actual_labels" = "$expected_labels" ] || {
+  echo "patch expected_snapshot does not match the authoritative GitHub reread (issue=$actual_issue project=$project_id status=$actual_status labels=$actual_labels)" >&2
+  exit 65
+}
+
+# Resolve every target before the first write. `operation_plan` has only finite,
+# pre-approved operation kinds and server-derived IDs, in patch source order.
+operation_plan=
+while IFS= read -r operation; do
+  type=$(printf '%s' "$operation" | jq -r '.type')
+  value=$(printf '%s' "$operation" | jq -r '.value')
+  case "$type" in
+    set_status)
+      option_id=$(printf '%s' "$snapshot" | jq -er --arg field "$status_field_id" --arg value "$value" '[.data.repository.projectV2.fields.nodes[] | select(.id == $field) | .options[] | select(.name == $value) | .id] | if length == 1 then .[0] else error("status option must resolve exactly once") end')
+      operation_plan="${operation_plan}${type}|${option_id}\n"
+      ;;
+    add_label)
+      label_id=$(printf '%s' "$snapshot" | jq -er --arg value "$value" '[.data.repository.labels.nodes[] | select(.name == $value) | .id] | if length == 1 then .[0] else error("label must resolve exactly once") end')
+      operation_plan="${operation_plan}${type}|${label_id}\n"
+      ;;
+    remove_label)
+      label_id=$(printf '%s' "$snapshot" | jq -er --arg value "$value" '[.data.repository.labels.nodes[] | select(.name == $value) | .id] | if length == 1 then .[0] else error("label must resolve exactly once") end')
+      operation_plan="${operation_plan}${type}|${label_id}\n"
+      ;;
+  esac
+done <<EOF
+$(jq -c '.operations[]' "$patch")
+EOF
+
+printf '%b' "$operation_plan" | while IFS='|' read -r type target_id; do
+  case "$type" in
+    set_status)
+      gh api graphql -f query='mutation ReferenceTriageSetStatus($project: ID!, $item: ID!, $field: ID!, $option: String!) { updateProjectV2ItemFieldValue(input: {projectId: $project, itemId: $item, fieldId: $field, value: {singleSelectOptionId: $option}}) { projectV2Item { id } } }' -F project="$project_id" -F item="$item_id" -F field="$status_field_id" -F option="$target_id" >/dev/null
+      ;;
+    add_label)
+      gh api graphql -f query='mutation ReferenceTriageAddLabels($issue: ID!, $labels: [ID!]!) { addLabelsToLabelable(input: {labelableId: $issue, labelIds: $labels}) { clientMutationId } }' -F issue="$issue_id" -F labels[]="$target_id" >/dev/null
+      ;;
+    remove_label)
+      gh api graphql -f query='mutation ReferenceTriageRemoveLabels($issue: ID!, $labels: [ID!]!) { removeLabelsFromLabelable(input: {labelableId: $issue, labelIds: $labels}) { clientMutationId } }' -F issue="$issue_id" -F labels[]="$target_id" >/dev/null
+      ;;
+  esac
+done

--- a/docs/examples/github-project-drain/tools/apply-triage-patch.sh
+++ b/docs/examples/github-project-drain/tools/apply-triage-patch.sh
@@ -78,7 +78,7 @@ snapshot_query='query ReferenceTriageSnapshot($owner: String!, $name: String!, $
       id
       fields(first: 100) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } }
     }
-    labels(first: 100) { nodes { id name } }
+    labels(first: 100) { nodes { id name } pageInfo { hasNextPage endCursor } }
     issue(number: $issue) {
       id number labels(first: 100) { nodes { id name } }
       projectItems(first: 100) {
@@ -91,6 +91,55 @@ snapshot_query='query ReferenceTriageSnapshot($owner: String!, $name: String!, $
   }
 }'
 snapshot=$(gh api graphql -f query="$snapshot_query" -F owner="$owner" -F name="$name" -F project="$project_number" -F issue="$issue_number")
+
+# The first snapshot carries the issue's authoritative current labels and the
+# first repository-label page. Resolve every repository label page before any
+# preflight target lookup so an allowlisted label beyond page one is not treated
+# as unavailable (or accidentally resolved against a partial catalogue).
+repository_labels=$(printf '%s' "$snapshot" | jq -ce '.data.repository.labels.nodes')
+labels_page_info=$(printf '%s' "$snapshot" | jq -ce '
+  .data.repository.labels.pageInfo
+  | if type == "object"
+      and (.hasNextPage | type == "boolean")
+      and has("endCursor")
+    then .
+    else error("repository label pageInfo is malformed")
+    end
+')
+labels_has_next=$(printf '%s' "$labels_page_info" | jq -r '.hasNextPage')
+labels_cursor=$(printf '%s' "$labels_page_info" | jq -r '
+  if .hasNextPage then
+    .endCursor | if type == "string" and length > 0 then . else error("repository label page is missing a cursor") end
+  else ""
+  end
+')
+labels_page_query='query ReferenceTriageRepositoryLabels($owner: String!, $name: String!, $cursor: String!) {
+  repository(owner: $owner, name: $name) {
+    labels(first: 100, after: $cursor) { nodes { id name } pageInfo { hasNextPage endCursor } }
+  }
+}'
+while [ "$labels_has_next" = true ]; do
+  [ -n "$labels_cursor" ] || { echo "repository label pagination omitted its cursor" >&2; exit 65; }
+  labels_page=$(gh api graphql -f query="$labels_page_query" -F owner="$owner" -F name="$name" -F cursor="$labels_cursor")
+  next_labels=$(printf '%s' "$labels_page" | jq -ce '.data.repository.labels.nodes')
+  repository_labels=$(printf '%s\n%s\n' "$repository_labels" "$next_labels" | jq -sce 'add')
+  labels_page_info=$(printf '%s' "$labels_page" | jq -ce '
+    .data.repository.labels.pageInfo
+    | if type == "object"
+        and (.hasNextPage | type == "boolean")
+        and has("endCursor")
+      then .
+      else error("repository label pageInfo is malformed")
+      end
+  ')
+  labels_has_next=$(printf '%s' "$labels_page_info" | jq -r '.hasNextPage')
+  labels_cursor=$(printf '%s' "$labels_page_info" | jq -r '
+    if .hasNextPage then
+      .endCursor | if type == "string" and length > 0 then . else error("repository label page is missing a cursor") end
+    else ""
+    end
+  ')
+done
 
 project_id=$(printf '%s' "$snapshot" | jq -er '.data.repository.projectV2.id')
 status_field_id=$(printf '%s' "$snapshot" | jq -er --arg name "$status_field" '[.data.repository.projectV2.fields.nodes[] | select(.name == $name) | .id] | if length == 1 then .[0] else error("status field must resolve exactly once") end')
@@ -120,11 +169,11 @@ while IFS= read -r operation; do
       operation_plan="${operation_plan}${type}|${option_id}\n"
       ;;
     add_label)
-      label_id=$(printf '%s' "$snapshot" | jq -er --arg value "$value" '[.data.repository.labels.nodes[] | select(.name == $value) | .id] | if length == 1 then .[0] else error("label must resolve exactly once") end')
+      label_id=$(printf '%s' "$repository_labels" | jq -er --arg value "$value" '[.[] | select(.name == $value) | .id] | if length == 1 then .[0] else error("label must resolve exactly once") end')
       operation_plan="${operation_plan}${type}|${label_id}\n"
       ;;
     remove_label)
-      label_id=$(printf '%s' "$snapshot" | jq -er --arg value "$value" '[.data.repository.labels.nodes[] | select(.name == $value) | .id] | if length == 1 then .[0] else error("label must resolve exactly once") end')
+      label_id=$(printf '%s' "$repository_labels" | jq -er --arg value "$value" '[.[] | select(.name == $value) | .id] | if length == 1 then .[0] else error("label must resolve exactly once") end')
       operation_plan="${operation_plan}${type}|${label_id}\n"
       ;;
   esac

--- a/docs/github-project-drain.md
+++ b/docs/github-project-drain.md
@@ -1,0 +1,92 @@
+# GitHub Project reference configuration
+
+[`examples/github-project-drain/`](examples/github-project-drain/) is a copyable reference for
+running an issue-driven GitHub Project with generic Ensemble configuration contracts. Copy the
+whole directory into a private configuration directory and adapt its
+[`config.yaml`](examples/github-project-drain/config.yaml), prompts, schemas, and
+[`tools/apply-triage-patch.sh`](examples/github-project-drain/tools/apply-triage-patch.sh)
+together. It is not a built-in `github_project_drain` runtime mode.
+
+## What to replace
+
+Replace the repository, Project number, state and label predicates, priority order, Project field
+display names, actor identities, branch policy, agents, paths, scheduler capacities, and deadlines.
+The `tracker.github.status_field` value is the readable Project field name used for normalization.
+`authorization.event.field` is different: it must be the opaque immutable Project status-field
+node ID discovered for your Project (the reference placeholder is `PVTSSF_example_status`).
+Activation or dispatch fails closed when that event field is missing, unavailable from the adapter,
+or does not match fresh status-event evidence.
+
+The reference uses selected named `pipelines`, `scheduler.lanes`, and `workflow_selection` rules.
+The names `planning`, `delivery`, `triage`, `epic-closure`, and `human-attention` are ordinary
+configuration keys; their state and label meanings stay in this directory. Delivery alone requires
+the `ready-for-agent` label, and rules that must respect native dependencies use
+`require_unblocked: true`.
+
+## Planning and delivery
+
+The default planning handoff is human-authorized. `draft-plan` snapshots an Artifact and publishes
+a marker-bound plan comment, then routes `revision` to an immutable `wait_for_event` publication
+acknowledgement or `operator_required` to marker-bound operator attention. The acknowledgement
+retains the same Run until an allowlisted actor supplies a qualifying post-Artifact status event.
+To make that policy automatic, explicitly change the protected step to `automatic_transition`,
+give it a `tracker_state`, and authorize the entry transition; it is not a default.
+
+Delivery snapshots implementation output, obtains independent immutable review and verification
+assessments, then uses a deterministic gate and normal repository finalization. The example
+declares a bounded delivery-repair policy and a merge-queue policy. Change the repository's
+`finalize.merge` to `manual`, `auto` with an allowed method, or `merge_queue` according to the
+repository's live policy. No label or assignee is merge eligibility: finalization reads the
+repository's own merge policy and current pull-request facts.
+
+Repository finalization is configured per repository, not per selected pipeline. Keep planning,
+triage, and human-attention agents non-mutating; if a private copy needs different publication
+policy per pipeline, use separate repository configurations or stop at the delivery boundary
+instead of treating this reference as a new runtime mode.
+
+Tune lane capacities, the `repository` resource, recovery budget, and `one_shot.deadline_ms` for
+your operating limits. These are policy inputs, not promises of agent capacity.
+
+## Triage, epics, and attention
+
+Triage is deliberately draft then authorize then apply. The drafter emits the strict
+[`triage-patch.schema.json`](examples/github-project-drain/schemas/triage-patch.schema.json) and
+the configuration publishes only its bounded summary and snapshots its Artifact.
+`apply-triage-patch` immutably consumes that direct Artifact only after a fresh allowlisted
+`Triage approved` post-Artifact status event. It has no `approval` field: approval is a post-step
+decision primitive, retained here only for the genuine epic-close acknowledgement. Its prompt
+renders the producer's exact compact `dependency_outputs[0].output_json`, directs the applier to
+materialize that value unchanged, then invokes the bundled helper with the exact repository,
+Project number, status-field name, issue number, and authorized workspace patch.
+
+The helper is a privileged, example-local boundary. It requires `gh`, `jq`, authenticated GitHub
+access, and a Project-visible issue. Install the copied helper at a trusted absolute path that the
+agent runtime can execute, then replace the placeholder path in `prompts/triage-apply.md`; agent
+working directories are issue workspaces, not the configuration directory. It validates schema
+version and exact shape, checks an
+expected post-approval issue/Project/status/labels snapshot against an authoritative reread,
+requires every field, option, item, and label target to resolve exactly once for the entire patch
+before the first write, and
+permits only the configured `set_status`, `add_label`, and `remove_label` values. Malformed,
+stale, ambiguous, unavailable, or out-of-policy patches fail before any mutation; it neither
+interprets prose nor accepts arbitrary GraphQL input.
+
+The unblocked epic rule routes a schema enum either to an approval-protected closure
+acknowledgement or to a marker-bound comment plus durable operator-attention item. The reference
+defaults closure to an approval checkpoint. Removing that checkpoint is an explicit automatic
+policy choice. The human-attention rule similarly records opaque durable attention; it does not
+implement, publish, or create a special runtime role.
+
+## Required capabilities and fail-closed boundaries
+
+This reference needs generic Project field discovery and normalization, selected-rule native
+blocker data, authenticated exclusive ownership, marker-bound comments, immutable status-event
+evidence, durable attention history, and repository finalization/merge-policy reads. It also needs
+the helper prerequisites above. Unsupported event evidence, ambiguous Project membership, missing
+permissions, absent durable history, or a helper preflight mismatch stops the relevant path.
+Triage and human-attention lanes are intentionally `idle_only`, while `Triage approved`,
+`Awaiting review`, and `Awaiting merge` stay active so held and delivery-projection records can
+reconcile. None falls back to a built-in drain mode.
+
+For the generic configuration vocabulary, see the [Configuration Reference](configuration.md)
+and [Pipeline Guide](pipelines.md).

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -12,6 +12,8 @@ A configuration can replace the legacy top-level pipeline with named `pipelines`
 `scheduler.lanes`, and `workflow_selection` rules. The selector matches normalized issue state,
 labels, and blockers without assigning built-in meanings such as planning or delivery to them.
 The matching rule chooses both the executable pipeline and the live-worker capacity lane.
+For a checked-in copy/adapt composition of this mechanism with GitHub Project normalization,
+authorization, and attention policy, see [GitHub Project reference configuration](github-project-drain.md).
 
 For fresh work, Ensemble evaluates and orders the candidate snapshot, then refreshes the selected
 issue by stable ID immediately before the existing claim operation. The refreshed issue must still
@@ -181,6 +183,8 @@ partition every direct successor exactly once.
     cases:
       agreement: [accept_agreement]
       disagreement: [escalate]
+    terminals:
+      disagreement: { state: Needs human }
 - name: accept_agreement
   agent: agreement_handler
   depends: [choose_review_path]
@@ -195,10 +199,14 @@ output, attempt, transcript, artifact, or dependency-output entry. A shared join
 dependency to settle and runs when at least one passed. A run containing only `Passed` and `Skipped`
 terminal steps succeeds.
 
-The selected case and a source-output digest are stored in the run snapshot, so restart and a
-downstream retry retain the choice. Resetting the source resets its descendants and removes affected
-route decisions. Missing or unmatched route evidence fails the route closed and halts; routes do
-not support automatic retry, fixup, defaults, coercion, predicates, dynamic nodes, or loops.
+An optional `terminals` mapping gives selected cases an opaque successful terminal state. Mapping
+keys must name declared cases, states must be non-blank, and a pipeline may have at most one
+terminal-bearing route. The selected case and a source-output digest are stored in the run snapshot,
+so restart, finalization, and a downstream retry retain the choice; unmapped cases use the
+pipeline's `on_success`, while failures always use `on_failure`. Resetting the source resets its
+descendants and removes affected route decisions. Missing or unmatched route evidence fails the
+route closed and halts; routes do not support automatic retry, fixup, defaults, coercion,
+predicates, dynamic nodes, or loops.
 
 ## Durable post-output actions
 


### PR DESCRIPTION
## Summary

- add a copyable GitHub Project drain reference configuration with prompts, schemas, and bounded fail-closed triage tooling
- document installation, adaptation, authorization, routing, and recovery behavior
- exercise the copied bundle through core validation and black-box web, WireMock, and ACPX product scenarios

## Verification

- `cargo test -p ensemble-core --test github_project_drain_reference`
- `SKIP_UI_BUILD=1 cargo test -p ensemble-cli --features web-ui --test product_e2e github_project_drain_reference_ -- --nocapture`
- `cargo test --workspace --exclude ensemble-desktop`
- `SKIP_UI_BUILD=1 cargo check -p ensemble-cli --features web-ui`
- `cargo clippy --workspace --exclude ensemble-desktop -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #515